### PR TITLE
Normalize generated OTel dashboard JSON structure

### DIFF
--- a/packages/apache_otel/kibana/dashboard/apache_otel-overview.json
+++ b/packages/apache_otel/kibana/dashboard/apache_otel-overview.json
@@ -2,10 +2,2331 @@
   "attributes": {
     "title": "[Apache OTel] Overview",
     "description": "Overview of Apache HTTP Server health and performance from OpenTelemetry metrics.",
-    "panelsJSON": "[{\"panelIndex\": \"887981e6-1ee5-4087-096b-af81cff49944\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 16, \"h\": 12, \"i\": \"887981e6-1ee5-4087-096b-af81cff49944\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [Apache OTel] Overview\\n\\nThis dashboard provides an overview of Apache HTTP Server health and performance via OpenTelemetry metrics:\\n- Request rate and traffic throughput\\n- Worker pool utilization (busy vs idle)\\n- Active and asynchronous connection counts\\n- Server load averages (1m, 5m, 15m)\\n- CPU load and CPU time breakdown by mode\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"f1e0d86e-84d4-93fe-5f7b-bef3ab9bdfa0\", \"gridData\": {\"x\": 16, \"y\": 0, \"w\": 8, \"h\": 6, \"i\": \"f1e0d86e-84d4-93fe-5f7b-bef3ab9bdfa0\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Uptime\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"62c51441-02ae-70c0-8031-2d31119b2859\", \"layerType\": \"data\", \"metricAccessor\": \"fdcdc26f-c739-3ede-5856-c6377252da21\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.uptime IS NOT NULL\\n| STATS uptime_sec = MAX(LAST_OVER_TIME(apache.uptime))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"62c51441-02ae-70c0-8031-2d31119b2859\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.uptime IS NOT NULL\\n| STATS uptime_sec = MAX(LAST_OVER_TIME(apache.uptime))\"}, \"columns\": [{\"fieldName\": \"uptime_sec\", \"columnId\": \"fdcdc26f-c739-3ede-5856-c6377252da21\", \"label\": \"Uptime\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"duration\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"uptime_sec\", \"columnId\": \"fdcdc26f-c739-3ede-5856-c6377252da21\", \"label\": \"Uptime\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"duration\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"e520f2f7-162a-8ae2-3c9d-4fe5cd5508d9\", \"gridData\": {\"x\": 24, \"y\": 0, \"w\": 8, \"h\": 6, \"i\": \"e520f2f7-162a-8ae2-3c9d-4fe5cd5508d9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Request Rate\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"e33a8656-2b80-caa1-2d6c-3cc359a0d15a\", \"layerType\": \"data\", \"metricAccessor\": \"30c41641-aeeb-f02b-c9e9-0857472b9bea\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.requests IS NOT NULL\\n| STATS request_rate = SUM(RATE(apache.requests))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e33a8656-2b80-caa1-2d6c-3cc359a0d15a\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.requests IS NOT NULL\\n| STATS request_rate = SUM(RATE(apache.requests))\"}, \"columns\": [{\"fieldName\": \"request_rate\", \"columnId\": \"30c41641-aeeb-f02b-c9e9-0857472b9bea\", \"label\": \"Request Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \" req/s\"}}}}], \"allColumns\": [{\"fieldName\": \"request_rate\", \"columnId\": \"30c41641-aeeb-f02b-c9e9-0857472b9bea\", \"label\": \"Request Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \" req/s\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"81c12fbb-84e1-8af8-787e-7f8943490b9c\", \"gridData\": {\"x\": 32, \"y\": 0, \"w\": 8, \"h\": 6, \"i\": \"81c12fbb-84e1-8af8-787e-7f8943490b9c\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Traffic Rate\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"126816f6-3f7c-c116-41ea-ea057702cdbe\", \"layerType\": \"data\", \"metricAccessor\": \"6960bff6-6245-c4f2-4dd3-b4ead5e62fec\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.traffic IS NOT NULL\\n| STATS traffic_rate = SUM(RATE(apache.traffic))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"126816f6-3f7c-c116-41ea-ea057702cdbe\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.traffic IS NOT NULL\\n| STATS traffic_rate = SUM(RATE(apache.traffic))\"}, \"columns\": [{\"fieldName\": \"traffic_rate\", \"columnId\": \"6960bff6-6245-c4f2-4dd3-b4ead5e62fec\", \"label\": \"Traffic Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 1, \"suffix\": \"/s\"}}}}], \"allColumns\": [{\"fieldName\": \"traffic_rate\", \"columnId\": \"6960bff6-6245-c4f2-4dd3-b4ead5e62fec\", \"label\": \"Traffic Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 1, \"suffix\": \"/s\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"ac7d975a-8037-c750-c277-27b39069530a\", \"gridData\": {\"x\": 40, \"y\": 0, \"w\": 8, \"h\": 6, \"i\": \"ac7d975a-8037-c750-c277-27b39069530a\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"CPU Load\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"2b5bb6b6-0e27-0250-d30b-d195fc22e900\", \"layerType\": \"data\", \"metricAccessor\": \"dfb69e92-4c05-c625-71fa-d92de5c16b35\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.cpu.load IS NOT NULL\\n| STATS cpu_load = MAX(AVG_OVER_TIME(apache.cpu.load))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"2b5bb6b6-0e27-0250-d30b-d195fc22e900\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.cpu.load IS NOT NULL\\n| STATS cpu_load = MAX(AVG_OVER_TIME(apache.cpu.load))\"}, \"columns\": [{\"fieldName\": \"cpu_load\", \"columnId\": \"dfb69e92-4c05-c625-71fa-d92de5c16b35\", \"label\": \"CPU Load\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \" %\"}}}}], \"allColumns\": [{\"fieldName\": \"cpu_load\", \"columnId\": \"dfb69e92-4c05-c625-71fa-d92de5c16b35\", \"label\": \"CPU Load\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \" %\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"2e15537b-ed9c-bf4c-8f36-c383700afb65\", \"gridData\": {\"x\": 16, \"y\": 6, \"w\": 8, \"h\": 6, \"i\": \"2e15537b-ed9c-bf4c-8f36-c383700afb65\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Active Connections\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"42f675ea-5da4-357e-d8e0-e60656df4566\", \"layerType\": \"data\", \"metricAccessor\": \"0d5e45ec-5006-3db4-9583-26496cee66a4\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.current_connections IS NOT NULL\\n| STATS connections = MAX(LAST_OVER_TIME(apache.current_connections))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"42f675ea-5da4-357e-d8e0-e60656df4566\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.current_connections IS NOT NULL\\n| STATS connections = MAX(LAST_OVER_TIME(apache.current_connections))\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"0d5e45ec-5006-3db4-9583-26496cee66a4\", \"label\": \"Active Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"0d5e45ec-5006-3db4-9583-26496cee66a4\", \"label\": \"Active Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"8c951b8b-02a8-fc7d-6960-273855fb0feb\", \"gridData\": {\"x\": 24, \"y\": 6, \"w\": 8, \"h\": 6, \"i\": \"8c951b8b-02a8-fc7d-6960-273855fb0feb\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Busy Workers\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"ae44035c-504e-1b3e-39f7-670ce64cff8e\", \"layerType\": \"data\", \"metricAccessor\": \"e11edd16-eb74-3c9e-afcc-6ebf37c2010e\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.workers IS NOT NULL AND attributes.state == \\\"busy\\\"\\n| STATS busy = MAX(LAST_OVER_TIME(apache.workers))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ae44035c-504e-1b3e-39f7-670ce64cff8e\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.workers IS NOT NULL AND attributes.state == \\\"busy\\\"\\n| STATS busy = MAX(LAST_OVER_TIME(apache.workers))\"}, \"columns\": [{\"fieldName\": \"busy\", \"columnId\": \"e11edd16-eb74-3c9e-afcc-6ebf37c2010e\", \"label\": \"Busy Workers\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"busy\", \"columnId\": \"e11edd16-eb74-3c9e-afcc-6ebf37c2010e\", \"label\": \"Busy Workers\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"efdc2bf8-ae2d-b2e2-164c-cbff0bca4550\", \"gridData\": {\"x\": 32, \"y\": 6, \"w\": 8, \"h\": 6, \"i\": \"efdc2bf8-ae2d-b2e2-164c-cbff0bca4550\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Idle Workers\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"241bdec7-9aef-0f0e-80fa-482e2dfb234d\", \"layerType\": \"data\", \"metricAccessor\": \"ea3e09e1-928f-e6e3-e87a-4f1facbda987\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.workers IS NOT NULL AND attributes.state == \\\"idle\\\"\\n| STATS idle = MAX(LAST_OVER_TIME(apache.workers))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"241bdec7-9aef-0f0e-80fa-482e2dfb234d\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.workers IS NOT NULL AND attributes.state == \\\"idle\\\"\\n| STATS idle = MAX(LAST_OVER_TIME(apache.workers))\"}, \"columns\": [{\"fieldName\": \"idle\", \"columnId\": \"ea3e09e1-928f-e6e3-e87a-4f1facbda987\", \"label\": \"Idle Workers\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"idle\", \"columnId\": \"ea3e09e1-928f-e6e3-e87a-4f1facbda987\", \"label\": \"Idle Workers\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"cb8ead79-d8c5-13fa-1f94-520e63c21f06\", \"gridData\": {\"x\": 40, \"y\": 6, \"w\": 8, \"h\": 6, \"i\": \"cb8ead79-d8c5-13fa-1f94-520e63c21f06\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Server Load (1m)\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"e83cab11-7a00-9602-0b56-1c485f3907df\", \"layerType\": \"data\", \"metricAccessor\": \"d982b0fc-5bb2-be0e-cb24-3a8bcaa68ff1\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE `apache.load.1` IS NOT NULL\\n| STATS load_1m = MAX(AVG_OVER_TIME(`apache.load.1`))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e83cab11-7a00-9602-0b56-1c485f3907df\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE `apache.load.1` IS NOT NULL\\n| STATS load_1m = MAX(AVG_OVER_TIME(`apache.load.1`))\"}, \"columns\": [{\"fieldName\": \"load_1m\", \"columnId\": \"d982b0fc-5bb2-be0e-cb24-3a8bcaa68ff1\", \"label\": \"Server Load (1m)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"allColumns\": [{\"fieldName\": \"load_1m\", \"columnId\": \"d982b0fc-5bb2-be0e-cb24-3a8bcaa68ff1\", \"label\": \"Server Load (1m)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"efc3c390-5ded-e443-91d9-88410c2a103b\", \"gridData\": {\"x\": 0, \"y\": 12, \"w\": 48, \"h\": 3, \"i\": \"efc3c390-5ded-e443-91d9-88410c2a103b\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Traffic & Performance\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Traffic & Performance\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"8359485a-f93f-f780-cc8b-d2316ce56e05\", \"gridData\": {\"x\": 0, \"y\": 15, \"w\": 24, \"h\": 12, \"i\": \"8359485a-f93f-f780-cc8b-d2316ce56e05\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Rate Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cc8c29f6-cecf-7c2f-2cde-09b6993c8dda\", \"accessors\": [\"da50b277-a4b4-8f8f-b0fc-3547d19ce4e7\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.requests IS NOT NULL\\n| STATS request_rate = SUM(RATE(apache.requests)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cc8c29f6-cecf-7c2f-2cde-09b6993c8dda\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.requests IS NOT NULL\\n| STATS request_rate = SUM(RATE(apache.requests)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"request_rate\", \"columnId\": \"da50b277-a4b4-8f8f-b0fc-3547d19ce4e7\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"request_rate\", \"columnId\": \"da50b277-a4b4-8f8f-b0fc-3547d19ce4e7\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"399a4d4b-22a8-537f-9a47-f9e6e51582e0\", \"gridData\": {\"x\": 24, \"y\": 15, \"w\": 24, \"h\": 12, \"i\": \"399a4d4b-22a8-537f-9a47-f9e6e51582e0\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Traffic Throughput Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"bb43a991-a05e-7ae5-31bc-0d5fc9b6ba35\", \"accessors\": [\"0a590185-7c11-df2c-ee40-7f6d8bf66747\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.traffic IS NOT NULL\\n| STATS traffic_rate = SUM(RATE(apache.traffic)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"bb43a991-a05e-7ae5-31bc-0d5fc9b6ba35\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.traffic IS NOT NULL\\n| STATS traffic_rate = SUM(RATE(apache.traffic)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"traffic_rate\", \"columnId\": \"0a590185-7c11-df2c-ee40-7f6d8bf66747\", \"label\": \"Bytes/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"traffic_rate\", \"columnId\": \"0a590185-7c11-df2c-ee40-7f6d8bf66747\", \"label\": \"Bytes/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f63c8a06-4917-e9eb-d460-342789708dbe\", \"gridData\": {\"x\": 0, \"y\": 27, \"w\": 48, \"h\": 3, \"i\": \"f63c8a06-4917-e9eb-d460-342789708dbe\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Workers & Connections\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Workers & Connections\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"d4db9150-8807-90e5-632d-679e4b1129fe\", \"gridData\": {\"x\": 0, \"y\": 30, \"w\": 24, \"h\": 12, \"i\": \"d4db9150-8807-90e5-632d-679e4b1129fe\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Workers by State Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"f992d766-f537-a743-2823-fe6ad986bd77\", \"accessors\": [\"efdd14aa-d709-1aeb-133f-e482afc17510\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"858f983c-47c4-c5e4-81cd-e4647af3d816\", \"colorMapping\": {\"assignments\": [{\"rule\": {\"type\": \"matchExactly\", \"values\": [\"busy\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#E7664C\"}, \"touched\": false}, {\"rule\": {\"type\": \"matchExactly\", \"values\": [\"idle\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#54B399\"}, \"touched\": false}], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.workers IS NOT NULL\\n| STATS workers = MAX(LAST_OVER_TIME(apache.workers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.state\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"f992d766-f537-a743-2823-fe6ad986bd77\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.workers IS NOT NULL\\n| STATS workers = MAX(LAST_OVER_TIME(apache.workers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.state\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"workers\", \"columnId\": \"efdd14aa-d709-1aeb-133f-e482afc17510\", \"label\": \"Workers\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.state\", \"columnId\": \"858f983c-47c4-c5e4-81cd-e4647af3d816\", \"label\": \"attributes.state\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"workers\", \"columnId\": \"efdd14aa-d709-1aeb-133f-e482afc17510\", \"label\": \"Workers\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.state\", \"columnId\": \"858f983c-47c4-c5e4-81cd-e4647af3d816\", \"label\": \"attributes.state\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"80006d9a-5de5-4b99-12ce-486e55a7d0ce\", \"gridData\": {\"x\": 24, \"y\": 30, \"w\": 24, \"h\": 12, \"i\": \"80006d9a-5de5-4b99-12ce-486e55a7d0ce\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Connections Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"9a204f64-a963-c32d-9274-f61b9163c03f\", \"accessors\": [\"a6f23ea5-a740-7b7e-a503-4d6d95104dab\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.current_connections IS NOT NULL\\n| STATS connections = MAX(LAST_OVER_TIME(apache.current_connections)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"9a204f64-a963-c32d-9274-f61b9163c03f\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.current_connections IS NOT NULL\\n| STATS connections = MAX(LAST_OVER_TIME(apache.current_connections)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"a6f23ea5-a740-7b7e-a503-4d6d95104dab\", \"label\": \"Active Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"a6f23ea5-a740-7b7e-a503-4d6d95104dab\", \"label\": \"Active Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"ff32905c-4ec6-d1bd-0bee-be75d4bca877\", \"gridData\": {\"x\": 0, \"y\": 42, \"w\": 24, \"h\": 12, \"i\": \"ff32905c-4ec6-d1bd-0bee-be75d4bca877\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Scoreboard Worker States Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"2bb62dbf-6be1-7853-f3bc-028c82e8245e\", \"accessors\": [\"39924052-228d-bef3-6004-a8132e5223c5\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"858f983c-47c4-c5e4-81cd-e4647af3d816\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.scoreboard IS NOT NULL\\n| STATS count = MAX(LAST_OVER_TIME(apache.scoreboard)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.state\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"2bb62dbf-6be1-7853-f3bc-028c82e8245e\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.scoreboard IS NOT NULL\\n| STATS count = MAX(LAST_OVER_TIME(apache.scoreboard)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.state\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"count\", \"columnId\": \"39924052-228d-bef3-6004-a8132e5223c5\", \"label\": \"Workers\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.state\", \"columnId\": \"858f983c-47c4-c5e4-81cd-e4647af3d816\", \"label\": \"attributes.state\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"count\", \"columnId\": \"39924052-228d-bef3-6004-a8132e5223c5\", \"label\": \"Workers\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.state\", \"columnId\": \"858f983c-47c4-c5e4-81cd-e4647af3d816\", \"label\": \"attributes.state\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f04ea16d-49bf-689f-3dcf-43d35ccf3ca6\", \"gridData\": {\"x\": 24, \"y\": 42, \"w\": 24, \"h\": 12, \"i\": \"f04ea16d-49bf-689f-3dcf-43d35ccf3ca6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Async Connections by State Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cc3d2d54-decf-6944-080b-4621f94cc1b9\", \"accessors\": [\"f4c1eef1-bc79-8e51-891f-28b869de8362\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"9971b195-1efa-59ca-be30-c9c1bc6f0c19\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.connections.async IS NOT NULL\\n| STATS connections = MAX(LAST_OVER_TIME(apache.connections.async)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.connection_state\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cc3d2d54-decf-6944-080b-4621f94cc1b9\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.connections.async IS NOT NULL\\n| STATS connections = MAX(LAST_OVER_TIME(apache.connections.async)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.connection_state\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"f4c1eef1-bc79-8e51-891f-28b869de8362\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.connection_state\", \"columnId\": \"9971b195-1efa-59ca-be30-c9c1bc6f0c19\", \"label\": \"attributes.connection_state\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"f4c1eef1-bc79-8e51-891f-28b869de8362\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.connection_state\", \"columnId\": \"9971b195-1efa-59ca-be30-c9c1bc6f0c19\", \"label\": \"attributes.connection_state\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"3613a751-e533-3134-cccd-cdb572c26b67\", \"gridData\": {\"x\": 0, \"y\": 54, \"w\": 48, \"h\": 3, \"i\": \"3613a751-e533-3134-cccd-cdb572c26b67\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"System Resources\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## System Resources\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"f9e49625-213d-5db0-c983-de18f7dc82d9\", \"gridData\": {\"x\": 0, \"y\": 57, \"w\": 24, \"h\": 12, \"i\": \"f9e49625-213d-5db0-c983-de18f7dc82d9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Server Load Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"f371dc04-2dd7-5742-e1b1-debdca3c6e8a\", \"accessors\": [\"e5126c0e-b5f6-7599-d5c4-f9150db01196\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"7ea769df-bcc3-a33b-ff2b-a76e718be641\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| FORK ( WHERE `apache.load.1` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.1`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \\\"1 minute\\\" ) ( WHERE `apache.load.5` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.5`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \\\"5 minutes\\\" ) ( WHERE `apache.load.15` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.15`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \\\"15 minutes\\\" )\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"f371dc04-2dd7-5742-e1b1-debdca3c6e8a\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| FORK ( WHERE `apache.load.1` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.1`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \\\"1 minute\\\" ) ( WHERE `apache.load.5` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.5`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \\\"5 minutes\\\" ) ( WHERE `apache.load.15` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.15`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \\\"15 minutes\\\" )\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"load\", \"columnId\": \"e5126c0e-b5f6-7599-d5c4-f9150db01196\", \"label\": \"Load\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"period\", \"columnId\": \"7ea769df-bcc3-a33b-ff2b-a76e718be641\", \"label\": \"period\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"load\", \"columnId\": \"e5126c0e-b5f6-7599-d5c4-f9150db01196\", \"label\": \"Load\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"period\", \"columnId\": \"7ea769df-bcc3-a33b-ff2b-a76e718be641\", \"label\": \"period\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"a9a36696-a097-1cd0-83af-34af4ad26fda\", \"gridData\": {\"x\": 24, \"y\": 57, \"w\": 24, \"h\": 12, \"i\": \"a9a36696-a097-1cd0-83af-34af4ad26fda\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"CPU Time by Mode Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"24d22a7b-962c-606a-e896-706f8ee179d3\", \"accessors\": [\"528d31d8-b27c-24dd-f6ed-1346b399ed0a\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"eae4ec36-98ac-7948-c0bd-cc2e677d9f7f\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.cpu.time IS NOT NULL\\n| STATS cpu_time_rate = SUM(RATE(apache.cpu.time)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.mode\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"24d22a7b-962c-606a-e896-706f8ee179d3\": {\"query\": {\"esql\": \"TS metrics-apachereceiver.otel-*\\n| WHERE apache.cpu.time IS NOT NULL\\n| STATS cpu_time_rate = SUM(RATE(apache.cpu.time)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.mode\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"cpu_time_rate\", \"columnId\": \"528d31d8-b27c-24dd-f6ed-1346b399ed0a\", \"label\": \"CPU jiffs/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.mode\", \"columnId\": \"eae4ec36-98ac-7948-c0bd-cc2e677d9f7f\", \"label\": \"attributes.mode\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"cpu_time_rate\", \"columnId\": \"528d31d8-b27c-24dd-f6ed-1346b399ed0a\", \"label\": \"CPU jiffs/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.mode\", \"columnId\": \"eae4ec36-98ac-7948-c0bd-cc2e677d9f7f\", \"label\": \"attributes.mode\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "887981e6-1ee5-4087-096b-af81cff49944",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 16,
+          "h": 12,
+          "i": "887981e6-1ee5-4087-096b-af81cff49944"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## [Apache OTel] Overview\n\nThis dashboard provides an overview of Apache HTTP Server health and performance via OpenTelemetry metrics:\n- Request rate and traffic throughput\n- Worker pool utilization (busy vs idle)\n- Active and asynchronous connection counts\n- Server load averages (1m, 5m, 15m)\n- CPU load and CPU time breakdown by mode\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "f1e0d86e-84d4-93fe-5f7b-bef3ab9bdfa0",
+        "gridData": {
+          "x": 16,
+          "y": 0,
+          "w": 8,
+          "h": 6,
+          "i": "f1e0d86e-84d4-93fe-5f7b-bef3ab9bdfa0"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Uptime",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "62c51441-02ae-70c0-8031-2d31119b2859",
+                "layerType": "data",
+                "metricAccessor": "fdcdc26f-c739-3ede-5856-c6377252da21",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.uptime IS NOT NULL\n| STATS uptime_sec = MAX(LAST_OVER_TIME(apache.uptime))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "62c51441-02ae-70c0-8031-2d31119b2859": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.uptime IS NOT NULL\n| STATS uptime_sec = MAX(LAST_OVER_TIME(apache.uptime))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "uptime_sec",
+                          "columnId": "fdcdc26f-c739-3ede-5856-c6377252da21",
+                          "label": "Uptime",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "duration",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "uptime_sec",
+                          "columnId": "fdcdc26f-c739-3ede-5856-c6377252da21",
+                          "label": "Uptime",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "duration",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "e520f2f7-162a-8ae2-3c9d-4fe5cd5508d9",
+        "gridData": {
+          "x": 24,
+          "y": 0,
+          "w": 8,
+          "h": 6,
+          "i": "e520f2f7-162a-8ae2-3c9d-4fe5cd5508d9"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Request Rate",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "e33a8656-2b80-caa1-2d6c-3cc359a0d15a",
+                "layerType": "data",
+                "metricAccessor": "30c41641-aeeb-f02b-c9e9-0857472b9bea",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.requests IS NOT NULL\n| STATS request_rate = SUM(RATE(apache.requests))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e33a8656-2b80-caa1-2d6c-3cc359a0d15a": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.requests IS NOT NULL\n| STATS request_rate = SUM(RATE(apache.requests))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "request_rate",
+                          "columnId": "30c41641-aeeb-f02b-c9e9-0857472b9bea",
+                          "label": "Request Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": " req/s"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "request_rate",
+                          "columnId": "30c41641-aeeb-f02b-c9e9-0857472b9bea",
+                          "label": "Request Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": " req/s"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "81c12fbb-84e1-8af8-787e-7f8943490b9c",
+        "gridData": {
+          "x": 32,
+          "y": 0,
+          "w": 8,
+          "h": 6,
+          "i": "81c12fbb-84e1-8af8-787e-7f8943490b9c"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Traffic Rate",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "126816f6-3f7c-c116-41ea-ea057702cdbe",
+                "layerType": "data",
+                "metricAccessor": "6960bff6-6245-c4f2-4dd3-b4ead5e62fec",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.traffic IS NOT NULL\n| STATS traffic_rate = SUM(RATE(apache.traffic))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "126816f6-3f7c-c116-41ea-ea057702cdbe": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.traffic IS NOT NULL\n| STATS traffic_rate = SUM(RATE(apache.traffic))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "traffic_rate",
+                          "columnId": "6960bff6-6245-c4f2-4dd3-b4ead5e62fec",
+                          "label": "Traffic Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/s"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "traffic_rate",
+                          "columnId": "6960bff6-6245-c4f2-4dd3-b4ead5e62fec",
+                          "label": "Traffic Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/s"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "ac7d975a-8037-c750-c277-27b39069530a",
+        "gridData": {
+          "x": 40,
+          "y": 0,
+          "w": 8,
+          "h": 6,
+          "i": "ac7d975a-8037-c750-c277-27b39069530a"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "CPU Load",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "2b5bb6b6-0e27-0250-d30b-d195fc22e900",
+                "layerType": "data",
+                "metricAccessor": "dfb69e92-4c05-c625-71fa-d92de5c16b35",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.cpu.load IS NOT NULL\n| STATS cpu_load = MAX(AVG_OVER_TIME(apache.cpu.load))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "2b5bb6b6-0e27-0250-d30b-d195fc22e900": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.cpu.load IS NOT NULL\n| STATS cpu_load = MAX(AVG_OVER_TIME(apache.cpu.load))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "cpu_load",
+                          "columnId": "dfb69e92-4c05-c625-71fa-d92de5c16b35",
+                          "label": "CPU Load",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": " %"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "cpu_load",
+                          "columnId": "dfb69e92-4c05-c625-71fa-d92de5c16b35",
+                          "label": "CPU Load",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": " %"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "2e15537b-ed9c-bf4c-8f36-c383700afb65",
+        "gridData": {
+          "x": 16,
+          "y": 6,
+          "w": 8,
+          "h": 6,
+          "i": "2e15537b-ed9c-bf4c-8f36-c383700afb65"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Active Connections",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "42f675ea-5da4-357e-d8e0-e60656df4566",
+                "layerType": "data",
+                "metricAccessor": "0d5e45ec-5006-3db4-9583-26496cee66a4",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.current_connections IS NOT NULL\n| STATS connections = MAX(LAST_OVER_TIME(apache.current_connections))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "42f675ea-5da4-357e-d8e0-e60656df4566": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.current_connections IS NOT NULL\n| STATS connections = MAX(LAST_OVER_TIME(apache.current_connections))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "0d5e45ec-5006-3db4-9583-26496cee66a4",
+                          "label": "Active Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "0d5e45ec-5006-3db4-9583-26496cee66a4",
+                          "label": "Active Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "8c951b8b-02a8-fc7d-6960-273855fb0feb",
+        "gridData": {
+          "x": 24,
+          "y": 6,
+          "w": 8,
+          "h": 6,
+          "i": "8c951b8b-02a8-fc7d-6960-273855fb0feb"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Busy Workers",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "ae44035c-504e-1b3e-39f7-670ce64cff8e",
+                "layerType": "data",
+                "metricAccessor": "e11edd16-eb74-3c9e-afcc-6ebf37c2010e",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.workers IS NOT NULL AND attributes.state == \"busy\"\n| STATS busy = MAX(LAST_OVER_TIME(apache.workers))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ae44035c-504e-1b3e-39f7-670ce64cff8e": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.workers IS NOT NULL AND attributes.state == \"busy\"\n| STATS busy = MAX(LAST_OVER_TIME(apache.workers))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "busy",
+                          "columnId": "e11edd16-eb74-3c9e-afcc-6ebf37c2010e",
+                          "label": "Busy Workers",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "busy",
+                          "columnId": "e11edd16-eb74-3c9e-afcc-6ebf37c2010e",
+                          "label": "Busy Workers",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "efdc2bf8-ae2d-b2e2-164c-cbff0bca4550",
+        "gridData": {
+          "x": 32,
+          "y": 6,
+          "w": 8,
+          "h": 6,
+          "i": "efdc2bf8-ae2d-b2e2-164c-cbff0bca4550"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Idle Workers",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "241bdec7-9aef-0f0e-80fa-482e2dfb234d",
+                "layerType": "data",
+                "metricAccessor": "ea3e09e1-928f-e6e3-e87a-4f1facbda987",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.workers IS NOT NULL AND attributes.state == \"idle\"\n| STATS idle = MAX(LAST_OVER_TIME(apache.workers))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "241bdec7-9aef-0f0e-80fa-482e2dfb234d": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.workers IS NOT NULL AND attributes.state == \"idle\"\n| STATS idle = MAX(LAST_OVER_TIME(apache.workers))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "idle",
+                          "columnId": "ea3e09e1-928f-e6e3-e87a-4f1facbda987",
+                          "label": "Idle Workers",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "idle",
+                          "columnId": "ea3e09e1-928f-e6e3-e87a-4f1facbda987",
+                          "label": "Idle Workers",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "cb8ead79-d8c5-13fa-1f94-520e63c21f06",
+        "gridData": {
+          "x": 40,
+          "y": 6,
+          "w": 8,
+          "h": 6,
+          "i": "cb8ead79-d8c5-13fa-1f94-520e63c21f06"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Server Load (1m)",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "e83cab11-7a00-9602-0b56-1c485f3907df",
+                "layerType": "data",
+                "metricAccessor": "d982b0fc-5bb2-be0e-cb24-3a8bcaa68ff1",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE `apache.load.1` IS NOT NULL\n| STATS load_1m = MAX(AVG_OVER_TIME(`apache.load.1`))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e83cab11-7a00-9602-0b56-1c485f3907df": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE `apache.load.1` IS NOT NULL\n| STATS load_1m = MAX(AVG_OVER_TIME(`apache.load.1`))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "load_1m",
+                          "columnId": "d982b0fc-5bb2-be0e-cb24-3a8bcaa68ff1",
+                          "label": "Server Load (1m)",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "load_1m",
+                          "columnId": "d982b0fc-5bb2-be0e-cb24-3a8bcaa68ff1",
+                          "label": "Server Load (1m)",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "efc3c390-5ded-e443-91d9-88410c2a103b",
+        "gridData": {
+          "x": 0,
+          "y": 12,
+          "w": 48,
+          "h": 3,
+          "i": "efc3c390-5ded-e443-91d9-88410c2a103b"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Traffic & Performance",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Traffic & Performance"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "8359485a-f93f-f780-cc8b-d2316ce56e05",
+        "gridData": {
+          "x": 0,
+          "y": 15,
+          "w": 24,
+          "h": 12,
+          "i": "8359485a-f93f-f780-cc8b-d2316ce56e05"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Request Rate Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "cc8c29f6-cecf-7c2f-2cde-09b6993c8dda",
+                    "accessors": [
+                      "da50b277-a4b4-8f8f-b0fc-3547d19ce4e7"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.requests IS NOT NULL\n| STATS request_rate = SUM(RATE(apache.requests)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cc8c29f6-cecf-7c2f-2cde-09b6993c8dda": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.requests IS NOT NULL\n| STATS request_rate = SUM(RATE(apache.requests)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "request_rate",
+                          "columnId": "da50b277-a4b4-8f8f-b0fc-3547d19ce4e7",
+                          "label": "Requests/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "request_rate",
+                          "columnId": "da50b277-a4b4-8f8f-b0fc-3547d19ce4e7",
+                          "label": "Requests/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "399a4d4b-22a8-537f-9a47-f9e6e51582e0",
+        "gridData": {
+          "x": 24,
+          "y": 15,
+          "w": 24,
+          "h": 12,
+          "i": "399a4d4b-22a8-537f-9a47-f9e6e51582e0"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Traffic Throughput Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "bb43a991-a05e-7ae5-31bc-0d5fc9b6ba35",
+                    "accessors": [
+                      "0a590185-7c11-df2c-ee40-7f6d8bf66747"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.traffic IS NOT NULL\n| STATS traffic_rate = SUM(RATE(apache.traffic)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "bb43a991-a05e-7ae5-31bc-0d5fc9b6ba35": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.traffic IS NOT NULL\n| STATS traffic_rate = SUM(RATE(apache.traffic)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "traffic_rate",
+                          "columnId": "0a590185-7c11-df2c-ee40-7f6d8bf66747",
+                          "label": "Bytes/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "traffic_rate",
+                          "columnId": "0a590185-7c11-df2c-ee40-7f6d8bf66747",
+                          "label": "Bytes/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "f63c8a06-4917-e9eb-d460-342789708dbe",
+        "gridData": {
+          "x": 0,
+          "y": 27,
+          "w": 48,
+          "h": 3,
+          "i": "f63c8a06-4917-e9eb-d460-342789708dbe"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Workers & Connections",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Workers & Connections"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "d4db9150-8807-90e5-632d-679e4b1129fe",
+        "gridData": {
+          "x": 0,
+          "y": 30,
+          "w": 24,
+          "h": 12,
+          "i": "d4db9150-8807-90e5-632d-679e4b1129fe"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Workers by State Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "f992d766-f537-a743-2823-fe6ad986bd77",
+                    "accessors": [
+                      "efdd14aa-d709-1aeb-133f-e482afc17510"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "858f983c-47c4-c5e4-81cd-e4647af3d816",
+                    "colorMapping": {
+                      "assignments": [
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "busy"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#E7664C"
+                          },
+                          "touched": false
+                        },
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "idle"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#54B399"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.workers IS NOT NULL\n| STATS workers = MAX(LAST_OVER_TIME(apache.workers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.state\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "f992d766-f537-a743-2823-fe6ad986bd77": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.workers IS NOT NULL\n| STATS workers = MAX(LAST_OVER_TIME(apache.workers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.state\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "workers",
+                          "columnId": "efdd14aa-d709-1aeb-133f-e482afc17510",
+                          "label": "Workers",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.state",
+                          "columnId": "858f983c-47c4-c5e4-81cd-e4647af3d816",
+                          "label": "attributes.state",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "workers",
+                          "columnId": "efdd14aa-d709-1aeb-133f-e482afc17510",
+                          "label": "Workers",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.state",
+                          "columnId": "858f983c-47c4-c5e4-81cd-e4647af3d816",
+                          "label": "attributes.state",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "80006d9a-5de5-4b99-12ce-486e55a7d0ce",
+        "gridData": {
+          "x": 24,
+          "y": 30,
+          "w": 24,
+          "h": 12,
+          "i": "80006d9a-5de5-4b99-12ce-486e55a7d0ce"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Active Connections Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "9a204f64-a963-c32d-9274-f61b9163c03f",
+                    "accessors": [
+                      "a6f23ea5-a740-7b7e-a503-4d6d95104dab"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.current_connections IS NOT NULL\n| STATS connections = MAX(LAST_OVER_TIME(apache.current_connections)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "9a204f64-a963-c32d-9274-f61b9163c03f": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.current_connections IS NOT NULL\n| STATS connections = MAX(LAST_OVER_TIME(apache.current_connections)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "a6f23ea5-a740-7b7e-a503-4d6d95104dab",
+                          "label": "Active Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "a6f23ea5-a740-7b7e-a503-4d6d95104dab",
+                          "label": "Active Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "ff32905c-4ec6-d1bd-0bee-be75d4bca877",
+        "gridData": {
+          "x": 0,
+          "y": 42,
+          "w": 24,
+          "h": 12,
+          "i": "ff32905c-4ec6-d1bd-0bee-be75d4bca877"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Scoreboard Worker States Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "2bb62dbf-6be1-7853-f3bc-028c82e8245e",
+                    "accessors": [
+                      "39924052-228d-bef3-6004-a8132e5223c5"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "858f983c-47c4-c5e4-81cd-e4647af3d816",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.scoreboard IS NOT NULL\n| STATS count = MAX(LAST_OVER_TIME(apache.scoreboard)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.state\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "2bb62dbf-6be1-7853-f3bc-028c82e8245e": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.scoreboard IS NOT NULL\n| STATS count = MAX(LAST_OVER_TIME(apache.scoreboard)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.state\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "count",
+                          "columnId": "39924052-228d-bef3-6004-a8132e5223c5",
+                          "label": "Workers",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.state",
+                          "columnId": "858f983c-47c4-c5e4-81cd-e4647af3d816",
+                          "label": "attributes.state",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "count",
+                          "columnId": "39924052-228d-bef3-6004-a8132e5223c5",
+                          "label": "Workers",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.state",
+                          "columnId": "858f983c-47c4-c5e4-81cd-e4647af3d816",
+                          "label": "attributes.state",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "f04ea16d-49bf-689f-3dcf-43d35ccf3ca6",
+        "gridData": {
+          "x": 24,
+          "y": 42,
+          "w": 24,
+          "h": 12,
+          "i": "f04ea16d-49bf-689f-3dcf-43d35ccf3ca6"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Async Connections by State Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "cc3d2d54-decf-6944-080b-4621f94cc1b9",
+                    "accessors": [
+                      "f4c1eef1-bc79-8e51-891f-28b869de8362"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "9971b195-1efa-59ca-be30-c9c1bc6f0c19",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.connections.async IS NOT NULL\n| STATS connections = MAX(LAST_OVER_TIME(apache.connections.async)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.connection_state\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cc3d2d54-decf-6944-080b-4621f94cc1b9": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.connections.async IS NOT NULL\n| STATS connections = MAX(LAST_OVER_TIME(apache.connections.async)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.connection_state\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "f4c1eef1-bc79-8e51-891f-28b869de8362",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.connection_state",
+                          "columnId": "9971b195-1efa-59ca-be30-c9c1bc6f0c19",
+                          "label": "attributes.connection_state",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "f4c1eef1-bc79-8e51-891f-28b869de8362",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.connection_state",
+                          "columnId": "9971b195-1efa-59ca-be30-c9c1bc6f0c19",
+                          "label": "attributes.connection_state",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "3613a751-e533-3134-cccd-cdb572c26b67",
+        "gridData": {
+          "x": 0,
+          "y": 54,
+          "w": 48,
+          "h": 3,
+          "i": "3613a751-e533-3134-cccd-cdb572c26b67"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "System Resources",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## System Resources"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "f9e49625-213d-5db0-c983-de18f7dc82d9",
+        "gridData": {
+          "x": 0,
+          "y": 57,
+          "w": 24,
+          "h": 12,
+          "i": "f9e49625-213d-5db0-c983-de18f7dc82d9"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Server Load Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "f371dc04-2dd7-5742-e1b1-debdca3c6e8a",
+                    "accessors": [
+                      "e5126c0e-b5f6-7599-d5c4-f9150db01196"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "7ea769df-bcc3-a33b-ff2b-a76e718be641",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| FORK ( WHERE `apache.load.1` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.1`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \"1 minute\" ) ( WHERE `apache.load.5` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.5`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \"5 minutes\" ) ( WHERE `apache.load.15` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.15`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \"15 minutes\" )\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "f371dc04-2dd7-5742-e1b1-debdca3c6e8a": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| FORK ( WHERE `apache.load.1` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.1`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \"1 minute\" ) ( WHERE `apache.load.5` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.5`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \"5 minutes\" ) ( WHERE `apache.load.15` IS NOT NULL | STATS load = MAX(AVG_OVER_TIME(`apache.load.15`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL period = \"15 minutes\" )\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "load",
+                          "columnId": "e5126c0e-b5f6-7599-d5c4-f9150db01196",
+                          "label": "Load",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "period",
+                          "columnId": "7ea769df-bcc3-a33b-ff2b-a76e718be641",
+                          "label": "period",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "load",
+                          "columnId": "e5126c0e-b5f6-7599-d5c4-f9150db01196",
+                          "label": "Load",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "period",
+                          "columnId": "7ea769df-bcc3-a33b-ff2b-a76e718be641",
+                          "label": "period",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "a9a36696-a097-1cd0-83af-34af4ad26fda",
+        "gridData": {
+          "x": 24,
+          "y": 57,
+          "w": 24,
+          "h": 12,
+          "i": "a9a36696-a097-1cd0-83af-34af4ad26fda"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "CPU Time by Mode Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "24d22a7b-962c-606a-e896-706f8ee179d3",
+                    "accessors": [
+                      "528d31d8-b27c-24dd-f6ed-1346b399ed0a"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "eae4ec36-98ac-7948-c0bd-cc2e677d9f7f",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.cpu.time IS NOT NULL\n| STATS cpu_time_rate = SUM(RATE(apache.cpu.time)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.mode\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "24d22a7b-962c-606a-e896-706f8ee179d3": {
+                      "query": {
+                        "esql": "TS metrics-apachereceiver.otel-*\n| WHERE apache.cpu.time IS NOT NULL\n| STATS cpu_time_rate = SUM(RATE(apache.cpu.time)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.mode\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "cpu_time_rate",
+                          "columnId": "528d31d8-b27c-24dd-f6ed-1346b399ed0a",
+                          "label": "CPU jiffs/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.mode",
+                          "columnId": "eae4ec36-98ac-7948-c0bd-cc2e677d9f7f",
+                          "label": "attributes.mode",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "cpu_time_rate",
+                          "columnId": "528d31d8-b27c-24dd-f6ed-1346b399ed0a",
+                          "label": "CPU jiffs/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.mode",
+                          "columnId": "eae4ec36-98ac-7948-c0bd-cc2e677d9f7f",
+                          "label": "attributes.mode",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"apachereceiver.otel\"}},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"apachereceiver.otel\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "data_stream.dataset",
+              "field": "data_stream.dataset",
+              "params": {
+                "query": "apachereceiver.otel"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "apachereceiver.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": true,
     "timeFrom": "now-1h",
@@ -14,8 +2335,50 @@
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"9ee7a268-5cc6-b546-db6e-96929c9a955b\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"9ee7a268-5cc6-b546-db6e-96929c9a955b\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"resource.attributes.apache.server.name\",\"title\":\"Server name\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"a18657f3-9386-7419-0c1e-db380f1b3b06\":{\"grow\":false,\"order\":1,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"a18657f3-9386-7419-0c1e-db380f1b3b06\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"resource.attributes.host.name\",\"title\":\"Host\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "9ee7a268-5cc6-b546-db6e-96929c9a955b": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "9ee7a268-5cc6-b546-db6e-96929c9a955b",
+            "dataViewId": "metrics-*",
+            "fieldName": "resource.attributes.apache.server.name",
+            "title": "Server name",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "a18657f3-9386-7419-0c1e-db380f1b3b06": {
+          "grow": false,
+          "order": 1,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "a18657f3-9386-7419-0c1e-db380f1b3b06",
+            "dataViewId": "metrics-*",
+            "fieldName": "resource.attributes.host.name",
+            "title": "Host",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/aws_vpcflow_otel/kibana/dashboard/aws_vpcflow_otel-interface.json
+++ b/packages/aws_vpcflow_otel/kibana/dashboard/aws_vpcflow_otel-interface.json
@@ -2,18 +2,2004 @@
   "attributes": {
     "title": "[AWS VPC OTEL] Interface Analysis",
     "description": "Per-interface analysis for investigating specific network interfaces",
-    "panelsJSON": "[{\"panelIndex\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"ef117464-3e9c-10b3-bb29-d1d6f9d3c452\", \"order\": 1, \"label\": \"Traffic Analysis\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_ef117464-3e9c-10b3-bb29-d1d6f9d3c452_dashboard\"}, {\"id\": \"1f78b936-37d7-285d-d766-136934e7d1c5\", \"order\": 2, \"label\": \"Interface Analysis\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_1f78b936-37d7-285d-d766-136934e7d1c5_dashboard\"}]}}}, {\"panelIndex\": \"2ea8f295-e522-487f-a359-8461dcf0b3ae\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 10, \"h\": 4, \"i\": \"2ea8f295-e522-487f-a359-8461dcf0b3ae\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Total Interfaces\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"a85ce253-317d-17de-edc1-a5c8c1d22dca\", \"layerType\": \"data\", \"metricAccessor\": \"1a0f2338-4f67-13c0-12cd-bb8c5e0dd6fa\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL\\n| STATS total_interfaces = COUNT_DISTINCT(network.interface.name)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"a85ce253-317d-17de-edc1-a5c8c1d22dca\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL\\n| STATS total_interfaces = COUNT_DISTINCT(network.interface.name)\"}, \"columns\": [{\"fieldName\": \"total_interfaces\", \"columnId\": \"1a0f2338-4f67-13c0-12cd-bb8c5e0dd6fa\", \"label\": \"Total Interfaces\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"total_interfaces\", \"columnId\": \"1a0f2338-4f67-13c0-12cd-bb8c5e0dd6fa\", \"label\": \"Total Interfaces\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"2a61bdad-f795-143f-c433-7ec51229e12b\", \"gridData\": {\"x\": 10, \"y\": 2, \"w\": 9, \"h\": 4, \"i\": \"2a61bdad-f795-143f-c433-7ec51229e12b\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Total Flow Records\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"ef16c77d-474f-0e07-5ef4-bd4b64978a9e\", \"layerType\": \"data\", \"metricAccessor\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\"\\n| STATS total_flows = COUNT()\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ef16c77d-474f-0e07-5ef4-bd4b64978a9e\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\"\\n| STATS total_flows = COUNT()\"}, \"columns\": [{\"fieldName\": \"total_flows\", \"columnId\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"label\": \"Flow Records\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"total_flows\", \"columnId\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"label\": \"Flow Records\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"99d196b0-8aad-ba50-e6b9-0404742e584f\", \"gridData\": {\"x\": 19, \"y\": 2, \"w\": 10, \"h\": 4, \"i\": \"99d196b0-8aad-ba50-e6b9-0404742e584f\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unique Source IPs\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"e77e8578-c3d7-93b4-9b94-c8612ee5d922\", \"layerType\": \"data\", \"metricAccessor\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND source.address IS NOT NULL\\n| STATS unique_sources = COUNT_DISTINCT(source.address)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e77e8578-c3d7-93b4-9b94-c8612ee5d922\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND source.address IS NOT NULL\\n| STATS unique_sources = COUNT_DISTINCT(source.address)\"}, \"columns\": [{\"fieldName\": \"unique_sources\", \"columnId\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"label\": \"Unique Sources\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_sources\", \"columnId\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"label\": \"Unique Sources\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"bf5fae40-24a4-b3f8-515e-bf507b735855\", \"gridData\": {\"x\": 29, \"y\": 2, \"w\": 9, \"h\": 4, \"i\": \"bf5fae40-24a4-b3f8-515e-bf507b735855\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unique Destination IPs\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"91098f81-a84e-b536-b595-9947df7e0286\", \"layerType\": \"data\", \"metricAccessor\": \"6f71393e-a5d6-8aea-79e8-bf89db24a2cd\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.address IS NOT NULL\\n| STATS unique_destinations = COUNT_DISTINCT(destination.address)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"91098f81-a84e-b536-b595-9947df7e0286\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.address IS NOT NULL\\n| STATS unique_destinations = COUNT_DISTINCT(destination.address)\"}, \"columns\": [{\"fieldName\": \"unique_destinations\", \"columnId\": \"6f71393e-a5d6-8aea-79e8-bf89db24a2cd\", \"label\": \"Unique Destinations\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_destinations\", \"columnId\": \"6f71393e-a5d6-8aea-79e8-bf89db24a2cd\", \"label\": \"Unique Destinations\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"05127ed8-bfb6-769b-1187-b516b6281fd5\", \"gridData\": {\"x\": 38, \"y\": 2, \"w\": 10, \"h\": 4, \"i\": \"05127ed8-bfb6-769b-1187-b516b6281fd5\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unique Protocols\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"43d4fe41-3a19-c47b-8995-f399cb74b224\", \"layerType\": \"data\", \"metricAccessor\": \"e960f750-fb9b-7807-8707-6f84b1a96407\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL\\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"43d4fe41-3a19-c47b-8995-f399cb74b224\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL\\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)\"}, \"columns\": [{\"fieldName\": \"unique_protocols\", \"columnId\": \"e960f750-fb9b-7807-8707-6f84b1a96407\", \"label\": \"Protocols\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_protocols\", \"columnId\": \"e960f750-fb9b-7807-8707-6f84b1a96407\", \"label\": \"Protocols\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"fef8d903-cb40-2fda-5d3e-28e8f0c932ef\", \"gridData\": {\"x\": 0, \"y\": 6, \"w\": 48, \"h\": 10, \"i\": \"fef8d903-cb40-2fda-5d3e-28e8f0c932ef\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Interface Traffic Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"49eac460-fc63-615a-2f87-81c1549b724a\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\", \"xTitle\": \"@timestamp\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": true, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL\\n| STATS flow_count = COUNT() BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"49eac460-fc63-615a-2f87-81c1549b724a\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL\\n| STATS flow_count = COUNT() BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"label\": \"Time\", \"customLabel\": true, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"label\": \"Time\", \"customLabel\": true, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"adaa0317-51bc-6c50-15e6-52a39ef03202\", \"gridData\": {\"x\": 0, \"y\": 16, \"w\": 48, \"h\": 13, \"i\": \"adaa0317-51bc-6c50-15e6-52a39ef03202\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Interface Traffic Analysis\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"e69124be-e423-08e1-38bd-b7737db7d972\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"b569b462-851f-619c-5e78-87185e395392\", \"colorMapping\": {\"assignments\": [{\"rule\": {\"type\": \"matchExactly\", \"values\": [\"REJECT\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#BD271E\"}, \"touched\": false}, {\"rule\": {\"type\": \"matchExactly\", \"values\": [\"ACCEPT\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#00BF6F\"}, \"touched\": false}], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL AND aws.vpc.flow.action IS NOT NULL\\n| STATS flow_count = COUNT() BY network.interface.name, aws.vpc.flow.action\\n| SORT flow_count DESC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e69124be-e423-08e1-38bd-b7737db7d972\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL AND aws.vpc.flow.action IS NOT NULL\\n| STATS flow_count = COUNT() BY network.interface.name, aws.vpc.flow.action\\n| SORT flow_count DESC\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.interface.name\", \"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"label\": \"Interface\", \"customLabel\": true}, {\"fieldName\": \"aws.vpc.flow.action\", \"columnId\": \"b569b462-851f-619c-5e78-87185e395392\", \"label\": \"aws.vpc.flow.action\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.interface.name\", \"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"label\": \"Interface\", \"customLabel\": true}, {\"fieldName\": \"aws.vpc.flow.action\", \"columnId\": \"b569b462-851f-619c-5e78-87185e395392\", \"label\": \"aws.vpc.flow.action\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f9182045-dc1d-31e5-b81e-27f5bd16ff9c\", \"gridData\": {\"x\": 0, \"y\": 29, \"w\": 48, \"h\": 13, \"i\": \"f9182045-dc1d-31e5-b81e-27f5bd16ff9c\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Interfaces by Bandwidth\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"eb76e04e-49aa-53f9-5c2b-11b083858c37\", \"accessors\": [\"919207e1-ae62-2daa-a393-71b91f587045\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Bytes\", \"yLeftTitle\": \"Bytes\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL AND aws.vpc.flow.bytes IS NOT NULL\\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY network.interface.name\\n| SORT total_bytes DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"eb76e04e-49aa-53f9-5c2b-11b083858c37\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL AND aws.vpc.flow.bytes IS NOT NULL\\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY network.interface.name\\n| SORT total_bytes DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"total_bytes\", \"columnId\": \"919207e1-ae62-2daa-a393-71b91f587045\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"network.interface.name\", \"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"label\": \"Interface\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"total_bytes\", \"columnId\": \"919207e1-ae62-2daa-a393-71b91f587045\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"network.interface.name\", \"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"label\": \"Interface\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"1eab5b68-9434-43c6-98ad-d51f3aadb3fb\", \"gridData\": {\"x\": 0, \"y\": 42, \"w\": 48, \"h\": 3, \"i\": \"1eab5b68-9434-43c6-98ad-d51f3aadb3fb\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"### Traffic Details\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"69ec49ba-9c04-dbbc-0d09-e50275665719\", \"gridData\": {\"x\": 0, \"y\": 45, \"w\": 24, \"h\": 12, \"i\": \"69ec49ba-9c04-dbbc-0d09-e50275665719\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Accepted vs Rejected by Protocol\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"af52d88f-d5e3-079d-febc-29f36c627aaf\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"b569b462-851f-619c-5e78-87185e395392\", \"colorMapping\": {\"assignments\": [{\"rule\": {\"type\": \"matchExactly\", \"values\": [\"REJECT\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#BD271E\"}, \"touched\": false}, {\"rule\": {\"type\": \"matchExactly\", \"values\": [\"ACCEPT\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#00BF6F\"}, \"touched\": false}], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL AND aws.vpc.flow.action IS NOT NULL\\n| STATS flow_count = COUNT() BY network.protocol.name, aws.vpc.flow.action\\n| SORT flow_count DESC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"af52d88f-d5e3-079d-febc-29f36c627aaf\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL AND aws.vpc.flow.action IS NOT NULL\\n| STATS flow_count = COUNT() BY network.protocol.name, aws.vpc.flow.action\\n| SORT flow_count DESC\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}, {\"fieldName\": \"aws.vpc.flow.action\", \"columnId\": \"b569b462-851f-619c-5e78-87185e395392\", \"label\": \"aws.vpc.flow.action\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}, {\"fieldName\": \"aws.vpc.flow.action\", \"columnId\": \"b569b462-851f-619c-5e78-87185e395392\", \"label\": \"aws.vpc.flow.action\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"2875d3aa-1373-71ee-b0d2-f0aa04554ea9\", \"gridData\": {\"x\": 24, \"y\": 45, \"w\": 24, \"h\": 12, \"i\": \"2875d3aa-1373-71ee-b0d2-f0aa04554ea9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Bandwidth by Protocol\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"c7c115db-cff2-ff5e-a58b-57546d5b8b1a\", \"accessors\": [\"919207e1-ae62-2daa-a393-71b91f587045\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Bytes\", \"yLeftTitle\": \"Bytes\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL AND aws.vpc.flow.bytes IS NOT NULL\\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY network.protocol.name\\n| SORT total_bytes DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"c7c115db-cff2-ff5e-a58b-57546d5b8b1a\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL AND aws.vpc.flow.bytes IS NOT NULL\\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY network.protocol.name\\n| SORT total_bytes DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"total_bytes\", \"columnId\": \"919207e1-ae62-2daa-a393-71b91f587045\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"total_bytes\", \"columnId\": \"919207e1-ae62-2daa-a393-71b91f587045\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"761d486b-b322-2804-eb80-b81ddfea00ad\", \"gridData\": {\"x\": 0, \"y\": 57, \"w\": 48, \"h\": 3, \"i\": \"761d486b-b322-2804-eb80-b81ddfea00ad\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"### Account Analysis\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"7b17d2f3-3bb1-baff-095d-7455961d6ccb\", \"gridData\": {\"x\": 0, \"y\": 60, \"w\": 48, \"h\": 13, \"i\": \"7b17d2f3-3bb1-baff-095d-7455961d6ccb\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Traffic by Cloud Account\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"e992b5db-6433-dcae-fb6e-1bbc9aad9441\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"0e17532e-14eb-9b11-6af6-1e0ef9882621\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"77d9a380-6526-50d5-a027-461069942dc1\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"5d8547e6-f902-5398-7064-05c335d75a0b\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"ab08f77f-ca5a-892b-838b-1377e35744f9\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"ce6ccb2c-a77b-ec23-130a-fb87ed00783c\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"9a9f1d47-5037-6e50-65b5-0327fddbbf20\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"ff9a7672-747a-7faa-8f22-bbb7fd61c2e2\", \"layerType\": \"data\", \"paging\": {\"size\": 10, \"enabled\": true}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND cloud.account.id IS NOT NULL\\n| EVAL is_accepted = CASE(aws.vpc.flow.action == \\\"ACCEPT\\\", 1, 0)\\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \\\"REJECT\\\", 1, 0)\\n| STATS total_flows = COUNT(), accepted_flows = SUM(is_accepted), rejected_flows = SUM(is_rejected), total_bytes = SUM(aws.vpc.flow.bytes), unique_interfaces = COUNT_DISTINCT(network.interface.name), unique_sources = COUNT_DISTINCT(source.address) BY cloud.account.id\\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\\n| SORT total_flows DESC\\n| LIMIT 100\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ff9a7672-747a-7faa-8f22-bbb7fd61c2e2\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND cloud.account.id IS NOT NULL\\n| EVAL is_accepted = CASE(aws.vpc.flow.action == \\\"ACCEPT\\\", 1, 0)\\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \\\"REJECT\\\", 1, 0)\\n| STATS total_flows = COUNT(), accepted_flows = SUM(is_accepted), rejected_flows = SUM(is_rejected), total_bytes = SUM(aws.vpc.flow.bytes), unique_interfaces = COUNT_DISTINCT(network.interface.name), unique_sources = COUNT_DISTINCT(source.address) BY cloud.account.id\\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\\n| SORT total_flows DESC\\n| LIMIT 100\"}, \"columns\": [{\"fieldName\": \"cloud.account.id\", \"columnId\": \"e992b5db-6433-dcae-fb6e-1bbc9aad9441\", \"label\": \"Cloud Account ID\", \"customLabel\": true}, {\"fieldName\": \"total_flows\", \"columnId\": \"0e17532e-14eb-9b11-6af6-1e0ef9882621\", \"label\": \"Total Flows\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"accepted_flows\", \"columnId\": \"77d9a380-6526-50d5-a027-461069942dc1\", \"label\": \"Accepted\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"rejected_flows\", \"columnId\": \"5d8547e6-f902-5398-7064-05c335d75a0b\", \"label\": \"Rejected\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"rejection_rate\", \"columnId\": \"ab08f77f-ca5a-892b-838b-1377e35744f9\", \"label\": \"Rejection %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"total_bytes\", \"columnId\": \"ce6ccb2c-a77b-ec23-130a-fb87ed00783c\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"unique_interfaces\", \"columnId\": \"9a9f1d47-5037-6e50-65b5-0327fddbbf20\", \"label\": \"Interfaces\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"unique_sources\", \"columnId\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"label\": \"Unique Sources\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"cloud.account.id\", \"columnId\": \"e992b5db-6433-dcae-fb6e-1bbc9aad9441\", \"label\": \"Cloud Account ID\", \"customLabel\": true}, {\"fieldName\": \"total_flows\", \"columnId\": \"0e17532e-14eb-9b11-6af6-1e0ef9882621\", \"label\": \"Total Flows\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"accepted_flows\", \"columnId\": \"77d9a380-6526-50d5-a027-461069942dc1\", \"label\": \"Accepted\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"rejected_flows\", \"columnId\": \"5d8547e6-f902-5398-7064-05c335d75a0b\", \"label\": \"Rejected\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"rejection_rate\", \"columnId\": \"ab08f77f-ca5a-892b-838b-1377e35744f9\", \"label\": \"Rejection %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"total_bytes\", \"columnId\": \"ce6ccb2c-a77b-ec23-130a-fb87ed00783c\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"unique_interfaces\", \"columnId\": \"9a9f1d47-5037-6e50-65b5-0327fddbbf20\", \"label\": \"Interfaces\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"unique_sources\", \"columnId\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"label\": \"Unique Sources\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "ef117464-3e9c-10b3-bb29-d1d6f9d3c452",
+                "order": 1,
+                "label": "Traffic Analysis",
+                "type": "dashboardLink",
+                "destinationRefName": "link_ef117464-3e9c-10b3-bb29-d1d6f9d3c452_dashboard"
+              },
+              {
+                "id": "1f78b936-37d7-285d-d766-136934e7d1c5",
+                "order": 2,
+                "label": "Interface Analysis",
+                "type": "dashboardLink",
+                "destinationRefName": "link_1f78b936-37d7-285d-d766-136934e7d1c5_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "2ea8f295-e522-487f-a359-8461dcf0b3ae",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 10,
+          "h": 4,
+          "i": "2ea8f295-e522-487f-a359-8461dcf0b3ae"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Total Interfaces",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "a85ce253-317d-17de-edc1-a5c8c1d22dca",
+                "layerType": "data",
+                "metricAccessor": "1a0f2338-4f67-13c0-12cd-bb8c5e0dd6fa",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL\n| STATS total_interfaces = COUNT_DISTINCT(network.interface.name)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "a85ce253-317d-17de-edc1-a5c8c1d22dca": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL\n| STATS total_interfaces = COUNT_DISTINCT(network.interface.name)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total_interfaces",
+                          "columnId": "1a0f2338-4f67-13c0-12cd-bb8c5e0dd6fa",
+                          "label": "Total Interfaces",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total_interfaces",
+                          "columnId": "1a0f2338-4f67-13c0-12cd-bb8c5e0dd6fa",
+                          "label": "Total Interfaces",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "2a61bdad-f795-143f-c433-7ec51229e12b",
+        "gridData": {
+          "x": 10,
+          "y": 2,
+          "w": 9,
+          "h": 4,
+          "i": "2a61bdad-f795-143f-c433-7ec51229e12b"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Total Flow Records",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "ef16c77d-474f-0e07-5ef4-bd4b64978a9e",
+                "layerType": "data",
+                "metricAccessor": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\"\n| STATS total_flows = COUNT()"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ef16c77d-474f-0e07-5ef4-bd4b64978a9e": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\"\n| STATS total_flows = COUNT()"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                          "label": "Flow Records",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                          "label": "Flow Records",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "99d196b0-8aad-ba50-e6b9-0404742e584f",
+        "gridData": {
+          "x": 19,
+          "y": 2,
+          "w": 10,
+          "h": 4,
+          "i": "99d196b0-8aad-ba50-e6b9-0404742e584f"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unique Source IPs",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "e77e8578-c3d7-93b4-9b94-c8612ee5d922",
+                "layerType": "data",
+                "metricAccessor": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND source.address IS NOT NULL\n| STATS unique_sources = COUNT_DISTINCT(source.address)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e77e8578-c3d7-93b4-9b94-c8612ee5d922": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND source.address IS NOT NULL\n| STATS unique_sources = COUNT_DISTINCT(source.address)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_sources",
+                          "columnId": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                          "label": "Unique Sources",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_sources",
+                          "columnId": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                          "label": "Unique Sources",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "bf5fae40-24a4-b3f8-515e-bf507b735855",
+        "gridData": {
+          "x": 29,
+          "y": 2,
+          "w": 9,
+          "h": 4,
+          "i": "bf5fae40-24a4-b3f8-515e-bf507b735855"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unique Destination IPs",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "91098f81-a84e-b536-b595-9947df7e0286",
+                "layerType": "data",
+                "metricAccessor": "6f71393e-a5d6-8aea-79e8-bf89db24a2cd",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.address IS NOT NULL\n| STATS unique_destinations = COUNT_DISTINCT(destination.address)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "91098f81-a84e-b536-b595-9947df7e0286": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.address IS NOT NULL\n| STATS unique_destinations = COUNT_DISTINCT(destination.address)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_destinations",
+                          "columnId": "6f71393e-a5d6-8aea-79e8-bf89db24a2cd",
+                          "label": "Unique Destinations",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_destinations",
+                          "columnId": "6f71393e-a5d6-8aea-79e8-bf89db24a2cd",
+                          "label": "Unique Destinations",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "05127ed8-bfb6-769b-1187-b516b6281fd5",
+        "gridData": {
+          "x": 38,
+          "y": 2,
+          "w": 10,
+          "h": 4,
+          "i": "05127ed8-bfb6-769b-1187-b516b6281fd5"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unique Protocols",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "43d4fe41-3a19-c47b-8995-f399cb74b224",
+                "layerType": "data",
+                "metricAccessor": "e960f750-fb9b-7807-8707-6f84b1a96407",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "43d4fe41-3a19-c47b-8995-f399cb74b224": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_protocols",
+                          "columnId": "e960f750-fb9b-7807-8707-6f84b1a96407",
+                          "label": "Protocols",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_protocols",
+                          "columnId": "e960f750-fb9b-7807-8707-6f84b1a96407",
+                          "label": "Protocols",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "fef8d903-cb40-2fda-5d3e-28e8f0c932ef",
+        "gridData": {
+          "x": 0,
+          "y": 6,
+          "w": 48,
+          "h": 10,
+          "i": "fef8d903-cb40-2fda-5d3e-28e8f0c932ef"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Interface Traffic Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "49eac460-fc63-615a-2f87-81c1549b724a",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "xTitle": "@timestamp",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL\n| STATS flow_count = COUNT() BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "49eac460-fc63-615a-2f87-81c1549b724a": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL\n| STATS flow_count = COUNT() BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                          "label": "Time",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                          "label": "Time",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "adaa0317-51bc-6c50-15e6-52a39ef03202",
+        "gridData": {
+          "x": 0,
+          "y": 16,
+          "w": 48,
+          "h": 13,
+          "i": "adaa0317-51bc-6c50-15e6-52a39ef03202"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Interface Traffic Analysis",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "e69124be-e423-08e1-38bd-b7737db7d972",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "b569b462-851f-619c-5e78-87185e395392",
+                    "colorMapping": {
+                      "assignments": [
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "REJECT"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#BD271E"
+                          },
+                          "touched": false
+                        },
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "ACCEPT"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#00BF6F"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL AND aws.vpc.flow.action IS NOT NULL\n| STATS flow_count = COUNT() BY network.interface.name, aws.vpc.flow.action\n| SORT flow_count DESC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e69124be-e423-08e1-38bd-b7737db7d972": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL AND aws.vpc.flow.action IS NOT NULL\n| STATS flow_count = COUNT() BY network.interface.name, aws.vpc.flow.action\n| SORT flow_count DESC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.interface.name",
+                          "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                          "label": "Interface",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.action",
+                          "columnId": "b569b462-851f-619c-5e78-87185e395392",
+                          "label": "aws.vpc.flow.action",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.interface.name",
+                          "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                          "label": "Interface",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.action",
+                          "columnId": "b569b462-851f-619c-5e78-87185e395392",
+                          "label": "aws.vpc.flow.action",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "f9182045-dc1d-31e5-b81e-27f5bd16ff9c",
+        "gridData": {
+          "x": 0,
+          "y": 29,
+          "w": 48,
+          "h": 13,
+          "i": "f9182045-dc1d-31e5-b81e-27f5bd16ff9c"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Interfaces by Bandwidth",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "eb76e04e-49aa-53f9-5c2b-11b083858c37",
+                    "accessors": [
+                      "919207e1-ae62-2daa-a393-71b91f587045"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Bytes",
+                "yLeftTitle": "Bytes",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL AND aws.vpc.flow.bytes IS NOT NULL\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY network.interface.name\n| SORT total_bytes DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "eb76e04e-49aa-53f9-5c2b-11b083858c37": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL AND aws.vpc.flow.bytes IS NOT NULL\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY network.interface.name\n| SORT total_bytes DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "919207e1-ae62-2daa-a393-71b91f587045",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.interface.name",
+                          "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                          "label": "Interface",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "919207e1-ae62-2daa-a393-71b91f587045",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.interface.name",
+                          "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                          "label": "Interface",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "1eab5b68-9434-43c6-98ad-d51f3aadb3fb",
+        "gridData": {
+          "x": 0,
+          "y": 42,
+          "w": 48,
+          "h": 3,
+          "i": "1eab5b68-9434-43c6-98ad-d51f3aadb3fb"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "### Traffic Details"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "69ec49ba-9c04-dbbc-0d09-e50275665719",
+        "gridData": {
+          "x": 0,
+          "y": 45,
+          "w": 24,
+          "h": 12,
+          "i": "69ec49ba-9c04-dbbc-0d09-e50275665719"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Accepted vs Rejected by Protocol",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "af52d88f-d5e3-079d-febc-29f36c627aaf",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "b569b462-851f-619c-5e78-87185e395392",
+                    "colorMapping": {
+                      "assignments": [
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "REJECT"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#BD271E"
+                          },
+                          "touched": false
+                        },
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "ACCEPT"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#00BF6F"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL AND aws.vpc.flow.action IS NOT NULL\n| STATS flow_count = COUNT() BY network.protocol.name, aws.vpc.flow.action\n| SORT flow_count DESC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "af52d88f-d5e3-079d-febc-29f36c627aaf": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL AND aws.vpc.flow.action IS NOT NULL\n| STATS flow_count = COUNT() BY network.protocol.name, aws.vpc.flow.action\n| SORT flow_count DESC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.action",
+                          "columnId": "b569b462-851f-619c-5e78-87185e395392",
+                          "label": "aws.vpc.flow.action",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.action",
+                          "columnId": "b569b462-851f-619c-5e78-87185e395392",
+                          "label": "aws.vpc.flow.action",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "2875d3aa-1373-71ee-b0d2-f0aa04554ea9",
+        "gridData": {
+          "x": 24,
+          "y": 45,
+          "w": 24,
+          "h": 12,
+          "i": "2875d3aa-1373-71ee-b0d2-f0aa04554ea9"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Bandwidth by Protocol",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "c7c115db-cff2-ff5e-a58b-57546d5b8b1a",
+                    "accessors": [
+                      "919207e1-ae62-2daa-a393-71b91f587045"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Bytes",
+                "yLeftTitle": "Bytes",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL AND aws.vpc.flow.bytes IS NOT NULL\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY network.protocol.name\n| SORT total_bytes DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "c7c115db-cff2-ff5e-a58b-57546d5b8b1a": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL AND aws.vpc.flow.bytes IS NOT NULL\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY network.protocol.name\n| SORT total_bytes DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "919207e1-ae62-2daa-a393-71b91f587045",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "919207e1-ae62-2daa-a393-71b91f587045",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "761d486b-b322-2804-eb80-b81ddfea00ad",
+        "gridData": {
+          "x": 0,
+          "y": 57,
+          "w": 48,
+          "h": 3,
+          "i": "761d486b-b322-2804-eb80-b81ddfea00ad"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "### Account Analysis"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "7b17d2f3-3bb1-baff-095d-7455961d6ccb",
+        "gridData": {
+          "x": 0,
+          "y": 60,
+          "w": 48,
+          "h": 13,
+          "i": "7b17d2f3-3bb1-baff-095d-7455961d6ccb"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Traffic by Cloud Account",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "e992b5db-6433-dcae-fb6e-1bbc9aad9441",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "0e17532e-14eb-9b11-6af6-1e0ef9882621",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "77d9a380-6526-50d5-a027-461069942dc1",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "5d8547e6-f902-5398-7064-05c335d75a0b",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "ab08f77f-ca5a-892b-838b-1377e35744f9",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "ce6ccb2c-a77b-ec23-130a-fb87ed00783c",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "9a9f1d47-5037-6e50-65b5-0327fddbbf20",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "ff9a7672-747a-7faa-8f22-bbb7fd61c2e2",
+                "layerType": "data",
+                "paging": {
+                  "size": 10,
+                  "enabled": true
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND cloud.account.id IS NOT NULL\n| EVAL is_accepted = CASE(aws.vpc.flow.action == \"ACCEPT\", 1, 0)\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \"REJECT\", 1, 0)\n| STATS total_flows = COUNT(), accepted_flows = SUM(is_accepted), rejected_flows = SUM(is_rejected), total_bytes = SUM(aws.vpc.flow.bytes), unique_interfaces = COUNT_DISTINCT(network.interface.name), unique_sources = COUNT_DISTINCT(source.address) BY cloud.account.id\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\n| SORT total_flows DESC\n| LIMIT 100"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ff9a7672-747a-7faa-8f22-bbb7fd61c2e2": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND cloud.account.id IS NOT NULL\n| EVAL is_accepted = CASE(aws.vpc.flow.action == \"ACCEPT\", 1, 0)\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \"REJECT\", 1, 0)\n| STATS total_flows = COUNT(), accepted_flows = SUM(is_accepted), rejected_flows = SUM(is_rejected), total_bytes = SUM(aws.vpc.flow.bytes), unique_interfaces = COUNT_DISTINCT(network.interface.name), unique_sources = COUNT_DISTINCT(source.address) BY cloud.account.id\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\n| SORT total_flows DESC\n| LIMIT 100"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "cloud.account.id",
+                          "columnId": "e992b5db-6433-dcae-fb6e-1bbc9aad9441",
+                          "label": "Cloud Account ID",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "0e17532e-14eb-9b11-6af6-1e0ef9882621",
+                          "label": "Total Flows",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "accepted_flows",
+                          "columnId": "77d9a380-6526-50d5-a027-461069942dc1",
+                          "label": "Accepted",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "rejected_flows",
+                          "columnId": "5d8547e6-f902-5398-7064-05c335d75a0b",
+                          "label": "Rejected",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "ab08f77f-ca5a-892b-838b-1377e35744f9",
+                          "label": "Rejection %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "ce6ccb2c-a77b-ec23-130a-fb87ed00783c",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "unique_interfaces",
+                          "columnId": "9a9f1d47-5037-6e50-65b5-0327fddbbf20",
+                          "label": "Interfaces",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "unique_sources",
+                          "columnId": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                          "label": "Unique Sources",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "cloud.account.id",
+                          "columnId": "e992b5db-6433-dcae-fb6e-1bbc9aad9441",
+                          "label": "Cloud Account ID",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "0e17532e-14eb-9b11-6af6-1e0ef9882621",
+                          "label": "Total Flows",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "accepted_flows",
+                          "columnId": "77d9a380-6526-50d5-a027-461069942dc1",
+                          "label": "Accepted",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "rejected_flows",
+                          "columnId": "5d8547e6-f902-5398-7064-05c335d75a0b",
+                          "label": "Rejected",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "ab08f77f-ca5a-892b-838b-1377e35744f9",
+                          "label": "Rejection %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "ce6ccb2c-a77b-ec23-130a-fb87ed00783c",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "unique_interfaces",
+                          "columnId": "9a9f1d47-5037-6e50-65b5-0327fddbbf20",
+                          "label": "Interfaces",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "unique_sources",
+                          "columnId": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                          "label": "Unique Sources",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"aws.vpcflow.otel\"}},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"aws.vpcflow.otel\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "data_stream.dataset",
+              "field": "data_stream.dataset",
+              "params": {
+                "query": "aws.vpcflow.otel"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "aws.vpcflow.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": false,
     "version": 1,
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"e155cda7-38a2-040c-3e6a-33339866c123\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"e155cda7-38a2-040c-3e6a-33339866c123\",\"dataViewId\":\"logs-*\",\"fieldName\":\"cloud.account.id\",\"title\":\"Cloud Account ID\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"41c0e666-862f-ba61-3001-48c7a555c788\":{\"grow\":false,\"order\":1,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"41c0e666-862f-ba61-3001-48c7a555c788\",\"dataViewId\":\"logs-*\",\"fieldName\":\"network.interface.name\",\"title\":\"Network Interface\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"a6de1714-9b30-7483-8189-4f53daa21992\":{\"grow\":false,\"order\":2,\"width\":\"small\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"a6de1714-9b30-7483-8189-4f53daa21992\",\"dataViewId\":\"logs-*\",\"fieldName\":\"aws.vpc.flow.action\",\"title\":\"Action\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"056d9865-1eaa-90fa-a56d-28cf7d889abb\":{\"grow\":false,\"order\":3,\"width\":\"small\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"056d9865-1eaa-90fa-a56d-28cf7d889abb\",\"dataViewId\":\"logs-*\",\"fieldName\":\"destination.port\",\"title\":\"Destination Port\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"2ab2d2c5-ce3e-9cbb-e027-36ca1ac94987\":{\"grow\":false,\"order\":4,\"width\":\"small\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2ab2d2c5-ce3e-9cbb-e027-36ca1ac94987\",\"dataViewId\":\"logs-*\",\"fieldName\":\"network.protocol.name\",\"title\":\"Protocol\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "e155cda7-38a2-040c-3e6a-33339866c123": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "e155cda7-38a2-040c-3e6a-33339866c123",
+            "dataViewId": "logs-*",
+            "fieldName": "cloud.account.id",
+            "title": "Cloud Account ID",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "41c0e666-862f-ba61-3001-48c7a555c788": {
+          "grow": false,
+          "order": 1,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "41c0e666-862f-ba61-3001-48c7a555c788",
+            "dataViewId": "logs-*",
+            "fieldName": "network.interface.name",
+            "title": "Network Interface",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "a6de1714-9b30-7483-8189-4f53daa21992": {
+          "grow": false,
+          "order": 2,
+          "width": "small",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "a6de1714-9b30-7483-8189-4f53daa21992",
+            "dataViewId": "logs-*",
+            "fieldName": "aws.vpc.flow.action",
+            "title": "Action",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "056d9865-1eaa-90fa-a56d-28cf7d889abb": {
+          "grow": false,
+          "order": 3,
+          "width": "small",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "056d9865-1eaa-90fa-a56d-28cf7d889abb",
+            "dataViewId": "logs-*",
+            "fieldName": "destination.port",
+            "title": "Destination Port",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "2ab2d2c5-ce3e-9cbb-e027-36ca1ac94987": {
+          "grow": false,
+          "order": 4,
+          "width": "small",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "2ab2d2c5-ce3e-9cbb-e027-36ca1ac94987",
+            "dataViewId": "logs-*",
+            "fieldName": "network.protocol.name",
+            "title": "Protocol",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/aws_vpcflow_otel/kibana/dashboard/aws_vpcflow_otel-overview.json
+++ b/packages/aws_vpcflow_otel/kibana/dashboard/aws_vpcflow_otel-overview.json
@@ -2,18 +2,1503 @@
   "attributes": {
     "title": "[AWS VPC OTEL] VPC Flow Logs Overview",
     "description": "High-level status and trends for AWS VPC Flow Logs",
-    "panelsJSON": "[{\"panelIndex\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"ef117464-3e9c-10b3-bb29-d1d6f9d3c452\", \"order\": 1, \"label\": \"Traffic Analysis\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_ef117464-3e9c-10b3-bb29-d1d6f9d3c452_dashboard\"}, {\"id\": \"1f78b936-37d7-285d-d766-136934e7d1c5\", \"order\": 2, \"label\": \"Interface Analysis\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_1f78b936-37d7-285d-d766-136934e7d1c5_dashboard\"}]}}}, {\"panelIndex\": \"bd629351-72a6-1b01-5d19-8742824832b2\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"bd629351-72a6-1b01-5d19-8742824832b2\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Total Flow Records\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"ef16c77d-474f-0e07-5ef4-bd4b64978a9e\", \"layerType\": \"data\", \"metricAccessor\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\"\\n| STATS total_flows = COUNT()\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ef16c77d-474f-0e07-5ef4-bd4b64978a9e\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\"\\n| STATS total_flows = COUNT()\"}, \"columns\": [{\"fieldName\": \"total_flows\", \"columnId\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"label\": \"Flow Records\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"total_flows\", \"columnId\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"label\": \"Flow Records\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"702a9e78-9511-30ce-35b0-7363b89feb3a\", \"gridData\": {\"x\": 8, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"702a9e78-9511-30ce-35b0-7363b89feb3a\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Rejection Rate\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"408b0212-35ed-93c9-3fa4-6c4d45a5529a\", \"layerType\": \"data\", \"metricAccessor\": \"9c0e3410-038b-6719-10fe-c0b7dcdb1661\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\"\\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \\\"REJECT\\\", 1, 0)\\n| STATS total_flows = COUNT(), rejected_flows = SUM(is_rejected)\\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"408b0212-35ed-93c9-3fa4-6c4d45a5529a\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\"\\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \\\"REJECT\\\", 1, 0)\\n| STATS total_flows = COUNT(), rejected_flows = SUM(is_rejected)\\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\"}, \"columns\": [{\"fieldName\": \"rejection_rate\", \"columnId\": \"9c0e3410-038b-6719-10fe-c0b7dcdb1661\", \"label\": \"Rejection Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}], \"allColumns\": [{\"fieldName\": \"rejection_rate\", \"columnId\": \"9c0e3410-038b-6719-10fe-c0b7dcdb1661\", \"label\": \"Rejection Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"02dea1e9-98d8-ebdb-8de7-2c8e5a58cdb0\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"02dea1e9-98d8-ebdb-8de7-2c8e5a58cdb0\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Total Bandwidth\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"337fb98f-7f76-f938-2845-6f58fdf75293\", \"layerType\": \"data\", \"metricAccessor\": \"03eba9e2-2cf9-1d68-2650-755bd2d9e597\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.bytes IS NOT NULL\\n| STATS total_bytes = SUM(aws.vpc.flow.bytes)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"337fb98f-7f76-f938-2845-6f58fdf75293\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.bytes IS NOT NULL\\n| STATS total_bytes = SUM(aws.vpc.flow.bytes)\"}, \"columns\": [{\"fieldName\": \"total_bytes\", \"columnId\": \"03eba9e2-2cf9-1d68-2650-755bd2d9e597\", \"label\": \"Total Bandwidth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}], \"allColumns\": [{\"fieldName\": \"total_bytes\", \"columnId\": \"03eba9e2-2cf9-1d68-2650-755bd2d9e597\", \"label\": \"Total Bandwidth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"0270393e-7718-e582-dbe7-012e82e8a8c3\", \"gridData\": {\"x\": 24, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"0270393e-7718-e582-dbe7-012e82e8a8c3\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Active Interfaces\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"6a08262c-2332-2838-fb58-8a5fd87684ec\", \"layerType\": \"data\", \"metricAccessor\": \"aa2c8b79-c5b5-6397-f8d6-c88927000036\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL\\n| STATS unique_interfaces = COUNT_DISTINCT(network.interface.name)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"6a08262c-2332-2838-fb58-8a5fd87684ec\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.interface.name IS NOT NULL\\n| STATS unique_interfaces = COUNT_DISTINCT(network.interface.name)\"}, \"columns\": [{\"fieldName\": \"unique_interfaces\", \"columnId\": \"aa2c8b79-c5b5-6397-f8d6-c88927000036\", \"label\": \"Active Interfaces\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_interfaces\", \"columnId\": \"aa2c8b79-c5b5-6397-f8d6-c88927000036\", \"label\": \"Active Interfaces\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"3f61df3e-ea38-cc27-4ca5-51883bd6fd60\", \"gridData\": {\"x\": 32, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"3f61df3e-ea38-cc27-4ca5-51883bd6fd60\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Cloud Accounts\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"294f0005-4c19-86fc-cf8e-14af39f92c91\", \"layerType\": \"data\", \"metricAccessor\": \"6e74fc88-b67a-8194-16b6-d47c7e4f28ec\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND cloud.account.id IS NOT NULL\\n| STATS unique_accounts = COUNT_DISTINCT(cloud.account.id)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"294f0005-4c19-86fc-cf8e-14af39f92c91\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND cloud.account.id IS NOT NULL\\n| STATS unique_accounts = COUNT_DISTINCT(cloud.account.id)\"}, \"columns\": [{\"fieldName\": \"unique_accounts\", \"columnId\": \"6e74fc88-b67a-8194-16b6-d47c7e4f28ec\", \"label\": \"Cloud Accounts\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_accounts\", \"columnId\": \"6e74fc88-b67a-8194-16b6-d47c7e4f28ec\", \"label\": \"Cloud Accounts\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"94a9f077-163d-a5ad-64d8-c737ad685dc0\", \"gridData\": {\"x\": 40, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"94a9f077-163d-a5ad-64d8-c737ad685dc0\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unique Protocols\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"09ab4be5-8d36-0b19-e476-2b94ccd3a963\", \"layerType\": \"data\", \"metricAccessor\": \"3a1e329b-d835-6d77-081b-284b63f45d2a\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL\\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"09ab4be5-8d36-0b19-e476-2b94ccd3a963\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL\\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)\"}, \"columns\": [{\"fieldName\": \"unique_protocols\", \"columnId\": \"3a1e329b-d835-6d77-081b-284b63f45d2a\", \"label\": \"Unique Protocols\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_protocols\", \"columnId\": \"3a1e329b-d835-6d77-081b-284b63f45d2a\", \"label\": \"Unique Protocols\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"4fbf4ca7-dcc6-5ac9-62bd-2003437198af\", \"gridData\": {\"x\": 0, \"y\": 6, \"w\": 48, \"h\": 3, \"i\": \"4fbf4ca7-dcc6-5ac9-62bd-2003437198af\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"### Quick Insights\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"957d8421-c6df-c04e-694d-af1efa47eb13\", \"gridData\": {\"x\": 0, \"y\": 9, \"w\": 24, \"h\": 10, \"i\": \"957d8421-c6df-c04e-694d-af1efa47eb13\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top 5 Interfaces by Rejected Traffic\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"b22f58d0-b7e3-d4fa-fb04-2d0e70cbe4eb\", \"accessors\": [\"f630df79-f8a9-f64f-80c7-1024f4165283\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"negative\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Rejected Flows\", \"yLeftTitle\": \"Rejected Flows\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\" AND network.interface.name IS NOT NULL\\n| STATS rejected_count = COUNT() BY network.interface.name\\n| SORT rejected_count DESC\\n| LIMIT 5\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"b22f58d0-b7e3-d4fa-fb04-2d0e70cbe4eb\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\" AND network.interface.name IS NOT NULL\\n| STATS rejected_count = COUNT() BY network.interface.name\\n| SORT rejected_count DESC\\n| LIMIT 5\"}, \"columns\": [{\"fieldName\": \"rejected_count\", \"columnId\": \"f630df79-f8a9-f64f-80c7-1024f4165283\", \"label\": \"Rejected Flows\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.interface.name\", \"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"label\": \"Interface\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"rejected_count\", \"columnId\": \"f630df79-f8a9-f64f-80c7-1024f4165283\", \"label\": \"Rejected Flows\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.interface.name\", \"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"label\": \"Interface\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"05f20f27-09dc-3e6b-0bbd-5f172c570c43\", \"gridData\": {\"x\": 24, \"y\": 9, \"w\": 24, \"h\": 10, \"i\": \"05f20f27-09dc-3e6b-0bbd-5f172c570c43\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top 5 Rejected Destination Ports\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"91250883-07e5-aa21-58c6-33844a6f5d5f\", \"accessors\": [\"f630df79-f8a9-f64f-80c7-1024f4165283\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"negative\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Rejected Flows\", \"yLeftTitle\": \"Rejected Flows\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\" AND destination.port IS NOT NULL\\n| STATS rejected_count = COUNT() BY destination.port\\n| SORT rejected_count DESC\\n| LIMIT 5\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"91250883-07e5-aa21-58c6-33844a6f5d5f\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\" AND destination.port IS NOT NULL\\n| STATS rejected_count = COUNT() BY destination.port\\n| SORT rejected_count DESC\\n| LIMIT 5\"}, \"columns\": [{\"fieldName\": \"rejected_count\", \"columnId\": \"f630df79-f8a9-f64f-80c7-1024f4165283\", \"label\": \"Rejected Flows\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"rejected_count\", \"columnId\": \"f630df79-f8a9-f64f-80c7-1024f4165283\", \"label\": \"Rejected Flows\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"1558a61c-c148-cee0-f4a9-878de91e8208\", \"gridData\": {\"x\": 0, \"y\": 19, \"w\": 48, \"h\": 3, \"i\": \"1558a61c-c148-cee0-f4a9-878de91e8208\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"### Time-Series Trends\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"1753cae9-2621-37b2-439a-3223f9375139\", \"gridData\": {\"x\": 0, \"y\": 22, \"w\": 48, \"h\": 12, \"i\": \"1753cae9-2621-37b2-439a-3223f9375139\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Traffic Volume Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"99471935-94a6-3765-5318-c3cd504903a8\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"b569b462-851f-619c-5e78-87185e395392\", \"colorMapping\": {\"assignments\": [{\"rule\": {\"type\": \"matchExactly\", \"values\": [\"REJECT\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#BD271E\"}, \"touched\": false}, {\"rule\": {\"type\": \"matchExactly\", \"values\": [\"ACCEPT\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#00BF6F\"}, \"touched\": false}], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\", \"xTitle\": \"@timestamp\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": true, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action IS NOT NULL\\n| STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"99471935-94a6-3765-5318-c3cd504903a8\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action IS NOT NULL\\n| STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"label\": \"Time\", \"customLabel\": true, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"aws.vpc.flow.action\", \"columnId\": \"b569b462-851f-619c-5e78-87185e395392\", \"label\": \"aws.vpc.flow.action\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"label\": \"Time\", \"customLabel\": true, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"aws.vpc.flow.action\", \"columnId\": \"b569b462-851f-619c-5e78-87185e395392\", \"label\": \"aws.vpc.flow.action\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"6edfa1fc-0751-5ac6-4067-cd871ce99bbc\", \"gridData\": {\"x\": 0, \"y\": 34, \"w\": 48, \"h\": 12, \"i\": \"6edfa1fc-0751-5ac6-4067-cd871ce99bbc\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Bandwidth Usage Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"7cc7e54e-4729-1ea6-9407-dcc80cd6b5e8\", \"accessors\": [\"919207e1-ae62-2daa-a393-71b91f587045\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\", \"xTitle\": \"@timestamp\", \"yTitle\": \"Bandwidth\", \"yLeftTitle\": \"Bandwidth\", \"axisTitlesVisibilitySettings\": {\"x\": true, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.bytes IS NOT NULL\\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"7cc7e54e-4729-1ea6-9407-dcc80cd6b5e8\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.bytes IS NOT NULL\\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"total_bytes\", \"columnId\": \"919207e1-ae62-2daa-a393-71b91f587045\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"label\": \"Time\", \"customLabel\": true, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"total_bytes\", \"columnId\": \"919207e1-ae62-2daa-a393-71b91f587045\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"label\": \"Time\", \"customLabel\": true, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "ef117464-3e9c-10b3-bb29-d1d6f9d3c452",
+                "order": 1,
+                "label": "Traffic Analysis",
+                "type": "dashboardLink",
+                "destinationRefName": "link_ef117464-3e9c-10b3-bb29-d1d6f9d3c452_dashboard"
+              },
+              {
+                "id": "1f78b936-37d7-285d-d766-136934e7d1c5",
+                "order": 2,
+                "label": "Interface Analysis",
+                "type": "dashboardLink",
+                "destinationRefName": "link_1f78b936-37d7-285d-d766-136934e7d1c5_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "bd629351-72a6-1b01-5d19-8742824832b2",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "bd629351-72a6-1b01-5d19-8742824832b2"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Total Flow Records",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "ef16c77d-474f-0e07-5ef4-bd4b64978a9e",
+                "layerType": "data",
+                "metricAccessor": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\"\n| STATS total_flows = COUNT()"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ef16c77d-474f-0e07-5ef4-bd4b64978a9e": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\"\n| STATS total_flows = COUNT()"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                          "label": "Flow Records",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                          "label": "Flow Records",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "702a9e78-9511-30ce-35b0-7363b89feb3a",
+        "gridData": {
+          "x": 8,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "702a9e78-9511-30ce-35b0-7363b89feb3a"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Rejection Rate",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "408b0212-35ed-93c9-3fa4-6c4d45a5529a",
+                "layerType": "data",
+                "metricAccessor": "9c0e3410-038b-6719-10fe-c0b7dcdb1661",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\"\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \"REJECT\", 1, 0)\n| STATS total_flows = COUNT(), rejected_flows = SUM(is_rejected)\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "408b0212-35ed-93c9-3fa4-6c4d45a5529a": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\"\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \"REJECT\", 1, 0)\n| STATS total_flows = COUNT(), rejected_flows = SUM(is_rejected)\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "9c0e3410-038b-6719-10fe-c0b7dcdb1661",
+                          "label": "Rejection Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "9c0e3410-038b-6719-10fe-c0b7dcdb1661",
+                          "label": "Rejection Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "02dea1e9-98d8-ebdb-8de7-2c8e5a58cdb0",
+        "gridData": {
+          "x": 16,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "02dea1e9-98d8-ebdb-8de7-2c8e5a58cdb0"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Total Bandwidth",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "337fb98f-7f76-f938-2845-6f58fdf75293",
+                "layerType": "data",
+                "metricAccessor": "03eba9e2-2cf9-1d68-2650-755bd2d9e597",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.bytes IS NOT NULL\n| STATS total_bytes = SUM(aws.vpc.flow.bytes)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "337fb98f-7f76-f938-2845-6f58fdf75293": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.bytes IS NOT NULL\n| STATS total_bytes = SUM(aws.vpc.flow.bytes)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "03eba9e2-2cf9-1d68-2650-755bd2d9e597",
+                          "label": "Total Bandwidth",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "03eba9e2-2cf9-1d68-2650-755bd2d9e597",
+                          "label": "Total Bandwidth",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "0270393e-7718-e582-dbe7-012e82e8a8c3",
+        "gridData": {
+          "x": 24,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "0270393e-7718-e582-dbe7-012e82e8a8c3"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Active Interfaces",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "6a08262c-2332-2838-fb58-8a5fd87684ec",
+                "layerType": "data",
+                "metricAccessor": "aa2c8b79-c5b5-6397-f8d6-c88927000036",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL\n| STATS unique_interfaces = COUNT_DISTINCT(network.interface.name)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "6a08262c-2332-2838-fb58-8a5fd87684ec": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.interface.name IS NOT NULL\n| STATS unique_interfaces = COUNT_DISTINCT(network.interface.name)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_interfaces",
+                          "columnId": "aa2c8b79-c5b5-6397-f8d6-c88927000036",
+                          "label": "Active Interfaces",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_interfaces",
+                          "columnId": "aa2c8b79-c5b5-6397-f8d6-c88927000036",
+                          "label": "Active Interfaces",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "3f61df3e-ea38-cc27-4ca5-51883bd6fd60",
+        "gridData": {
+          "x": 32,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "3f61df3e-ea38-cc27-4ca5-51883bd6fd60"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Cloud Accounts",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "294f0005-4c19-86fc-cf8e-14af39f92c91",
+                "layerType": "data",
+                "metricAccessor": "6e74fc88-b67a-8194-16b6-d47c7e4f28ec",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND cloud.account.id IS NOT NULL\n| STATS unique_accounts = COUNT_DISTINCT(cloud.account.id)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "294f0005-4c19-86fc-cf8e-14af39f92c91": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND cloud.account.id IS NOT NULL\n| STATS unique_accounts = COUNT_DISTINCT(cloud.account.id)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_accounts",
+                          "columnId": "6e74fc88-b67a-8194-16b6-d47c7e4f28ec",
+                          "label": "Cloud Accounts",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_accounts",
+                          "columnId": "6e74fc88-b67a-8194-16b6-d47c7e4f28ec",
+                          "label": "Cloud Accounts",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "94a9f077-163d-a5ad-64d8-c737ad685dc0",
+        "gridData": {
+          "x": 40,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "94a9f077-163d-a5ad-64d8-c737ad685dc0"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unique Protocols",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "09ab4be5-8d36-0b19-e476-2b94ccd3a963",
+                "layerType": "data",
+                "metricAccessor": "3a1e329b-d835-6d77-081b-284b63f45d2a",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "09ab4be5-8d36-0b19-e476-2b94ccd3a963": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_protocols",
+                          "columnId": "3a1e329b-d835-6d77-081b-284b63f45d2a",
+                          "label": "Unique Protocols",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_protocols",
+                          "columnId": "3a1e329b-d835-6d77-081b-284b63f45d2a",
+                          "label": "Unique Protocols",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "4fbf4ca7-dcc6-5ac9-62bd-2003437198af",
+        "gridData": {
+          "x": 0,
+          "y": 6,
+          "w": 48,
+          "h": 3,
+          "i": "4fbf4ca7-dcc6-5ac9-62bd-2003437198af"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "### Quick Insights"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "957d8421-c6df-c04e-694d-af1efa47eb13",
+        "gridData": {
+          "x": 0,
+          "y": 9,
+          "w": 24,
+          "h": 10,
+          "i": "957d8421-c6df-c04e-694d-af1efa47eb13"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top 5 Interfaces by Rejected Traffic",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "b22f58d0-b7e3-d4fa-fb04-2d0e70cbe4eb",
+                    "accessors": [
+                      "f630df79-f8a9-f64f-80c7-1024f4165283"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "negative",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Rejected Flows",
+                "yLeftTitle": "Rejected Flows",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\" AND network.interface.name IS NOT NULL\n| STATS rejected_count = COUNT() BY network.interface.name\n| SORT rejected_count DESC\n| LIMIT 5"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "b22f58d0-b7e3-d4fa-fb04-2d0e70cbe4eb": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\" AND network.interface.name IS NOT NULL\n| STATS rejected_count = COUNT() BY network.interface.name\n| SORT rejected_count DESC\n| LIMIT 5"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rejected_count",
+                          "columnId": "f630df79-f8a9-f64f-80c7-1024f4165283",
+                          "label": "Rejected Flows",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.interface.name",
+                          "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                          "label": "Interface",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rejected_count",
+                          "columnId": "f630df79-f8a9-f64f-80c7-1024f4165283",
+                          "label": "Rejected Flows",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.interface.name",
+                          "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                          "label": "Interface",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "05f20f27-09dc-3e6b-0bbd-5f172c570c43",
+        "gridData": {
+          "x": 24,
+          "y": 9,
+          "w": 24,
+          "h": 10,
+          "i": "05f20f27-09dc-3e6b-0bbd-5f172c570c43"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top 5 Rejected Destination Ports",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "91250883-07e5-aa21-58c6-33844a6f5d5f",
+                    "accessors": [
+                      "f630df79-f8a9-f64f-80c7-1024f4165283"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "negative",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Rejected Flows",
+                "yLeftTitle": "Rejected Flows",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\" AND destination.port IS NOT NULL\n| STATS rejected_count = COUNT() BY destination.port\n| SORT rejected_count DESC\n| LIMIT 5"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "91250883-07e5-aa21-58c6-33844a6f5d5f": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\" AND destination.port IS NOT NULL\n| STATS rejected_count = COUNT() BY destination.port\n| SORT rejected_count DESC\n| LIMIT 5"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rejected_count",
+                          "columnId": "f630df79-f8a9-f64f-80c7-1024f4165283",
+                          "label": "Rejected Flows",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rejected_count",
+                          "columnId": "f630df79-f8a9-f64f-80c7-1024f4165283",
+                          "label": "Rejected Flows",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "1558a61c-c148-cee0-f4a9-878de91e8208",
+        "gridData": {
+          "x": 0,
+          "y": 19,
+          "w": 48,
+          "h": 3,
+          "i": "1558a61c-c148-cee0-f4a9-878de91e8208"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "### Time-Series Trends"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "1753cae9-2621-37b2-439a-3223f9375139",
+        "gridData": {
+          "x": 0,
+          "y": 22,
+          "w": 48,
+          "h": 12,
+          "i": "1753cae9-2621-37b2-439a-3223f9375139"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Traffic Volume Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "99471935-94a6-3765-5318-c3cd504903a8",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "b569b462-851f-619c-5e78-87185e395392",
+                    "colorMapping": {
+                      "assignments": [
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "REJECT"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#BD271E"
+                          },
+                          "touched": false
+                        },
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "ACCEPT"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#00BF6F"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "xTitle": "@timestamp",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action IS NOT NULL\n| STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "99471935-94a6-3765-5318-c3cd504903a8": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action IS NOT NULL\n| STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                          "label": "Time",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.action",
+                          "columnId": "b569b462-851f-619c-5e78-87185e395392",
+                          "label": "aws.vpc.flow.action",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                          "label": "Time",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.action",
+                          "columnId": "b569b462-851f-619c-5e78-87185e395392",
+                          "label": "aws.vpc.flow.action",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "6edfa1fc-0751-5ac6-4067-cd871ce99bbc",
+        "gridData": {
+          "x": 0,
+          "y": 34,
+          "w": 48,
+          "h": 12,
+          "i": "6edfa1fc-0751-5ac6-4067-cd871ce99bbc"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Bandwidth Usage Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "7cc7e54e-4729-1ea6-9407-dcc80cd6b5e8",
+                    "accessors": [
+                      "919207e1-ae62-2daa-a393-71b91f587045"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "xTitle": "@timestamp",
+                "yTitle": "Bandwidth",
+                "yLeftTitle": "Bandwidth",
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.bytes IS NOT NULL\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "7cc7e54e-4729-1ea6-9407-dcc80cd6b5e8": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.bytes IS NOT NULL\n| STATS total_bytes = SUM(aws.vpc.flow.bytes) BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "919207e1-ae62-2daa-a393-71b91f587045",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                          "label": "Time",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "919207e1-ae62-2daa-a393-71b91f587045",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                          "label": "Time",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"aws.vpcflow.otel\"}},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"aws.vpcflow.otel\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "data_stream.dataset",
+              "field": "data_stream.dataset",
+              "params": {
+                "query": "aws.vpcflow.otel"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "aws.vpcflow.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": false,
     "version": 1,
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"e155cda7-38a2-040c-3e6a-33339866c123\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"e155cda7-38a2-040c-3e6a-33339866c123\",\"dataViewId\":\"logs-*\",\"fieldName\":\"cloud.account.id\",\"title\":\"Cloud Account ID\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"41c0e666-862f-ba61-3001-48c7a555c788\":{\"grow\":false,\"order\":1,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"41c0e666-862f-ba61-3001-48c7a555c788\",\"dataViewId\":\"logs-*\",\"fieldName\":\"network.interface.name\",\"title\":\"Network Interface\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"a6de1714-9b30-7483-8189-4f53daa21992\":{\"grow\":false,\"order\":2,\"width\":\"small\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"a6de1714-9b30-7483-8189-4f53daa21992\",\"dataViewId\":\"logs-*\",\"fieldName\":\"aws.vpc.flow.action\",\"title\":\"Action\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "e155cda7-38a2-040c-3e6a-33339866c123": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "e155cda7-38a2-040c-3e6a-33339866c123",
+            "dataViewId": "logs-*",
+            "fieldName": "cloud.account.id",
+            "title": "Cloud Account ID",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "41c0e666-862f-ba61-3001-48c7a555c788": {
+          "grow": false,
+          "order": 1,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "41c0e666-862f-ba61-3001-48c7a555c788",
+            "dataViewId": "logs-*",
+            "fieldName": "network.interface.name",
+            "title": "Network Interface",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "a6de1714-9b30-7483-8189-4f53daa21992": {
+          "grow": false,
+          "order": 2,
+          "width": "small",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "a6de1714-9b30-7483-8189-4f53daa21992",
+            "dataViewId": "logs-*",
+            "fieldName": "aws.vpc.flow.action",
+            "title": "Action",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/aws_vpcflow_otel/kibana/dashboard/aws_vpcflow_otel-traffic.json
+++ b/packages/aws_vpcflow_otel/kibana/dashboard/aws_vpcflow_otel-traffic.json
@@ -2,18 +2,2682 @@
   "attributes": {
     "title": "[AWS VPC OTEL] Traffic Analysis",
     "description": "Detailed traffic distribution, source analysis, and security deep dive",
-    "panelsJSON": "[{\"panelIndex\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"ef117464-3e9c-10b3-bb29-d1d6f9d3c452\", \"order\": 1, \"label\": \"Traffic Analysis\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_ef117464-3e9c-10b3-bb29-d1d6f9d3c452_dashboard\"}, {\"id\": \"1f78b936-37d7-285d-d766-136934e7d1c5\", \"order\": 2, \"label\": \"Interface Analysis\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_1f78b936-37d7-285d-d766-136934e7d1c5_dashboard\"}]}}}, {\"panelIndex\": \"d52e5724-45e6-6551-60c3-8d99b4e5c435\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 10, \"h\": 4, \"i\": \"d52e5724-45e6-6551-60c3-8d99b4e5c435\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Total Flow Records\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"ef16c77d-474f-0e07-5ef4-bd4b64978a9e\", \"layerType\": \"data\", \"metricAccessor\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\"\\n| STATS total_flows = COUNT()\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ef16c77d-474f-0e07-5ef4-bd4b64978a9e\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\"\\n| STATS total_flows = COUNT()\"}, \"columns\": [{\"fieldName\": \"total_flows\", \"columnId\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"label\": \"Flow Records\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"total_flows\", \"columnId\": \"673e6b96-cdc3-3207-b791-0b3f4fb41dba\", \"label\": \"Flow Records\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"19ea32b5-8afa-4855-772a-64f301699a2f\", \"gridData\": {\"x\": 10, \"y\": 2, \"w\": 10, \"h\": 4, \"i\": \"19ea32b5-8afa-4855-772a-64f301699a2f\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unique Source IPs\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"e77e8578-c3d7-93b4-9b94-c8612ee5d922\", \"layerType\": \"data\", \"metricAccessor\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND source.address IS NOT NULL\\n| STATS unique_sources = COUNT_DISTINCT(source.address)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e77e8578-c3d7-93b4-9b94-c8612ee5d922\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND source.address IS NOT NULL\\n| STATS unique_sources = COUNT_DISTINCT(source.address)\"}, \"columns\": [{\"fieldName\": \"unique_sources\", \"columnId\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"label\": \"Unique Sources\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_sources\", \"columnId\": \"9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d\", \"label\": \"Unique Sources\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"c2a2f81c-d9b7-ae27-a260-b59ed2e01a55\", \"gridData\": {\"x\": 20, \"y\": 2, \"w\": 9, \"h\": 4, \"i\": \"c2a2f81c-d9b7-ae27-a260-b59ed2e01a55\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unique Destination IPs\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"91098f81-a84e-b536-b595-9947df7e0286\", \"layerType\": \"data\", \"metricAccessor\": \"6f71393e-a5d6-8aea-79e8-bf89db24a2cd\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.address IS NOT NULL\\n| STATS unique_destinations = COUNT_DISTINCT(destination.address)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"91098f81-a84e-b536-b595-9947df7e0286\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.address IS NOT NULL\\n| STATS unique_destinations = COUNT_DISTINCT(destination.address)\"}, \"columns\": [{\"fieldName\": \"unique_destinations\", \"columnId\": \"6f71393e-a5d6-8aea-79e8-bf89db24a2cd\", \"label\": \"Unique Destinations\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_destinations\", \"columnId\": \"6f71393e-a5d6-8aea-79e8-bf89db24a2cd\", \"label\": \"Unique Destinations\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"418f69a0-177f-f005-7540-23da36cd7c43\", \"gridData\": {\"x\": 29, \"y\": 2, \"w\": 10, \"h\": 4, \"i\": \"418f69a0-177f-f005-7540-23da36cd7c43\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unique Protocols\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"43d4fe41-3a19-c47b-8995-f399cb74b224\", \"layerType\": \"data\", \"metricAccessor\": \"e960f750-fb9b-7807-8707-6f84b1a96407\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL\\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"43d4fe41-3a19-c47b-8995-f399cb74b224\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL\\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)\"}, \"columns\": [{\"fieldName\": \"unique_protocols\", \"columnId\": \"e960f750-fb9b-7807-8707-6f84b1a96407\", \"label\": \"Protocols\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_protocols\", \"columnId\": \"e960f750-fb9b-7807-8707-6f84b1a96407\", \"label\": \"Protocols\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"a9434d8d-826a-d525-b65c-f96f447b98df\", \"gridData\": {\"x\": 39, \"y\": 2, \"w\": 9, \"h\": 4, \"i\": \"a9434d8d-826a-d525-b65c-f96f447b98df\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unique Destination Ports\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"bab780cb-63c4-84a4-ff61-b93bb9810e23\", \"layerType\": \"data\", \"metricAccessor\": \"4b9d811c-d13d-6e05-754f-eed400db3d9a\", \"showBar\": false}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.port IS NOT NULL\\n| STATS unique_ports = COUNT_DISTINCT(destination.port)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"bab780cb-63c4-84a4-ff61-b93bb9810e23\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.port IS NOT NULL\\n| STATS unique_ports = COUNT_DISTINCT(destination.port)\"}, \"columns\": [{\"fieldName\": \"unique_ports\", \"columnId\": \"4b9d811c-d13d-6e05-754f-eed400db3d9a\", \"label\": \"Dest Ports\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unique_ports\", \"columnId\": \"4b9d811c-d13d-6e05-754f-eed400db3d9a\", \"label\": \"Dest Ports\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"a3ee7fb6-d070-5ab7-c98f-b905bfa5cab9\", \"gridData\": {\"x\": 0, \"y\": 6, \"w\": 48, \"h\": 10, \"i\": \"a3ee7fb6-d070-5ab7-c98f-b905bfa5cab9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Traffic by Action Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"99471935-94a6-3765-5318-c3cd504903a8\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"b569b462-851f-619c-5e78-87185e395392\", \"colorMapping\": {\"assignments\": [{\"rule\": {\"type\": \"matchExactly\", \"values\": [\"REJECT\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#BD271E\"}, \"touched\": false}, {\"rule\": {\"type\": \"matchExactly\", \"values\": [\"ACCEPT\"]}, \"color\": {\"type\": \"colorCode\", \"colorCode\": \"#00BF6F\"}, \"touched\": false}], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\", \"xTitle\": \"@timestamp\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": true, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action IS NOT NULL\\n| STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"99471935-94a6-3765-5318-c3cd504903a8\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action IS NOT NULL\\n| STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"label\": \"Time\", \"customLabel\": true, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"aws.vpc.flow.action\", \"columnId\": \"b569b462-851f-619c-5e78-87185e395392\", \"label\": \"aws.vpc.flow.action\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"f5872ebb-4e77-90f5-2418-365a17960f1f\", \"label\": \"Time\", \"customLabel\": true, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"aws.vpc.flow.action\", \"columnId\": \"b569b462-851f-619c-5e78-87185e395392\", \"label\": \"aws.vpc.flow.action\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"1a0ebea3-d7c3-f94a-a16a-b6fc8b15453d\", \"gridData\": {\"x\": 0, \"y\": 16, \"w\": 24, \"h\": 12, \"i\": \"1a0ebea3-d7c3-f94a-a16a-b6fc8b15453d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Protocols\", \"visualizationType\": \"lnsPie\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"a7554187-7770-bf76-a312-2144a5540fb0\", \"layerType\": \"data\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}, \"primaryGroups\": [\"b81a2a3c-14d7-2453-2032-02b2242947ee\"], \"metrics\": [\"f9e36592-2264-8d45-f59b-cfdf0be5cb51\"], \"numberDisplay\": \"percent\", \"categoryDisplay\": \"default\", \"legendDisplay\": \"default\", \"nestedLegend\": false}], \"shape\": \"pie\"}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL\\n| STATS flow_count = COUNT() BY network.protocol.name\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"a7554187-7770-bf76-a312-2144a5540fb0\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND network.protocol.name IS NOT NULL\\n| STATS flow_count = COUNT() BY network.protocol.name\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"f9e36592-2264-8d45-f59b-cfdf0be5cb51\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"f9e36592-2264-8d45-f59b-cfdf0be5cb51\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"ecf540b7-4fb4-3c72-ec6f-def8b60936ce\", \"gridData\": {\"x\": 24, \"y\": 16, \"w\": 24, \"h\": 12, \"i\": \"ecf540b7-4fb4-3c72-ec6f-def8b60936ce\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Destination Ports\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"323cea78-1adf-af1f-8e9e-3881254e01b0\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.port IS NOT NULL\\n| STATS flow_count = COUNT() BY destination.port\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"323cea78-1adf-af1f-8e9e-3881254e01b0\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.port IS NOT NULL\\n| STATS flow_count = COUNT() BY destination.port\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"9bb34872-674a-9335-c976-5794eebc5b7e\", \"gridData\": {\"x\": 0, \"y\": 28, \"w\": 48, \"h\": 3, \"i\": \"9bb34872-674a-9335-c976-5794eebc5b7e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"### Source Analysis\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"e53589c7-8eef-1911-61b5-14a75a22475e\", \"gridData\": {\"x\": 0, \"y\": 31, \"w\": 48, \"h\": 13, \"i\": \"e53589c7-8eef-1911-61b5-14a75a22475e\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Source IPs - Detailed\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"0e17532e-14eb-9b11-6af6-1e0ef9882621\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"77d9a380-6526-50d5-a027-461069942dc1\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"5d8547e6-f902-5398-7064-05c335d75a0b\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"ab08f77f-ca5a-892b-838b-1377e35744f9\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"ce6ccb2c-a77b-ec23-130a-fb87ed00783c\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"03088b5e-ecf3-303c-a32c-0dffe2f9b794\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"0171af4f-7089-bfa3-9109-8cc130c04620\", \"layerType\": \"data\", \"paging\": {\"size\": 10, \"enabled\": true}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND source.address IS NOT NULL\\n| EVAL is_accepted = CASE(aws.vpc.flow.action == \\\"ACCEPT\\\", 1, 0)\\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \\\"REJECT\\\", 1, 0)\\n| STATS total_flows = COUNT(), accepted_flows = SUM(is_accepted), rejected_flows = SUM(is_rejected), total_bytes = SUM(aws.vpc.flow.bytes), total_packets = SUM(aws.vpc.flow.packets) BY source.address\\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\\n| SORT total_flows DESC\\n| LIMIT 20\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"0171af4f-7089-bfa3-9109-8cc130c04620\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND source.address IS NOT NULL\\n| EVAL is_accepted = CASE(aws.vpc.flow.action == \\\"ACCEPT\\\", 1, 0)\\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \\\"REJECT\\\", 1, 0)\\n| STATS total_flows = COUNT(), accepted_flows = SUM(is_accepted), rejected_flows = SUM(is_rejected), total_bytes = SUM(aws.vpc.flow.bytes), total_packets = SUM(aws.vpc.flow.packets) BY source.address\\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\\n| SORT total_flows DESC\\n| LIMIT 20\"}, \"columns\": [{\"fieldName\": \"source.address\", \"columnId\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"label\": \"Source IP\", \"customLabel\": true}, {\"fieldName\": \"total_flows\", \"columnId\": \"0e17532e-14eb-9b11-6af6-1e0ef9882621\", \"label\": \"Total Flows\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"accepted_flows\", \"columnId\": \"77d9a380-6526-50d5-a027-461069942dc1\", \"label\": \"Accepted\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"rejected_flows\", \"columnId\": \"5d8547e6-f902-5398-7064-05c335d75a0b\", \"label\": \"Rejected\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"rejection_rate\", \"columnId\": \"ab08f77f-ca5a-892b-838b-1377e35744f9\", \"label\": \"Rejection %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"total_bytes\", \"columnId\": \"ce6ccb2c-a77b-ec23-130a-fb87ed00783c\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"total_packets\", \"columnId\": \"03088b5e-ecf3-303c-a32c-0dffe2f9b794\", \"label\": \"Packets\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"source.address\", \"columnId\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"label\": \"Source IP\", \"customLabel\": true}, {\"fieldName\": \"total_flows\", \"columnId\": \"0e17532e-14eb-9b11-6af6-1e0ef9882621\", \"label\": \"Total Flows\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"accepted_flows\", \"columnId\": \"77d9a380-6526-50d5-a027-461069942dc1\", \"label\": \"Accepted\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"rejected_flows\", \"columnId\": \"5d8547e6-f902-5398-7064-05c335d75a0b\", \"label\": \"Rejected\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"rejection_rate\", \"columnId\": \"ab08f77f-ca5a-892b-838b-1377e35744f9\", \"label\": \"Rejection %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"total_bytes\", \"columnId\": \"ce6ccb2c-a77b-ec23-130a-fb87ed00783c\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"total_packets\", \"columnId\": \"03088b5e-ecf3-303c-a32c-0dffe2f9b794\", \"label\": \"Packets\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"e0e9c4a7-fe7d-308a-35cb-06988e829786\", \"gridData\": {\"x\": 0, \"y\": 44, \"w\": 48, \"h\": 3, \"i\": \"e0e9c4a7-fe7d-308a-35cb-06988e829786\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"### Security Deep Dive\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"fc6ede7b-5f7f-51fa-e976-4f022ce2a776\", \"gridData\": {\"x\": 0, \"y\": 47, \"w\": 24, \"h\": 12, \"i\": \"fc6ede7b-5f7f-51fa-e976-4f022ce2a776\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Rejected Traffic by Protocol\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"166cc54e-727c-50fe-e7f0-fc90a3d5b061\", \"accessors\": [\"80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"negative\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Rejected Count\", \"yLeftTitle\": \"Rejected Count\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\" AND network.protocol.name IS NOT NULL\\n| STATS rejected_count = COUNT() BY network.protocol.name\\n| SORT rejected_count DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"166cc54e-727c-50fe-e7f0-fc90a3d5b061\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\" AND network.protocol.name IS NOT NULL\\n| STATS rejected_count = COUNT() BY network.protocol.name\\n| SORT rejected_count DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"rejected_count\", \"columnId\": \"80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6\", \"label\": \"Rejected Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"rejected_count\", \"columnId\": \"80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6\", \"label\": \"Rejected Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"78530514-74bc-a2d5-8d31-bd3d0f9182f8\", \"gridData\": {\"x\": 24, \"y\": 47, \"w\": 24, \"h\": 12, \"i\": \"78530514-74bc-a2d5-8d31-bd3d0f9182f8\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Rejected Ports\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"718a7624-3b62-0276-69a0-d283faad8a75\", \"accessors\": [\"80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"negative\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Rejected Count\", \"yLeftTitle\": \"Rejected Count\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\" AND destination.port IS NOT NULL\\n| STATS rejected_count = COUNT() BY destination.port\\n| SORT rejected_count DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"718a7624-3b62-0276-69a0-d283faad8a75\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\" AND destination.port IS NOT NULL\\n| STATS rejected_count = COUNT() BY destination.port\\n| SORT rejected_count DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"rejected_count\", \"columnId\": \"80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6\", \"label\": \"Rejected Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"rejected_count\", \"columnId\": \"80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6\", \"label\": \"Rejected Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"0800f497-4545-6bd5-8a58-c9855f670572\", \"gridData\": {\"x\": 0, \"y\": 59, \"w\": 48, \"h\": 13, \"i\": \"0800f497-4545-6bd5-8a58-c9855f670572\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Detailed Rejection Logs\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"1a2627cc-4656-11d0-a70b-1eddf548e921\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"366b4cb6-3376-f652-0125-6881c68169cd\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"ca180367-8dba-9671-069e-b19084667732\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"b9ddfc71-f60e-c020-42f2-374dc66be145\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"64304942-2fe5-33b8-1482-ba7c38ee5076\", \"layerType\": \"data\", \"paging\": {\"size\": 15, \"enabled\": true}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\"\\n| KEEP @timestamp, source.address, destination.address, destination.port, network.protocol.name, network.interface.name, aws.vpc.flow.bytes, aws.vpc.flow.packets\\n| SORT @timestamp DESC\\n| LIMIT 1000\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"64304942-2fe5-33b8-1482-ba7c38ee5076\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND aws.vpc.flow.action == \\\"REJECT\\\"\\n| KEEP @timestamp, source.address, destination.address, destination.port, network.protocol.name, network.interface.name, aws.vpc.flow.bytes, aws.vpc.flow.packets\\n| SORT @timestamp DESC\\n| LIMIT 1000\"}, \"columns\": [{\"fieldName\": \"@timestamp\", \"columnId\": \"1a2627cc-4656-11d0-a70b-1eddf548e921\", \"label\": \"Timestamp\", \"customLabel\": true}, {\"fieldName\": \"source.address\", \"columnId\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"label\": \"Source IP\", \"customLabel\": true}, {\"fieldName\": \"destination.address\", \"columnId\": \"366b4cb6-3376-f652-0125-6881c68169cd\", \"label\": \"Destination IP\", \"customLabel\": true}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}, {\"fieldName\": \"network.interface.name\", \"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"label\": \"Interface\", \"customLabel\": true}, {\"fieldName\": \"aws.vpc.flow.bytes\", \"columnId\": \"ca180367-8dba-9671-069e-b19084667732\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"aws.vpc.flow.packets\", \"columnId\": \"b9ddfc71-f60e-c020-42f2-374dc66be145\", \"label\": \"Packets\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"@timestamp\", \"columnId\": \"1a2627cc-4656-11d0-a70b-1eddf548e921\", \"label\": \"Timestamp\", \"customLabel\": true}, {\"fieldName\": \"source.address\", \"columnId\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"label\": \"Source IP\", \"customLabel\": true}, {\"fieldName\": \"destination.address\", \"columnId\": \"366b4cb6-3376-f652-0125-6881c68169cd\", \"label\": \"Destination IP\", \"customLabel\": true}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}, {\"fieldName\": \"network.protocol.name\", \"columnId\": \"b81a2a3c-14d7-2453-2032-02b2242947ee\", \"label\": \"Protocol\", \"customLabel\": true}, {\"fieldName\": \"network.interface.name\", \"columnId\": \"c58e61db-8bd4-f17c-021e-82a7fe50eeb5\", \"label\": \"Interface\", \"customLabel\": true}, {\"fieldName\": \"aws.vpc.flow.bytes\", \"columnId\": \"ca180367-8dba-9671-069e-b19084667732\", \"label\": \"Bytes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"aws.vpc.flow.packets\", \"columnId\": \"b9ddfc71-f60e-c020-42f2-374dc66be145\", \"label\": \"Packets\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"d09c5dd0-c0f0-ed37-4ae3-43ea3972c25d\", \"gridData\": {\"x\": 0, \"y\": 72, \"w\": 48, \"h\": 3, \"i\": \"d09c5dd0-c0f0-ed37-4ae3-43ea3972c25d\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"### Top Sources and Destinations\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"336e6bdb-8186-5269-04a1-1cfe8763b894\", \"gridData\": {\"x\": 0, \"y\": 75, \"w\": 16, \"h\": 12, \"i\": \"336e6bdb-8186-5269-04a1-1cfe8763b894\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Destination Ports\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"323cea78-1adf-af1f-8e9e-3881254e01b0\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.port IS NOT NULL\\n| STATS flow_count = COUNT() BY destination.port\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"323cea78-1adf-af1f-8e9e-3881254e01b0\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.port IS NOT NULL\\n| STATS flow_count = COUNT() BY destination.port\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.port\", \"columnId\": \"d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f\", \"label\": \"Dest Port\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"d3302995-9522-9062-1dfb-848a6e97ccf6\", \"gridData\": {\"x\": 16, \"y\": 75, \"w\": 16, \"h\": 12, \"i\": \"d3302995-9522-9062-1dfb-848a6e97ccf6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Destination IPs\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"06b6b49f-b46a-00c2-a5e4-86112b59140f\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"366b4cb6-3376-f652-0125-6881c68169cd\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.address IS NOT NULL\\n| STATS flow_count = COUNT() BY destination.address\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"06b6b49f-b46a-00c2-a5e4-86112b59140f\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND destination.address IS NOT NULL\\n| STATS flow_count = COUNT() BY destination.address\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.address\", \"columnId\": \"366b4cb6-3376-f652-0125-6881c68169cd\", \"label\": \"Destination IP\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"destination.address\", \"columnId\": \"366b4cb6-3376-f652-0125-6881c68169cd\", \"label\": \"Destination IP\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"410f943c-6118-fabb-4b45-6a8cd2057490\", \"gridData\": {\"x\": 32, \"y\": 75, \"w\": 16, \"h\": 12, \"i\": \"410f943c-6118-fabb-4b45-6a8cd2057490\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Source IPs\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"65ab073d-79fc-eaba-a9d4-e387ed182fbf\", \"accessors\": [\"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\"], \"layerType\": \"data\", \"seriesType\": \"bar_stacked\", \"xAccessor\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"bar_stacked\", \"legend\": {\"isVisible\": false, \"position\": \"right\"}, \"valueLabels\": \"hide\", \"yTitle\": \"Flow Count\", \"yLeftTitle\": \"Flow Count\", \"axisTitlesVisibilitySettings\": {\"x\": false, \"yLeft\": true, \"yRight\": false}}, \"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND source.address IS NOT NULL\\n| STATS flow_count = COUNT() BY source.address\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"65ab073d-79fc-eaba-a9d4-e387ed182fbf\": {\"query\": {\"esql\": \"FROM logs-*\\n| WHERE data_stream.dataset == \\\"aws.vpcflow.otel\\\" AND source.address IS NOT NULL\\n| STATS flow_count = COUNT() BY source.address\\n| SORT flow_count DESC\\n| LIMIT 10\"}, \"columns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"source.address\", \"columnId\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"label\": \"Source IP\", \"customLabel\": true}], \"allColumns\": [{\"fieldName\": \"flow_count\", \"columnId\": \"7e75e440-9f2e-7dee-7e38-c0f4e56f835e\", \"label\": \"Flow Count\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"source.address\", \"columnId\": \"4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f\", \"label\": \"Source IP\", \"customLabel\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "ef117464-3e9c-10b3-bb29-d1d6f9d3c452",
+                "order": 1,
+                "label": "Traffic Analysis",
+                "type": "dashboardLink",
+                "destinationRefName": "link_ef117464-3e9c-10b3-bb29-d1d6f9d3c452_dashboard"
+              },
+              {
+                "id": "1f78b936-37d7-285d-d766-136934e7d1c5",
+                "order": 2,
+                "label": "Interface Analysis",
+                "type": "dashboardLink",
+                "destinationRefName": "link_1f78b936-37d7-285d-d766-136934e7d1c5_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "d52e5724-45e6-6551-60c3-8d99b4e5c435",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 10,
+          "h": 4,
+          "i": "d52e5724-45e6-6551-60c3-8d99b4e5c435"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Total Flow Records",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "ef16c77d-474f-0e07-5ef4-bd4b64978a9e",
+                "layerType": "data",
+                "metricAccessor": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\"\n| STATS total_flows = COUNT()"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ef16c77d-474f-0e07-5ef4-bd4b64978a9e": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\"\n| STATS total_flows = COUNT()"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                          "label": "Flow Records",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "673e6b96-cdc3-3207-b791-0b3f4fb41dba",
+                          "label": "Flow Records",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "19ea32b5-8afa-4855-772a-64f301699a2f",
+        "gridData": {
+          "x": 10,
+          "y": 2,
+          "w": 10,
+          "h": 4,
+          "i": "19ea32b5-8afa-4855-772a-64f301699a2f"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unique Source IPs",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "e77e8578-c3d7-93b4-9b94-c8612ee5d922",
+                "layerType": "data",
+                "metricAccessor": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND source.address IS NOT NULL\n| STATS unique_sources = COUNT_DISTINCT(source.address)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e77e8578-c3d7-93b4-9b94-c8612ee5d922": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND source.address IS NOT NULL\n| STATS unique_sources = COUNT_DISTINCT(source.address)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_sources",
+                          "columnId": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                          "label": "Unique Sources",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_sources",
+                          "columnId": "9d5d3b2a-5721-b422-3a22-7d5f0e4a5c8d",
+                          "label": "Unique Sources",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "c2a2f81c-d9b7-ae27-a260-b59ed2e01a55",
+        "gridData": {
+          "x": 20,
+          "y": 2,
+          "w": 9,
+          "h": 4,
+          "i": "c2a2f81c-d9b7-ae27-a260-b59ed2e01a55"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unique Destination IPs",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "91098f81-a84e-b536-b595-9947df7e0286",
+                "layerType": "data",
+                "metricAccessor": "6f71393e-a5d6-8aea-79e8-bf89db24a2cd",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.address IS NOT NULL\n| STATS unique_destinations = COUNT_DISTINCT(destination.address)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "91098f81-a84e-b536-b595-9947df7e0286": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.address IS NOT NULL\n| STATS unique_destinations = COUNT_DISTINCT(destination.address)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_destinations",
+                          "columnId": "6f71393e-a5d6-8aea-79e8-bf89db24a2cd",
+                          "label": "Unique Destinations",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_destinations",
+                          "columnId": "6f71393e-a5d6-8aea-79e8-bf89db24a2cd",
+                          "label": "Unique Destinations",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "418f69a0-177f-f005-7540-23da36cd7c43",
+        "gridData": {
+          "x": 29,
+          "y": 2,
+          "w": 10,
+          "h": 4,
+          "i": "418f69a0-177f-f005-7540-23da36cd7c43"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unique Protocols",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "43d4fe41-3a19-c47b-8995-f399cb74b224",
+                "layerType": "data",
+                "metricAccessor": "e960f750-fb9b-7807-8707-6f84b1a96407",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "43d4fe41-3a19-c47b-8995-f399cb74b224": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL\n| STATS unique_protocols = COUNT_DISTINCT(network.protocol.name)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_protocols",
+                          "columnId": "e960f750-fb9b-7807-8707-6f84b1a96407",
+                          "label": "Protocols",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_protocols",
+                          "columnId": "e960f750-fb9b-7807-8707-6f84b1a96407",
+                          "label": "Protocols",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "a9434d8d-826a-d525-b65c-f96f447b98df",
+        "gridData": {
+          "x": 39,
+          "y": 2,
+          "w": 9,
+          "h": 4,
+          "i": "a9434d8d-826a-d525-b65c-f96f447b98df"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unique Destination Ports",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "bab780cb-63c4-84a4-ff61-b93bb9810e23",
+                "layerType": "data",
+                "metricAccessor": "4b9d811c-d13d-6e05-754f-eed400db3d9a",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.port IS NOT NULL\n| STATS unique_ports = COUNT_DISTINCT(destination.port)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "bab780cb-63c4-84a4-ff61-b93bb9810e23": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.port IS NOT NULL\n| STATS unique_ports = COUNT_DISTINCT(destination.port)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unique_ports",
+                          "columnId": "4b9d811c-d13d-6e05-754f-eed400db3d9a",
+                          "label": "Dest Ports",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unique_ports",
+                          "columnId": "4b9d811c-d13d-6e05-754f-eed400db3d9a",
+                          "label": "Dest Ports",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "a3ee7fb6-d070-5ab7-c98f-b905bfa5cab9",
+        "gridData": {
+          "x": 0,
+          "y": 6,
+          "w": 48,
+          "h": 10,
+          "i": "a3ee7fb6-d070-5ab7-c98f-b905bfa5cab9"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Traffic by Action Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "99471935-94a6-3765-5318-c3cd504903a8",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "b569b462-851f-619c-5e78-87185e395392",
+                    "colorMapping": {
+                      "assignments": [
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "REJECT"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#BD271E"
+                          },
+                          "touched": false
+                        },
+                        {
+                          "rule": {
+                            "type": "matchExactly",
+                            "values": [
+                              "ACCEPT"
+                            ]
+                          },
+                          "color": {
+                            "type": "colorCode",
+                            "colorCode": "#00BF6F"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "xTitle": "@timestamp",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action IS NOT NULL\n| STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "99471935-94a6-3765-5318-c3cd504903a8": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action IS NOT NULL\n| STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                          "label": "Time",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.action",
+                          "columnId": "b569b462-851f-619c-5e78-87185e395392",
+                          "label": "aws.vpc.flow.action",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "f5872ebb-4e77-90f5-2418-365a17960f1f",
+                          "label": "Time",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.action",
+                          "columnId": "b569b462-851f-619c-5e78-87185e395392",
+                          "label": "aws.vpc.flow.action",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "1a0ebea3-d7c3-f94a-a16a-b6fc8b15453d",
+        "gridData": {
+          "x": 0,
+          "y": 16,
+          "w": 24,
+          "h": 12,
+          "i": "1a0ebea3-d7c3-f94a-a16a-b6fc8b15453d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Protocols",
+            "visualizationType": "lnsPie",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "a7554187-7770-bf76-a312-2144a5540fb0",
+                    "layerType": "data",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    },
+                    "primaryGroups": [
+                      "b81a2a3c-14d7-2453-2032-02b2242947ee"
+                    ],
+                    "metrics": [
+                      "f9e36592-2264-8d45-f59b-cfdf0be5cb51"
+                    ],
+                    "numberDisplay": "percent",
+                    "categoryDisplay": "default",
+                    "legendDisplay": "default",
+                    "nestedLegend": false
+                  }
+                ],
+                "shape": "pie"
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL\n| STATS flow_count = COUNT() BY network.protocol.name\n| SORT flow_count DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "a7554187-7770-bf76-a312-2144a5540fb0": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND network.protocol.name IS NOT NULL\n| STATS flow_count = COUNT() BY network.protocol.name\n| SORT flow_count DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "f9e36592-2264-8d45-f59b-cfdf0be5cb51",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "f9e36592-2264-8d45-f59b-cfdf0be5cb51",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "ecf540b7-4fb4-3c72-ec6f-def8b60936ce",
+        "gridData": {
+          "x": 24,
+          "y": 16,
+          "w": 24,
+          "h": 12,
+          "i": "ecf540b7-4fb4-3c72-ec6f-def8b60936ce"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Destination Ports",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "323cea78-1adf-af1f-8e9e-3881254e01b0",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.port IS NOT NULL\n| STATS flow_count = COUNT() BY destination.port\n| SORT flow_count DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "323cea78-1adf-af1f-8e9e-3881254e01b0": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.port IS NOT NULL\n| STATS flow_count = COUNT() BY destination.port\n| SORT flow_count DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "9bb34872-674a-9335-c976-5794eebc5b7e",
+        "gridData": {
+          "x": 0,
+          "y": 28,
+          "w": 48,
+          "h": 3,
+          "i": "9bb34872-674a-9335-c976-5794eebc5b7e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "### Source Analysis"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "e53589c7-8eef-1911-61b5-14a75a22475e",
+        "gridData": {
+          "x": 0,
+          "y": 31,
+          "w": 48,
+          "h": 13,
+          "i": "e53589c7-8eef-1911-61b5-14a75a22475e"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Source IPs - Detailed",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "0e17532e-14eb-9b11-6af6-1e0ef9882621",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "77d9a380-6526-50d5-a027-461069942dc1",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "5d8547e6-f902-5398-7064-05c335d75a0b",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "ab08f77f-ca5a-892b-838b-1377e35744f9",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "ce6ccb2c-a77b-ec23-130a-fb87ed00783c",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "03088b5e-ecf3-303c-a32c-0dffe2f9b794",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "0171af4f-7089-bfa3-9109-8cc130c04620",
+                "layerType": "data",
+                "paging": {
+                  "size": 10,
+                  "enabled": true
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND source.address IS NOT NULL\n| EVAL is_accepted = CASE(aws.vpc.flow.action == \"ACCEPT\", 1, 0)\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \"REJECT\", 1, 0)\n| STATS total_flows = COUNT(), accepted_flows = SUM(is_accepted), rejected_flows = SUM(is_rejected), total_bytes = SUM(aws.vpc.flow.bytes), total_packets = SUM(aws.vpc.flow.packets) BY source.address\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\n| SORT total_flows DESC\n| LIMIT 20"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "0171af4f-7089-bfa3-9109-8cc130c04620": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND source.address IS NOT NULL\n| EVAL is_accepted = CASE(aws.vpc.flow.action == \"ACCEPT\", 1, 0)\n| EVAL is_rejected = CASE(aws.vpc.flow.action == \"REJECT\", 1, 0)\n| STATS total_flows = COUNT(), accepted_flows = SUM(is_accepted), rejected_flows = SUM(is_rejected), total_bytes = SUM(aws.vpc.flow.bytes), total_packets = SUM(aws.vpc.flow.packets) BY source.address\n| EVAL rejection_rate = CASE(total_flows > 0, rejected_flows::double / total_flows::double, 0)\n| SORT total_flows DESC\n| LIMIT 20"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "source.address",
+                          "columnId": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                          "label": "Source IP",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "0e17532e-14eb-9b11-6af6-1e0ef9882621",
+                          "label": "Total Flows",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "accepted_flows",
+                          "columnId": "77d9a380-6526-50d5-a027-461069942dc1",
+                          "label": "Accepted",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "rejected_flows",
+                          "columnId": "5d8547e6-f902-5398-7064-05c335d75a0b",
+                          "label": "Rejected",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "ab08f77f-ca5a-892b-838b-1377e35744f9",
+                          "label": "Rejection %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "ce6ccb2c-a77b-ec23-130a-fb87ed00783c",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "total_packets",
+                          "columnId": "03088b5e-ecf3-303c-a32c-0dffe2f9b794",
+                          "label": "Packets",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "source.address",
+                          "columnId": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                          "label": "Source IP",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "total_flows",
+                          "columnId": "0e17532e-14eb-9b11-6af6-1e0ef9882621",
+                          "label": "Total Flows",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "accepted_flows",
+                          "columnId": "77d9a380-6526-50d5-a027-461069942dc1",
+                          "label": "Accepted",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "rejected_flows",
+                          "columnId": "5d8547e6-f902-5398-7064-05c335d75a0b",
+                          "label": "Rejected",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "ab08f77f-ca5a-892b-838b-1377e35744f9",
+                          "label": "Rejection %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "total_bytes",
+                          "columnId": "ce6ccb2c-a77b-ec23-130a-fb87ed00783c",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "total_packets",
+                          "columnId": "03088b5e-ecf3-303c-a32c-0dffe2f9b794",
+                          "label": "Packets",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "e0e9c4a7-fe7d-308a-35cb-06988e829786",
+        "gridData": {
+          "x": 0,
+          "y": 44,
+          "w": 48,
+          "h": 3,
+          "i": "e0e9c4a7-fe7d-308a-35cb-06988e829786"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "### Security Deep Dive"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "fc6ede7b-5f7f-51fa-e976-4f022ce2a776",
+        "gridData": {
+          "x": 0,
+          "y": 47,
+          "w": 24,
+          "h": 12,
+          "i": "fc6ede7b-5f7f-51fa-e976-4f022ce2a776"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Rejected Traffic by Protocol",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "166cc54e-727c-50fe-e7f0-fc90a3d5b061",
+                    "accessors": [
+                      "80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "negative",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Rejected Count",
+                "yLeftTitle": "Rejected Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\" AND network.protocol.name IS NOT NULL\n| STATS rejected_count = COUNT() BY network.protocol.name\n| SORT rejected_count DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "166cc54e-727c-50fe-e7f0-fc90a3d5b061": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\" AND network.protocol.name IS NOT NULL\n| STATS rejected_count = COUNT() BY network.protocol.name\n| SORT rejected_count DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rejected_count",
+                          "columnId": "80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6",
+                          "label": "Rejected Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rejected_count",
+                          "columnId": "80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6",
+                          "label": "Rejected Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "78530514-74bc-a2d5-8d31-bd3d0f9182f8",
+        "gridData": {
+          "x": 24,
+          "y": 47,
+          "w": 24,
+          "h": 12,
+          "i": "78530514-74bc-a2d5-8d31-bd3d0f9182f8"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Rejected Ports",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "718a7624-3b62-0276-69a0-d283faad8a75",
+                    "accessors": [
+                      "80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "negative",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Rejected Count",
+                "yLeftTitle": "Rejected Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\" AND destination.port IS NOT NULL\n| STATS rejected_count = COUNT() BY destination.port\n| SORT rejected_count DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "718a7624-3b62-0276-69a0-d283faad8a75": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\" AND destination.port IS NOT NULL\n| STATS rejected_count = COUNT() BY destination.port\n| SORT rejected_count DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rejected_count",
+                          "columnId": "80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6",
+                          "label": "Rejected Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rejected_count",
+                          "columnId": "80a1ef92-a0a7-4bbf-24e6-fcdb11e4b3c6",
+                          "label": "Rejected Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "0800f497-4545-6bd5-8a58-c9855f670572",
+        "gridData": {
+          "x": 0,
+          "y": 59,
+          "w": 48,
+          "h": 13,
+          "i": "0800f497-4545-6bd5-8a58-c9855f670572"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Detailed Rejection Logs",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "1a2627cc-4656-11d0-a70b-1eddf548e921",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "366b4cb6-3376-f652-0125-6881c68169cd",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "ca180367-8dba-9671-069e-b19084667732",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "b9ddfc71-f60e-c020-42f2-374dc66be145",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "64304942-2fe5-33b8-1482-ba7c38ee5076",
+                "layerType": "data",
+                "paging": {
+                  "size": 15,
+                  "enabled": true
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\"\n| KEEP @timestamp, source.address, destination.address, destination.port, network.protocol.name, network.interface.name, aws.vpc.flow.bytes, aws.vpc.flow.packets\n| SORT @timestamp DESC\n| LIMIT 1000"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "64304942-2fe5-33b8-1482-ba7c38ee5076": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND aws.vpc.flow.action == \"REJECT\"\n| KEEP @timestamp, source.address, destination.address, destination.port, network.protocol.name, network.interface.name, aws.vpc.flow.bytes, aws.vpc.flow.packets\n| SORT @timestamp DESC\n| LIMIT 1000"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "@timestamp",
+                          "columnId": "1a2627cc-4656-11d0-a70b-1eddf548e921",
+                          "label": "Timestamp",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "source.address",
+                          "columnId": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                          "label": "Source IP",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "destination.address",
+                          "columnId": "366b4cb6-3376-f652-0125-6881c68169cd",
+                          "label": "Destination IP",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "network.interface.name",
+                          "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                          "label": "Interface",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.bytes",
+                          "columnId": "ca180367-8dba-9671-069e-b19084667732",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.packets",
+                          "columnId": "b9ddfc71-f60e-c020-42f2-374dc66be145",
+                          "label": "Packets",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "@timestamp",
+                          "columnId": "1a2627cc-4656-11d0-a70b-1eddf548e921",
+                          "label": "Timestamp",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "source.address",
+                          "columnId": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                          "label": "Source IP",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "destination.address",
+                          "columnId": "366b4cb6-3376-f652-0125-6881c68169cd",
+                          "label": "Destination IP",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "network.protocol.name",
+                          "columnId": "b81a2a3c-14d7-2453-2032-02b2242947ee",
+                          "label": "Protocol",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "network.interface.name",
+                          "columnId": "c58e61db-8bd4-f17c-021e-82a7fe50eeb5",
+                          "label": "Interface",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.bytes",
+                          "columnId": "ca180367-8dba-9671-069e-b19084667732",
+                          "label": "Bytes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "aws.vpc.flow.packets",
+                          "columnId": "b9ddfc71-f60e-c020-42f2-374dc66be145",
+                          "label": "Packets",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "d09c5dd0-c0f0-ed37-4ae3-43ea3972c25d",
+        "gridData": {
+          "x": 0,
+          "y": 72,
+          "w": 48,
+          "h": 3,
+          "i": "d09c5dd0-c0f0-ed37-4ae3-43ea3972c25d"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "### Top Sources and Destinations"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "336e6bdb-8186-5269-04a1-1cfe8763b894",
+        "gridData": {
+          "x": 0,
+          "y": 75,
+          "w": 16,
+          "h": 12,
+          "i": "336e6bdb-8186-5269-04a1-1cfe8763b894"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Destination Ports",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "323cea78-1adf-af1f-8e9e-3881254e01b0",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.port IS NOT NULL\n| STATS flow_count = COUNT() BY destination.port\n| SORT flow_count DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "323cea78-1adf-af1f-8e9e-3881254e01b0": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.port IS NOT NULL\n| STATS flow_count = COUNT() BY destination.port\n| SORT flow_count DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.port",
+                          "columnId": "d96118cf-e8d4-3a89-2b3e-89d5eeb3c54f",
+                          "label": "Dest Port",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "d3302995-9522-9062-1dfb-848a6e97ccf6",
+        "gridData": {
+          "x": 16,
+          "y": 75,
+          "w": 16,
+          "h": 12,
+          "i": "d3302995-9522-9062-1dfb-848a6e97ccf6"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Destination IPs",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "06b6b49f-b46a-00c2-a5e4-86112b59140f",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "366b4cb6-3376-f652-0125-6881c68169cd",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.address IS NOT NULL\n| STATS flow_count = COUNT() BY destination.address\n| SORT flow_count DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "06b6b49f-b46a-00c2-a5e4-86112b59140f": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND destination.address IS NOT NULL\n| STATS flow_count = COUNT() BY destination.address\n| SORT flow_count DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.address",
+                          "columnId": "366b4cb6-3376-f652-0125-6881c68169cd",
+                          "label": "Destination IP",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "destination.address",
+                          "columnId": "366b4cb6-3376-f652-0125-6881c68169cd",
+                          "label": "Destination IP",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "410f943c-6118-fabb-4b45-6a8cd2057490",
+        "gridData": {
+          "x": 32,
+          "y": 75,
+          "w": 16,
+          "h": 12,
+          "i": "410f943c-6118-fabb-4b45-6a8cd2057490"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Source IPs",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "65ab073d-79fc-eaba-a9d4-e387ed182fbf",
+                    "accessors": [
+                      "7e75e440-9f2e-7dee-7e38-c0f4e56f835e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "bar_stacked",
+                "legend": {
+                  "isVisible": false,
+                  "position": "right"
+                },
+                "valueLabels": "hide",
+                "yTitle": "Flow Count",
+                "yLeftTitle": "Flow Count",
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": false
+                }
+              },
+              "query": {
+                "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND source.address IS NOT NULL\n| STATS flow_count = COUNT() BY source.address\n| SORT flow_count DESC\n| LIMIT 10"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "65ab073d-79fc-eaba-a9d4-e387ed182fbf": {
+                      "query": {
+                        "esql": "FROM logs-*\n| WHERE data_stream.dataset == \"aws.vpcflow.otel\" AND source.address IS NOT NULL\n| STATS flow_count = COUNT() BY source.address\n| SORT flow_count DESC\n| LIMIT 10"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "source.address",
+                          "columnId": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                          "label": "Source IP",
+                          "customLabel": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "flow_count",
+                          "columnId": "7e75e440-9f2e-7dee-7e38-c0f4e56f835e",
+                          "label": "Flow Count",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "source.address",
+                          "columnId": "4cb6775d-bc03-5e8b-c2d7-2ac88307ac3f",
+                          "label": "Source IP",
+                          "customLabel": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"aws.vpcflow.otel\"}},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"aws.vpcflow.otel\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "data_stream.dataset",
+              "field": "data_stream.dataset",
+              "params": {
+                "query": "aws.vpcflow.otel"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "aws.vpcflow.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": false,
     "version": 1,
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"e155cda7-38a2-040c-3e6a-33339866c123\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"e155cda7-38a2-040c-3e6a-33339866c123\",\"dataViewId\":\"logs-*\",\"fieldName\":\"cloud.account.id\",\"title\":\"Cloud Account ID\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"41c0e666-862f-ba61-3001-48c7a555c788\":{\"grow\":false,\"order\":1,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"41c0e666-862f-ba61-3001-48c7a555c788\",\"dataViewId\":\"logs-*\",\"fieldName\":\"network.interface.name\",\"title\":\"Network Interface\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"a6de1714-9b30-7483-8189-4f53daa21992\":{\"grow\":false,\"order\":2,\"width\":\"small\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"a6de1714-9b30-7483-8189-4f53daa21992\",\"dataViewId\":\"logs-*\",\"fieldName\":\"aws.vpc.flow.action\",\"title\":\"Action\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"2ab2d2c5-ce3e-9cbb-e027-36ca1ac94987\":{\"grow\":false,\"order\":3,\"width\":\"small\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2ab2d2c5-ce3e-9cbb-e027-36ca1ac94987\",\"dataViewId\":\"logs-*\",\"fieldName\":\"network.protocol.name\",\"title\":\"Protocol\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"056d9865-1eaa-90fa-a56d-28cf7d889abb\":{\"grow\":false,\"order\":4,\"width\":\"small\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"056d9865-1eaa-90fa-a56d-28cf7d889abb\",\"dataViewId\":\"logs-*\",\"fieldName\":\"destination.port\",\"title\":\"Destination Port\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"dc63970a-1a81-ce93-33e1-c32236299d7d\":{\"grow\":false,\"order\":5,\"width\":\"small\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"dc63970a-1a81-ce93-33e1-c32236299d7d\",\"dataViewId\":\"logs-*\",\"fieldName\":\"source.port\",\"title\":\"Source Port\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "e155cda7-38a2-040c-3e6a-33339866c123": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "e155cda7-38a2-040c-3e6a-33339866c123",
+            "dataViewId": "logs-*",
+            "fieldName": "cloud.account.id",
+            "title": "Cloud Account ID",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "41c0e666-862f-ba61-3001-48c7a555c788": {
+          "grow": false,
+          "order": 1,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "41c0e666-862f-ba61-3001-48c7a555c788",
+            "dataViewId": "logs-*",
+            "fieldName": "network.interface.name",
+            "title": "Network Interface",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "a6de1714-9b30-7483-8189-4f53daa21992": {
+          "grow": false,
+          "order": 2,
+          "width": "small",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "a6de1714-9b30-7483-8189-4f53daa21992",
+            "dataViewId": "logs-*",
+            "fieldName": "aws.vpc.flow.action",
+            "title": "Action",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "2ab2d2c5-ce3e-9cbb-e027-36ca1ac94987": {
+          "grow": false,
+          "order": 3,
+          "width": "small",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "2ab2d2c5-ce3e-9cbb-e027-36ca1ac94987",
+            "dataViewId": "logs-*",
+            "fieldName": "network.protocol.name",
+            "title": "Protocol",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "056d9865-1eaa-90fa-a56d-28cf7d889abb": {
+          "grow": false,
+          "order": 4,
+          "width": "small",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "056d9865-1eaa-90fa-a56d-28cf7d889abb",
+            "dataViewId": "logs-*",
+            "fieldName": "destination.port",
+            "title": "Destination Port",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "dc63970a-1a81-ce93-33e1-c32236299d7d": {
+          "grow": false,
+          "order": 5,
+          "width": "small",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "dc63970a-1a81-ce93-33e1-c32236299d7d",
+            "dataViewId": "logs-*",
+            "fieldName": "source.port",
+            "title": "Source Port",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/cockroachdb_otel/kibana/dashboard/cockroachdb_otel-overview.json
+++ b/packages/cockroachdb_otel/kibana/dashboard/cockroachdb_otel-overview.json
@@ -2,18 +2,2100 @@
   "attributes": {
     "title": "[CockroachDB OTel] Overview",
     "description": "Cluster health, availability, and golden signals for CockroachDB. Covers live nodes, replication status, SQL throughput, errors, CPU, and storage.",
-    "panelsJSON": "[{\"panelIndex\": \"91144e9b-fac7-b44d-0b1d-8339201b83cb\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"91144e9b-fac7-b44d-0b1d-8339201b83cb\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"b986582c-6093-3b85-1b1f-c667124bd189\", \"order\": 1, \"label\": \"Storage\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_b986582c-6093-3b85-1b1f-c667124bd189_dashboard\"}, {\"id\": \"0ce5133a-1601-c0e1-50df-1375499c41f7\", \"order\": 2, \"label\": \"SQL & Transactions\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_0ce5133a-1601-c0e1-50df-1375499c41f7_dashboard\"}, {\"id\": \"4da2826a-7c0c-9dc0-3fe3-52ae1dc165de\", \"order\": 3, \"label\": \"Replication & Ranges\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_4da2826a-7c0c-9dc0-3fe3-52ae1dc165de_dashboard\"}]}}}, {\"panelIndex\": \"0563dba8-e018-01bf-7e3c-91932750954e\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 16, \"h\": 12, \"i\": \"0563dba8-e018-01bf-7e3c-91932750954e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [CockroachDB OTel] Overview\\n\\nThis dashboard provides cluster health and golden signals:\\n- Live nodes and replication status (unavailable/under-replicated ranges)\\n- SQL throughput and connection counts\\n- Error rates (failures, aborts, contention)\\n- CPU and memory utilization\\n- Storage capacity and LSM health indicators\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"85fe31d3-39c2-098d-7621-0bfb60ec2617\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"85fe31d3-39c2-098d-7621-0bfb60ec2617\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Live Nodes\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"73fe9ed6-3e8b-7f8d-9fd8-a8b68e3507f9\", \"layerType\": \"data\", \"metricAccessor\": \"4dd919fa-c329-21c9-e733-9bc4060e671d\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE liveness_livenodes IS NOT NULL\\n| STATS live_nodes = MAX(LAST_OVER_TIME(liveness_livenodes))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"73fe9ed6-3e8b-7f8d-9fd8-a8b68e3507f9\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE liveness_livenodes IS NOT NULL\\n| STATS live_nodes = MAX(LAST_OVER_TIME(liveness_livenodes))\"}, \"columns\": [{\"fieldName\": \"live_nodes\", \"columnId\": \"4dd919fa-c329-21c9-e733-9bc4060e671d\", \"label\": \"Live Nodes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"live_nodes\", \"columnId\": \"4dd919fa-c329-21c9-e733-9bc4060e671d\", \"label\": \"Live Nodes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"2adb512e-3b90-5c72-229f-1c4e2cf74ab5\", \"gridData\": {\"x\": 24, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"2adb512e-3b90-5c72-229f-1c4e2cf74ab5\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unavailable Ranges\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"0663746f-6668-62f3-bdd0-e17117b906e4\", \"layerType\": \"data\", \"metricAccessor\": \"16feeb31-ae6c-2035-e385-23308694d955\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_unavailable IS NOT NULL\\n| STATS unavailable = MAX(LAST_OVER_TIME(ranges_unavailable))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"0663746f-6668-62f3-bdd0-e17117b906e4\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_unavailable IS NOT NULL\\n| STATS unavailable = MAX(LAST_OVER_TIME(ranges_unavailable))\"}, \"columns\": [{\"fieldName\": \"unavailable\", \"columnId\": \"16feeb31-ae6c-2035-e385-23308694d955\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unavailable\", \"columnId\": \"16feeb31-ae6c-2035-e385-23308694d955\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"2081f589-c35c-9d64-6ce3-369784734a43\", \"gridData\": {\"x\": 32, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"2081f589-c35c-9d64-6ce3-369784734a43\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Under-Replicated Ranges\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"df2a3bb8-f4f8-cf30-d40e-2c38ddd029e1\", \"layerType\": \"data\", \"metricAccessor\": \"675c390f-4892-5fe5-7a81-67c0d2a5ffa7\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_underreplicated IS NOT NULL\\n| STATS underreplicated = MAX(LAST_OVER_TIME(ranges_underreplicated))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"df2a3bb8-f4f8-cf30-d40e-2c38ddd029e1\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_underreplicated IS NOT NULL\\n| STATS underreplicated = MAX(LAST_OVER_TIME(ranges_underreplicated))\"}, \"columns\": [{\"fieldName\": \"underreplicated\", \"columnId\": \"675c390f-4892-5fe5-7a81-67c0d2a5ffa7\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"underreplicated\", \"columnId\": \"675c390f-4892-5fe5-7a81-67c0d2a5ffa7\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"9c04f562-44dd-305c-0799-ef4963337ce1\", \"gridData\": {\"x\": 40, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"9c04f562-44dd-305c-0799-ef4963337ce1\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"SQL Connections\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"bc739b12-051a-1845-a561-bbd7eaeb7cdd\", \"layerType\": \"data\", \"metricAccessor\": \"54eb225e-d32d-0c12-87b2-39b1e449eb24\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL\\n| STATS conns = SUM(LAST_OVER_TIME(sql_conns))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"bc739b12-051a-1845-a561-bbd7eaeb7cdd\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL\\n| STATS conns = SUM(LAST_OVER_TIME(sql_conns))\"}, \"columns\": [{\"fieldName\": \"conns\", \"columnId\": \"54eb225e-d32d-0c12-87b2-39b1e449eb24\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"conns\", \"columnId\": \"54eb225e-d32d-0c12-87b2-39b1e449eb24\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"a18576df-58ee-a92f-73d2-30d71ece3cfa\", \"gridData\": {\"x\": 16, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"a18576df-58ee-a92f-73d2-30d71ece3cfa\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"SQL Failures (rate)\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"7ca3e837-63c7-1edf-1afc-5a288f101dad\", \"layerType\": \"data\", \"metricAccessor\": \"8a0fdda1-1c1f-8cb6-97a6-774336468203\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_failure_count IS NOT NULL\\n| STATS fail_rate = SUM(RATE(sql_failure_count))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"7ca3e837-63c7-1edf-1afc-5a288f101dad\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_failure_count IS NOT NULL\\n| STATS fail_rate = SUM(RATE(sql_failure_count))\"}, \"columns\": [{\"fieldName\": \"fail_rate\", \"columnId\": \"8a0fdda1-1c1f-8cb6-97a6-774336468203\", \"label\": \"Failures/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"allColumns\": [{\"fieldName\": \"fail_rate\", \"columnId\": \"8a0fdda1-1c1f-8cb6-97a6-774336468203\", \"label\": \"Failures/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"253dbdde-bc54-c1f4-0eaf-d2e8387f2c4b\", \"gridData\": {\"x\": 24, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"253dbdde-bc54-c1f4-0eaf-d2e8387f2c4b\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"CPU Utilization\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"cd9d96e1-f9da-56f8-391b-58be6afe29dc\", \"layerType\": \"data\", \"metricAccessor\": \"332d305c-0d34-8b87-eef2-744cee3e8914\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sys_cpu_combined_percent_normalized IS NOT NULL\\n| STATS avg_cpu = AVG(AVG_OVER_TIME(sys_cpu_combined_percent_normalized))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cd9d96e1-f9da-56f8-391b-58be6afe29dc\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sys_cpu_combined_percent_normalized IS NOT NULL\\n| STATS avg_cpu = AVG(AVG_OVER_TIME(sys_cpu_combined_percent_normalized))\"}, \"columns\": [{\"fieldName\": \"avg_cpu\", \"columnId\": \"332d305c-0d34-8b87-eef2-744cee3e8914\", \"label\": \"CPU %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}], \"allColumns\": [{\"fieldName\": \"avg_cpu\", \"columnId\": \"332d305c-0d34-8b87-eef2-744cee3e8914\", \"label\": \"CPU %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"96315cee-00f8-dc49-287c-5586ec57cb03\", \"gridData\": {\"x\": 32, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"96315cee-00f8-dc49-287c-5586ec57cb03\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"IO Overload\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"31107a35-ca00-d025-7169-5fcdd594d99c\", \"layerType\": \"data\", \"metricAccessor\": \"4db5cf58-cf78-3468-f88c-d4637075ca22\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE admission_io_overload IS NOT NULL\\n| STATS avg_io = AVG(AVG_OVER_TIME(admission_io_overload))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"31107a35-ca00-d025-7169-5fcdd594d99c\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE admission_io_overload IS NOT NULL\\n| STATS avg_io = AVG(AVG_OVER_TIME(admission_io_overload))\"}, \"columns\": [{\"fieldName\": \"avg_io\", \"columnId\": \"4db5cf58-cf78-3468-f88c-d4637075ca22\", \"label\": \"IO Overload\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"allColumns\": [{\"fieldName\": \"avg_io\", \"columnId\": \"4db5cf58-cf78-3468-f88c-d4637075ca22\", \"label\": \"IO Overload\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"55f5b21e-5abf-aff0-00f9-621cd9edc51f\", \"gridData\": {\"x\": 40, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"55f5b21e-5abf-aff0-00f9-621cd9edc51f\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Write Stalls\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"9a0d002c-2635-c43f-352c-255d62d3107a\", \"layerType\": \"data\", \"metricAccessor\": \"e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_write_stalls IS NOT NULL\\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"9a0d002c-2635-c43f-352c-255d62d3107a\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_write_stalls IS NOT NULL\\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls))\"}, \"columns\": [{\"fieldName\": \"stalls\", \"columnId\": \"e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8\", \"label\": \"Write Stalls\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"stalls\", \"columnId\": \"e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8\", \"label\": \"Write Stalls\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"c5796a7f-4774-9b72-64e5-2eb4a44ff69d\", \"gridData\": {\"x\": 0, \"y\": 14, \"w\": 48, \"h\": 3, \"i\": \"c5796a7f-4774-9b72-64e5-2eb4a44ff69d\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"SQL Throughput\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## SQL Throughput\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"cea8ca49-7315-884e-8fcc-f84e82e3b78d\", \"gridData\": {\"x\": 0, \"y\": 17, \"w\": 48, \"h\": 12, \"i\": \"cea8ca49-7315-884e-8fcc-f84e82e3b78d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Statement Rate by Type\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"f55da783-4810-f2be-77db-aeeb36a39e4b\", \"accessors\": [\"c83abc0a-d16f-a488-8bc6-56f6074f164e\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"5550a10a-5d61-636f-e232-b95fcb75936c\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE sql_select_count IS NOT NULL | STATS rate = SUM(RATE(sql_select_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"SELECT\\\" ) ( WHERE sql_insert_count IS NOT NULL | STATS rate = SUM(RATE(sql_insert_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"INSERT\\\" ) ( WHERE sql_update_count IS NOT NULL | STATS rate = SUM(RATE(sql_update_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"UPDATE\\\" ) ( WHERE sql_delete_count IS NOT NULL | STATS rate = SUM(RATE(sql_delete_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"DELETE\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, stmt_type\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"f55da783-4810-f2be-77db-aeeb36a39e4b\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE sql_select_count IS NOT NULL | STATS rate = SUM(RATE(sql_select_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"SELECT\\\" ) ( WHERE sql_insert_count IS NOT NULL | STATS rate = SUM(RATE(sql_insert_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"INSERT\\\" ) ( WHERE sql_update_count IS NOT NULL | STATS rate = SUM(RATE(sql_update_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"UPDATE\\\" ) ( WHERE sql_delete_count IS NOT NULL | STATS rate = SUM(RATE(sql_delete_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"DELETE\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, stmt_type\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"rate\", \"columnId\": \"c83abc0a-d16f-a488-8bc6-56f6074f164e\", \"label\": \"Statements/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"stmt_type\", \"columnId\": \"5550a10a-5d61-636f-e232-b95fcb75936c\", \"label\": \"stmt_type\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rate\", \"columnId\": \"c83abc0a-d16f-a488-8bc6-56f6074f164e\", \"label\": \"Statements/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"stmt_type\", \"columnId\": \"5550a10a-5d61-636f-e232-b95fcb75936c\", \"label\": \"stmt_type\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"d91ce98f-feee-fffa-751a-2e45f3de162f\", \"gridData\": {\"x\": 0, \"y\": 29, \"w\": 48, \"h\": 3, \"i\": \"d91ce98f-feee-fffa-751a-2e45f3de162f\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Errors & Resources\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Errors & Resources\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"47f2cea8-a7d6-d7e2-b87c-689f431e14e2\", \"gridData\": {\"x\": 0, \"y\": 32, \"w\": 24, \"h\": 10, \"i\": \"47f2cea8-a7d6-d7e2-b87c-689f431e14e2\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"SQL Error Rate\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"b307fdc0-239f-ba1e-d122-70bd02c3b74d\", \"accessors\": [\"84ff45a6-8b14-b205-854b-4652a16a59ec\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_failure_count IS NOT NULL\\n| STATS fail_rate = SUM(RATE(sql_failure_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"b307fdc0-239f-ba1e-d122-70bd02c3b74d\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_failure_count IS NOT NULL\\n| STATS fail_rate = SUM(RATE(sql_failure_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"fail_rate\", \"columnId\": \"84ff45a6-8b14-b205-854b-4652a16a59ec\", \"label\": \"Failures/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"fail_rate\", \"columnId\": \"84ff45a6-8b14-b205-854b-4652a16a59ec\", \"label\": \"Failures/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"065fa6fd-a955-0e57-9ce9-18be6e209ce5\", \"gridData\": {\"x\": 24, \"y\": 32, \"w\": 24, \"h\": 10, \"i\": \"065fa6fd-a955-0e57-9ce9-18be6e209ce5\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"CPU Utilization by Node\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"a227f389-b4d4-250a-606c-2e41fb792fa2\", \"accessors\": [\"3d05970f-8dde-339b-4a2e-509e8b0f8bd2\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sys_cpu_combined_percent_normalized IS NOT NULL\\n| STATS cpu = AVG(AVG_OVER_TIME(sys_cpu_combined_percent_normalized)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"a227f389-b4d4-250a-606c-2e41fb792fa2\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sys_cpu_combined_percent_normalized IS NOT NULL\\n| STATS cpu = AVG(AVG_OVER_TIME(sys_cpu_combined_percent_normalized)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"cpu\", \"columnId\": \"3d05970f-8dde-339b-4a2e-509e8b0f8bd2\", \"label\": \"CPU %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.node_id\", \"columnId\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"label\": \"attributes.node_id\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"cpu\", \"columnId\": \"3d05970f-8dde-339b-4a2e-509e8b0f8bd2\", \"label\": \"CPU %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.node_id\", \"columnId\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"label\": \"attributes.node_id\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"718a929c-885e-5f84-2e00-7158bcf0795b\", \"gridData\": {\"x\": 0, \"y\": 42, \"w\": 24, \"h\": 10, \"i\": \"718a929c-885e-5f84-2e00-7158bcf0795b\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"SQL Connections by Node\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"5d8877cb-b113-753a-7758-ccfcbf9f6b5a\", \"accessors\": [\"3b16427e-963d-b9a3-984b-86e239911d61\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL\\n| STATS conns = MAX(LAST_OVER_TIME(sql_conns)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"5d8877cb-b113-753a-7758-ccfcbf9f6b5a\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL\\n| STATS conns = MAX(LAST_OVER_TIME(sql_conns)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"conns\", \"columnId\": \"3b16427e-963d-b9a3-984b-86e239911d61\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.node_id\", \"columnId\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"label\": \"attributes.node_id\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"conns\", \"columnId\": \"3b16427e-963d-b9a3-984b-86e239911d61\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.node_id\", \"columnId\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"label\": \"attributes.node_id\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"b53fb5c2-f2ad-0ce2-0f83-8a9053cc7608\", \"gridData\": {\"x\": 24, \"y\": 42, \"w\": 24, \"h\": 10, \"i\": \"b53fb5c2-f2ad-0ce2-0f83-8a9053cc7608\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"RPC Round-Trip Latency\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"1ea293f0-10cc-fb9c-935b-1c6bcbdefeae\", \"accessors\": [\"1817a049-abdd-1c82-f309-f3dbedfad473\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rpc_connection_avg_round_trip_latency IS NOT NULL\\n| STATS latency_ns = AVG(LAST_OVER_TIME(rpc_connection_avg_round_trip_latency)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| EVAL latency_ms = latency_ns / 1000000\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"1ea293f0-10cc-fb9c-935b-1c6bcbdefeae\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rpc_connection_avg_round_trip_latency IS NOT NULL\\n| STATS latency_ns = AVG(LAST_OVER_TIME(rpc_connection_avg_round_trip_latency)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| EVAL latency_ms = latency_ns / 1000000\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"latency_ms\", \"columnId\": \"1817a049-abdd-1c82-f309-f3dbedfad473\", \"label\": \"Latency (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \" ms\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"latency_ms\", \"columnId\": \"1817a049-abdd-1c82-f309-f3dbedfad473\", \"label\": \"Latency (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \" ms\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"166fd40d-a200-0671-1866-f2a618618bad\", \"gridData\": {\"x\": 0, \"y\": 52, \"w\": 48, \"h\": 3, \"i\": \"166fd40d-a200-0671-1866-f2a618618bad\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Detail\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Detail\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"51c0f434-0989-fccb-96f9-d383bc8af240\", \"gridData\": {\"x\": 0, \"y\": 55, \"w\": 48, \"h\": 12, \"i\": \"51c0f434-0989-fccb-96f9-d383bc8af240\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Stores by Unavailable and Under-Replicated Ranges\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"ec092daf-aacf-2d45-1465-91b9e43093f2\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"215068d9-3c1a-69b5-f341-fe571bf3a778\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"92f054d9-cc72-bdef-c205-ac8ac33e04f0\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"dee56107-75a4-b1cf-20d4-58131bb65e33\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"95223284-01eb-ae61-df26-9caf51b45dbd\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_unavailable IS NOT NULL OR ranges_underreplicated IS NOT NULL\\n| STATS unavailable = MAX(COALESCE(ranges_unavailable, 0)), underreplicated = MAX(COALESCE(ranges_underreplicated, 0)), ranges = MAX(COALESCE(ranges, 0)) BY node_id = attributes.node_id, store = attributes.store, host = resource.attributes.host.name\\n| SORT unavailable DESC, underreplicated DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"95223284-01eb-ae61-df26-9caf51b45dbd\": {\"query\": {\"esql\": \"FROM metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_unavailable IS NOT NULL OR ranges_underreplicated IS NOT NULL\\n| STATS unavailable = MAX(COALESCE(ranges_unavailable, 0)), underreplicated = MAX(COALESCE(ranges_underreplicated, 0)), ranges = MAX(COALESCE(ranges, 0)) BY node_id = attributes.node_id, store = attributes.store, host = resource.attributes.host.name\\n| SORT unavailable DESC, underreplicated DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"node_id\", \"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"label\": \"Node ID\", \"customLabel\": true}, {\"fieldName\": \"store\", \"columnId\": \"ec092daf-aacf-2d45-1465-91b9e43093f2\", \"label\": \"Store\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"ranges\", \"columnId\": \"215068d9-3c1a-69b5-f341-fe571bf3a778\", \"label\": \"Ranges\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"unavailable\", \"columnId\": \"92f054d9-cc72-bdef-c205-ac8ac33e04f0\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"underreplicated\", \"columnId\": \"dee56107-75a4-b1cf-20d4-58131bb65e33\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"node_id\", \"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"label\": \"Node ID\", \"customLabel\": true}, {\"fieldName\": \"store\", \"columnId\": \"ec092daf-aacf-2d45-1465-91b9e43093f2\", \"label\": \"Store\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"ranges\", \"columnId\": \"215068d9-3c1a-69b5-f341-fe571bf3a778\", \"label\": \"Ranges\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"unavailable\", \"columnId\": \"92f054d9-cc72-bdef-c205-ac8ac33e04f0\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"underreplicated\", \"columnId\": \"dee56107-75a4-b1cf-20d4-58131bb65e33\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "b986582c-6093-3b85-1b1f-c667124bd189",
+                "order": 1,
+                "label": "Storage",
+                "type": "dashboardLink",
+                "destinationRefName": "link_b986582c-6093-3b85-1b1f-c667124bd189_dashboard"
+              },
+              {
+                "id": "0ce5133a-1601-c0e1-50df-1375499c41f7",
+                "order": 2,
+                "label": "SQL & Transactions",
+                "type": "dashboardLink",
+                "destinationRefName": "link_0ce5133a-1601-c0e1-50df-1375499c41f7_dashboard"
+              },
+              {
+                "id": "4da2826a-7c0c-9dc0-3fe3-52ae1dc165de",
+                "order": 3,
+                "label": "Replication & Ranges",
+                "type": "dashboardLink",
+                "destinationRefName": "link_4da2826a-7c0c-9dc0-3fe3-52ae1dc165de_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "0563dba8-e018-01bf-7e3c-91932750954e",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 16,
+          "h": 12,
+          "i": "0563dba8-e018-01bf-7e3c-91932750954e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## [CockroachDB OTel] Overview\n\nThis dashboard provides cluster health and golden signals:\n- Live nodes and replication status (unavailable/under-replicated ranges)\n- SQL throughput and connection counts\n- Error rates (failures, aborts, contention)\n- CPU and memory utilization\n- Storage capacity and LSM health indicators\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "85fe31d3-39c2-098d-7621-0bfb60ec2617",
+        "gridData": {
+          "x": 16,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "85fe31d3-39c2-098d-7621-0bfb60ec2617"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Live Nodes",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "73fe9ed6-3e8b-7f8d-9fd8-a8b68e3507f9",
+                "layerType": "data",
+                "metricAccessor": "4dd919fa-c329-21c9-e733-9bc4060e671d",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE liveness_livenodes IS NOT NULL\n| STATS live_nodes = MAX(LAST_OVER_TIME(liveness_livenodes))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "73fe9ed6-3e8b-7f8d-9fd8-a8b68e3507f9": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE liveness_livenodes IS NOT NULL\n| STATS live_nodes = MAX(LAST_OVER_TIME(liveness_livenodes))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "live_nodes",
+                          "columnId": "4dd919fa-c329-21c9-e733-9bc4060e671d",
+                          "label": "Live Nodes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "live_nodes",
+                          "columnId": "4dd919fa-c329-21c9-e733-9bc4060e671d",
+                          "label": "Live Nodes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "2adb512e-3b90-5c72-229f-1c4e2cf74ab5",
+        "gridData": {
+          "x": 24,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "2adb512e-3b90-5c72-229f-1c4e2cf74ab5"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unavailable Ranges",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "0663746f-6668-62f3-bdd0-e17117b906e4",
+                "layerType": "data",
+                "metricAccessor": "16feeb31-ae6c-2035-e385-23308694d955",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_unavailable IS NOT NULL\n| STATS unavailable = MAX(LAST_OVER_TIME(ranges_unavailable))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "0663746f-6668-62f3-bdd0-e17117b906e4": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_unavailable IS NOT NULL\n| STATS unavailable = MAX(LAST_OVER_TIME(ranges_unavailable))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "16feeb31-ae6c-2035-e385-23308694d955",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "16feeb31-ae6c-2035-e385-23308694d955",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "2081f589-c35c-9d64-6ce3-369784734a43",
+        "gridData": {
+          "x": 32,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "2081f589-c35c-9d64-6ce3-369784734a43"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Under-Replicated Ranges",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "df2a3bb8-f4f8-cf30-d40e-2c38ddd029e1",
+                "layerType": "data",
+                "metricAccessor": "675c390f-4892-5fe5-7a81-67c0d2a5ffa7",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_underreplicated IS NOT NULL\n| STATS underreplicated = MAX(LAST_OVER_TIME(ranges_underreplicated))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "df2a3bb8-f4f8-cf30-d40e-2c38ddd029e1": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_underreplicated IS NOT NULL\n| STATS underreplicated = MAX(LAST_OVER_TIME(ranges_underreplicated))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "underreplicated",
+                          "columnId": "675c390f-4892-5fe5-7a81-67c0d2a5ffa7",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "underreplicated",
+                          "columnId": "675c390f-4892-5fe5-7a81-67c0d2a5ffa7",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "9c04f562-44dd-305c-0799-ef4963337ce1",
+        "gridData": {
+          "x": 40,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "9c04f562-44dd-305c-0799-ef4963337ce1"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "SQL Connections",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "bc739b12-051a-1845-a561-bbd7eaeb7cdd",
+                "layerType": "data",
+                "metricAccessor": "54eb225e-d32d-0c12-87b2-39b1e449eb24",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL\n| STATS conns = SUM(LAST_OVER_TIME(sql_conns))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "bc739b12-051a-1845-a561-bbd7eaeb7cdd": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL\n| STATS conns = SUM(LAST_OVER_TIME(sql_conns))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "conns",
+                          "columnId": "54eb225e-d32d-0c12-87b2-39b1e449eb24",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "conns",
+                          "columnId": "54eb225e-d32d-0c12-87b2-39b1e449eb24",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "a18576df-58ee-a92f-73d2-30d71ece3cfa",
+        "gridData": {
+          "x": 16,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "a18576df-58ee-a92f-73d2-30d71ece3cfa"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "SQL Failures (rate)",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "7ca3e837-63c7-1edf-1afc-5a288f101dad",
+                "layerType": "data",
+                "metricAccessor": "8a0fdda1-1c1f-8cb6-97a6-774336468203",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_failure_count IS NOT NULL\n| STATS fail_rate = SUM(RATE(sql_failure_count))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "7ca3e837-63c7-1edf-1afc-5a288f101dad": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_failure_count IS NOT NULL\n| STATS fail_rate = SUM(RATE(sql_failure_count))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "fail_rate",
+                          "columnId": "8a0fdda1-1c1f-8cb6-97a6-774336468203",
+                          "label": "Failures/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "fail_rate",
+                          "columnId": "8a0fdda1-1c1f-8cb6-97a6-774336468203",
+                          "label": "Failures/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "253dbdde-bc54-c1f4-0eaf-d2e8387f2c4b",
+        "gridData": {
+          "x": 24,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "253dbdde-bc54-c1f4-0eaf-d2e8387f2c4b"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "CPU Utilization",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "cd9d96e1-f9da-56f8-391b-58be6afe29dc",
+                "layerType": "data",
+                "metricAccessor": "332d305c-0d34-8b87-eef2-744cee3e8914",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sys_cpu_combined_percent_normalized IS NOT NULL\n| STATS avg_cpu = AVG(AVG_OVER_TIME(sys_cpu_combined_percent_normalized))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cd9d96e1-f9da-56f8-391b-58be6afe29dc": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sys_cpu_combined_percent_normalized IS NOT NULL\n| STATS avg_cpu = AVG(AVG_OVER_TIME(sys_cpu_combined_percent_normalized))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "avg_cpu",
+                          "columnId": "332d305c-0d34-8b87-eef2-744cee3e8914",
+                          "label": "CPU %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "avg_cpu",
+                          "columnId": "332d305c-0d34-8b87-eef2-744cee3e8914",
+                          "label": "CPU %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "96315cee-00f8-dc49-287c-5586ec57cb03",
+        "gridData": {
+          "x": 32,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "96315cee-00f8-dc49-287c-5586ec57cb03"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "IO Overload",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "31107a35-ca00-d025-7169-5fcdd594d99c",
+                "layerType": "data",
+                "metricAccessor": "4db5cf58-cf78-3468-f88c-d4637075ca22",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE admission_io_overload IS NOT NULL\n| STATS avg_io = AVG(AVG_OVER_TIME(admission_io_overload))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "31107a35-ca00-d025-7169-5fcdd594d99c": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE admission_io_overload IS NOT NULL\n| STATS avg_io = AVG(AVG_OVER_TIME(admission_io_overload))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "avg_io",
+                          "columnId": "4db5cf58-cf78-3468-f88c-d4637075ca22",
+                          "label": "IO Overload",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "avg_io",
+                          "columnId": "4db5cf58-cf78-3468-f88c-d4637075ca22",
+                          "label": "IO Overload",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "55f5b21e-5abf-aff0-00f9-621cd9edc51f",
+        "gridData": {
+          "x": 40,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "55f5b21e-5abf-aff0-00f9-621cd9edc51f"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Write Stalls",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "9a0d002c-2635-c43f-352c-255d62d3107a",
+                "layerType": "data",
+                "metricAccessor": "e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_write_stalls IS NOT NULL\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "9a0d002c-2635-c43f-352c-255d62d3107a": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_write_stalls IS NOT NULL\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "stalls",
+                          "columnId": "e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8",
+                          "label": "Write Stalls",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "stalls",
+                          "columnId": "e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8",
+                          "label": "Write Stalls",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "c5796a7f-4774-9b72-64e5-2eb4a44ff69d",
+        "gridData": {
+          "x": 0,
+          "y": 14,
+          "w": 48,
+          "h": 3,
+          "i": "c5796a7f-4774-9b72-64e5-2eb4a44ff69d"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "SQL Throughput",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## SQL Throughput"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "cea8ca49-7315-884e-8fcc-f84e82e3b78d",
+        "gridData": {
+          "x": 0,
+          "y": 17,
+          "w": 48,
+          "h": 12,
+          "i": "cea8ca49-7315-884e-8fcc-f84e82e3b78d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Statement Rate by Type",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "f55da783-4810-f2be-77db-aeeb36a39e4b",
+                    "accessors": [
+                      "c83abc0a-d16f-a488-8bc6-56f6074f164e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "5550a10a-5d61-636f-e232-b95fcb75936c",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE sql_select_count IS NOT NULL | STATS rate = SUM(RATE(sql_select_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"SELECT\" ) ( WHERE sql_insert_count IS NOT NULL | STATS rate = SUM(RATE(sql_insert_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"INSERT\" ) ( WHERE sql_update_count IS NOT NULL | STATS rate = SUM(RATE(sql_update_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"UPDATE\" ) ( WHERE sql_delete_count IS NOT NULL | STATS rate = SUM(RATE(sql_delete_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"DELETE\" )\n| STATS rate = SUM(rate) BY time_bucket, stmt_type\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "f55da783-4810-f2be-77db-aeeb36a39e4b": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE sql_select_count IS NOT NULL | STATS rate = SUM(RATE(sql_select_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"SELECT\" ) ( WHERE sql_insert_count IS NOT NULL | STATS rate = SUM(RATE(sql_insert_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"INSERT\" ) ( WHERE sql_update_count IS NOT NULL | STATS rate = SUM(RATE(sql_update_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"UPDATE\" ) ( WHERE sql_delete_count IS NOT NULL | STATS rate = SUM(RATE(sql_delete_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"DELETE\" )\n| STATS rate = SUM(rate) BY time_bucket, stmt_type\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "c83abc0a-d16f-a488-8bc6-56f6074f164e",
+                          "label": "Statements/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "stmt_type",
+                          "columnId": "5550a10a-5d61-636f-e232-b95fcb75936c",
+                          "label": "stmt_type",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "c83abc0a-d16f-a488-8bc6-56f6074f164e",
+                          "label": "Statements/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "stmt_type",
+                          "columnId": "5550a10a-5d61-636f-e232-b95fcb75936c",
+                          "label": "stmt_type",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "d91ce98f-feee-fffa-751a-2e45f3de162f",
+        "gridData": {
+          "x": 0,
+          "y": 29,
+          "w": 48,
+          "h": 3,
+          "i": "d91ce98f-feee-fffa-751a-2e45f3de162f"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Errors & Resources",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Errors & Resources"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "47f2cea8-a7d6-d7e2-b87c-689f431e14e2",
+        "gridData": {
+          "x": 0,
+          "y": 32,
+          "w": 24,
+          "h": 10,
+          "i": "47f2cea8-a7d6-d7e2-b87c-689f431e14e2"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "SQL Error Rate",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "b307fdc0-239f-ba1e-d122-70bd02c3b74d",
+                    "accessors": [
+                      "84ff45a6-8b14-b205-854b-4652a16a59ec"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_failure_count IS NOT NULL\n| STATS fail_rate = SUM(RATE(sql_failure_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "b307fdc0-239f-ba1e-d122-70bd02c3b74d": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_failure_count IS NOT NULL\n| STATS fail_rate = SUM(RATE(sql_failure_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "fail_rate",
+                          "columnId": "84ff45a6-8b14-b205-854b-4652a16a59ec",
+                          "label": "Failures/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "fail_rate",
+                          "columnId": "84ff45a6-8b14-b205-854b-4652a16a59ec",
+                          "label": "Failures/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "065fa6fd-a955-0e57-9ce9-18be6e209ce5",
+        "gridData": {
+          "x": 24,
+          "y": 32,
+          "w": 24,
+          "h": 10,
+          "i": "065fa6fd-a955-0e57-9ce9-18be6e209ce5"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "CPU Utilization by Node",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "a227f389-b4d4-250a-606c-2e41fb792fa2",
+                    "accessors": [
+                      "3d05970f-8dde-339b-4a2e-509e8b0f8bd2"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sys_cpu_combined_percent_normalized IS NOT NULL\n| STATS cpu = AVG(AVG_OVER_TIME(sys_cpu_combined_percent_normalized)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "a227f389-b4d4-250a-606c-2e41fb792fa2": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sys_cpu_combined_percent_normalized IS NOT NULL\n| STATS cpu = AVG(AVG_OVER_TIME(sys_cpu_combined_percent_normalized)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "cpu",
+                          "columnId": "3d05970f-8dde-339b-4a2e-509e8b0f8bd2",
+                          "label": "CPU %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.node_id",
+                          "columnId": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                          "label": "attributes.node_id",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "cpu",
+                          "columnId": "3d05970f-8dde-339b-4a2e-509e8b0f8bd2",
+                          "label": "CPU %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.node_id",
+                          "columnId": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                          "label": "attributes.node_id",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "718a929c-885e-5f84-2e00-7158bcf0795b",
+        "gridData": {
+          "x": 0,
+          "y": 42,
+          "w": 24,
+          "h": 10,
+          "i": "718a929c-885e-5f84-2e00-7158bcf0795b"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "SQL Connections by Node",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "5d8877cb-b113-753a-7758-ccfcbf9f6b5a",
+                    "accessors": [
+                      "3b16427e-963d-b9a3-984b-86e239911d61"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL\n| STATS conns = MAX(LAST_OVER_TIME(sql_conns)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "5d8877cb-b113-753a-7758-ccfcbf9f6b5a": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL\n| STATS conns = MAX(LAST_OVER_TIME(sql_conns)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "conns",
+                          "columnId": "3b16427e-963d-b9a3-984b-86e239911d61",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.node_id",
+                          "columnId": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                          "label": "attributes.node_id",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "conns",
+                          "columnId": "3b16427e-963d-b9a3-984b-86e239911d61",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.node_id",
+                          "columnId": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                          "label": "attributes.node_id",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "b53fb5c2-f2ad-0ce2-0f83-8a9053cc7608",
+        "gridData": {
+          "x": 24,
+          "y": 42,
+          "w": 24,
+          "h": 10,
+          "i": "b53fb5c2-f2ad-0ce2-0f83-8a9053cc7608"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "RPC Round-Trip Latency",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "1ea293f0-10cc-fb9c-935b-1c6bcbdefeae",
+                    "accessors": [
+                      "1817a049-abdd-1c82-f309-f3dbedfad473"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rpc_connection_avg_round_trip_latency IS NOT NULL\n| STATS latency_ns = AVG(LAST_OVER_TIME(rpc_connection_avg_round_trip_latency)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL latency_ms = latency_ns / 1000000\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "1ea293f0-10cc-fb9c-935b-1c6bcbdefeae": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rpc_connection_avg_round_trip_latency IS NOT NULL\n| STATS latency_ns = AVG(LAST_OVER_TIME(rpc_connection_avg_round_trip_latency)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL latency_ms = latency_ns / 1000000\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "latency_ms",
+                          "columnId": "1817a049-abdd-1c82-f309-f3dbedfad473",
+                          "label": "Latency (ms)",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": " ms"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "latency_ms",
+                          "columnId": "1817a049-abdd-1c82-f309-f3dbedfad473",
+                          "label": "Latency (ms)",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": " ms"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "166fd40d-a200-0671-1866-f2a618618bad",
+        "gridData": {
+          "x": 0,
+          "y": 52,
+          "w": 48,
+          "h": 3,
+          "i": "166fd40d-a200-0671-1866-f2a618618bad"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Detail",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Detail"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "51c0f434-0989-fccb-96f9-d383bc8af240",
+        "gridData": {
+          "x": 0,
+          "y": 55,
+          "w": 48,
+          "h": 12,
+          "i": "51c0f434-0989-fccb-96f9-d383bc8af240"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Stores by Unavailable and Under-Replicated Ranges",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "ec092daf-aacf-2d45-1465-91b9e43093f2",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "215068d9-3c1a-69b5-f341-fe571bf3a778",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "92f054d9-cc72-bdef-c205-ac8ac33e04f0",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "dee56107-75a4-b1cf-20d4-58131bb65e33",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "95223284-01eb-ae61-df26-9caf51b45dbd",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "FROM metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_unavailable IS NOT NULL OR ranges_underreplicated IS NOT NULL\n| STATS unavailable = MAX(COALESCE(ranges_unavailable, 0)), underreplicated = MAX(COALESCE(ranges_underreplicated, 0)), ranges = MAX(COALESCE(ranges, 0)) BY node_id = attributes.node_id, store = attributes.store, host = resource.attributes.host.name\n| SORT unavailable DESC, underreplicated DESC\n| LIMIT 50"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "95223284-01eb-ae61-df26-9caf51b45dbd": {
+                      "query": {
+                        "esql": "FROM metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_unavailable IS NOT NULL OR ranges_underreplicated IS NOT NULL\n| STATS unavailable = MAX(COALESCE(ranges_unavailable, 0)), underreplicated = MAX(COALESCE(ranges_underreplicated, 0)), ranges = MAX(COALESCE(ranges, 0)) BY node_id = attributes.node_id, store = attributes.store, host = resource.attributes.host.name\n| SORT unavailable DESC, underreplicated DESC\n| LIMIT 50"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "node_id",
+                          "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                          "label": "Node ID",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "store",
+                          "columnId": "ec092daf-aacf-2d45-1465-91b9e43093f2",
+                          "label": "Store",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "host",
+                          "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                          "label": "Host",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "ranges",
+                          "columnId": "215068d9-3c1a-69b5-f341-fe571bf3a778",
+                          "label": "Ranges",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "92f054d9-cc72-bdef-c205-ac8ac33e04f0",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "underreplicated",
+                          "columnId": "dee56107-75a4-b1cf-20d4-58131bb65e33",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "node_id",
+                          "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                          "label": "Node ID",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "store",
+                          "columnId": "ec092daf-aacf-2d45-1465-91b9e43093f2",
+                          "label": "Store",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "host",
+                          "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                          "label": "Host",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "ranges",
+                          "columnId": "215068d9-3c1a-69b5-f341-fe571bf3a778",
+                          "label": "Ranges",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "92f054d9-cc72-bdef-c205-ac8ac33e04f0",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "underreplicated",
+                          "columnId": "dee56107-75a4-b1cf-20d4-58131bb65e33",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"resource.attributes.service.name\",\"field\":\"resource.attributes.service.name\",\"params\":{\"query\":\"cockroachdb\"}},\"query\":{\"match_phrase\":{\"resource.attributes.service.name\":\"cockroachdb\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "resource.attributes.service.name",
+              "field": "resource.attributes.service.name",
+              "params": {
+                "query": "cockroachdb"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "resource.attributes.service.name": "cockroachdb"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": false,
     "version": 1,
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"2283c92c-f236-d98b-8f14-b4f4a80d676a\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2283c92c-f236-d98b-8f14-b4f4a80d676a\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"attributes.node_id\",\"title\":\"Node\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "2283c92c-f236-d98b-8f14-b4f4a80d676a": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "2283c92c-f236-d98b-8f14-b4f4a80d676a",
+            "dataViewId": "metrics-*",
+            "fieldName": "attributes.node_id",
+            "title": "Node",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/cockroachdb_otel/kibana/dashboard/cockroachdb_otel-replication.json
+++ b/packages/cockroachdb_otel/kibana/dashboard/cockroachdb_otel-replication.json
@@ -2,18 +2,2422 @@
   "attributes": {
     "title": "[CockroachDB OTel] Replication & Ranges",
     "description": "Range distribution, replication health, and rebalancing activity. Monitor ranges per store, unavailable/under-replicated ranges, lease transfers, and rebalancing.",
-    "panelsJSON": "[{\"panelIndex\": \"91144e9b-fac7-b44d-0b1d-8339201b83cb\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"91144e9b-fac7-b44d-0b1d-8339201b83cb\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"b986582c-6093-3b85-1b1f-c667124bd189\", \"order\": 1, \"label\": \"Storage\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_b986582c-6093-3b85-1b1f-c667124bd189_dashboard\"}, {\"id\": \"0ce5133a-1601-c0e1-50df-1375499c41f7\", \"order\": 2, \"label\": \"SQL & Transactions\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_0ce5133a-1601-c0e1-50df-1375499c41f7_dashboard\"}, {\"id\": \"4da2826a-7c0c-9dc0-3fe3-52ae1dc165de\", \"order\": 3, \"label\": \"Replication & Ranges\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_4da2826a-7c0c-9dc0-3fe3-52ae1dc165de_dashboard\"}]}}}, {\"panelIndex\": \"0563dba8-e018-01bf-7e3c-91932750954e\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 16, \"h\": 12, \"i\": \"0563dba8-e018-01bf-7e3c-91932750954e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [CockroachDB OTel] Replication & Ranges\\n\\nThis dashboard monitors replication and range distribution:\\n- Live nodes and liveness heartbeats\\n- Ranges and replicas per store\\n- Unavailable and under-replicated ranges\\n- Lease transfers and rebalancing activity\\n- Range splits and merges\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"85fe31d3-39c2-098d-7621-0bfb60ec2617\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"85fe31d3-39c2-098d-7621-0bfb60ec2617\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Live Nodes\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"0ab9ff29-09fd-f1ac-5f77-1e62d3d4dcae\", \"layerType\": \"data\", \"metricAccessor\": \"3a97c1dc-bbfd-b401-26ed-c034eaed5f2b\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE liveness_livenodes IS NOT NULL\\n| STATS live = MAX(LAST_OVER_TIME(liveness_livenodes))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"0ab9ff29-09fd-f1ac-5f77-1e62d3d4dcae\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE liveness_livenodes IS NOT NULL\\n| STATS live = MAX(LAST_OVER_TIME(liveness_livenodes))\"}, \"columns\": [{\"fieldName\": \"live\", \"columnId\": \"3a97c1dc-bbfd-b401-26ed-c034eaed5f2b\", \"label\": \"Live Nodes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"live\", \"columnId\": \"3a97c1dc-bbfd-b401-26ed-c034eaed5f2b\", \"label\": \"Live Nodes\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f399931d-7719-b6c1-7817-fdab2693864c\", \"gridData\": {\"x\": 24, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"f399931d-7719-b6c1-7817-fdab2693864c\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Total Ranges\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"3e829a25-33d2-fcff-a47c-36ae677a0e37\", \"layerType\": \"data\", \"metricAccessor\": \"48f690c2-871b-c208-b922-f5f244639ab6\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges IS NOT NULL\\n| STATS total = SUM(LAST_OVER_TIME(ranges))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"3e829a25-33d2-fcff-a47c-36ae677a0e37\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges IS NOT NULL\\n| STATS total = SUM(LAST_OVER_TIME(ranges))\"}, \"columns\": [{\"fieldName\": \"total\", \"columnId\": \"48f690c2-871b-c208-b922-f5f244639ab6\", \"label\": \"Ranges\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"total\", \"columnId\": \"48f690c2-871b-c208-b922-f5f244639ab6\", \"label\": \"Ranges\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"e86a3981-7746-72b6-94e2-6a0faa746a7b\", \"gridData\": {\"x\": 32, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"e86a3981-7746-72b6-94e2-6a0faa746a7b\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Unavailable Ranges\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"cf65b417-5ea3-fef4-e8d0-8b992a644597\", \"layerType\": \"data\", \"metricAccessor\": \"16feeb31-ae6c-2035-e385-23308694d955\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_unavailable IS NOT NULL\\n| STATS unavailable = SUM(LAST_OVER_TIME(ranges_unavailable))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cf65b417-5ea3-fef4-e8d0-8b992a644597\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_unavailable IS NOT NULL\\n| STATS unavailable = SUM(LAST_OVER_TIME(ranges_unavailable))\"}, \"columns\": [{\"fieldName\": \"unavailable\", \"columnId\": \"16feeb31-ae6c-2035-e385-23308694d955\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"unavailable\", \"columnId\": \"16feeb31-ae6c-2035-e385-23308694d955\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"79d98faa-ca65-4bec-5571-d54676339d90\", \"gridData\": {\"x\": 40, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"79d98faa-ca65-4bec-5571-d54676339d90\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Under-Replicated\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"cbfb7201-b53a-7f53-d603-4366f77a29f2\", \"layerType\": \"data\", \"metricAccessor\": \"0593e549-7b17-f543-e604-ddfd90c103cd\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_underreplicated IS NOT NULL\\n| STATS under = SUM(LAST_OVER_TIME(ranges_underreplicated))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cbfb7201-b53a-7f53-d603-4366f77a29f2\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_underreplicated IS NOT NULL\\n| STATS under = SUM(LAST_OVER_TIME(ranges_underreplicated))\"}, \"columns\": [{\"fieldName\": \"under\", \"columnId\": \"0593e549-7b17-f543-e604-ddfd90c103cd\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"under\", \"columnId\": \"0593e549-7b17-f543-e604-ddfd90c103cd\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"8c51c833-272e-371d-7f3f-82f2f032459e\", \"gridData\": {\"x\": 16, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"8c51c833-272e-371d-7f3f-82f2f032459e\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Lease Transfers (rate)\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"f5b2a691-9daa-1429-cb7d-d9daff6aa5da\", \"layerType\": \"data\", \"metricAccessor\": \"a837ccd6-b387-f1a9-2342-032736a877ad\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE leases_transfers_success IS NOT NULL\\n| STATS rate = SUM(RATE(leases_transfers_success))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"f5b2a691-9daa-1429-cb7d-d9daff6aa5da\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE leases_transfers_success IS NOT NULL\\n| STATS rate = SUM(RATE(leases_transfers_success))\"}, \"columns\": [{\"fieldName\": \"rate\", \"columnId\": \"a837ccd6-b387-f1a9-2342-032736a877ad\", \"label\": \"Transfers/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"allColumns\": [{\"fieldName\": \"rate\", \"columnId\": \"a837ccd6-b387-f1a9-2342-032736a877ad\", \"label\": \"Transfers/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"7f89b852-452d-41dc-1658-37e5fc6ccfe7\", \"gridData\": {\"x\": 24, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"7f89b852-452d-41dc-1658-37e5fc6ccfe7\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Lease Transfer Errors\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"018e25ca-a360-443e-8dfa-1ce9a2761575\", \"layerType\": \"data\", \"metricAccessor\": \"4d9d3d0e-6d21-1896-8080-6b3d08046a31\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE leases_transfers_error IS NOT NULL\\n| STATS err_rate = SUM(RATE(leases_transfers_error))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"018e25ca-a360-443e-8dfa-1ce9a2761575\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE leases_transfers_error IS NOT NULL\\n| STATS err_rate = SUM(RATE(leases_transfers_error))\"}, \"columns\": [{\"fieldName\": \"err_rate\", \"columnId\": \"4d9d3d0e-6d21-1896-8080-6b3d08046a31\", \"label\": \"Errors/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"allColumns\": [{\"fieldName\": \"err_rate\", \"columnId\": \"4d9d3d0e-6d21-1896-8080-6b3d08046a31\", \"label\": \"Errors/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"3a8daffd-fb51-b653-b647-ac16b21762b5\", \"gridData\": {\"x\": 0, \"y\": 14, \"w\": 48, \"h\": 3, \"i\": \"3a8daffd-fb51-b653-b647-ac16b21762b5\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Replication Status\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Replication Status\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"a335324e-9dc2-e659-8efd-01318f7e9c63\", \"gridData\": {\"x\": 0, \"y\": 17, \"w\": 24, \"h\": 10, \"i\": \"a335324e-9dc2-e659-8efd-01318f7e9c63\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Unavailable Ranges by Store\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"53481c5d-ecfb-2355-6e12-74f156e7caa5\", \"accessors\": [\"bfb7762f-984d-bc09-d2c3-f992b69463c3\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_unavailable IS NOT NULL\\n| STATS unavailable = MAX(LAST_OVER_TIME(ranges_unavailable)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"53481c5d-ecfb-2355-6e12-74f156e7caa5\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_unavailable IS NOT NULL\\n| STATS unavailable = MAX(LAST_OVER_TIME(ranges_unavailable)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"unavailable\", \"columnId\": \"bfb7762f-984d-bc09-d2c3-f992b69463c3\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"unavailable\", \"columnId\": \"bfb7762f-984d-bc09-d2c3-f992b69463c3\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"1fd46856-739f-0173-34c2-fa463492b1ab\", \"gridData\": {\"x\": 24, \"y\": 17, \"w\": 24, \"h\": 10, \"i\": \"1fd46856-739f-0173-34c2-fa463492b1ab\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Under-Replicated Ranges by Store\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"64b64d74-580e-e839-e678-94ecadb75ff2\", \"accessors\": [\"aec822d0-7b26-4f17-5ad1-48c3336204fa\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_underreplicated IS NOT NULL\\n| STATS underreplicated = MAX(LAST_OVER_TIME(ranges_underreplicated)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"64b64d74-580e-e839-e678-94ecadb75ff2\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges_underreplicated IS NOT NULL\\n| STATS underreplicated = MAX(LAST_OVER_TIME(ranges_underreplicated)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"underreplicated\", \"columnId\": \"aec822d0-7b26-4f17-5ad1-48c3336204fa\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"underreplicated\", \"columnId\": \"aec822d0-7b26-4f17-5ad1-48c3336204fa\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"35ea9465-b9a4-cce1-b60e-55457360fb1d\", \"gridData\": {\"x\": 0, \"y\": 27, \"w\": 48, \"h\": 3, \"i\": \"35ea9465-b9a4-cce1-b60e-55457360fb1d\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Range Distribution\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Range Distribution\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"20ed7679-3fb7-20fe-9f3b-5ecb88f2b2dc\", \"gridData\": {\"x\": 0, \"y\": 30, \"w\": 24, \"h\": 10, \"i\": \"20ed7679-3fb7-20fe-9f3b-5ecb88f2b2dc\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Ranges and Leaseholders by Store\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"c5bbc738-7841-f1bd-7680-20419364aa9f\", \"accessors\": [\"bb565d86-81d9-2bc3-6430-dd233cb3c45f\", \"31bbb5d6-9321-0582-0e31-5c9c890005c4\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges IS NOT NULL OR replicas_leaseholders IS NOT NULL\\n| STATS ranges_count = AVG(LAST_OVER_TIME(ranges)), leaseholders = AVG(LAST_OVER_TIME(replicas_leaseholders)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| EVAL ranges_count = COALESCE(ranges_count, 0)\\n| EVAL leaseholders = COALESCE(leaseholders, 0)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"c5bbc738-7841-f1bd-7680-20419364aa9f\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges IS NOT NULL OR replicas_leaseholders IS NOT NULL\\n| STATS ranges_count = AVG(LAST_OVER_TIME(ranges)), leaseholders = AVG(LAST_OVER_TIME(replicas_leaseholders)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| EVAL ranges_count = COALESCE(ranges_count, 0)\\n| EVAL leaseholders = COALESCE(leaseholders, 0)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"ranges_count\", \"columnId\": \"bb565d86-81d9-2bc3-6430-dd233cb3c45f\", \"label\": \"Ranges\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"leaseholders\", \"columnId\": \"31bbb5d6-9321-0582-0e31-5c9c890005c4\", \"label\": \"Leaseholders\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"ranges_count\", \"columnId\": \"bb565d86-81d9-2bc3-6430-dd233cb3c45f\", \"label\": \"Ranges\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"leaseholders\", \"columnId\": \"31bbb5d6-9321-0582-0e31-5c9c890005c4\", \"label\": \"Leaseholders\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"7c843a5e-3c27-09da-7b7e-f65898c2e2a4\", \"gridData\": {\"x\": 24, \"y\": 30, \"w\": 24, \"h\": 10, \"i\": \"7c843a5e-3c27-09da-7b7e-f65898c2e2a4\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Replicas by Store\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"df2003ed-e97e-90d8-7f20-5fbf89622f44\", \"accessors\": [\"ef9ed33a-23fe-07c0-5be2-7f153cf45ae3\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE replicas IS NOT NULL\\n| STATS replicas_count = MAX(LAST_OVER_TIME(replicas)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"df2003ed-e97e-90d8-7f20-5fbf89622f44\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE replicas IS NOT NULL\\n| STATS replicas_count = MAX(LAST_OVER_TIME(replicas)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"replicas_count\", \"columnId\": \"ef9ed33a-23fe-07c0-5be2-7f153cf45ae3\", \"label\": \"Replicas\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"replicas_count\", \"columnId\": \"ef9ed33a-23fe-07c0-5be2-7f153cf45ae3\", \"label\": \"Replicas\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"9ba98426-1658-9fd4-36ad-e4062963db5c\", \"gridData\": {\"x\": 0, \"y\": 40, \"w\": 48, \"h\": 3, \"i\": \"9ba98426-1658-9fd4-36ad-e4062963db5c\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Rebalancing\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Rebalancing\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"8316ad52-69f5-2686-f57f-0bba90ea69a2\", \"gridData\": {\"x\": 0, \"y\": 43, \"w\": 48, \"h\": 10, \"i\": \"8316ad52-69f5-2686-f57f-0bba90ea69a2\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Lease Transfers and Range Rebalances\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"05b04a71-1f6d-d97d-5b74-dac5880eefb8\", \"accessors\": [\"acbe57cb-7673-b948-23ea-86291bc8aaae\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"6639ccba-e614-f27f-4fcb-187e9a9456a0\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE rebalancing_lease_transfers IS NOT NULL | STATS rate = SUM(RATE(rebalancing_lease_transfers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \\\"Lease Transfers\\\" ) ( WHERE rebalancing_range_rebalances IS NOT NULL | STATS rate = SUM(RATE(rebalancing_range_rebalances)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \\\"Range Rebalances\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, op\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"05b04a71-1f6d-d97d-5b74-dac5880eefb8\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE rebalancing_lease_transfers IS NOT NULL | STATS rate = SUM(RATE(rebalancing_lease_transfers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \\\"Lease Transfers\\\" ) ( WHERE rebalancing_range_rebalances IS NOT NULL | STATS rate = SUM(RATE(rebalancing_range_rebalances)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \\\"Range Rebalances\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, op\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"rate\", \"columnId\": \"acbe57cb-7673-b948-23ea-86291bc8aaae\", \"label\": \"Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"op\", \"columnId\": \"6639ccba-e614-f27f-4fcb-187e9a9456a0\", \"label\": \"op\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rate\", \"columnId\": \"acbe57cb-7673-b948-23ea-86291bc8aaae\", \"label\": \"Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"op\", \"columnId\": \"6639ccba-e614-f27f-4fcb-187e9a9456a0\", \"label\": \"op\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"51c04c8a-d21c-f9c3-2169-b8434b755e6c\", \"gridData\": {\"x\": 0, \"y\": 53, \"w\": 24, \"h\": 10, \"i\": \"51c04c8a-d21c-f9c3-2169-b8434b755e6c\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Liveness Heartbeats\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"265fa52e-e6f6-a66d-b1c0-4b828e9402ac\", \"accessors\": [\"f0cbc336-3d3b-b19e-4dbf-a0818353fbcc\", \"12344e37-ef83-d514-1e76-811e56b08289\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE liveness_heartbeatfailures IS NOT NULL OR liveness_heartbeatsuccesses IS NOT NULL\\n| STATS failures = SUM(RATE(liveness_heartbeatfailures)), successes = SUM(RATE(liveness_heartbeatsuccesses)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| EVAL failures = COALESCE(failures, 0)\\n| EVAL successes = COALESCE(successes, 0)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"265fa52e-e6f6-a66d-b1c0-4b828e9402ac\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE liveness_heartbeatfailures IS NOT NULL OR liveness_heartbeatsuccesses IS NOT NULL\\n| STATS failures = SUM(RATE(liveness_heartbeatfailures)), successes = SUM(RATE(liveness_heartbeatsuccesses)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| EVAL failures = COALESCE(failures, 0)\\n| EVAL successes = COALESCE(successes, 0)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"failures\", \"columnId\": \"f0cbc336-3d3b-b19e-4dbf-a0818353fbcc\", \"label\": \"Failures/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"successes\", \"columnId\": \"12344e37-ef83-d514-1e76-811e56b08289\", \"label\": \"Successes/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"failures\", \"columnId\": \"f0cbc336-3d3b-b19e-4dbf-a0818353fbcc\", \"label\": \"Failures/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"successes\", \"columnId\": \"12344e37-ef83-d514-1e76-811e56b08289\", \"label\": \"Successes/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"43633d31-cc2b-cc07-1152-cad66174a452\", \"gridData\": {\"x\": 24, \"y\": 53, \"w\": 24, \"h\": 10, \"i\": \"43633d31-cc2b-cc07-1152-cad66174a452\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Range Splits and Merges\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cfb9d919-c927-a47b-a1ea-12c34433e2b6\", \"accessors\": [\"acbe57cb-7673-b948-23ea-86291bc8aaae\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"6639ccba-e614-f27f-4fcb-187e9a9456a0\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE range_splits IS NOT NULL | STATS rate = SUM(RATE(range_splits)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \\\"Splits\\\" ) ( WHERE range_merges IS NOT NULL | STATS rate = SUM(RATE(range_merges)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \\\"Merges\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, op\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cfb9d919-c927-a47b-a1ea-12c34433e2b6\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE range_splits IS NOT NULL | STATS rate = SUM(RATE(range_splits)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \\\"Splits\\\" ) ( WHERE range_merges IS NOT NULL | STATS rate = SUM(RATE(range_merges)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \\\"Merges\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, op\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"rate\", \"columnId\": \"acbe57cb-7673-b948-23ea-86291bc8aaae\", \"label\": \"Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"op\", \"columnId\": \"6639ccba-e614-f27f-4fcb-187e9a9456a0\", \"label\": \"op\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rate\", \"columnId\": \"acbe57cb-7673-b948-23ea-86291bc8aaae\", \"label\": \"Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"op\", \"columnId\": \"6639ccba-e614-f27f-4fcb-187e9a9456a0\", \"label\": \"op\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"7aae511f-aafd-88ff-4718-595b8916fe00\", \"gridData\": {\"x\": 0, \"y\": 63, \"w\": 48, \"h\": 3, \"i\": \"7aae511f-aafd-88ff-4718-595b8916fe00\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Detail\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Detail\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"c7d1f6df-982a-46ec-dede-1133b44c64f7\", \"gridData\": {\"x\": 0, \"y\": 66, \"w\": 48, \"h\": 12, \"i\": \"c7d1f6df-982a-46ec-dede-1133b44c64f7\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Store Summary\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"ec092daf-aacf-2d45-1465-91b9e43093f2\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"4d5e49a9-57a4-7882-28b3-d288fa5c44e3\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"619037af-10c6-4dfb-6310-2b7ea9719473\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"190dfa59-3b76-e03b-0ade-e4df202b867f\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"92f054d9-cc72-bdef-c205-ac8ac33e04f0\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"dee56107-75a4-b1cf-20d4-58131bb65e33\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"451d6bd3-44b6-a6df-9d2d-dfbf816cb83b\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges IS NOT NULL\\n| STATS ranges_count = MAX(ranges), replicas_count = MAX(replicas), leaseholders = MAX(replicas_leaseholders), unavailable = MAX(COALESCE(ranges_unavailable, 0)), underreplicated = MAX(COALESCE(ranges_underreplicated, 0)) BY node_id = attributes.node_id, store = attributes.store, host = resource.attributes.host.name\\n| SORT ranges_count DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"451d6bd3-44b6-a6df-9d2d-dfbf816cb83b\": {\"query\": {\"esql\": \"FROM metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE ranges IS NOT NULL\\n| STATS ranges_count = MAX(ranges), replicas_count = MAX(replicas), leaseholders = MAX(replicas_leaseholders), unavailable = MAX(COALESCE(ranges_unavailable, 0)), underreplicated = MAX(COALESCE(ranges_underreplicated, 0)) BY node_id = attributes.node_id, store = attributes.store, host = resource.attributes.host.name\\n| SORT ranges_count DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"node_id\", \"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"label\": \"Node ID\", \"customLabel\": true}, {\"fieldName\": \"store\", \"columnId\": \"ec092daf-aacf-2d45-1465-91b9e43093f2\", \"label\": \"Store\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"ranges_count\", \"columnId\": \"4d5e49a9-57a4-7882-28b3-d288fa5c44e3\", \"label\": \"Ranges\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"replicas_count\", \"columnId\": \"619037af-10c6-4dfb-6310-2b7ea9719473\", \"label\": \"Replicas\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"leaseholders\", \"columnId\": \"190dfa59-3b76-e03b-0ade-e4df202b867f\", \"label\": \"Leaseholders\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"unavailable\", \"columnId\": \"92f054d9-cc72-bdef-c205-ac8ac33e04f0\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"underreplicated\", \"columnId\": \"dee56107-75a4-b1cf-20d4-58131bb65e33\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"node_id\", \"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"label\": \"Node ID\", \"customLabel\": true}, {\"fieldName\": \"store\", \"columnId\": \"ec092daf-aacf-2d45-1465-91b9e43093f2\", \"label\": \"Store\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"ranges_count\", \"columnId\": \"4d5e49a9-57a4-7882-28b3-d288fa5c44e3\", \"label\": \"Ranges\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"replicas_count\", \"columnId\": \"619037af-10c6-4dfb-6310-2b7ea9719473\", \"label\": \"Replicas\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"leaseholders\", \"columnId\": \"190dfa59-3b76-e03b-0ade-e4df202b867f\", \"label\": \"Leaseholders\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"unavailable\", \"columnId\": \"92f054d9-cc72-bdef-c205-ac8ac33e04f0\", \"label\": \"Unavailable\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"underreplicated\", \"columnId\": \"dee56107-75a4-b1cf-20d4-58131bb65e33\", \"label\": \"Under-Replicated\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "b986582c-6093-3b85-1b1f-c667124bd189",
+                "order": 1,
+                "label": "Storage",
+                "type": "dashboardLink",
+                "destinationRefName": "link_b986582c-6093-3b85-1b1f-c667124bd189_dashboard"
+              },
+              {
+                "id": "0ce5133a-1601-c0e1-50df-1375499c41f7",
+                "order": 2,
+                "label": "SQL & Transactions",
+                "type": "dashboardLink",
+                "destinationRefName": "link_0ce5133a-1601-c0e1-50df-1375499c41f7_dashboard"
+              },
+              {
+                "id": "4da2826a-7c0c-9dc0-3fe3-52ae1dc165de",
+                "order": 3,
+                "label": "Replication & Ranges",
+                "type": "dashboardLink",
+                "destinationRefName": "link_4da2826a-7c0c-9dc0-3fe3-52ae1dc165de_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "0563dba8-e018-01bf-7e3c-91932750954e",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 16,
+          "h": 12,
+          "i": "0563dba8-e018-01bf-7e3c-91932750954e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## [CockroachDB OTel] Replication & Ranges\n\nThis dashboard monitors replication and range distribution:\n- Live nodes and liveness heartbeats\n- Ranges and replicas per store\n- Unavailable and under-replicated ranges\n- Lease transfers and rebalancing activity\n- Range splits and merges\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "85fe31d3-39c2-098d-7621-0bfb60ec2617",
+        "gridData": {
+          "x": 16,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "85fe31d3-39c2-098d-7621-0bfb60ec2617"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Live Nodes",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "0ab9ff29-09fd-f1ac-5f77-1e62d3d4dcae",
+                "layerType": "data",
+                "metricAccessor": "3a97c1dc-bbfd-b401-26ed-c034eaed5f2b",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE liveness_livenodes IS NOT NULL\n| STATS live = MAX(LAST_OVER_TIME(liveness_livenodes))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "0ab9ff29-09fd-f1ac-5f77-1e62d3d4dcae": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE liveness_livenodes IS NOT NULL\n| STATS live = MAX(LAST_OVER_TIME(liveness_livenodes))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "live",
+                          "columnId": "3a97c1dc-bbfd-b401-26ed-c034eaed5f2b",
+                          "label": "Live Nodes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "live",
+                          "columnId": "3a97c1dc-bbfd-b401-26ed-c034eaed5f2b",
+                          "label": "Live Nodes",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "f399931d-7719-b6c1-7817-fdab2693864c",
+        "gridData": {
+          "x": 24,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "f399931d-7719-b6c1-7817-fdab2693864c"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Total Ranges",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "3e829a25-33d2-fcff-a47c-36ae677a0e37",
+                "layerType": "data",
+                "metricAccessor": "48f690c2-871b-c208-b922-f5f244639ab6",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges IS NOT NULL\n| STATS total = SUM(LAST_OVER_TIME(ranges))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "3e829a25-33d2-fcff-a47c-36ae677a0e37": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges IS NOT NULL\n| STATS total = SUM(LAST_OVER_TIME(ranges))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total",
+                          "columnId": "48f690c2-871b-c208-b922-f5f244639ab6",
+                          "label": "Ranges",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total",
+                          "columnId": "48f690c2-871b-c208-b922-f5f244639ab6",
+                          "label": "Ranges",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "e86a3981-7746-72b6-94e2-6a0faa746a7b",
+        "gridData": {
+          "x": 32,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "e86a3981-7746-72b6-94e2-6a0faa746a7b"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Unavailable Ranges",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "cf65b417-5ea3-fef4-e8d0-8b992a644597",
+                "layerType": "data",
+                "metricAccessor": "16feeb31-ae6c-2035-e385-23308694d955",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_unavailable IS NOT NULL\n| STATS unavailable = SUM(LAST_OVER_TIME(ranges_unavailable))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cf65b417-5ea3-fef4-e8d0-8b992a644597": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_unavailable IS NOT NULL\n| STATS unavailable = SUM(LAST_OVER_TIME(ranges_unavailable))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "16feeb31-ae6c-2035-e385-23308694d955",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "16feeb31-ae6c-2035-e385-23308694d955",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "79d98faa-ca65-4bec-5571-d54676339d90",
+        "gridData": {
+          "x": 40,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "79d98faa-ca65-4bec-5571-d54676339d90"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Under-Replicated",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "cbfb7201-b53a-7f53-d603-4366f77a29f2",
+                "layerType": "data",
+                "metricAccessor": "0593e549-7b17-f543-e604-ddfd90c103cd",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_underreplicated IS NOT NULL\n| STATS under = SUM(LAST_OVER_TIME(ranges_underreplicated))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cbfb7201-b53a-7f53-d603-4366f77a29f2": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_underreplicated IS NOT NULL\n| STATS under = SUM(LAST_OVER_TIME(ranges_underreplicated))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "under",
+                          "columnId": "0593e549-7b17-f543-e604-ddfd90c103cd",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "under",
+                          "columnId": "0593e549-7b17-f543-e604-ddfd90c103cd",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "8c51c833-272e-371d-7f3f-82f2f032459e",
+        "gridData": {
+          "x": 16,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "8c51c833-272e-371d-7f3f-82f2f032459e"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Lease Transfers (rate)",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "f5b2a691-9daa-1429-cb7d-d9daff6aa5da",
+                "layerType": "data",
+                "metricAccessor": "a837ccd6-b387-f1a9-2342-032736a877ad",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE leases_transfers_success IS NOT NULL\n| STATS rate = SUM(RATE(leases_transfers_success))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "f5b2a691-9daa-1429-cb7d-d9daff6aa5da": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE leases_transfers_success IS NOT NULL\n| STATS rate = SUM(RATE(leases_transfers_success))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "a837ccd6-b387-f1a9-2342-032736a877ad",
+                          "label": "Transfers/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "a837ccd6-b387-f1a9-2342-032736a877ad",
+                          "label": "Transfers/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "7f89b852-452d-41dc-1658-37e5fc6ccfe7",
+        "gridData": {
+          "x": 24,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "7f89b852-452d-41dc-1658-37e5fc6ccfe7"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Lease Transfer Errors",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "018e25ca-a360-443e-8dfa-1ce9a2761575",
+                "layerType": "data",
+                "metricAccessor": "4d9d3d0e-6d21-1896-8080-6b3d08046a31",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE leases_transfers_error IS NOT NULL\n| STATS err_rate = SUM(RATE(leases_transfers_error))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "018e25ca-a360-443e-8dfa-1ce9a2761575": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE leases_transfers_error IS NOT NULL\n| STATS err_rate = SUM(RATE(leases_transfers_error))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "err_rate",
+                          "columnId": "4d9d3d0e-6d21-1896-8080-6b3d08046a31",
+                          "label": "Errors/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "err_rate",
+                          "columnId": "4d9d3d0e-6d21-1896-8080-6b3d08046a31",
+                          "label": "Errors/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "3a8daffd-fb51-b653-b647-ac16b21762b5",
+        "gridData": {
+          "x": 0,
+          "y": 14,
+          "w": 48,
+          "h": 3,
+          "i": "3a8daffd-fb51-b653-b647-ac16b21762b5"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Replication Status",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Replication Status"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "a335324e-9dc2-e659-8efd-01318f7e9c63",
+        "gridData": {
+          "x": 0,
+          "y": 17,
+          "w": 24,
+          "h": 10,
+          "i": "a335324e-9dc2-e659-8efd-01318f7e9c63"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Unavailable Ranges by Store",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "53481c5d-ecfb-2355-6e12-74f156e7caa5",
+                    "accessors": [
+                      "bfb7762f-984d-bc09-d2c3-f992b69463c3"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_unavailable IS NOT NULL\n| STATS unavailable = MAX(LAST_OVER_TIME(ranges_unavailable)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "53481c5d-ecfb-2355-6e12-74f156e7caa5": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_unavailable IS NOT NULL\n| STATS unavailable = MAX(LAST_OVER_TIME(ranges_unavailable)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "bfb7762f-984d-bc09-d2c3-f992b69463c3",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "bfb7762f-984d-bc09-d2c3-f992b69463c3",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "1fd46856-739f-0173-34c2-fa463492b1ab",
+        "gridData": {
+          "x": 24,
+          "y": 17,
+          "w": 24,
+          "h": 10,
+          "i": "1fd46856-739f-0173-34c2-fa463492b1ab"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Under-Replicated Ranges by Store",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "64b64d74-580e-e839-e678-94ecadb75ff2",
+                    "accessors": [
+                      "aec822d0-7b26-4f17-5ad1-48c3336204fa"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_underreplicated IS NOT NULL\n| STATS underreplicated = MAX(LAST_OVER_TIME(ranges_underreplicated)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "64b64d74-580e-e839-e678-94ecadb75ff2": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges_underreplicated IS NOT NULL\n| STATS underreplicated = MAX(LAST_OVER_TIME(ranges_underreplicated)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "underreplicated",
+                          "columnId": "aec822d0-7b26-4f17-5ad1-48c3336204fa",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "underreplicated",
+                          "columnId": "aec822d0-7b26-4f17-5ad1-48c3336204fa",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "35ea9465-b9a4-cce1-b60e-55457360fb1d",
+        "gridData": {
+          "x": 0,
+          "y": 27,
+          "w": 48,
+          "h": 3,
+          "i": "35ea9465-b9a4-cce1-b60e-55457360fb1d"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Range Distribution",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Range Distribution"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "20ed7679-3fb7-20fe-9f3b-5ecb88f2b2dc",
+        "gridData": {
+          "x": 0,
+          "y": 30,
+          "w": 24,
+          "h": 10,
+          "i": "20ed7679-3fb7-20fe-9f3b-5ecb88f2b2dc"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Ranges and Leaseholders by Store",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "c5bbc738-7841-f1bd-7680-20419364aa9f",
+                    "accessors": [
+                      "bb565d86-81d9-2bc3-6430-dd233cb3c45f",
+                      "31bbb5d6-9321-0582-0e31-5c9c890005c4"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges IS NOT NULL OR replicas_leaseholders IS NOT NULL\n| STATS ranges_count = AVG(LAST_OVER_TIME(ranges)), leaseholders = AVG(LAST_OVER_TIME(replicas_leaseholders)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| EVAL ranges_count = COALESCE(ranges_count, 0)\n| EVAL leaseholders = COALESCE(leaseholders, 0)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "c5bbc738-7841-f1bd-7680-20419364aa9f": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges IS NOT NULL OR replicas_leaseholders IS NOT NULL\n| STATS ranges_count = AVG(LAST_OVER_TIME(ranges)), leaseholders = AVG(LAST_OVER_TIME(replicas_leaseholders)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| EVAL ranges_count = COALESCE(ranges_count, 0)\n| EVAL leaseholders = COALESCE(leaseholders, 0)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "ranges_count",
+                          "columnId": "bb565d86-81d9-2bc3-6430-dd233cb3c45f",
+                          "label": "Ranges",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "leaseholders",
+                          "columnId": "31bbb5d6-9321-0582-0e31-5c9c890005c4",
+                          "label": "Leaseholders",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "ranges_count",
+                          "columnId": "bb565d86-81d9-2bc3-6430-dd233cb3c45f",
+                          "label": "Ranges",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "leaseholders",
+                          "columnId": "31bbb5d6-9321-0582-0e31-5c9c890005c4",
+                          "label": "Leaseholders",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "7c843a5e-3c27-09da-7b7e-f65898c2e2a4",
+        "gridData": {
+          "x": 24,
+          "y": 30,
+          "w": 24,
+          "h": 10,
+          "i": "7c843a5e-3c27-09da-7b7e-f65898c2e2a4"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Replicas by Store",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "df2003ed-e97e-90d8-7f20-5fbf89622f44",
+                    "accessors": [
+                      "ef9ed33a-23fe-07c0-5be2-7f153cf45ae3"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE replicas IS NOT NULL\n| STATS replicas_count = MAX(LAST_OVER_TIME(replicas)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "df2003ed-e97e-90d8-7f20-5fbf89622f44": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE replicas IS NOT NULL\n| STATS replicas_count = MAX(LAST_OVER_TIME(replicas)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "replicas_count",
+                          "columnId": "ef9ed33a-23fe-07c0-5be2-7f153cf45ae3",
+                          "label": "Replicas",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "replicas_count",
+                          "columnId": "ef9ed33a-23fe-07c0-5be2-7f153cf45ae3",
+                          "label": "Replicas",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "9ba98426-1658-9fd4-36ad-e4062963db5c",
+        "gridData": {
+          "x": 0,
+          "y": 40,
+          "w": 48,
+          "h": 3,
+          "i": "9ba98426-1658-9fd4-36ad-e4062963db5c"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Rebalancing",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Rebalancing"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "8316ad52-69f5-2686-f57f-0bba90ea69a2",
+        "gridData": {
+          "x": 0,
+          "y": 43,
+          "w": 48,
+          "h": 10,
+          "i": "8316ad52-69f5-2686-f57f-0bba90ea69a2"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Lease Transfers and Range Rebalances",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "05b04a71-1f6d-d97d-5b74-dac5880eefb8",
+                    "accessors": [
+                      "acbe57cb-7673-b948-23ea-86291bc8aaae"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "6639ccba-e614-f27f-4fcb-187e9a9456a0",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE rebalancing_lease_transfers IS NOT NULL | STATS rate = SUM(RATE(rebalancing_lease_transfers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \"Lease Transfers\" ) ( WHERE rebalancing_range_rebalances IS NOT NULL | STATS rate = SUM(RATE(rebalancing_range_rebalances)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \"Range Rebalances\" )\n| STATS rate = SUM(rate) BY time_bucket, op\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "05b04a71-1f6d-d97d-5b74-dac5880eefb8": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE rebalancing_lease_transfers IS NOT NULL | STATS rate = SUM(RATE(rebalancing_lease_transfers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \"Lease Transfers\" ) ( WHERE rebalancing_range_rebalances IS NOT NULL | STATS rate = SUM(RATE(rebalancing_range_rebalances)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \"Range Rebalances\" )\n| STATS rate = SUM(rate) BY time_bucket, op\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "acbe57cb-7673-b948-23ea-86291bc8aaae",
+                          "label": "Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "op",
+                          "columnId": "6639ccba-e614-f27f-4fcb-187e9a9456a0",
+                          "label": "op",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "acbe57cb-7673-b948-23ea-86291bc8aaae",
+                          "label": "Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "op",
+                          "columnId": "6639ccba-e614-f27f-4fcb-187e9a9456a0",
+                          "label": "op",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "51c04c8a-d21c-f9c3-2169-b8434b755e6c",
+        "gridData": {
+          "x": 0,
+          "y": 53,
+          "w": 24,
+          "h": 10,
+          "i": "51c04c8a-d21c-f9c3-2169-b8434b755e6c"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Liveness Heartbeats",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "265fa52e-e6f6-a66d-b1c0-4b828e9402ac",
+                    "accessors": [
+                      "f0cbc336-3d3b-b19e-4dbf-a0818353fbcc",
+                      "12344e37-ef83-d514-1e76-811e56b08289"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE liveness_heartbeatfailures IS NOT NULL OR liveness_heartbeatsuccesses IS NOT NULL\n| STATS failures = SUM(RATE(liveness_heartbeatfailures)), successes = SUM(RATE(liveness_heartbeatsuccesses)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL failures = COALESCE(failures, 0)\n| EVAL successes = COALESCE(successes, 0)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "265fa52e-e6f6-a66d-b1c0-4b828e9402ac": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE liveness_heartbeatfailures IS NOT NULL OR liveness_heartbeatsuccesses IS NOT NULL\n| STATS failures = SUM(RATE(liveness_heartbeatfailures)), successes = SUM(RATE(liveness_heartbeatsuccesses)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL failures = COALESCE(failures, 0)\n| EVAL successes = COALESCE(successes, 0)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "failures",
+                          "columnId": "f0cbc336-3d3b-b19e-4dbf-a0818353fbcc",
+                          "label": "Failures/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "successes",
+                          "columnId": "12344e37-ef83-d514-1e76-811e56b08289",
+                          "label": "Successes/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "failures",
+                          "columnId": "f0cbc336-3d3b-b19e-4dbf-a0818353fbcc",
+                          "label": "Failures/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "successes",
+                          "columnId": "12344e37-ef83-d514-1e76-811e56b08289",
+                          "label": "Successes/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "43633d31-cc2b-cc07-1152-cad66174a452",
+        "gridData": {
+          "x": 24,
+          "y": 53,
+          "w": 24,
+          "h": 10,
+          "i": "43633d31-cc2b-cc07-1152-cad66174a452"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Range Splits and Merges",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "cfb9d919-c927-a47b-a1ea-12c34433e2b6",
+                    "accessors": [
+                      "acbe57cb-7673-b948-23ea-86291bc8aaae"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "6639ccba-e614-f27f-4fcb-187e9a9456a0",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE range_splits IS NOT NULL | STATS rate = SUM(RATE(range_splits)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \"Splits\" ) ( WHERE range_merges IS NOT NULL | STATS rate = SUM(RATE(range_merges)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \"Merges\" )\n| STATS rate = SUM(rate) BY time_bucket, op\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cfb9d919-c927-a47b-a1ea-12c34433e2b6": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE range_splits IS NOT NULL | STATS rate = SUM(RATE(range_splits)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \"Splits\" ) ( WHERE range_merges IS NOT NULL | STATS rate = SUM(RATE(range_merges)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL op = \"Merges\" )\n| STATS rate = SUM(rate) BY time_bucket, op\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "acbe57cb-7673-b948-23ea-86291bc8aaae",
+                          "label": "Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "op",
+                          "columnId": "6639ccba-e614-f27f-4fcb-187e9a9456a0",
+                          "label": "op",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "acbe57cb-7673-b948-23ea-86291bc8aaae",
+                          "label": "Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "op",
+                          "columnId": "6639ccba-e614-f27f-4fcb-187e9a9456a0",
+                          "label": "op",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "7aae511f-aafd-88ff-4718-595b8916fe00",
+        "gridData": {
+          "x": 0,
+          "y": 63,
+          "w": 48,
+          "h": 3,
+          "i": "7aae511f-aafd-88ff-4718-595b8916fe00"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Detail",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Detail"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "c7d1f6df-982a-46ec-dede-1133b44c64f7",
+        "gridData": {
+          "x": 0,
+          "y": 66,
+          "w": 48,
+          "h": 12,
+          "i": "c7d1f6df-982a-46ec-dede-1133b44c64f7"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Store Summary",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "ec092daf-aacf-2d45-1465-91b9e43093f2",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "4d5e49a9-57a4-7882-28b3-d288fa5c44e3",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "619037af-10c6-4dfb-6310-2b7ea9719473",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "190dfa59-3b76-e03b-0ade-e4df202b867f",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "92f054d9-cc72-bdef-c205-ac8ac33e04f0",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "dee56107-75a4-b1cf-20d4-58131bb65e33",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "451d6bd3-44b6-a6df-9d2d-dfbf816cb83b",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "FROM metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges IS NOT NULL\n| STATS ranges_count = MAX(ranges), replicas_count = MAX(replicas), leaseholders = MAX(replicas_leaseholders), unavailable = MAX(COALESCE(ranges_unavailable, 0)), underreplicated = MAX(COALESCE(ranges_underreplicated, 0)) BY node_id = attributes.node_id, store = attributes.store, host = resource.attributes.host.name\n| SORT ranges_count DESC\n| LIMIT 50"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "451d6bd3-44b6-a6df-9d2d-dfbf816cb83b": {
+                      "query": {
+                        "esql": "FROM metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE ranges IS NOT NULL\n| STATS ranges_count = MAX(ranges), replicas_count = MAX(replicas), leaseholders = MAX(replicas_leaseholders), unavailable = MAX(COALESCE(ranges_unavailable, 0)), underreplicated = MAX(COALESCE(ranges_underreplicated, 0)) BY node_id = attributes.node_id, store = attributes.store, host = resource.attributes.host.name\n| SORT ranges_count DESC\n| LIMIT 50"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "node_id",
+                          "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                          "label": "Node ID",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "store",
+                          "columnId": "ec092daf-aacf-2d45-1465-91b9e43093f2",
+                          "label": "Store",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "host",
+                          "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                          "label": "Host",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "ranges_count",
+                          "columnId": "4d5e49a9-57a4-7882-28b3-d288fa5c44e3",
+                          "label": "Ranges",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "replicas_count",
+                          "columnId": "619037af-10c6-4dfb-6310-2b7ea9719473",
+                          "label": "Replicas",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "leaseholders",
+                          "columnId": "190dfa59-3b76-e03b-0ade-e4df202b867f",
+                          "label": "Leaseholders",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "92f054d9-cc72-bdef-c205-ac8ac33e04f0",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "underreplicated",
+                          "columnId": "dee56107-75a4-b1cf-20d4-58131bb65e33",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "node_id",
+                          "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                          "label": "Node ID",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "store",
+                          "columnId": "ec092daf-aacf-2d45-1465-91b9e43093f2",
+                          "label": "Store",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "host",
+                          "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                          "label": "Host",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "ranges_count",
+                          "columnId": "4d5e49a9-57a4-7882-28b3-d288fa5c44e3",
+                          "label": "Ranges",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "replicas_count",
+                          "columnId": "619037af-10c6-4dfb-6310-2b7ea9719473",
+                          "label": "Replicas",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "leaseholders",
+                          "columnId": "190dfa59-3b76-e03b-0ade-e4df202b867f",
+                          "label": "Leaseholders",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "unavailable",
+                          "columnId": "92f054d9-cc72-bdef-c205-ac8ac33e04f0",
+                          "label": "Unavailable",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "underreplicated",
+                          "columnId": "dee56107-75a4-b1cf-20d4-58131bb65e33",
+                          "label": "Under-Replicated",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"resource.attributes.service.name\",\"field\":\"resource.attributes.service.name\",\"params\":{\"query\":\"cockroachdb\"}},\"query\":{\"match_phrase\":{\"resource.attributes.service.name\":\"cockroachdb\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "resource.attributes.service.name",
+              "field": "resource.attributes.service.name",
+              "params": {
+                "query": "cockroachdb"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "resource.attributes.service.name": "cockroachdb"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": false,
     "version": 1,
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"2283c92c-f236-d98b-8f14-b4f4a80d676a\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2283c92c-f236-d98b-8f14-b4f4a80d676a\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"attributes.node_id\",\"title\":\"Node\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "2283c92c-f236-d98b-8f14-b4f4a80d676a": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "2283c92c-f236-d98b-8f14-b4f4a80d676a",
+            "dataViewId": "metrics-*",
+            "fieldName": "attributes.node_id",
+            "title": "Node",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/cockroachdb_otel/kibana/dashboard/cockroachdb_otel-sql-transactions.json
+++ b/packages/cockroachdb_otel/kibana/dashboard/cockroachdb_otel-sql-transactions.json
@@ -2,18 +2,2001 @@
   "attributes": {
     "title": "[CockroachDB OTel] SQL & Transactions",
     "description": "SQL statement rates, transaction throughput, errors, and contention. Monitor SELECT/INSERT/UPDATE/DELETE rates, connection counts, failures, aborts, and deadlocks.",
-    "panelsJSON": "[{\"panelIndex\": \"91144e9b-fac7-b44d-0b1d-8339201b83cb\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"91144e9b-fac7-b44d-0b1d-8339201b83cb\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"b986582c-6093-3b85-1b1f-c667124bd189\", \"order\": 1, \"label\": \"Storage\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_b986582c-6093-3b85-1b1f-c667124bd189_dashboard\"}, {\"id\": \"0ce5133a-1601-c0e1-50df-1375499c41f7\", \"order\": 2, \"label\": \"SQL & Transactions\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_0ce5133a-1601-c0e1-50df-1375499c41f7_dashboard\"}, {\"id\": \"4da2826a-7c0c-9dc0-3fe3-52ae1dc165de\", \"order\": 3, \"label\": \"Replication & Ranges\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_4da2826a-7c0c-9dc0-3fe3-52ae1dc165de_dashboard\"}]}}}, {\"panelIndex\": \"0563dba8-e018-01bf-7e3c-91932750954e\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 16, \"h\": 12, \"i\": \"0563dba8-e018-01bf-7e3c-91932750954e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [CockroachDB OTel] SQL & Transactions\\n\\nThis dashboard monitors SQL workload health:\\n- Statement rates by type (SELECT, INSERT, UPDATE, DELETE)\\n- Transaction throughput (BEGIN, COMMIT, ABORT)\\n- Connection counts and failures\\n- Error rates and contention\\n- Transaction restarts and deadlocks\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"64591ac4-86a7-960d-64a6-2b398c5e3b43\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"64591ac4-86a7-960d-64a6-2b398c5e3b43\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"SQL Statements/sec\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"4c0f5cab-f94a-8188-36b0-e162e454ebea\", \"layerType\": \"data\", \"metricAccessor\": \"82751210-a960-8aaf-e5a6-22c073ef441e\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| STATS s = SUM(RATE(sql_select_count)), i = SUM(RATE(sql_insert_count)), u = SUM(RATE(sql_update_count)), d = SUM(RATE(sql_delete_count))\\n| EVAL total = COALESCE(s, 0) + COALESCE(i, 0) + COALESCE(u, 0) + COALESCE(d, 0)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"4c0f5cab-f94a-8188-36b0-e162e454ebea\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| STATS s = SUM(RATE(sql_select_count)), i = SUM(RATE(sql_insert_count)), u = SUM(RATE(sql_update_count)), d = SUM(RATE(sql_delete_count))\\n| EVAL total = COALESCE(s, 0) + COALESCE(i, 0) + COALESCE(u, 0) + COALESCE(d, 0)\"}, \"columns\": [{\"fieldName\": \"total\", \"columnId\": \"82751210-a960-8aaf-e5a6-22c073ef441e\", \"label\": \"Stmts/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}], \"allColumns\": [{\"fieldName\": \"total\", \"columnId\": \"82751210-a960-8aaf-e5a6-22c073ef441e\", \"label\": \"Stmts/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"3bf4ccd6-76b1-bd0f-0bf3-601613a88555\", \"gridData\": {\"x\": 24, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"3bf4ccd6-76b1-bd0f-0bf3-601613a88555\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"SQL Failures/sec\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"7ca3e837-63c7-1edf-1afc-5a288f101dad\", \"layerType\": \"data\", \"metricAccessor\": \"8a0fdda1-1c1f-8cb6-97a6-774336468203\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_failure_count IS NOT NULL\\n| STATS fail_rate = SUM(RATE(sql_failure_count))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"7ca3e837-63c7-1edf-1afc-5a288f101dad\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_failure_count IS NOT NULL\\n| STATS fail_rate = SUM(RATE(sql_failure_count))\"}, \"columns\": [{\"fieldName\": \"fail_rate\", \"columnId\": \"8a0fdda1-1c1f-8cb6-97a6-774336468203\", \"label\": \"Failures/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"allColumns\": [{\"fieldName\": \"fail_rate\", \"columnId\": \"8a0fdda1-1c1f-8cb6-97a6-774336468203\", \"label\": \"Failures/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f28a233c-15f8-9100-2179-f7ced989f97d\", \"gridData\": {\"x\": 32, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"f28a233c-15f8-9100-2179-f7ced989f97d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Txn Aborts/sec\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"84034a22-b15b-2758-55b0-cd98b1eae5fe\", \"layerType\": \"data\", \"metricAccessor\": \"3bf9c8bd-ec1d-40ae-a05f-0e5dfdd55cbf\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_txn_abort_count IS NOT NULL\\n| STATS abort_rate = SUM(RATE(sql_txn_abort_count))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"84034a22-b15b-2758-55b0-cd98b1eae5fe\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_txn_abort_count IS NOT NULL\\n| STATS abort_rate = SUM(RATE(sql_txn_abort_count))\"}, \"columns\": [{\"fieldName\": \"abort_rate\", \"columnId\": \"3bf9c8bd-ec1d-40ae-a05f-0e5dfdd55cbf\", \"label\": \"Aborts/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"allColumns\": [{\"fieldName\": \"abort_rate\", \"columnId\": \"3bf9c8bd-ec1d-40ae-a05f-0e5dfdd55cbf\", \"label\": \"Aborts/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"63d54815-1670-0f7b-96f7-bea8c3afb338\", \"gridData\": {\"x\": 40, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"63d54815-1670-0f7b-96f7-bea8c3afb338\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Active Connections\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"bc739b12-051a-1845-a561-bbd7eaeb7cdd\", \"layerType\": \"data\", \"metricAccessor\": \"54eb225e-d32d-0c12-87b2-39b1e449eb24\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL\\n| STATS conns = SUM(LAST_OVER_TIME(sql_conns))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"bc739b12-051a-1845-a561-bbd7eaeb7cdd\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL\\n| STATS conns = SUM(LAST_OVER_TIME(sql_conns))\"}, \"columns\": [{\"fieldName\": \"conns\", \"columnId\": \"54eb225e-d32d-0c12-87b2-39b1e449eb24\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"conns\", \"columnId\": \"54eb225e-d32d-0c12-87b2-39b1e449eb24\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"9a79b054-4110-aea2-a7d0-1bcf8cf4a30b\", \"gridData\": {\"x\": 16, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"9a79b054-4110-aea2-a7d0-1bcf8cf4a30b\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Contended Queries/sec\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"fc81c6b4-0c6e-3e4c-e11d-73ad89c70dd8\", \"layerType\": \"data\", \"metricAccessor\": \"26785974-e94b-9e5c-0aaf-66c336f90547\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_distsql_contended_queries_count IS NOT NULL\\n| STATS contended = SUM(RATE(sql_distsql_contended_queries_count))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"fc81c6b4-0c6e-3e4c-e11d-73ad89c70dd8\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_distsql_contended_queries_count IS NOT NULL\\n| STATS contended = SUM(RATE(sql_distsql_contended_queries_count))\"}, \"columns\": [{\"fieldName\": \"contended\", \"columnId\": \"26785974-e94b-9e5c-0aaf-66c336f90547\", \"label\": \"Contended/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"allColumns\": [{\"fieldName\": \"contended\", \"columnId\": \"26785974-e94b-9e5c-0aaf-66c336f90547\", \"label\": \"Contended/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"71316c52-334f-0ea3-c4ed-4b06f7d69dd6\", \"gridData\": {\"x\": 24, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"71316c52-334f-0ea3-c4ed-4b06f7d69dd6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Deadlocks (total)\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"97beaa22-e8e5-ec0d-8180-0ea2583e0e40\", \"layerType\": \"data\", \"metricAccessor\": \"da5c8244-4b94-a5ba-06c2-082e9750cc26\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE txnwaitqueue_deadlocks_total IS NOT NULL\\n| STATS deadlocks = MAX(LAST_OVER_TIME(txnwaitqueue_deadlocks_total))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"97beaa22-e8e5-ec0d-8180-0ea2583e0e40\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE txnwaitqueue_deadlocks_total IS NOT NULL\\n| STATS deadlocks = MAX(LAST_OVER_TIME(txnwaitqueue_deadlocks_total))\"}, \"columns\": [{\"fieldName\": \"deadlocks\", \"columnId\": \"da5c8244-4b94-a5ba-06c2-082e9750cc26\", \"label\": \"Deadlocks\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"deadlocks\", \"columnId\": \"da5c8244-4b94-a5ba-06c2-082e9750cc26\", \"label\": \"Deadlocks\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"8a8d9673-f874-03fc-4297-f72c40df94fa\", \"gridData\": {\"x\": 0, \"y\": 14, \"w\": 48, \"h\": 3, \"i\": \"8a8d9673-f874-03fc-4297-f72c40df94fa\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Statement Rates\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Statement Rates\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"cea8ca49-7315-884e-8fcc-f84e82e3b78d\", \"gridData\": {\"x\": 0, \"y\": 17, \"w\": 48, \"h\": 12, \"i\": \"cea8ca49-7315-884e-8fcc-f84e82e3b78d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Statement Rate by Type\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"f55da783-4810-f2be-77db-aeeb36a39e4b\", \"accessors\": [\"c83abc0a-d16f-a488-8bc6-56f6074f164e\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"5550a10a-5d61-636f-e232-b95fcb75936c\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE sql_select_count IS NOT NULL | STATS rate = SUM(RATE(sql_select_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"SELECT\\\" ) ( WHERE sql_insert_count IS NOT NULL | STATS rate = SUM(RATE(sql_insert_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"INSERT\\\" ) ( WHERE sql_update_count IS NOT NULL | STATS rate = SUM(RATE(sql_update_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"UPDATE\\\" ) ( WHERE sql_delete_count IS NOT NULL | STATS rate = SUM(RATE(sql_delete_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"DELETE\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, stmt_type\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"f55da783-4810-f2be-77db-aeeb36a39e4b\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE sql_select_count IS NOT NULL | STATS rate = SUM(RATE(sql_select_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"SELECT\\\" ) ( WHERE sql_insert_count IS NOT NULL | STATS rate = SUM(RATE(sql_insert_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"INSERT\\\" ) ( WHERE sql_update_count IS NOT NULL | STATS rate = SUM(RATE(sql_update_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"UPDATE\\\" ) ( WHERE sql_delete_count IS NOT NULL | STATS rate = SUM(RATE(sql_delete_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \\\"DELETE\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, stmt_type\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"rate\", \"columnId\": \"c83abc0a-d16f-a488-8bc6-56f6074f164e\", \"label\": \"Statements/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"stmt_type\", \"columnId\": \"5550a10a-5d61-636f-e232-b95fcb75936c\", \"label\": \"stmt_type\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rate\", \"columnId\": \"c83abc0a-d16f-a488-8bc6-56f6074f164e\", \"label\": \"Statements/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"stmt_type\", \"columnId\": \"5550a10a-5d61-636f-e232-b95fcb75936c\", \"label\": \"stmt_type\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"52fd9c93-00c4-9228-2bff-d3e110feb734\", \"gridData\": {\"x\": 0, \"y\": 29, \"w\": 48, \"h\": 3, \"i\": \"52fd9c93-00c4-9228-2bff-d3e110feb734\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Transactions\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Transactions\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"6852b253-e896-005d-f106-39072e5f12e6\", \"gridData\": {\"x\": 0, \"y\": 32, \"w\": 24, \"h\": 10, \"i\": \"6852b253-e896-005d-f106-39072e5f12e6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Transaction Throughput\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"77b24f86-ac4a-dad6-e6d8-ef7e83285888\", \"accessors\": [\"347e67eb-c80f-ecef-7950-75e942f313f6\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"6ff1d91c-b388-9db5-f152-28e65c7c2f7e\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE sql_txn_begin_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_begin_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \\\"BEGIN\\\" ) ( WHERE sql_txn_commit_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_commit_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \\\"COMMIT\\\" ) ( WHERE sql_txn_abort_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_abort_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \\\"ABORT\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, txn_op\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"77b24f86-ac4a-dad6-e6d8-ef7e83285888\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE sql_txn_begin_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_begin_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \\\"BEGIN\\\" ) ( WHERE sql_txn_commit_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_commit_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \\\"COMMIT\\\" ) ( WHERE sql_txn_abort_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_abort_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \\\"ABORT\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, txn_op\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"rate\", \"columnId\": \"347e67eb-c80f-ecef-7950-75e942f313f6\", \"label\": \"Txns/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"txn_op\", \"columnId\": \"6ff1d91c-b388-9db5-f152-28e65c7c2f7e\", \"label\": \"txn_op\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rate\", \"columnId\": \"347e67eb-c80f-ecef-7950-75e942f313f6\", \"label\": \"Txns/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"txn_op\", \"columnId\": \"6ff1d91c-b388-9db5-f152-28e65c7c2f7e\", \"label\": \"txn_op\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"5187c309-b3f1-7392-b943-09a7fdde9dbe\", \"gridData\": {\"x\": 24, \"y\": 32, \"w\": 24, \"h\": 10, \"i\": \"5187c309-b3f1-7392-b943-09a7fdde9dbe\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"SQL Connections by Node\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"5d8877cb-b113-753a-7758-ccfcbf9f6b5a\", \"accessors\": [\"3b16427e-963d-b9a3-984b-86e239911d61\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL\\n| STATS conns = MAX(LAST_OVER_TIME(sql_conns)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"5d8877cb-b113-753a-7758-ccfcbf9f6b5a\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL\\n| STATS conns = MAX(LAST_OVER_TIME(sql_conns)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"conns\", \"columnId\": \"3b16427e-963d-b9a3-984b-86e239911d61\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.node_id\", \"columnId\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"label\": \"attributes.node_id\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"conns\", \"columnId\": \"3b16427e-963d-b9a3-984b-86e239911d61\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.node_id\", \"columnId\": \"f0a72105-ffd1-7671-6e9e-c4600a25e90c\", \"label\": \"attributes.node_id\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"66ffaa98-ca52-f8a5-806a-877398d917ae\", \"gridData\": {\"x\": 0, \"y\": 42, \"w\": 48, \"h\": 3, \"i\": \"66ffaa98-ca52-f8a5-806a-877398d917ae\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Errors\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Errors\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"04ca8bbb-6422-f3d7-ebaf-02300626927d\", \"gridData\": {\"x\": 0, \"y\": 45, \"w\": 24, \"h\": 10, \"i\": \"04ca8bbb-6422-f3d7-ebaf-02300626927d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"SQL Failures and Connection Failures\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"34d57575-9d19-5765-90e3-c536d573b1c2\", \"accessors\": [\"acbe57cb-7673-b948-23ea-86291bc8aaae\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"28881f06-803d-f868-4dc6-505238147b11\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE sql_failure_count IS NOT NULL | STATS rate = SUM(RATE(sql_failure_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL error_type = \\\"SQL Failures\\\" ) ( WHERE sql_conn_failures IS NOT NULL | STATS rate = SUM(RATE(sql_conn_failures)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL error_type = \\\"Conn Failures\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, error_type\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"34d57575-9d19-5765-90e3-c536d573b1c2\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE sql_failure_count IS NOT NULL | STATS rate = SUM(RATE(sql_failure_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL error_type = \\\"SQL Failures\\\" ) ( WHERE sql_conn_failures IS NOT NULL | STATS rate = SUM(RATE(sql_conn_failures)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL error_type = \\\"Conn Failures\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, error_type\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"rate\", \"columnId\": \"acbe57cb-7673-b948-23ea-86291bc8aaae\", \"label\": \"Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"error_type\", \"columnId\": \"28881f06-803d-f868-4dc6-505238147b11\", \"label\": \"error_type\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rate\", \"columnId\": \"acbe57cb-7673-b948-23ea-86291bc8aaae\", \"label\": \"Rate\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"error_type\", \"columnId\": \"28881f06-803d-f868-4dc6-505238147b11\", \"label\": \"error_type\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"29251368-c31f-5321-89da-425b4a44ceb3\", \"gridData\": {\"x\": 24, \"y\": 45, \"w\": 24, \"h\": 10, \"i\": \"29251368-c31f-5321-89da-425b4a44ceb3\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Transaction Restarts by Reason\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"98d879d9-9fb2-dd3c-1b89-54bf4dc34dd0\", \"accessors\": [\"b41ac9eb-d9ca-18d8-038a-88bd5211bb25\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"90da1c58-ce7c-8424-4dc4-8a28e9495bde\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE txn_restarts_serializable IS NOT NULL | STATS rate = SUM(RATE(txn_restarts_serializable)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL reason = \\\"Serializable\\\" ) ( WHERE txn_restarts_readwithinuncertainty IS NOT NULL | STATS rate = SUM(RATE(txn_restarts_readwithinuncertainty)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL reason = \\\"ReadWithinUncertainty\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, reason\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"98d879d9-9fb2-dd3c-1b89-54bf4dc34dd0\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| FORK ( WHERE txn_restarts_serializable IS NOT NULL | STATS rate = SUM(RATE(txn_restarts_serializable)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL reason = \\\"Serializable\\\" ) ( WHERE txn_restarts_readwithinuncertainty IS NOT NULL | STATS rate = SUM(RATE(txn_restarts_readwithinuncertainty)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL reason = \\\"ReadWithinUncertainty\\\" )\\n| STATS rate = SUM(rate) BY time_bucket, reason\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"rate\", \"columnId\": \"b41ac9eb-d9ca-18d8-038a-88bd5211bb25\", \"label\": \"Restarts/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"reason\", \"columnId\": \"90da1c58-ce7c-8424-4dc4-8a28e9495bde\", \"label\": \"reason\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rate\", \"columnId\": \"b41ac9eb-d9ca-18d8-038a-88bd5211bb25\", \"label\": \"Restarts/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2, \"suffix\": \"/sec\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"reason\", \"columnId\": \"90da1c58-ce7c-8424-4dc4-8a28e9495bde\", \"label\": \"reason\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"5ae5e6e1-09ca-0f49-e298-b1c93076798a\", \"gridData\": {\"x\": 0, \"y\": 55, \"w\": 48, \"h\": 3, \"i\": \"5ae5e6e1-09ca-0f49-e298-b1c93076798a\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Detail\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Detail\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"2b69b88b-0408-32fc-c202-c42a68c5f363\", \"gridData\": {\"x\": 0, \"y\": 58, \"w\": 48, \"h\": 12, \"i\": \"2b69b88b-0408-32fc-c202-c42a68c5f363\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"SQL Metrics by Node\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"4494c563-1b50-88d6-3376-c2407514ab06\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"510c3635-e048-906f-46a4-b4862e0d9030\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"b7fb1e3c-fc6f-6665-f139-f48dce931d99\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"069fbabc-0c68-23e9-f9b0-1067fc2b649f\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"137311aa-f971-8779-e6c1-8da2b83bb09a\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL OR sql_statements_active IS NOT NULL\\n| STATS conns = MAX(sql_conns), active_stmts = MAX(sql_statements_active), open_txns = MAX(sql_txns_open), mem_bytes = MAX(sql_mem_root_current) BY node_id = attributes.node_id, host = resource.attributes.host.name\\n| SORT node_id ASC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"137311aa-f971-8779-e6c1-8da2b83bb09a\": {\"query\": {\"esql\": \"FROM metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sql_conns IS NOT NULL OR sql_statements_active IS NOT NULL\\n| STATS conns = MAX(sql_conns), active_stmts = MAX(sql_statements_active), open_txns = MAX(sql_txns_open), mem_bytes = MAX(sql_mem_root_current) BY node_id = attributes.node_id, host = resource.attributes.host.name\\n| SORT node_id ASC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"node_id\", \"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"label\": \"Node ID\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"conns\", \"columnId\": \"4494c563-1b50-88d6-3376-c2407514ab06\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"active_stmts\", \"columnId\": \"510c3635-e048-906f-46a4-b4862e0d9030\", \"label\": \"Active Statements\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"open_txns\", \"columnId\": \"b7fb1e3c-fc6f-6665-f139-f48dce931d99\", \"label\": \"Open Txns\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"mem_bytes\", \"columnId\": \"069fbabc-0c68-23e9-f9b0-1067fc2b649f\", \"label\": \"SQL Memory\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}], \"allColumns\": [{\"fieldName\": \"node_id\", \"columnId\": \"9b5def11-3d62-3277-d7b6-b2a38979ddbd\", \"label\": \"Node ID\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"conns\", \"columnId\": \"4494c563-1b50-88d6-3376-c2407514ab06\", \"label\": \"Connections\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"active_stmts\", \"columnId\": \"510c3635-e048-906f-46a4-b4862e0d9030\", \"label\": \"Active Statements\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"open_txns\", \"columnId\": \"b7fb1e3c-fc6f-6665-f139-f48dce931d99\", \"label\": \"Open Txns\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"mem_bytes\", \"columnId\": \"069fbabc-0c68-23e9-f9b0-1067fc2b649f\", \"label\": \"SQL Memory\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "b986582c-6093-3b85-1b1f-c667124bd189",
+                "order": 1,
+                "label": "Storage",
+                "type": "dashboardLink",
+                "destinationRefName": "link_b986582c-6093-3b85-1b1f-c667124bd189_dashboard"
+              },
+              {
+                "id": "0ce5133a-1601-c0e1-50df-1375499c41f7",
+                "order": 2,
+                "label": "SQL & Transactions",
+                "type": "dashboardLink",
+                "destinationRefName": "link_0ce5133a-1601-c0e1-50df-1375499c41f7_dashboard"
+              },
+              {
+                "id": "4da2826a-7c0c-9dc0-3fe3-52ae1dc165de",
+                "order": 3,
+                "label": "Replication & Ranges",
+                "type": "dashboardLink",
+                "destinationRefName": "link_4da2826a-7c0c-9dc0-3fe3-52ae1dc165de_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "0563dba8-e018-01bf-7e3c-91932750954e",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 16,
+          "h": 12,
+          "i": "0563dba8-e018-01bf-7e3c-91932750954e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## [CockroachDB OTel] SQL & Transactions\n\nThis dashboard monitors SQL workload health:\n- Statement rates by type (SELECT, INSERT, UPDATE, DELETE)\n- Transaction throughput (BEGIN, COMMIT, ABORT)\n- Connection counts and failures\n- Error rates and contention\n- Transaction restarts and deadlocks\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "64591ac4-86a7-960d-64a6-2b398c5e3b43",
+        "gridData": {
+          "x": 16,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "64591ac4-86a7-960d-64a6-2b398c5e3b43"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "SQL Statements/sec",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "4c0f5cab-f94a-8188-36b0-e162e454ebea",
+                "layerType": "data",
+                "metricAccessor": "82751210-a960-8aaf-e5a6-22c073ef441e",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| STATS s = SUM(RATE(sql_select_count)), i = SUM(RATE(sql_insert_count)), u = SUM(RATE(sql_update_count)), d = SUM(RATE(sql_delete_count))\n| EVAL total = COALESCE(s, 0) + COALESCE(i, 0) + COALESCE(u, 0) + COALESCE(d, 0)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "4c0f5cab-f94a-8188-36b0-e162e454ebea": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| STATS s = SUM(RATE(sql_select_count)), i = SUM(RATE(sql_insert_count)), u = SUM(RATE(sql_update_count)), d = SUM(RATE(sql_delete_count))\n| EVAL total = COALESCE(s, 0) + COALESCE(i, 0) + COALESCE(u, 0) + COALESCE(d, 0)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total",
+                          "columnId": "82751210-a960-8aaf-e5a6-22c073ef441e",
+                          "label": "Stmts/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total",
+                          "columnId": "82751210-a960-8aaf-e5a6-22c073ef441e",
+                          "label": "Stmts/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "3bf4ccd6-76b1-bd0f-0bf3-601613a88555",
+        "gridData": {
+          "x": 24,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "3bf4ccd6-76b1-bd0f-0bf3-601613a88555"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "SQL Failures/sec",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "7ca3e837-63c7-1edf-1afc-5a288f101dad",
+                "layerType": "data",
+                "metricAccessor": "8a0fdda1-1c1f-8cb6-97a6-774336468203",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_failure_count IS NOT NULL\n| STATS fail_rate = SUM(RATE(sql_failure_count))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "7ca3e837-63c7-1edf-1afc-5a288f101dad": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_failure_count IS NOT NULL\n| STATS fail_rate = SUM(RATE(sql_failure_count))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "fail_rate",
+                          "columnId": "8a0fdda1-1c1f-8cb6-97a6-774336468203",
+                          "label": "Failures/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "fail_rate",
+                          "columnId": "8a0fdda1-1c1f-8cb6-97a6-774336468203",
+                          "label": "Failures/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "f28a233c-15f8-9100-2179-f7ced989f97d",
+        "gridData": {
+          "x": 32,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "f28a233c-15f8-9100-2179-f7ced989f97d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Txn Aborts/sec",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "84034a22-b15b-2758-55b0-cd98b1eae5fe",
+                "layerType": "data",
+                "metricAccessor": "3bf9c8bd-ec1d-40ae-a05f-0e5dfdd55cbf",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_txn_abort_count IS NOT NULL\n| STATS abort_rate = SUM(RATE(sql_txn_abort_count))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "84034a22-b15b-2758-55b0-cd98b1eae5fe": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_txn_abort_count IS NOT NULL\n| STATS abort_rate = SUM(RATE(sql_txn_abort_count))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "abort_rate",
+                          "columnId": "3bf9c8bd-ec1d-40ae-a05f-0e5dfdd55cbf",
+                          "label": "Aborts/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "abort_rate",
+                          "columnId": "3bf9c8bd-ec1d-40ae-a05f-0e5dfdd55cbf",
+                          "label": "Aborts/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "63d54815-1670-0f7b-96f7-bea8c3afb338",
+        "gridData": {
+          "x": 40,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "63d54815-1670-0f7b-96f7-bea8c3afb338"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Active Connections",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "bc739b12-051a-1845-a561-bbd7eaeb7cdd",
+                "layerType": "data",
+                "metricAccessor": "54eb225e-d32d-0c12-87b2-39b1e449eb24",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL\n| STATS conns = SUM(LAST_OVER_TIME(sql_conns))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "bc739b12-051a-1845-a561-bbd7eaeb7cdd": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL\n| STATS conns = SUM(LAST_OVER_TIME(sql_conns))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "conns",
+                          "columnId": "54eb225e-d32d-0c12-87b2-39b1e449eb24",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "conns",
+                          "columnId": "54eb225e-d32d-0c12-87b2-39b1e449eb24",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "9a79b054-4110-aea2-a7d0-1bcf8cf4a30b",
+        "gridData": {
+          "x": 16,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "9a79b054-4110-aea2-a7d0-1bcf8cf4a30b"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Contended Queries/sec",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "fc81c6b4-0c6e-3e4c-e11d-73ad89c70dd8",
+                "layerType": "data",
+                "metricAccessor": "26785974-e94b-9e5c-0aaf-66c336f90547",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_distsql_contended_queries_count IS NOT NULL\n| STATS contended = SUM(RATE(sql_distsql_contended_queries_count))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "fc81c6b4-0c6e-3e4c-e11d-73ad89c70dd8": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_distsql_contended_queries_count IS NOT NULL\n| STATS contended = SUM(RATE(sql_distsql_contended_queries_count))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "contended",
+                          "columnId": "26785974-e94b-9e5c-0aaf-66c336f90547",
+                          "label": "Contended/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "contended",
+                          "columnId": "26785974-e94b-9e5c-0aaf-66c336f90547",
+                          "label": "Contended/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "71316c52-334f-0ea3-c4ed-4b06f7d69dd6",
+        "gridData": {
+          "x": 24,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "71316c52-334f-0ea3-c4ed-4b06f7d69dd6"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Deadlocks (total)",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "97beaa22-e8e5-ec0d-8180-0ea2583e0e40",
+                "layerType": "data",
+                "metricAccessor": "da5c8244-4b94-a5ba-06c2-082e9750cc26",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE txnwaitqueue_deadlocks_total IS NOT NULL\n| STATS deadlocks = MAX(LAST_OVER_TIME(txnwaitqueue_deadlocks_total))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "97beaa22-e8e5-ec0d-8180-0ea2583e0e40": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE txnwaitqueue_deadlocks_total IS NOT NULL\n| STATS deadlocks = MAX(LAST_OVER_TIME(txnwaitqueue_deadlocks_total))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "deadlocks",
+                          "columnId": "da5c8244-4b94-a5ba-06c2-082e9750cc26",
+                          "label": "Deadlocks",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "deadlocks",
+                          "columnId": "da5c8244-4b94-a5ba-06c2-082e9750cc26",
+                          "label": "Deadlocks",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "8a8d9673-f874-03fc-4297-f72c40df94fa",
+        "gridData": {
+          "x": 0,
+          "y": 14,
+          "w": 48,
+          "h": 3,
+          "i": "8a8d9673-f874-03fc-4297-f72c40df94fa"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Statement Rates",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Statement Rates"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "cea8ca49-7315-884e-8fcc-f84e82e3b78d",
+        "gridData": {
+          "x": 0,
+          "y": 17,
+          "w": 48,
+          "h": 12,
+          "i": "cea8ca49-7315-884e-8fcc-f84e82e3b78d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Statement Rate by Type",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "f55da783-4810-f2be-77db-aeeb36a39e4b",
+                    "accessors": [
+                      "c83abc0a-d16f-a488-8bc6-56f6074f164e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "5550a10a-5d61-636f-e232-b95fcb75936c",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE sql_select_count IS NOT NULL | STATS rate = SUM(RATE(sql_select_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"SELECT\" ) ( WHERE sql_insert_count IS NOT NULL | STATS rate = SUM(RATE(sql_insert_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"INSERT\" ) ( WHERE sql_update_count IS NOT NULL | STATS rate = SUM(RATE(sql_update_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"UPDATE\" ) ( WHERE sql_delete_count IS NOT NULL | STATS rate = SUM(RATE(sql_delete_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"DELETE\" )\n| STATS rate = SUM(rate) BY time_bucket, stmt_type\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "f55da783-4810-f2be-77db-aeeb36a39e4b": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE sql_select_count IS NOT NULL | STATS rate = SUM(RATE(sql_select_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"SELECT\" ) ( WHERE sql_insert_count IS NOT NULL | STATS rate = SUM(RATE(sql_insert_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"INSERT\" ) ( WHERE sql_update_count IS NOT NULL | STATS rate = SUM(RATE(sql_update_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"UPDATE\" ) ( WHERE sql_delete_count IS NOT NULL | STATS rate = SUM(RATE(sql_delete_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL stmt_type = \"DELETE\" )\n| STATS rate = SUM(rate) BY time_bucket, stmt_type\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "c83abc0a-d16f-a488-8bc6-56f6074f164e",
+                          "label": "Statements/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "stmt_type",
+                          "columnId": "5550a10a-5d61-636f-e232-b95fcb75936c",
+                          "label": "stmt_type",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "c83abc0a-d16f-a488-8bc6-56f6074f164e",
+                          "label": "Statements/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "stmt_type",
+                          "columnId": "5550a10a-5d61-636f-e232-b95fcb75936c",
+                          "label": "stmt_type",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "52fd9c93-00c4-9228-2bff-d3e110feb734",
+        "gridData": {
+          "x": 0,
+          "y": 29,
+          "w": 48,
+          "h": 3,
+          "i": "52fd9c93-00c4-9228-2bff-d3e110feb734"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Transactions",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Transactions"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "6852b253-e896-005d-f106-39072e5f12e6",
+        "gridData": {
+          "x": 0,
+          "y": 32,
+          "w": 24,
+          "h": 10,
+          "i": "6852b253-e896-005d-f106-39072e5f12e6"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Transaction Throughput",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "77b24f86-ac4a-dad6-e6d8-ef7e83285888",
+                    "accessors": [
+                      "347e67eb-c80f-ecef-7950-75e942f313f6"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "6ff1d91c-b388-9db5-f152-28e65c7c2f7e",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE sql_txn_begin_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_begin_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \"BEGIN\" ) ( WHERE sql_txn_commit_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_commit_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \"COMMIT\" ) ( WHERE sql_txn_abort_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_abort_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \"ABORT\" )\n| STATS rate = SUM(rate) BY time_bucket, txn_op\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "77b24f86-ac4a-dad6-e6d8-ef7e83285888": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE sql_txn_begin_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_begin_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \"BEGIN\" ) ( WHERE sql_txn_commit_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_commit_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \"COMMIT\" ) ( WHERE sql_txn_abort_count IS NOT NULL | STATS rate = SUM(RATE(sql_txn_abort_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL txn_op = \"ABORT\" )\n| STATS rate = SUM(rate) BY time_bucket, txn_op\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "347e67eb-c80f-ecef-7950-75e942f313f6",
+                          "label": "Txns/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "txn_op",
+                          "columnId": "6ff1d91c-b388-9db5-f152-28e65c7c2f7e",
+                          "label": "txn_op",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "347e67eb-c80f-ecef-7950-75e942f313f6",
+                          "label": "Txns/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "txn_op",
+                          "columnId": "6ff1d91c-b388-9db5-f152-28e65c7c2f7e",
+                          "label": "txn_op",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "5187c309-b3f1-7392-b943-09a7fdde9dbe",
+        "gridData": {
+          "x": 24,
+          "y": 32,
+          "w": 24,
+          "h": 10,
+          "i": "5187c309-b3f1-7392-b943-09a7fdde9dbe"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "SQL Connections by Node",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "5d8877cb-b113-753a-7758-ccfcbf9f6b5a",
+                    "accessors": [
+                      "3b16427e-963d-b9a3-984b-86e239911d61"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL\n| STATS conns = MAX(LAST_OVER_TIME(sql_conns)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "5d8877cb-b113-753a-7758-ccfcbf9f6b5a": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL\n| STATS conns = MAX(LAST_OVER_TIME(sql_conns)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.node_id\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "conns",
+                          "columnId": "3b16427e-963d-b9a3-984b-86e239911d61",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.node_id",
+                          "columnId": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                          "label": "attributes.node_id",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "conns",
+                          "columnId": "3b16427e-963d-b9a3-984b-86e239911d61",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.node_id",
+                          "columnId": "f0a72105-ffd1-7671-6e9e-c4600a25e90c",
+                          "label": "attributes.node_id",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "66ffaa98-ca52-f8a5-806a-877398d917ae",
+        "gridData": {
+          "x": 0,
+          "y": 42,
+          "w": 48,
+          "h": 3,
+          "i": "66ffaa98-ca52-f8a5-806a-877398d917ae"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Errors",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Errors"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "04ca8bbb-6422-f3d7-ebaf-02300626927d",
+        "gridData": {
+          "x": 0,
+          "y": 45,
+          "w": 24,
+          "h": 10,
+          "i": "04ca8bbb-6422-f3d7-ebaf-02300626927d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "SQL Failures and Connection Failures",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "34d57575-9d19-5765-90e3-c536d573b1c2",
+                    "accessors": [
+                      "acbe57cb-7673-b948-23ea-86291bc8aaae"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "28881f06-803d-f868-4dc6-505238147b11",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE sql_failure_count IS NOT NULL | STATS rate = SUM(RATE(sql_failure_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL error_type = \"SQL Failures\" ) ( WHERE sql_conn_failures IS NOT NULL | STATS rate = SUM(RATE(sql_conn_failures)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL error_type = \"Conn Failures\" )\n| STATS rate = SUM(rate) BY time_bucket, error_type\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "34d57575-9d19-5765-90e3-c536d573b1c2": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE sql_failure_count IS NOT NULL | STATS rate = SUM(RATE(sql_failure_count)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL error_type = \"SQL Failures\" ) ( WHERE sql_conn_failures IS NOT NULL | STATS rate = SUM(RATE(sql_conn_failures)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL error_type = \"Conn Failures\" )\n| STATS rate = SUM(rate) BY time_bucket, error_type\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "acbe57cb-7673-b948-23ea-86291bc8aaae",
+                          "label": "Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "error_type",
+                          "columnId": "28881f06-803d-f868-4dc6-505238147b11",
+                          "label": "error_type",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "acbe57cb-7673-b948-23ea-86291bc8aaae",
+                          "label": "Rate",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "error_type",
+                          "columnId": "28881f06-803d-f868-4dc6-505238147b11",
+                          "label": "error_type",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "29251368-c31f-5321-89da-425b4a44ceb3",
+        "gridData": {
+          "x": 24,
+          "y": 45,
+          "w": 24,
+          "h": 10,
+          "i": "29251368-c31f-5321-89da-425b4a44ceb3"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Transaction Restarts by Reason",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "98d879d9-9fb2-dd3c-1b89-54bf4dc34dd0",
+                    "accessors": [
+                      "b41ac9eb-d9ca-18d8-038a-88bd5211bb25"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "90da1c58-ce7c-8424-4dc4-8a28e9495bde",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE txn_restarts_serializable IS NOT NULL | STATS rate = SUM(RATE(txn_restarts_serializable)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL reason = \"Serializable\" ) ( WHERE txn_restarts_readwithinuncertainty IS NOT NULL | STATS rate = SUM(RATE(txn_restarts_readwithinuncertainty)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL reason = \"ReadWithinUncertainty\" )\n| STATS rate = SUM(rate) BY time_bucket, reason\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "98d879d9-9fb2-dd3c-1b89-54bf4dc34dd0": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| FORK ( WHERE txn_restarts_serializable IS NOT NULL | STATS rate = SUM(RATE(txn_restarts_serializable)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL reason = \"Serializable\" ) ( WHERE txn_restarts_readwithinuncertainty IS NOT NULL | STATS rate = SUM(RATE(txn_restarts_readwithinuncertainty)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend) | EVAL reason = \"ReadWithinUncertainty\" )\n| STATS rate = SUM(rate) BY time_bucket, reason\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "b41ac9eb-d9ca-18d8-038a-88bd5211bb25",
+                          "label": "Restarts/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "reason",
+                          "columnId": "90da1c58-ce7c-8424-4dc4-8a28e9495bde",
+                          "label": "reason",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rate",
+                          "columnId": "b41ac9eb-d9ca-18d8-038a-88bd5211bb25",
+                          "label": "Restarts/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2,
+                                "suffix": "/sec"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "reason",
+                          "columnId": "90da1c58-ce7c-8424-4dc4-8a28e9495bde",
+                          "label": "reason",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "5ae5e6e1-09ca-0f49-e298-b1c93076798a",
+        "gridData": {
+          "x": 0,
+          "y": 55,
+          "w": 48,
+          "h": 3,
+          "i": "5ae5e6e1-09ca-0f49-e298-b1c93076798a"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Detail",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Detail"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "2b69b88b-0408-32fc-c202-c42a68c5f363",
+        "gridData": {
+          "x": 0,
+          "y": 58,
+          "w": 48,
+          "h": 12,
+          "i": "2b69b88b-0408-32fc-c202-c42a68c5f363"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "SQL Metrics by Node",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "4494c563-1b50-88d6-3376-c2407514ab06",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "510c3635-e048-906f-46a4-b4862e0d9030",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "b7fb1e3c-fc6f-6665-f139-f48dce931d99",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "069fbabc-0c68-23e9-f9b0-1067fc2b649f",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "137311aa-f971-8779-e6c1-8da2b83bb09a",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "FROM metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL OR sql_statements_active IS NOT NULL\n| STATS conns = MAX(sql_conns), active_stmts = MAX(sql_statements_active), open_txns = MAX(sql_txns_open), mem_bytes = MAX(sql_mem_root_current) BY node_id = attributes.node_id, host = resource.attributes.host.name\n| SORT node_id ASC\n| LIMIT 50"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "137311aa-f971-8779-e6c1-8da2b83bb09a": {
+                      "query": {
+                        "esql": "FROM metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sql_conns IS NOT NULL OR sql_statements_active IS NOT NULL\n| STATS conns = MAX(sql_conns), active_stmts = MAX(sql_statements_active), open_txns = MAX(sql_txns_open), mem_bytes = MAX(sql_mem_root_current) BY node_id = attributes.node_id, host = resource.attributes.host.name\n| SORT node_id ASC\n| LIMIT 50"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "node_id",
+                          "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                          "label": "Node ID",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "host",
+                          "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                          "label": "Host",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "conns",
+                          "columnId": "4494c563-1b50-88d6-3376-c2407514ab06",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "active_stmts",
+                          "columnId": "510c3635-e048-906f-46a4-b4862e0d9030",
+                          "label": "Active Statements",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "open_txns",
+                          "columnId": "b7fb1e3c-fc6f-6665-f139-f48dce931d99",
+                          "label": "Open Txns",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "mem_bytes",
+                          "columnId": "069fbabc-0c68-23e9-f9b0-1067fc2b649f",
+                          "label": "SQL Memory",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "node_id",
+                          "columnId": "9b5def11-3d62-3277-d7b6-b2a38979ddbd",
+                          "label": "Node ID",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "host",
+                          "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                          "label": "Host",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "conns",
+                          "columnId": "4494c563-1b50-88d6-3376-c2407514ab06",
+                          "label": "Connections",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "active_stmts",
+                          "columnId": "510c3635-e048-906f-46a4-b4862e0d9030",
+                          "label": "Active Statements",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "open_txns",
+                          "columnId": "b7fb1e3c-fc6f-6665-f139-f48dce931d99",
+                          "label": "Open Txns",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "mem_bytes",
+                          "columnId": "069fbabc-0c68-23e9-f9b0-1067fc2b649f",
+                          "label": "SQL Memory",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"resource.attributes.service.name\",\"field\":\"resource.attributes.service.name\",\"params\":{\"query\":\"cockroachdb\"}},\"query\":{\"match_phrase\":{\"resource.attributes.service.name\":\"cockroachdb\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "resource.attributes.service.name",
+              "field": "resource.attributes.service.name",
+              "params": {
+                "query": "cockroachdb"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "resource.attributes.service.name": "cockroachdb"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": false,
     "version": 1,
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"2283c92c-f236-d98b-8f14-b4f4a80d676a\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2283c92c-f236-d98b-8f14-b4f4a80d676a\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"attributes.node_id\",\"title\":\"Node\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "2283c92c-f236-d98b-8f14-b4f4a80d676a": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "2283c92c-f236-d98b-8f14-b4f4a80d676a",
+            "dataViewId": "metrics-*",
+            "fieldName": "attributes.node_id",
+            "title": "Node",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/cockroachdb_otel/kibana/dashboard/cockroachdb_otel-storage.json
+++ b/packages/cockroachdb_otel/kibana/dashboard/cockroachdb_otel-storage.json
@@ -2,18 +2,2144 @@
   "attributes": {
     "title": "[CockroachDB OTel] Storage",
     "description": "Storage capacity, LSM tree health, and disk I/O metrics. Monitor capacity usage, admission IO overload, L0 sublevels, read amplification, and write stalls.",
-    "panelsJSON": "[{\"panelIndex\": \"91144e9b-fac7-b44d-0b1d-8339201b83cb\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"91144e9b-fac7-b44d-0b1d-8339201b83cb\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"b986582c-6093-3b85-1b1f-c667124bd189\", \"order\": 1, \"label\": \"Storage\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_b986582c-6093-3b85-1b1f-c667124bd189_dashboard\"}, {\"id\": \"0ce5133a-1601-c0e1-50df-1375499c41f7\", \"order\": 2, \"label\": \"SQL & Transactions\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_0ce5133a-1601-c0e1-50df-1375499c41f7_dashboard\"}, {\"id\": \"4da2826a-7c0c-9dc0-3fe3-52ae1dc165de\", \"order\": 3, \"label\": \"Replication & Ranges\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_4da2826a-7c0c-9dc0-3fe3-52ae1dc165de_dashboard\"}]}}}, {\"panelIndex\": \"0563dba8-e018-01bf-7e3c-91932750954e\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 16, \"h\": 12, \"i\": \"0563dba8-e018-01bf-7e3c-91932750954e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [CockroachDB OTel] Storage\\n\\nThis dashboard monitors storage and LSM health:\\n- Capacity used, available, and utilization\\n- IO admission overload (>1.0 = overloaded)\\n- L0 sublevels and file count (compaction health)\\n- Read amplification (should be single digits)\\n- Write stalls and disk I/O queue depth\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"74117d03-dce4-ba18-82f3-3963920a84ae\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"74117d03-dce4-ba18-82f3-3963920a84ae\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Capacity Used %\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"25ff9254-1fce-4b7e-60ae-dc06ea0441ab\", \"layerType\": \"data\", \"metricAccessor\": \"476559d7-6cca-aaf6-90ac-0161d71872ff\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE capacity IS NOT NULL AND capacity_used IS NOT NULL\\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)), total = AVG(LAST_OVER_TIME(capacity))\\n| EVAL pct = CASE(total > 0, used / total * 100, 0)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"25ff9254-1fce-4b7e-60ae-dc06ea0441ab\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE capacity IS NOT NULL AND capacity_used IS NOT NULL\\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)), total = AVG(LAST_OVER_TIME(capacity))\\n| EVAL pct = CASE(total > 0, used / total * 100, 0)\"}, \"columns\": [{\"fieldName\": \"pct\", \"columnId\": \"476559d7-6cca-aaf6-90ac-0161d71872ff\", \"label\": \"Used %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"%\"}}}}], \"allColumns\": [{\"fieldName\": \"pct\", \"columnId\": \"476559d7-6cca-aaf6-90ac-0161d71872ff\", \"label\": \"Used %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"%\"}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"4a8fb810-af9e-d94d-f686-cae3ba5ad77e\", \"gridData\": {\"x\": 24, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"4a8fb810-af9e-d94d-f686-cae3ba5ad77e\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"IO Overload\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"31107a35-ca00-d025-7169-5fcdd594d99c\", \"layerType\": \"data\", \"metricAccessor\": \"4db5cf58-cf78-3468-f88c-d4637075ca22\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE admission_io_overload IS NOT NULL\\n| STATS avg_io = AVG(AVG_OVER_TIME(admission_io_overload))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"31107a35-ca00-d025-7169-5fcdd594d99c\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE admission_io_overload IS NOT NULL\\n| STATS avg_io = AVG(AVG_OVER_TIME(admission_io_overload))\"}, \"columns\": [{\"fieldName\": \"avg_io\", \"columnId\": \"4db5cf58-cf78-3468-f88c-d4637075ca22\", \"label\": \"IO Overload\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"allColumns\": [{\"fieldName\": \"avg_io\", \"columnId\": \"4db5cf58-cf78-3468-f88c-d4637075ca22\", \"label\": \"IO Overload\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"ffa30dca-0f13-dbef-0638-6317c8ff98fe\", \"gridData\": {\"x\": 32, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"ffa30dca-0f13-dbef-0638-6317c8ff98fe\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"L0 Sublevels\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"208f9b20-584b-7a4b-1891-697788cd0f47\", \"layerType\": \"data\", \"metricAccessor\": \"ed00ab6b-ba2d-3502-8aaf-f1d3c267d44c\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_l0_sublevels IS NOT NULL\\n| STATS max_l0 = MAX(MAX_OVER_TIME(storage_l0_sublevels))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"208f9b20-584b-7a4b-1891-697788cd0f47\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_l0_sublevels IS NOT NULL\\n| STATS max_l0 = MAX(MAX_OVER_TIME(storage_l0_sublevels))\"}, \"columns\": [{\"fieldName\": \"max_l0\", \"columnId\": \"ed00ab6b-ba2d-3502-8aaf-f1d3c267d44c\", \"label\": \"L0 Sublevels\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"max_l0\", \"columnId\": \"ed00ab6b-ba2d-3502-8aaf-f1d3c267d44c\", \"label\": \"L0 Sublevels\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"e0b0e4e2-f289-2149-eade-6993e16b6671\", \"gridData\": {\"x\": 40, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"e0b0e4e2-f289-2149-eade-6993e16b6671\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Read Amplification\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"5ff663e9-8cf2-ff7b-c406-691a02f74bd2\", \"layerType\": \"data\", \"metricAccessor\": \"5854d2c3-2dac-7ab1-f73a-29ce652a22b7\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rocksdb_read_amplification IS NOT NULL\\n| STATS avg_amp = AVG(AVG_OVER_TIME(rocksdb_read_amplification))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"5ff663e9-8cf2-ff7b-c406-691a02f74bd2\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rocksdb_read_amplification IS NOT NULL\\n| STATS avg_amp = AVG(AVG_OVER_TIME(rocksdb_read_amplification))\"}, \"columns\": [{\"fieldName\": \"avg_amp\", \"columnId\": \"5854d2c3-2dac-7ab1-f73a-29ce652a22b7\", \"label\": \"Read Amp\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"allColumns\": [{\"fieldName\": \"avg_amp\", \"columnId\": \"5854d2c3-2dac-7ab1-f73a-29ce652a22b7\", \"label\": \"Read Amp\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"b7e0d334-06f5-b322-44ba-4e65fa8f2b22\", \"gridData\": {\"x\": 16, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"b7e0d334-06f5-b322-44ba-4e65fa8f2b22\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Write Stalls\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"9a0d002c-2635-c43f-352c-255d62d3107a\", \"layerType\": \"data\", \"metricAccessor\": \"e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_write_stalls IS NOT NULL\\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"9a0d002c-2635-c43f-352c-255d62d3107a\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_write_stalls IS NOT NULL\\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls))\"}, \"columns\": [{\"fieldName\": \"stalls\", \"columnId\": \"e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8\", \"label\": \"Write Stalls\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"stalls\", \"columnId\": \"e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8\", \"label\": \"Write Stalls\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"ebf311bc-1b21-3274-faf9-d4cc48825d9f\", \"gridData\": {\"x\": 24, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"ebf311bc-1b21-3274-faf9-d4cc48825d9f\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"attributes\": {\"title\": \"Disk IO Queue\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"8ffdff35-1ab6-632f-715f-7965d178193c\", \"layerType\": \"data\", \"metricAccessor\": \"7f0d07a2-0bc5-8597-37ae-0c5ffe44e1c5\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sys_host_disk_iopsinprogress IS NOT NULL\\n| STATS iops = AVG(AVG_OVER_TIME(sys_host_disk_iopsinprogress))\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"8ffdff35-1ab6-632f-715f-7965d178193c\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE sys_host_disk_iopsinprogress IS NOT NULL\\n| STATS iops = AVG(AVG_OVER_TIME(sys_host_disk_iopsinprogress))\"}, \"columns\": [{\"fieldName\": \"iops\", \"columnId\": \"7f0d07a2-0bc5-8597-37ae-0c5ffe44e1c5\", \"label\": \"IO in Progress\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"allColumns\": [{\"fieldName\": \"iops\", \"columnId\": \"7f0d07a2-0bc5-8597-37ae-0c5ffe44e1c5\", \"label\": \"IO in Progress\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"eb309db0-3476-76d3-7f9a-2bc50766e4c4\", \"gridData\": {\"x\": 0, \"y\": 14, \"w\": 48, \"h\": 3, \"i\": \"eb309db0-3476-76d3-7f9a-2bc50766e4c4\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Capacity\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Capacity\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"03f6dd76-3f94-bf79-10ac-ebac07f89d62\", \"gridData\": {\"x\": 0, \"y\": 17, \"w\": 24, \"h\": 10, \"i\": \"03f6dd76-3f94-bf79-10ac-ebac07f89d62\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Capacity Utilization by Store\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"582b04ed-4846-a15d-20d6-f7b48dd32a7b\", \"layerType\": \"data\", \"metricAccessor\": \"774a6d32-dc14-50df-de28-35cac5ef94ad\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE capacity IS NOT NULL AND capacity_used IS NOT NULL\\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)), total = AVG(LAST_OVER_TIME(capacity)) BY store = attributes.store, node_id = attributes.node_id\\n| EVAL pct = CASE(total > 0, used / total * 100, 0)\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"582b04ed-4846-a15d-20d6-f7b48dd32a7b\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE capacity IS NOT NULL AND capacity_used IS NOT NULL\\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)), total = AVG(LAST_OVER_TIME(capacity)) BY store = attributes.store, node_id = attributes.node_id\\n| EVAL pct = CASE(total > 0, used / total * 100, 0)\"}, \"columns\": [{\"fieldName\": \"pct\", \"columnId\": \"774a6d32-dc14-50df-de28-35cac5ef94ad\", \"label\": \"Used %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 2}}}}], \"allColumns\": [{\"fieldName\": \"pct\", \"columnId\": \"774a6d32-dc14-50df-de28-35cac5ef94ad\", \"label\": \"Used %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"percent\", \"params\": {\"decimals\": 2}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"2d95fe99-8179-b2a2-b81d-1f233035d52d\", \"gridData\": {\"x\": 24, \"y\": 17, \"w\": 24, \"h\": 10, \"i\": \"2d95fe99-8179-b2a2-b81d-1f233035d52d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Capacity Used by Store\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"423780a8-5223-cd68-9a69-c47fdbd0ec28\", \"accessors\": [\"5fecf06d-d087-219e-e64b-0c92e8125dd4\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE capacity_used IS NOT NULL\\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"423780a8-5223-cd68-9a69-c47fdbd0ec28\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE capacity_used IS NOT NULL\\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"used\", \"columnId\": \"5fecf06d-d087-219e-e64b-0c92e8125dd4\", \"label\": \"Bytes Used\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"used\", \"columnId\": \"5fecf06d-d087-219e-e64b-0c92e8125dd4\", \"label\": \"Bytes Used\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"09272806-47dd-b1f3-9ed9-2187fcb55905\", \"gridData\": {\"x\": 0, \"y\": 27, \"w\": 48, \"h\": 3, \"i\": \"09272806-47dd-b1f3-9ed9-2187fcb55905\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"LSM Health\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## LSM Health\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"ab93d6dd-1ed6-9a0e-82b9-68be01c2ad5b\", \"gridData\": {\"x\": 0, \"y\": 30, \"w\": 24, \"h\": 10, \"i\": \"ab93d6dd-1ed6-9a0e-82b9-68be01c2ad5b\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"IO Admission Overload\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"898ccc6d-6db4-aa19-c648-16edffd0de9d\", \"accessors\": [\"86bf18e2-1ce3-93d7-49aa-b24c2f982b60\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE admission_io_overload IS NOT NULL\\n| STATS overload = AVG(AVG_OVER_TIME(admission_io_overload)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"898ccc6d-6db4-aa19-c648-16edffd0de9d\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE admission_io_overload IS NOT NULL\\n| STATS overload = AVG(AVG_OVER_TIME(admission_io_overload)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"overload\", \"columnId\": \"86bf18e2-1ce3-93d7-49aa-b24c2f982b60\", \"label\": \"IO Overload\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"overload\", \"columnId\": \"86bf18e2-1ce3-93d7-49aa-b24c2f982b60\", \"label\": \"IO Overload\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"104d2464-1283-e99c-1e4d-b908e77b03c1\", \"gridData\": {\"x\": 24, \"y\": 30, \"w\": 24, \"h\": 10, \"i\": \"104d2464-1283-e99c-1e4d-b908e77b03c1\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"L0 Sublevels and File Count\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"980586cb-53e7-fabe-7e68-b0aee20791d7\", \"accessors\": [\"8a4a3abc-b873-5854-0c11-b7020a02655f\", \"0f763549-a097-923d-992b-07fd3b31ff51\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_l0_sublevels IS NOT NULL OR storage_l0_num_files IS NOT NULL\\n| STATS l0_sublevels = AVG(AVG_OVER_TIME(storage_l0_sublevels)), l0_files = AVG(AVG_OVER_TIME(storage_l0_num_files)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| EVAL l0_sublevels = COALESCE(l0_sublevels, 0)\\n| EVAL l0_files = COALESCE(l0_files, 0)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"980586cb-53e7-fabe-7e68-b0aee20791d7\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_l0_sublevels IS NOT NULL OR storage_l0_num_files IS NOT NULL\\n| STATS l0_sublevels = AVG(AVG_OVER_TIME(storage_l0_sublevels)), l0_files = AVG(AVG_OVER_TIME(storage_l0_num_files)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| EVAL l0_sublevels = COALESCE(l0_sublevels, 0)\\n| EVAL l0_files = COALESCE(l0_files, 0)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"l0_sublevels\", \"columnId\": \"8a4a3abc-b873-5854-0c11-b7020a02655f\", \"label\": \"L0 Sublevels\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"l0_files\", \"columnId\": \"0f763549-a097-923d-992b-07fd3b31ff51\", \"label\": \"L0 Files\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"l0_sublevels\", \"columnId\": \"8a4a3abc-b873-5854-0c11-b7020a02655f\", \"label\": \"L0 Sublevels\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"l0_files\", \"columnId\": \"0f763549-a097-923d-992b-07fd3b31ff51\", \"label\": \"L0 Files\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"3b9e0432-3afd-6da4-93f6-ae2f8b13c414\", \"gridData\": {\"x\": 0, \"y\": 40, \"w\": 24, \"h\": 10, \"i\": \"3b9e0432-3afd-6da4-93f6-ae2f8b13c414\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Read Amplification\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"b16c913b-f824-4688-5da0-e6c3351c2075\", \"accessors\": [\"6b202c0c-89cf-6c9c-5569-3438ce499e8a\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rocksdb_read_amplification IS NOT NULL\\n| STATS amp = AVG(AVG_OVER_TIME(rocksdb_read_amplification)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"b16c913b-f824-4688-5da0-e6c3351c2075\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rocksdb_read_amplification IS NOT NULL\\n| STATS amp = AVG(AVG_OVER_TIME(rocksdb_read_amplification)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"amp\", \"columnId\": \"6b202c0c-89cf-6c9c-5569-3438ce499e8a\", \"label\": \"Read Amplification\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"amp\", \"columnId\": \"6b202c0c-89cf-6c9c-5569-3438ce499e8a\", \"label\": \"Read Amplification\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"8725989f-1cb8-2982-dcfd-8c0f29ee775d\", \"gridData\": {\"x\": 24, \"y\": 40, \"w\": 24, \"h\": 10, \"i\": \"8725989f-1cb8-2982-dcfd-8c0f29ee775d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Write Stalls\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"c64a953c-7812-6cfc-ba7b-958d486d9bc9\", \"accessors\": [\"eea69f37-b641-e8eb-dcca-249174cfe778\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"isVisible\": true, \"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_write_stalls IS NOT NULL\\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"c64a953c-7812-6cfc-ba7b-958d486d9bc9\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE storage_write_stalls IS NOT NULL\\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \\\"-\\\", TO_STRING(attributes.store))\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"stalls\", \"columnId\": \"eea69f37-b641-e8eb-dcca-249174cfe778\", \"label\": \"Write Stalls\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"stalls\", \"columnId\": \"eea69f37-b641-e8eb-dcca-249174cfe778\", \"label\": \"Write Stalls\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"node_store\", \"columnId\": \"e58e047c-4c7e-4e64-b315-eaa4261c2286\", \"label\": \"node_store\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"a18fc748-78b8-eb3e-5a27-230deca88367\", \"gridData\": {\"x\": 0, \"y\": 50, \"w\": 48, \"h\": 3, \"i\": \"a18fc748-78b8-eb3e-5a27-230deca88367\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"hidePanelTitles\": true, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"Block Cache\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Block Cache\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"41f2282e-1216-c431-ab97-c7a05dcac232\", \"gridData\": {\"x\": 0, \"y\": 53, \"w\": 24, \"h\": 10, \"i\": \"41f2282e-1216-c431-ab97-c7a05dcac232\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Block Cache Hit Rate\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"f19ae09e-be8c-abe9-34a3-db6f1b5afdf3\", \"accessors\": [\"c109b66c-f0cb-97b6-1952-944d348cb8ae\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rocksdb_block_cache_hits IS NOT NULL AND rocksdb_block_cache_misses IS NOT NULL\\n| STATS hits = SUM(INCREASE(rocksdb_block_cache_hits)), misses = SUM(INCREASE(rocksdb_block_cache_misses)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| EVAL hit_rate = CASE(hits + misses > 0, hits / (hits + misses) * 100, 0)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"f19ae09e-be8c-abe9-34a3-db6f1b5afdf3\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rocksdb_block_cache_hits IS NOT NULL AND rocksdb_block_cache_misses IS NOT NULL\\n| STATS hits = SUM(INCREASE(rocksdb_block_cache_hits)), misses = SUM(INCREASE(rocksdb_block_cache_misses)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| EVAL hit_rate = CASE(hits + misses > 0, hits / (hits + misses) * 100, 0)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"hit_rate\", \"columnId\": \"c109b66c-f0cb-97b6-1952-944d348cb8ae\", \"label\": \"Hit Rate %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"%\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"hit_rate\", \"columnId\": \"c109b66c-f0cb-97b6-1952-944d348cb8ae\", \"label\": \"Hit Rate %\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1, \"suffix\": \"%\"}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"a663dad8-7e5a-f12a-2432-07d08be37d5f\", \"gridData\": {\"x\": 24, \"y\": 53, \"w\": 24, \"h\": 10, \"i\": \"a663dad8-7e5a-f12a-2432-07d08be37d5f\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Block Cache Usage\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"eae48e84-7268-1283-e2a6-74078b604295\", \"accessors\": [\"d0dfbc49-3fe3-4444-09dd-17d272ec0873\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rocksdb_block_cache_usage IS NOT NULL\\n| STATS usage = AVG(LAST_OVER_TIME(rocksdb_block_cache_usage)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"eae48e84-7268-1283-e2a6-74078b604295\": {\"query\": {\"esql\": \"TS metrics-cockroachdb.otel-*\\n| WHERE resource.attributes.service.name == \\\"cockroachdb\\\"\\n| WHERE rocksdb_block_cache_usage IS NOT NULL\\n| STATS usage = AVG(LAST_OVER_TIME(rocksdb_block_cache_usage)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\"}, \"columns\": [{\"fieldName\": \"usage\", \"columnId\": \"d0dfbc49-3fe3-4444-09dd-17d272ec0873\", \"label\": \"Cache Usage\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"usage\", \"columnId\": \"d0dfbc49-3fe3-4444-09dd-17d272ec0873\", \"label\": \"Cache Usage\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"bytes\", \"params\": {\"decimals\": 2}}}}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "b986582c-6093-3b85-1b1f-c667124bd189",
+                "order": 1,
+                "label": "Storage",
+                "type": "dashboardLink",
+                "destinationRefName": "link_b986582c-6093-3b85-1b1f-c667124bd189_dashboard"
+              },
+              {
+                "id": "0ce5133a-1601-c0e1-50df-1375499c41f7",
+                "order": 2,
+                "label": "SQL & Transactions",
+                "type": "dashboardLink",
+                "destinationRefName": "link_0ce5133a-1601-c0e1-50df-1375499c41f7_dashboard"
+              },
+              {
+                "id": "4da2826a-7c0c-9dc0-3fe3-52ae1dc165de",
+                "order": 3,
+                "label": "Replication & Ranges",
+                "type": "dashboardLink",
+                "destinationRefName": "link_4da2826a-7c0c-9dc0-3fe3-52ae1dc165de_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "0563dba8-e018-01bf-7e3c-91932750954e",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 16,
+          "h": 12,
+          "i": "0563dba8-e018-01bf-7e3c-91932750954e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## [CockroachDB OTel] Storage\n\nThis dashboard monitors storage and LSM health:\n- Capacity used, available, and utilization\n- IO admission overload (>1.0 = overloaded)\n- L0 sublevels and file count (compaction health)\n- Read amplification (should be single digits)\n- Write stalls and disk I/O queue depth\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "74117d03-dce4-ba18-82f3-3963920a84ae",
+        "gridData": {
+          "x": 16,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "74117d03-dce4-ba18-82f3-3963920a84ae"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Capacity Used %",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "25ff9254-1fce-4b7e-60ae-dc06ea0441ab",
+                "layerType": "data",
+                "metricAccessor": "476559d7-6cca-aaf6-90ac-0161d71872ff",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE capacity IS NOT NULL AND capacity_used IS NOT NULL\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)), total = AVG(LAST_OVER_TIME(capacity))\n| EVAL pct = CASE(total > 0, used / total * 100, 0)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "25ff9254-1fce-4b7e-60ae-dc06ea0441ab": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE capacity IS NOT NULL AND capacity_used IS NOT NULL\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)), total = AVG(LAST_OVER_TIME(capacity))\n| EVAL pct = CASE(total > 0, used / total * 100, 0)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "pct",
+                          "columnId": "476559d7-6cca-aaf6-90ac-0161d71872ff",
+                          "label": "Used %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "%"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "pct",
+                          "columnId": "476559d7-6cca-aaf6-90ac-0161d71872ff",
+                          "label": "Used %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "%"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "4a8fb810-af9e-d94d-f686-cae3ba5ad77e",
+        "gridData": {
+          "x": 24,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "4a8fb810-af9e-d94d-f686-cae3ba5ad77e"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "IO Overload",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "31107a35-ca00-d025-7169-5fcdd594d99c",
+                "layerType": "data",
+                "metricAccessor": "4db5cf58-cf78-3468-f88c-d4637075ca22",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE admission_io_overload IS NOT NULL\n| STATS avg_io = AVG(AVG_OVER_TIME(admission_io_overload))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "31107a35-ca00-d025-7169-5fcdd594d99c": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE admission_io_overload IS NOT NULL\n| STATS avg_io = AVG(AVG_OVER_TIME(admission_io_overload))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "avg_io",
+                          "columnId": "4db5cf58-cf78-3468-f88c-d4637075ca22",
+                          "label": "IO Overload",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "avg_io",
+                          "columnId": "4db5cf58-cf78-3468-f88c-d4637075ca22",
+                          "label": "IO Overload",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "ffa30dca-0f13-dbef-0638-6317c8ff98fe",
+        "gridData": {
+          "x": 32,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "ffa30dca-0f13-dbef-0638-6317c8ff98fe"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "L0 Sublevels",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "208f9b20-584b-7a4b-1891-697788cd0f47",
+                "layerType": "data",
+                "metricAccessor": "ed00ab6b-ba2d-3502-8aaf-f1d3c267d44c",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_l0_sublevels IS NOT NULL\n| STATS max_l0 = MAX(MAX_OVER_TIME(storage_l0_sublevels))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "208f9b20-584b-7a4b-1891-697788cd0f47": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_l0_sublevels IS NOT NULL\n| STATS max_l0 = MAX(MAX_OVER_TIME(storage_l0_sublevels))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "max_l0",
+                          "columnId": "ed00ab6b-ba2d-3502-8aaf-f1d3c267d44c",
+                          "label": "L0 Sublevels",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "max_l0",
+                          "columnId": "ed00ab6b-ba2d-3502-8aaf-f1d3c267d44c",
+                          "label": "L0 Sublevels",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "e0b0e4e2-f289-2149-eade-6993e16b6671",
+        "gridData": {
+          "x": 40,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "e0b0e4e2-f289-2149-eade-6993e16b6671"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Read Amplification",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "5ff663e9-8cf2-ff7b-c406-691a02f74bd2",
+                "layerType": "data",
+                "metricAccessor": "5854d2c3-2dac-7ab1-f73a-29ce652a22b7",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rocksdb_read_amplification IS NOT NULL\n| STATS avg_amp = AVG(AVG_OVER_TIME(rocksdb_read_amplification))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "5ff663e9-8cf2-ff7b-c406-691a02f74bd2": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rocksdb_read_amplification IS NOT NULL\n| STATS avg_amp = AVG(AVG_OVER_TIME(rocksdb_read_amplification))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "avg_amp",
+                          "columnId": "5854d2c3-2dac-7ab1-f73a-29ce652a22b7",
+                          "label": "Read Amp",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "avg_amp",
+                          "columnId": "5854d2c3-2dac-7ab1-f73a-29ce652a22b7",
+                          "label": "Read Amp",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "b7e0d334-06f5-b322-44ba-4e65fa8f2b22",
+        "gridData": {
+          "x": 16,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "b7e0d334-06f5-b322-44ba-4e65fa8f2b22"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Write Stalls",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "9a0d002c-2635-c43f-352c-255d62d3107a",
+                "layerType": "data",
+                "metricAccessor": "e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_write_stalls IS NOT NULL\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "9a0d002c-2635-c43f-352c-255d62d3107a": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_write_stalls IS NOT NULL\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "stalls",
+                          "columnId": "e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8",
+                          "label": "Write Stalls",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "stalls",
+                          "columnId": "e5fa681f-ceda-5512-9f1d-4a1bfbfd87f8",
+                          "label": "Write Stalls",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "ebf311bc-1b21-3274-faf9-d4cc48825d9f",
+        "gridData": {
+          "x": 24,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "ebf311bc-1b21-3274-faf9-d4cc48825d9f"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "attributes": {
+            "title": "Disk IO Queue",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "8ffdff35-1ab6-632f-715f-7965d178193c",
+                "layerType": "data",
+                "metricAccessor": "7f0d07a2-0bc5-8597-37ae-0c5ffe44e1c5",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sys_host_disk_iopsinprogress IS NOT NULL\n| STATS iops = AVG(AVG_OVER_TIME(sys_host_disk_iopsinprogress))"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "8ffdff35-1ab6-632f-715f-7965d178193c": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE sys_host_disk_iopsinprogress IS NOT NULL\n| STATS iops = AVG(AVG_OVER_TIME(sys_host_disk_iopsinprogress))"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "iops",
+                          "columnId": "7f0d07a2-0bc5-8597-37ae-0c5ffe44e1c5",
+                          "label": "IO in Progress",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "iops",
+                          "columnId": "7f0d07a2-0bc5-8597-37ae-0c5ffe44e1c5",
+                          "label": "IO in Progress",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "eb309db0-3476-76d3-7f9a-2bc50766e4c4",
+        "gridData": {
+          "x": 0,
+          "y": 14,
+          "w": 48,
+          "h": 3,
+          "i": "eb309db0-3476-76d3-7f9a-2bc50766e4c4"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Capacity",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Capacity"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "03f6dd76-3f94-bf79-10ac-ebac07f89d62",
+        "gridData": {
+          "x": 0,
+          "y": 17,
+          "w": 24,
+          "h": 10,
+          "i": "03f6dd76-3f94-bf79-10ac-ebac07f89d62"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Capacity Utilization by Store",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "582b04ed-4846-a15d-20d6-f7b48dd32a7b",
+                "layerType": "data",
+                "metricAccessor": "774a6d32-dc14-50df-de28-35cac5ef94ad",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE capacity IS NOT NULL AND capacity_used IS NOT NULL\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)), total = AVG(LAST_OVER_TIME(capacity)) BY store = attributes.store, node_id = attributes.node_id\n| EVAL pct = CASE(total > 0, used / total * 100, 0)"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "582b04ed-4846-a15d-20d6-f7b48dd32a7b": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE capacity IS NOT NULL AND capacity_used IS NOT NULL\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)), total = AVG(LAST_OVER_TIME(capacity)) BY store = attributes.store, node_id = attributes.node_id\n| EVAL pct = CASE(total > 0, used / total * 100, 0)"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "pct",
+                          "columnId": "774a6d32-dc14-50df-de28-35cac5ef94ad",
+                          "label": "Used %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "pct",
+                          "columnId": "774a6d32-dc14-50df-de28-35cac5ef94ad",
+                          "label": "Used %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "percent",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "2d95fe99-8179-b2a2-b81d-1f233035d52d",
+        "gridData": {
+          "x": 24,
+          "y": 17,
+          "w": 24,
+          "h": 10,
+          "i": "2d95fe99-8179-b2a2-b81d-1f233035d52d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Capacity Used by Store",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "423780a8-5223-cd68-9a69-c47fdbd0ec28",
+                    "accessors": [
+                      "5fecf06d-d087-219e-e64b-0c92e8125dd4"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE capacity_used IS NOT NULL\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "423780a8-5223-cd68-9a69-c47fdbd0ec28": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE capacity_used IS NOT NULL\n| STATS used = AVG(LAST_OVER_TIME(capacity_used)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "used",
+                          "columnId": "5fecf06d-d087-219e-e64b-0c92e8125dd4",
+                          "label": "Bytes Used",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "used",
+                          "columnId": "5fecf06d-d087-219e-e64b-0c92e8125dd4",
+                          "label": "Bytes Used",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "09272806-47dd-b1f3-9ed9-2187fcb55905",
+        "gridData": {
+          "x": 0,
+          "y": 27,
+          "w": 48,
+          "h": 3,
+          "i": "09272806-47dd-b1f3-9ed9-2187fcb55905"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "LSM Health",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## LSM Health"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "ab93d6dd-1ed6-9a0e-82b9-68be01c2ad5b",
+        "gridData": {
+          "x": 0,
+          "y": 30,
+          "w": 24,
+          "h": 10,
+          "i": "ab93d6dd-1ed6-9a0e-82b9-68be01c2ad5b"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "IO Admission Overload",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "898ccc6d-6db4-aa19-c648-16edffd0de9d",
+                    "accessors": [
+                      "86bf18e2-1ce3-93d7-49aa-b24c2f982b60"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE admission_io_overload IS NOT NULL\n| STATS overload = AVG(AVG_OVER_TIME(admission_io_overload)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "898ccc6d-6db4-aa19-c648-16edffd0de9d": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE admission_io_overload IS NOT NULL\n| STATS overload = AVG(AVG_OVER_TIME(admission_io_overload)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "overload",
+                          "columnId": "86bf18e2-1ce3-93d7-49aa-b24c2f982b60",
+                          "label": "IO Overload",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "overload",
+                          "columnId": "86bf18e2-1ce3-93d7-49aa-b24c2f982b60",
+                          "label": "IO Overload",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "104d2464-1283-e99c-1e4d-b908e77b03c1",
+        "gridData": {
+          "x": 24,
+          "y": 30,
+          "w": 24,
+          "h": 10,
+          "i": "104d2464-1283-e99c-1e4d-b908e77b03c1"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "L0 Sublevels and File Count",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "980586cb-53e7-fabe-7e68-b0aee20791d7",
+                    "accessors": [
+                      "8a4a3abc-b873-5854-0c11-b7020a02655f",
+                      "0f763549-a097-923d-992b-07fd3b31ff51"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_l0_sublevels IS NOT NULL OR storage_l0_num_files IS NOT NULL\n| STATS l0_sublevels = AVG(AVG_OVER_TIME(storage_l0_sublevels)), l0_files = AVG(AVG_OVER_TIME(storage_l0_num_files)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL l0_sublevels = COALESCE(l0_sublevels, 0)\n| EVAL l0_files = COALESCE(l0_files, 0)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "980586cb-53e7-fabe-7e68-b0aee20791d7": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_l0_sublevels IS NOT NULL OR storage_l0_num_files IS NOT NULL\n| STATS l0_sublevels = AVG(AVG_OVER_TIME(storage_l0_sublevels)), l0_files = AVG(AVG_OVER_TIME(storage_l0_num_files)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL l0_sublevels = COALESCE(l0_sublevels, 0)\n| EVAL l0_files = COALESCE(l0_files, 0)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "l0_sublevels",
+                          "columnId": "8a4a3abc-b873-5854-0c11-b7020a02655f",
+                          "label": "L0 Sublevels",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "l0_files",
+                          "columnId": "0f763549-a097-923d-992b-07fd3b31ff51",
+                          "label": "L0 Files",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "l0_sublevels",
+                          "columnId": "8a4a3abc-b873-5854-0c11-b7020a02655f",
+                          "label": "L0 Sublevels",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "l0_files",
+                          "columnId": "0f763549-a097-923d-992b-07fd3b31ff51",
+                          "label": "L0 Files",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "3b9e0432-3afd-6da4-93f6-ae2f8b13c414",
+        "gridData": {
+          "x": 0,
+          "y": 40,
+          "w": 24,
+          "h": 10,
+          "i": "3b9e0432-3afd-6da4-93f6-ae2f8b13c414"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Read Amplification",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "b16c913b-f824-4688-5da0-e6c3351c2075",
+                    "accessors": [
+                      "6b202c0c-89cf-6c9c-5569-3438ce499e8a"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rocksdb_read_amplification IS NOT NULL\n| STATS amp = AVG(AVG_OVER_TIME(rocksdb_read_amplification)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "b16c913b-f824-4688-5da0-e6c3351c2075": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rocksdb_read_amplification IS NOT NULL\n| STATS amp = AVG(AVG_OVER_TIME(rocksdb_read_amplification)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "amp",
+                          "columnId": "6b202c0c-89cf-6c9c-5569-3438ce499e8a",
+                          "label": "Read Amplification",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "amp",
+                          "columnId": "6b202c0c-89cf-6c9c-5569-3438ce499e8a",
+                          "label": "Read Amplification",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "8725989f-1cb8-2982-dcfd-8c0f29ee775d",
+        "gridData": {
+          "x": 24,
+          "y": 40,
+          "w": 24,
+          "h": 10,
+          "i": "8725989f-1cb8-2982-dcfd-8c0f29ee775d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Write Stalls",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "c64a953c-7812-6cfc-ba7b-958d486d9bc9",
+                    "accessors": [
+                      "eea69f37-b641-e8eb-dcca-249174cfe778"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_write_stalls IS NOT NULL\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "c64a953c-7812-6cfc-ba7b-958d486d9bc9": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE storage_write_stalls IS NOT NULL\n| STATS stalls = MAX(LAST_OVER_TIME(storage_write_stalls)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), node_store = CONCAT(TO_STRING(attributes.node_id), \"-\", TO_STRING(attributes.store))\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "stalls",
+                          "columnId": "eea69f37-b641-e8eb-dcca-249174cfe778",
+                          "label": "Write Stalls",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "stalls",
+                          "columnId": "eea69f37-b641-e8eb-dcca-249174cfe778",
+                          "label": "Write Stalls",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "node_store",
+                          "columnId": "e58e047c-4c7e-4e64-b315-eaa4261c2286",
+                          "label": "node_store",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "a18fc748-78b8-eb3e-5a27-230deca88367",
+        "gridData": {
+          "x": 0,
+          "y": 50,
+          "w": 48,
+          "h": 3,
+          "i": "a18fc748-78b8-eb3e-5a27-230deca88367"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "hidePanelTitles": true,
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "Block Cache",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Block Cache"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "41f2282e-1216-c431-ab97-c7a05dcac232",
+        "gridData": {
+          "x": 0,
+          "y": 53,
+          "w": 24,
+          "h": 10,
+          "i": "41f2282e-1216-c431-ab97-c7a05dcac232"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Block Cache Hit Rate",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "f19ae09e-be8c-abe9-34a3-db6f1b5afdf3",
+                    "accessors": [
+                      "c109b66c-f0cb-97b6-1952-944d348cb8ae"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rocksdb_block_cache_hits IS NOT NULL AND rocksdb_block_cache_misses IS NOT NULL\n| STATS hits = SUM(INCREASE(rocksdb_block_cache_hits)), misses = SUM(INCREASE(rocksdb_block_cache_misses)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL hit_rate = CASE(hits + misses > 0, hits / (hits + misses) * 100, 0)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "f19ae09e-be8c-abe9-34a3-db6f1b5afdf3": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rocksdb_block_cache_hits IS NOT NULL AND rocksdb_block_cache_misses IS NOT NULL\n| STATS hits = SUM(INCREASE(rocksdb_block_cache_hits)), misses = SUM(INCREASE(rocksdb_block_cache_misses)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL hit_rate = CASE(hits + misses > 0, hits / (hits + misses) * 100, 0)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "hit_rate",
+                          "columnId": "c109b66c-f0cb-97b6-1952-944d348cb8ae",
+                          "label": "Hit Rate %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "%"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "hit_rate",
+                          "columnId": "c109b66c-f0cb-97b6-1952-944d348cb8ae",
+                          "label": "Hit Rate %",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1,
+                                "suffix": "%"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "a663dad8-7e5a-f12a-2432-07d08be37d5f",
+        "gridData": {
+          "x": 24,
+          "y": 53,
+          "w": 24,
+          "h": 10,
+          "i": "a663dad8-7e5a-f12a-2432-07d08be37d5f"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Block Cache Usage",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "eae48e84-7268-1283-e2a6-74078b604295",
+                    "accessors": [
+                      "d0dfbc49-3fe3-4444-09dd-17d272ec0873"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rocksdb_block_cache_usage IS NOT NULL\n| STATS usage = AVG(LAST_OVER_TIME(rocksdb_block_cache_usage)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "eae48e84-7268-1283-e2a6-74078b604295": {
+                      "query": {
+                        "esql": "TS metrics-cockroachdb.otel-*\n| WHERE resource.attributes.service.name == \"cockroachdb\"\n| WHERE rocksdb_block_cache_usage IS NOT NULL\n| STATS usage = AVG(LAST_OVER_TIME(rocksdb_block_cache_usage)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "usage",
+                          "columnId": "d0dfbc49-3fe3-4444-09dd-17d272ec0873",
+                          "label": "Cache Usage",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "usage",
+                          "columnId": "d0dfbc49-3fe3-4444-09dd-17d272ec0873",
+                          "label": "Cache Usage",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "bytes",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"resource.attributes.service.name\",\"field\":\"resource.attributes.service.name\",\"params\":{\"query\":\"cockroachdb\"}},\"query\":{\"match_phrase\":{\"resource.attributes.service.name\":\"cockroachdb\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "resource.attributes.service.name",
+              "field": "resource.attributes.service.name",
+              "params": {
+                "query": "cockroachdb"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "resource.attributes.service.name": "cockroachdb"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": false,
     "version": 1,
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"2283c92c-f236-d98b-8f14-b4f4a80d676a\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2283c92c-f236-d98b-8f14-b4f4a80d676a\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"attributes.node_id\",\"title\":\"Node\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "2283c92c-f236-d98b-8f14-b4f4a80d676a": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "2283c92c-f236-d98b-8f14-b4f4a80d676a",
+            "dataViewId": "metrics-*",
+            "fieldName": "attributes.node_id",
+            "title": "Node",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/iis_otel/kibana/dashboard/iis_otel-overview.json
+++ b/packages/iis_otel/kibana/dashboard/iis_otel-overview.json
@@ -2,10 +2,3095 @@
   "attributes": {
     "title": "[IIS OTel] Overview",
     "description": "Comprehensive operational visibility for IIS web servers instrumented via OpenTelemetry iisreceiver. Tracks application pool health, request handling capacity, traffic patterns, and resource utilization.",
-    "panelsJSON": "[{\"panelIndex\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"311e2098-d3cb-e8f4-bf13-b097739154c3\", \"order\": 1, \"label\": \"Sites & Pools\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard\"}]}}}, {\"panelIndex\": \"0563dba8-e018-01bf-7e3c-91932750954e\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 16, \"h\": 12, \"i\": \"0563dba8-e018-01bf-7e3c-91932750954e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [IIS OTel] Overview\\n\\nThis dashboard provides operational visibility for **IIS** instrumented via the OpenTelemetry **iisreceiver** (collector-contrib):\\n\\n- **Pool health** \\u2014 State and uptime; any pool not Running = outage\\n- **Request handling** \\u2014 Queue depth, age, rejections (primary saturation/error signals)\\n- **Traffic** \\u2014 Request rate by method, connections, network throughput\\n- **Resources** \\u2014 Active threads, bandwidth throttling\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"813ddedf-a285-d443-e8ec-de7939b683e7\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"813ddedf-a285-d443-e8ec-de7939b683e7\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Unhealthy Pools\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"e80039e9-1eb2-1829-e8f7-0ee07c079cf9\", \"layerType\": \"data\", \"metricAccessor\": \"0f9b7569-7ec6-4688-7d61-877cae7188af\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE `iis.application_pool.state` IS NOT NULL\\n| STATS unhealthy = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` != 3\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e80039e9-1eb2-1829-e8f7-0ee07c079cf9\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE `iis.application_pool.state` IS NOT NULL\\n| STATS unhealthy = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` != 3\\n\"}, \"columns\": [{\"fieldName\": \"unhealthy\", \"columnId\": \"0f9b7569-7ec6-4688-7d61-877cae7188af\", \"label\": \"unhealthy\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"unhealthy\", \"columnId\": \"0f9b7569-7ec6-4688-7d61-877cae7188af\", \"label\": \"unhealthy\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"95fa3c06-c2bd-c69a-db35-556c2f3c71d6\", \"gridData\": {\"x\": 24, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"95fa3c06-c2bd-c69a-db35-556c2f3c71d6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Pools Running\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"84f43c43-73a5-ce07-eae5-2a869bc01c39\", \"layerType\": \"data\", \"metricAccessor\": \"d4e02019-b446-715f-69d5-ee2e746edb50\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE `iis.application_pool.state` IS NOT NULL\\n| STATS pools_running = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` == 3\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"84f43c43-73a5-ce07-eae5-2a869bc01c39\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE `iis.application_pool.state` IS NOT NULL\\n| STATS pools_running = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` == 3\\n\"}, \"columns\": [{\"fieldName\": \"pools_running\", \"columnId\": \"d4e02019-b446-715f-69d5-ee2e746edb50\", \"label\": \"pools_running\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"pools_running\", \"columnId\": \"d4e02019-b446-715f-69d5-ee2e746edb50\", \"label\": \"pools_running\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"ab63f3d4-0787-0d45-2876-5028b2132cce\", \"gridData\": {\"x\": 32, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"ab63f3d4-0787-0d45-2876-5028b2132cce\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Rate\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"c924c3f4-3bec-ecd5-7532-09f9f09b8c7e\", \"layerType\": \"data\", \"metricAccessor\": \"b8b4df96-d61b-76cf-3ae0-10119f5ec31b\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`))\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"c924c3f4-3bec-ecd5-7532-09f9f09b8c7e\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`))\\n\"}, \"columns\": [{\"fieldName\": \"req_rate\", \"columnId\": \"b8b4df96-d61b-76cf-3ae0-10119f5ec31b\", \"label\": \"req_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"req_rate\", \"columnId\": \"b8b4df96-d61b-76cf-3ae0-10119f5ec31b\", \"label\": \"req_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"eac7ed13-3f78-1d43-4da3-b28d55f68ed9\", \"gridData\": {\"x\": 40, \"y\": 2, \"w\": 8, \"h\": 4, \"i\": \"eac7ed13-3f78-1d43-4da3-b28d55f68ed9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Rejected Requests\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"ec129854-26b4-acf0-4ac7-c3a259bbbc3d\", \"layerType\": \"data\", \"metricAccessor\": \"582f7d34-b4d5-a6c9-e48b-d06157a6ef74\", \"showBar\": false}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL\\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`))\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ec129854-26b4-acf0-4ac7-c3a259bbbc3d\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL\\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`))\\n\"}, \"columns\": [{\"fieldName\": \"rej_rate\", \"columnId\": \"582f7d34-b4d5-a6c9-e48b-d06157a6ef74\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"rej_rate\", \"columnId\": \"582f7d34-b4d5-a6c9-e48b-d06157a6ef74\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f6254395-a5b0-089a-6a73-298a6896dbc2\", \"gridData\": {\"x\": 16, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"f6254395-a5b0-089a-6a73-298a6896dbc2\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Max Queue Depth\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"86cec1c4-9f7d-c98c-88a1-2f0bd5a3d0eb\", \"layerType\": \"data\", \"metricAccessor\": \"7c6337ab-977d-1114-3e7c-0f9d4f55b9b6\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL\\n| STATS max_queue = MAX(`iis.request.queue.count`)\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"86cec1c4-9f7d-c98c-88a1-2f0bd5a3d0eb\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL\\n| STATS max_queue = MAX(`iis.request.queue.count`)\\n\"}, \"columns\": [{\"fieldName\": \"max_queue\", \"columnId\": \"7c6337ab-977d-1114-3e7c-0f9d4f55b9b6\", \"label\": \"max_queue\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"max_queue\", \"columnId\": \"7c6337ab-977d-1114-3e7c-0f9d4f55b9b6\", \"label\": \"max_queue\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"b20d2603-819c-4c4f-762e-406a5009f675\", \"gridData\": {\"x\": 24, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"b20d2603-819c-4c4f-762e-406a5009f675\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Max Queue Age\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"5b35ce18-ec94-aa56-07e0-cac121ebde99\", \"layerType\": \"data\", \"metricAccessor\": \"a7734371-c6e7-4544-62cf-a6c05723924a\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL\\n| STATS max_age = MAX(`iis.request.queue.age.max`)\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"5b35ce18-ec94-aa56-07e0-cac121ebde99\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL\\n| STATS max_age = MAX(`iis.request.queue.age.max`)\\n\"}, \"columns\": [{\"fieldName\": \"max_age\", \"columnId\": \"a7734371-c6e7-4544-62cf-a6c05723924a\", \"label\": \"max_age\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"max_age\", \"columnId\": \"a7734371-c6e7-4544-62cf-a6c05723924a\", \"label\": \"max_age\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"90a8c058-4a5c-8e56-a4d8-44db0887cca7\", \"gridData\": {\"x\": 32, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"90a8c058-4a5c-8e56-a4d8-44db0887cca7\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Connections\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"dcbdf011-f9ca-49fe-12f1-02c33cc0bc00\", \"layerType\": \"data\", \"metricAccessor\": \"2b3b5ebb-85ad-68e5-6139-59d7a2f18460\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.active` IS NOT NULL\\n| STATS connections = SUM(`iis.connection.active`)\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"dcbdf011-f9ca-49fe-12f1-02c33cc0bc00\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.active` IS NOT NULL\\n| STATS connections = SUM(`iis.connection.active`)\\n\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"2b3b5ebb-85ad-68e5-6139-59d7a2f18460\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"2b3b5ebb-85ad-68e5-6139-59d7a2f18460\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"7c65e231-552e-caaa-87a5-2e4e5ed1f96e\", \"gridData\": {\"x\": 40, \"y\": 6, \"w\": 8, \"h\": 4, \"i\": \"7c65e231-552e-caaa-87a5-2e4e5ed1f96e\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Threads\", \"visualizationType\": \"lnsMetric\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layerId\": \"e5ceceeb-8f86-9072-6e06-f82b575829e1\", \"layerType\": \"data\", \"metricAccessor\": \"50916375-279e-ffde-d978-76b56fcb2241\", \"showBar\": false}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`)\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e5ceceeb-8f86-9072-6e06-f82b575829e1\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`)\\n\"}, \"columns\": [{\"fieldName\": \"threads\", \"columnId\": \"50916375-279e-ffde-d978-76b56fcb2241\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"allColumns\": [{\"fieldName\": \"threads\", \"columnId\": \"50916375-279e-ffde-d978-76b56fcb2241\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"98dd998b-7197-65f6-2395-6f3b86cdb1e8\", \"gridData\": {\"x\": 0, \"y\": 14, \"w\": 48, \"h\": 3, \"i\": \"98dd998b-7197-65f6-2395-6f3b86cdb1e8\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Application Pool Health & State\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"34d9cc5f-7571-24f7-fef6-bd05516fb5b3\", \"gridData\": {\"x\": 0, \"y\": 17, \"w\": 24, \"h\": 12, \"i\": \"34d9cc5f-7571-24f7-fef6-bd05516fb5b3\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Application Pool Health \\u2014 State & Uptime Table\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"ee50b2c7-6646-dc9d-c57c-12e81f6509dd\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND (`iis.application_pool.state` IS NOT NULL OR `iis.application_pool.uptime` IS NOT NULL)\\n| STATS state = MAX(`iis.application_pool.state`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool, host = resource.attributes.host.name\\n| EVAL state_label = CASE( state == 1, \\\"Uninitialized\\\", state == 2, \\\"Initialized\\\", state == 3, \\\"Running\\\", state == 4, \\\"Disabling\\\", state == 5, \\\"Disabled\\\", state == 6, \\\"Shutdown Pending\\\", state == 7, \\\"Delete Pending\\\", \\\"Unknown\\\" )\\n| SORT pool ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ee50b2c7-6646-dc9d-c57c-12e81f6509dd\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND (`iis.application_pool.state` IS NOT NULL OR `iis.application_pool.uptime` IS NOT NULL)\\n| STATS state = MAX(`iis.application_pool.state`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool, host = resource.attributes.host.name\\n| EVAL state_label = CASE( state == 1, \\\"Uninitialized\\\", state == 2, \\\"Initialized\\\", state == 3, \\\"Running\\\", state == 4, \\\"Disabling\\\", state == 5, \\\"Disabled\\\", state == 6, \\\"Shutdown Pending\\\", state == 7, \\\"Delete Pending\\\", \\\"Unknown\\\" )\\n| SORT pool ASC\"}, \"columns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"state_label\", \"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"label\": \"State\", \"customLabel\": true}, {\"fieldName\": \"uptime\", \"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"label\": \"Uptime (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"host\", \"columnId\": \"29167533-4bae-824d-33b1-fad502657638\", \"label\": \"Host\", \"customLabel\": true}, {\"fieldName\": \"state_label\", \"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"label\": \"State\", \"customLabel\": true}, {\"fieldName\": \"uptime\", \"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"label\": \"Uptime (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"10d284ec-b188-cdbf-e310-0e39f6e87d33\", \"gridData\": {\"x\": 24, \"y\": 17, \"w\": 24, \"h\": 12, \"i\": \"10d284ec-b188-cdbf-e310-0e39f6e87d33\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Pool Uptime Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cd54e897-9fa3-89a4-ad7a-0c193dbff658\", \"accessors\": [\"44c283a7-8a78-dd3c-5b66-4c7e8ca5defc\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"c915ede9-a7d1-1075-b745-5b72743ca894\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.application_pool.uptime` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS uptime = MAX(`iis.application_pool.uptime`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), pool = iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cd54e897-9fa3-89a4-ad7a-0c193dbff658\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.application_pool.uptime` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS uptime = MAX(`iis.application_pool.uptime`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), pool = iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"uptime\", \"columnId\": \"44c283a7-8a78-dd3c-5b66-4c7e8ca5defc\", \"label\": \"uptime\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"pool\", \"columnId\": \"c915ede9-a7d1-1075-b745-5b72743ca894\", \"label\": \"pool\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"uptime\", \"columnId\": \"44c283a7-8a78-dd3c-5b66-4c7e8ca5defc\", \"label\": \"uptime\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"pool\", \"columnId\": \"c915ede9-a7d1-1075-b745-5b72743ca894\", \"label\": \"pool\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f3c72600-acb1-c4be-af9d-1055b48a0a2a\", \"gridData\": {\"x\": 0, \"y\": 29, \"w\": 48, \"h\": 3, \"i\": \"f3c72600-acb1-c4be-af9d-1055b48a0a2a\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Request Rate & Queue Metrics\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"6fea96a6-f528-9373-2e0e-386184013bbd\", \"gridData\": {\"x\": 0, \"y\": 32, \"w\": 24, \"h\": 12, \"i\": \"6fea96a6-f528-9373-2e0e-386184013bbd\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Rate by HTTP Method Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"51fe9a4a-6244-7681-e2ab-f521416d6e14\", \"accessors\": [\"b1911db0-e346-dde6-337e-a829f741712f\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.request\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"51fe9a4a-6244-7681-e2ab-f521416d6e14\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.request\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"req_rate\", \"columnId\": \"b1911db0-e346-dde6-337e-a829f741712f\", \"label\": \"req_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.request\", \"columnId\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"label\": \"attributes.request\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"req_rate\", \"columnId\": \"b1911db0-e346-dde6-337e-a829f741712f\", \"label\": \"req_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.request\", \"columnId\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"label\": \"attributes.request\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"4f435521-b3f6-be32-0518-4c26873c5dc9\", \"gridData\": {\"x\": 24, \"y\": 32, \"w\": 24, \"h\": 12, \"i\": \"4f435521-b3f6-be32-0518-4c26873c5dc9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Depth and Rejections Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"893d1400-cdbf-b21f-48b1-b0e98604a831\", \"accessors\": [\"e976855b-f978-6e5c-9596-70700fbfefb7\", \"dafc20a2-21a9-1560-3d32-082ef9c83e85\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\"\\n| STATS queue_depth = SUM(COALESCE(`iis.request.queue.count`, 0)), rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"893d1400-cdbf-b21f-48b1-b0e98604a831\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\"\\n| STATS queue_depth = SUM(COALESCE(`iis.request.queue.count`, 0)), rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"rej_rate\", \"columnId\": \"dafc20a2-21a9-1560-3d32-082ef9c83e85\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"rej_rate\", \"columnId\": \"dafc20a2-21a9-1560-3d32-082ef9c83e85\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"eee5aea0-a409-c924-2c9a-6904041a625c\", \"gridData\": {\"x\": 0, \"y\": 44, \"w\": 12, \"h\": 10, \"i\": \"eee5aea0-a409-c924-2c9a-6904041a625c\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Depth Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"c8b86171-f1f3-d287-82ea-c416c4c60863\", \"accessors\": [\"e976855b-f978-6e5c-9596-70700fbfefb7\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"bottom\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL\\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"c8b86171-f1f3-d287-82ea-c416c4c60863\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL\\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"872b997d-1b64-79cb-596e-27e82d85296d\", \"gridData\": {\"x\": 12, \"y\": 44, \"w\": 12, \"h\": 10, \"i\": \"872b997d-1b64-79cb-596e-27e82d85296d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Rejections Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"a4bed244-493a-e788-e13b-f8d4920a2037\", \"accessors\": [\"dafc20a2-21a9-1560-3d32-082ef9c83e85\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"bottom\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL\\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"a4bed244-493a-e788-e13b-f8d4920a2037\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL\\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"rej_rate\", \"columnId\": \"dafc20a2-21a9-1560-3d32-082ef9c83e85\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"rej_rate\", \"columnId\": \"dafc20a2-21a9-1560-3d32-082ef9c83e85\", \"label\": \"rej_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"e75467ea-82ca-9f6b-ae93-e22957fe1697\", \"gridData\": {\"x\": 24, \"y\": 44, \"w\": 24, \"h\": 10, \"i\": \"e75467ea-82ca-9f6b-ae93-e22957fe1697\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Age Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"9ea7ce9f-5bb4-72c5-5be9-c8b8f53b727b\", \"accessors\": [\"efce20bc-bdd4-19fc-3289-e7a670ec6e46\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL\\n| STATS max_age = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"9ea7ce9f-5bb4-72c5-5be9-c8b8f53b727b\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL\\n| STATS max_age = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"max_age\", \"columnId\": \"efce20bc-bdd4-19fc-3289-e7a670ec6e46\", \"label\": \"max_age\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"max_age\", \"columnId\": \"efce20bc-bdd4-19fc-3289-e7a670ec6e46\", \"label\": \"max_age\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"9a325fad-2e84-d2d6-4737-c9d5addbd26e\", \"gridData\": {\"x\": 0, \"y\": 54, \"w\": 48, \"h\": 3, \"i\": \"9a325fad-2e84-d2d6-4737-c9d5addbd26e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Traffic, Method Distribution & Network\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"c43a4883-7cb8-eb95-61e6-152104c9bd11\", \"gridData\": {\"x\": 0, \"y\": 57, \"w\": 12, \"h\": 10, \"i\": \"c43a4883-7cb8-eb95-61e6-152104c9bd11\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Method Distribution\", \"visualizationType\": \"lnsPie\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"672deec4-9160-eea9-ef60-c7e7673edd20\", \"layerType\": \"data\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}, \"primaryGroups\": [\"832a40a5-0d17-20cc-1799-0d4c98b841c4\"], \"metrics\": [\"e43af042-3fa3-61be-f3d7-62e1baefc7e7\"], \"numberDisplay\": \"percent\", \"categoryDisplay\": \"default\", \"legendDisplay\": \"default\", \"nestedLegend\": false}], \"shape\": \"pie\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS total = SUM(INCREASE(`iis.request.count`)) BY attributes.request\\n| SORT total DESC\\n| LIMIT 10\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"672deec4-9160-eea9-ef60-c7e7673edd20\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL\\n| STATS total = SUM(INCREASE(`iis.request.count`)) BY attributes.request\\n| SORT total DESC\\n| LIMIT 10\\n\"}, \"columns\": [{\"fieldName\": \"total\", \"columnId\": \"e43af042-3fa3-61be-f3d7-62e1baefc7e7\", \"label\": \"total\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"attributes.request\", \"columnId\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"label\": \"attributes.request\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"total\", \"columnId\": \"e43af042-3fa3-61be-f3d7-62e1baefc7e7\", \"label\": \"total\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"attributes.request\", \"columnId\": \"832a40a5-0d17-20cc-1799-0d4c98b841c4\", \"label\": \"attributes.request\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"d72aacf8-ee68-d4a1-e5f1-dbf65ea1d497\", \"gridData\": {\"x\": 12, \"y\": 57, \"w\": 24, \"h\": 10, \"i\": \"d72aacf8-ee68-d4a1-e5f1-dbf65ea1d497\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Network Throughput by Direction\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"2e13466d-46b0-3fe7-b853-613b5d3f6c5e\", \"accessors\": [\"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"fe86b495-7752-6f2d-44dc-203bce848544\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.io` IS NOT NULL\\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.direction\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"2e13466d-46b0-3fe7-b853-613b5d3f6c5e\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.io` IS NOT NULL\\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.direction\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"throughput\", \"columnId\": \"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\", \"label\": \"throughput\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.direction\", \"columnId\": \"fe86b495-7752-6f2d-44dc-203bce848544\", \"label\": \"attributes.direction\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"throughput\", \"columnId\": \"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\", \"label\": \"throughput\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"attributes.direction\", \"columnId\": \"fe86b495-7752-6f2d-44dc-203bce848544\", \"label\": \"attributes.direction\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"14976295-25a9-0b8c-cdc5-e98753bd2bbe\", \"gridData\": {\"x\": 36, \"y\": 57, \"w\": 12, \"h\": 10, \"i\": \"14976295-25a9-0b8c-cdc5-e98753bd2bbe\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Connection Attempts Rate\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"208be375-a11f-8910-a5ce-e993bdeb4a48\", \"accessors\": [\"0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"bottom\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.attempt.count` IS NOT NULL\\n| STATS conn_rate = SUM(RATE(`iis.connection.attempt.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"208be375-a11f-8910-a5ce-e993bdeb4a48\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.attempt.count` IS NOT NULL\\n| STATS conn_rate = SUM(RATE(`iis.connection.attempt.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"conn_rate\", \"columnId\": \"0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2\", \"label\": \"conn_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"conn_rate\", \"columnId\": \"0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2\", \"label\": \"conn_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"62953700-7a24-57d5-a2a0-ab0aa34c850a\", \"gridData\": {\"x\": 0, \"y\": 67, \"w\": 24, \"h\": 10, \"i\": \"62953700-7a24-57d5-a2a0-ab0aa34c850a\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Connections and Connection Attempts Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"af83e35f-7589-ecc6-71db-7e9e91d7300a\", \"accessors\": [\"e69a4803-c22b-cba0-e508-01c3fe86ec24\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND (`iis.connection.active` IS NOT NULL OR `iis.connection.attempt.count` IS NOT NULL)\\n| EVAL conn = COALESCE(`iis.connection.active`, 0)\\n| STATS connections = SUM(conn) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"af83e35f-7589-ecc6-71db-7e9e91d7300a\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND (`iis.connection.active` IS NOT NULL OR `iis.connection.attempt.count` IS NOT NULL)\\n| EVAL conn = COALESCE(`iis.connection.active`, 0)\\n| STATS connections = SUM(conn) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"e69a4803-c22b-cba0-e508-01c3fe86ec24\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"e69a4803-c22b-cba0-e508-01c3fe86ec24\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"937f0d95-1ed6-015e-58a6-47b6b543dae8\", \"gridData\": {\"x\": 24, \"y\": 67, \"w\": 24, \"h\": 10, \"i\": \"937f0d95-1ed6-015e-58a6-47b6b543dae8\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Threads Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cd2de242-0e52-9c46-5093-3fe9b7f25a2d\", \"accessors\": [\"9285a34b-2f64-b4a4-a660-df6762b1a5ef\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cd2de242-0e52-9c46-5093-3fe9b7f25a2d\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"threads\", \"columnId\": \"9285a34b-2f64-b4a4-a660-df6762b1a5ef\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"threads\", \"columnId\": \"9285a34b-2f64-b4a4-a660-df6762b1a5ef\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"c601e964-d18c-2c8d-e202-057197d76666\", \"gridData\": {\"x\": 0, \"y\": 77, \"w\": 24, \"h\": 10, \"i\": \"c601e964-d18c-2c8d-e202-057197d76666\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Bandwidth Throttling Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"7e0bb619-2f97-53d1-f665-2da5bec7f452\", \"accessors\": [\"f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.blocked` IS NOT NULL\\n| STATS blocked = SUM(RATE(`iis.network.blocked`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"7e0bb619-2f97-53d1-f665-2da5bec7f452\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.blocked` IS NOT NULL\\n| STATS blocked = SUM(RATE(`iis.network.blocked`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"blocked\", \"columnId\": \"f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6\", \"label\": \"blocked\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"blocked\", \"columnId\": \"f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6\", \"label\": \"blocked\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"33ec49e3-d414-5288-c27e-dd7c855b7ede\", \"gridData\": {\"x\": 0, \"y\": 87, \"w\": 48, \"h\": 3, \"i\": \"33ec49e3-d414-5288-c27e-dd7c855b7ede\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Top Sites & Application Pools\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"4b178876-d6bc-6817-cb95-9410be79a3d5\", \"gridData\": {\"x\": 0, \"y\": 90, \"w\": 24, \"h\": 15, \"i\": \"4b178876-d6bc-6817-cb95-9410be79a3d5\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Sites by Request Rate\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"1146ad2e-b45b-c51e-a472-c2a5df85e06d\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\\n| SORT req_rate DESC\\n| LIMIT 20\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"1146ad2e-b45b-c51e-a472-c2a5df85e06d\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\\n| SORT req_rate DESC\\n| LIMIT 20\"}, \"columns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"req_rate\", \"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"allColumns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"req_rate\", \"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"f5caab11-b09c-9683-20ca-e18a4a976389\", \"gridData\": {\"x\": 24, \"y\": 90, \"w\": 24, \"h\": 15, \"i\": \"f5caab11-b09c-9683-20ca-e18a4a976389\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Application Pools \\u2014 State Summary\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"383e53a9-74bd-03a4-5f81-ad611d89e4ab\", \"isTransposed\": false, \"isMetric\": true}, {\"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"ede5f01c-ef7b-064c-9b87-19ba855dec60\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND iis.application_pool IS NOT NULL\\n| STATS state = MAX(`iis.application_pool.state`), queue = MAX(`iis.request.queue.count`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool\\n| EVAL state_label = CASE( state == 1, \\\"Uninitialized\\\", state == 2, \\\"Initialized\\\", state == 3, \\\"Running\\\", state == 4, \\\"Disabling\\\", state == 5, \\\"Disabled\\\", state == 6, \\\"Shutdown Pending\\\", state == 7, \\\"Delete Pending\\\", \\\"Unknown\\\" )\\n| SORT pool ASC\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ede5f01c-ef7b-064c-9b87-19ba855dec60\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND iis.application_pool IS NOT NULL\\n| STATS state = MAX(`iis.application_pool.state`), queue = MAX(`iis.request.queue.count`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool\\n| EVAL state_label = CASE( state == 1, \\\"Uninitialized\\\", state == 2, \\\"Initialized\\\", state == 3, \\\"Running\\\", state == 4, \\\"Disabling\\\", state == 5, \\\"Disabled\\\", state == 6, \\\"Shutdown Pending\\\", state == 7, \\\"Delete Pending\\\", \\\"Unknown\\\" )\\n| SORT pool ASC\"}, \"columns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"state_label\", \"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"label\": \"State\", \"customLabel\": true}, {\"fieldName\": \"queue\", \"columnId\": \"383e53a9-74bd-03a4-5f81-ad611d89e4ab\", \"label\": \"Queue Depth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"uptime\", \"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"label\": \"Uptime (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"state_label\", \"columnId\": \"7c285696-c270-94aa-795d-ac176b29783d\", \"label\": \"State\", \"customLabel\": true}, {\"fieldName\": \"queue\", \"columnId\": \"383e53a9-74bd-03a4-5f81-ad611d89e4ab\", \"label\": \"Queue Depth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}, {\"fieldName\": \"uptime\", \"columnId\": \"769b48fc-2694-0312-2783-7980ecda30ca\", \"label\": \"Uptime (ms)\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "311e2098-d3cb-e8f4-bf13-b097739154c3",
+                "order": 1,
+                "label": "Sites & Pools",
+                "type": "dashboardLink",
+                "destinationRefName": "link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "0563dba8-e018-01bf-7e3c-91932750954e",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 16,
+          "h": 12,
+          "i": "0563dba8-e018-01bf-7e3c-91932750954e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## [IIS OTel] Overview\n\nThis dashboard provides operational visibility for **IIS** instrumented via the OpenTelemetry **iisreceiver** (collector-contrib):\n\n- **Pool health** \u2014 State and uptime; any pool not Running = outage\n- **Request handling** \u2014 Queue depth, age, rejections (primary saturation/error signals)\n- **Traffic** \u2014 Request rate by method, connections, network throughput\n- **Resources** \u2014 Active threads, bandwidth throttling\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "813ddedf-a285-d443-e8ec-de7939b683e7",
+        "gridData": {
+          "x": 16,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "813ddedf-a285-d443-e8ec-de7939b683e7"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Unhealthy Pools",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "e80039e9-1eb2-1829-e8f7-0ee07c079cf9",
+                "layerType": "data",
+                "metricAccessor": "0f9b7569-7ec6-4688-7d61-877cae7188af",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE `iis.application_pool.state` IS NOT NULL\n| STATS unhealthy = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` != 3\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e80039e9-1eb2-1829-e8f7-0ee07c079cf9": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE `iis.application_pool.state` IS NOT NULL\n| STATS unhealthy = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` != 3\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "unhealthy",
+                          "columnId": "0f9b7569-7ec6-4688-7d61-877cae7188af",
+                          "label": "unhealthy",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "unhealthy",
+                          "columnId": "0f9b7569-7ec6-4688-7d61-877cae7188af",
+                          "label": "unhealthy",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "95fa3c06-c2bd-c69a-db35-556c2f3c71d6",
+        "gridData": {
+          "x": 24,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "95fa3c06-c2bd-c69a-db35-556c2f3c71d6"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Pools Running",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "84f43c43-73a5-ce07-eae5-2a869bc01c39",
+                "layerType": "data",
+                "metricAccessor": "d4e02019-b446-715f-69d5-ee2e746edb50",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE `iis.application_pool.state` IS NOT NULL\n| STATS pools_running = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` == 3\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "84f43c43-73a5-ce07-eae5-2a869bc01c39": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE `iis.application_pool.state` IS NOT NULL\n| STATS pools_running = COUNT_DISTINCT(iis.application_pool) WHERE `iis.application_pool.state` == 3\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "pools_running",
+                          "columnId": "d4e02019-b446-715f-69d5-ee2e746edb50",
+                          "label": "pools_running",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "pools_running",
+                          "columnId": "d4e02019-b446-715f-69d5-ee2e746edb50",
+                          "label": "pools_running",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "ab63f3d4-0787-0d45-2876-5028b2132cce",
+        "gridData": {
+          "x": 32,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "ab63f3d4-0787-0d45-2876-5028b2132cce"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Request Rate",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "c924c3f4-3bec-ecd5-7532-09f9f09b8c7e",
+                "layerType": "data",
+                "metricAccessor": "b8b4df96-d61b-76cf-3ae0-10119f5ec31b",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`))\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "c924c3f4-3bec-ecd5-7532-09f9f09b8c7e": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`))\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "req_rate",
+                          "columnId": "b8b4df96-d61b-76cf-3ae0-10119f5ec31b",
+                          "label": "req_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "req_rate",
+                          "columnId": "b8b4df96-d61b-76cf-3ae0-10119f5ec31b",
+                          "label": "req_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "eac7ed13-3f78-1d43-4da3-b28d55f68ed9",
+        "gridData": {
+          "x": 40,
+          "y": 2,
+          "w": 8,
+          "h": 4,
+          "i": "eac7ed13-3f78-1d43-4da3-b28d55f68ed9"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Rejected Requests",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "ec129854-26b4-acf0-4ac7-c3a259bbbc3d",
+                "layerType": "data",
+                "metricAccessor": "582f7d34-b4d5-a6c9-e48b-d06157a6ef74",
+                "showBar": false
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`))\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ec129854-26b4-acf0-4ac7-c3a259bbbc3d": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`))\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rej_rate",
+                          "columnId": "582f7d34-b4d5-a6c9-e48b-d06157a6ef74",
+                          "label": "rej_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rej_rate",
+                          "columnId": "582f7d34-b4d5-a6c9-e48b-d06157a6ef74",
+                          "label": "rej_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "f6254395-a5b0-089a-6a73-298a6896dbc2",
+        "gridData": {
+          "x": 16,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "f6254395-a5b0-089a-6a73-298a6896dbc2"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Max Queue Depth",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "86cec1c4-9f7d-c98c-88a1-2f0bd5a3d0eb",
+                "layerType": "data",
+                "metricAccessor": "7c6337ab-977d-1114-3e7c-0f9d4f55b9b6",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL\n| STATS max_queue = MAX(`iis.request.queue.count`)\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "86cec1c4-9f7d-c98c-88a1-2f0bd5a3d0eb": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL\n| STATS max_queue = MAX(`iis.request.queue.count`)\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "max_queue",
+                          "columnId": "7c6337ab-977d-1114-3e7c-0f9d4f55b9b6",
+                          "label": "max_queue",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "max_queue",
+                          "columnId": "7c6337ab-977d-1114-3e7c-0f9d4f55b9b6",
+                          "label": "max_queue",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "b20d2603-819c-4c4f-762e-406a5009f675",
+        "gridData": {
+          "x": 24,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "b20d2603-819c-4c4f-762e-406a5009f675"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Max Queue Age",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "5b35ce18-ec94-aa56-07e0-cac121ebde99",
+                "layerType": "data",
+                "metricAccessor": "a7734371-c6e7-4544-62cf-a6c05723924a",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL\n| STATS max_age = MAX(`iis.request.queue.age.max`)\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "5b35ce18-ec94-aa56-07e0-cac121ebde99": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL\n| STATS max_age = MAX(`iis.request.queue.age.max`)\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "max_age",
+                          "columnId": "a7734371-c6e7-4544-62cf-a6c05723924a",
+                          "label": "max_age",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "max_age",
+                          "columnId": "a7734371-c6e7-4544-62cf-a6c05723924a",
+                          "label": "max_age",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "90a8c058-4a5c-8e56-a4d8-44db0887cca7",
+        "gridData": {
+          "x": 32,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "90a8c058-4a5c-8e56-a4d8-44db0887cca7"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Active Connections",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "dcbdf011-f9ca-49fe-12f1-02c33cc0bc00",
+                "layerType": "data",
+                "metricAccessor": "2b3b5ebb-85ad-68e5-6139-59d7a2f18460",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.active` IS NOT NULL\n| STATS connections = SUM(`iis.connection.active`)\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "dcbdf011-f9ca-49fe-12f1-02c33cc0bc00": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.active` IS NOT NULL\n| STATS connections = SUM(`iis.connection.active`)\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "2b3b5ebb-85ad-68e5-6139-59d7a2f18460",
+                          "label": "connections",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "2b3b5ebb-85ad-68e5-6139-59d7a2f18460",
+                          "label": "connections",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "7c65e231-552e-caaa-87a5-2e4e5ed1f96e",
+        "gridData": {
+          "x": 40,
+          "y": 6,
+          "w": 8,
+          "h": 4,
+          "i": "7c65e231-552e-caaa-87a5-2e4e5ed1f96e"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Active Threads",
+            "visualizationType": "lnsMetric",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layerId": "e5ceceeb-8f86-9072-6e06-f82b575829e1",
+                "layerType": "data",
+                "metricAccessor": "50916375-279e-ffde-d978-76b56fcb2241",
+                "showBar": false
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`)\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e5ceceeb-8f86-9072-6e06-f82b575829e1": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`)\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "threads",
+                          "columnId": "50916375-279e-ffde-d978-76b56fcb2241",
+                          "label": "threads",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "threads",
+                          "columnId": "50916375-279e-ffde-d978-76b56fcb2241",
+                          "label": "threads",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "98dd998b-7197-65f6-2395-6f3b86cdb1e8",
+        "gridData": {
+          "x": 0,
+          "y": 14,
+          "w": 48,
+          "h": 3,
+          "i": "98dd998b-7197-65f6-2395-6f3b86cdb1e8"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Application Pool Health & State\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "34d9cc5f-7571-24f7-fef6-bd05516fb5b3",
+        "gridData": {
+          "x": 0,
+          "y": 17,
+          "w": 24,
+          "h": 12,
+          "i": "34d9cc5f-7571-24f7-fef6-bd05516fb5b3"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Application Pool Health \u2014 State & Uptime Table",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "7c285696-c270-94aa-795d-ac176b29783d",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "769b48fc-2694-0312-2783-7980ecda30ca",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "ee50b2c7-6646-dc9d-c57c-12e81f6509dd",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND (`iis.application_pool.state` IS NOT NULL OR `iis.application_pool.uptime` IS NOT NULL)\n| STATS state = MAX(`iis.application_pool.state`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool, host = resource.attributes.host.name\n| EVAL state_label = CASE( state == 1, \"Uninitialized\", state == 2, \"Initialized\", state == 3, \"Running\", state == 4, \"Disabling\", state == 5, \"Disabled\", state == 6, \"Shutdown Pending\", state == 7, \"Delete Pending\", \"Unknown\" )\n| SORT pool ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ee50b2c7-6646-dc9d-c57c-12e81f6509dd": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND (`iis.application_pool.state` IS NOT NULL OR `iis.application_pool.uptime` IS NOT NULL)\n| STATS state = MAX(`iis.application_pool.state`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool, host = resource.attributes.host.name\n| EVAL state_label = CASE( state == 1, \"Uninitialized\", state == 2, \"Initialized\", state == 3, \"Running\", state == 4, \"Disabling\", state == 5, \"Disabled\", state == 6, \"Shutdown Pending\", state == 7, \"Delete Pending\", \"Unknown\" )\n| SORT pool ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "pool",
+                          "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                          "label": "Application Pool",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "host",
+                          "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                          "label": "Host",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "state_label",
+                          "columnId": "7c285696-c270-94aa-795d-ac176b29783d",
+                          "label": "State",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "uptime",
+                          "columnId": "769b48fc-2694-0312-2783-7980ecda30ca",
+                          "label": "Uptime (ms)",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "pool",
+                          "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                          "label": "Application Pool",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "host",
+                          "columnId": "29167533-4bae-824d-33b1-fad502657638",
+                          "label": "Host",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "state_label",
+                          "columnId": "7c285696-c270-94aa-795d-ac176b29783d",
+                          "label": "State",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "uptime",
+                          "columnId": "769b48fc-2694-0312-2783-7980ecda30ca",
+                          "label": "Uptime (ms)",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "10d284ec-b188-cdbf-e310-0e39f6e87d33",
+        "gridData": {
+          "x": 24,
+          "y": 17,
+          "w": 24,
+          "h": 12,
+          "i": "10d284ec-b188-cdbf-e310-0e39f6e87d33"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Pool Uptime Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "cd54e897-9fa3-89a4-ad7a-0c193dbff658",
+                    "accessors": [
+                      "44c283a7-8a78-dd3c-5b66-4c7e8ca5defc"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "c915ede9-a7d1-1075-b745-5b72743ca894",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.application_pool.uptime` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS uptime = MAX(`iis.application_pool.uptime`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), pool = iis.application_pool\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cd54e897-9fa3-89a4-ad7a-0c193dbff658": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.application_pool.uptime` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS uptime = MAX(`iis.application_pool.uptime`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), pool = iis.application_pool\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "uptime",
+                          "columnId": "44c283a7-8a78-dd3c-5b66-4c7e8ca5defc",
+                          "label": "uptime",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "pool",
+                          "columnId": "c915ede9-a7d1-1075-b745-5b72743ca894",
+                          "label": "pool",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "uptime",
+                          "columnId": "44c283a7-8a78-dd3c-5b66-4c7e8ca5defc",
+                          "label": "uptime",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "pool",
+                          "columnId": "c915ede9-a7d1-1075-b745-5b72743ca894",
+                          "label": "pool",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "f3c72600-acb1-c4be-af9d-1055b48a0a2a",
+        "gridData": {
+          "x": 0,
+          "y": 29,
+          "w": 48,
+          "h": 3,
+          "i": "f3c72600-acb1-c4be-af9d-1055b48a0a2a"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Request Rate & Queue Metrics\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "6fea96a6-f528-9373-2e0e-386184013bbd",
+        "gridData": {
+          "x": 0,
+          "y": 32,
+          "w": 24,
+          "h": 12,
+          "i": "6fea96a6-f528-9373-2e0e-386184013bbd"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Request Rate by HTTP Method Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "51fe9a4a-6244-7681-e2ab-f521416d6e14",
+                    "accessors": [
+                      "b1911db0-e346-dde6-337e-a829f741712f"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "832a40a5-0d17-20cc-1799-0d4c98b841c4",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.request\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "51fe9a4a-6244-7681-e2ab-f521416d6e14": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.request\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "req_rate",
+                          "columnId": "b1911db0-e346-dde6-337e-a829f741712f",
+                          "label": "req_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.request",
+                          "columnId": "832a40a5-0d17-20cc-1799-0d4c98b841c4",
+                          "label": "attributes.request",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "req_rate",
+                          "columnId": "b1911db0-e346-dde6-337e-a829f741712f",
+                          "label": "req_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.request",
+                          "columnId": "832a40a5-0d17-20cc-1799-0d4c98b841c4",
+                          "label": "attributes.request",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "4f435521-b3f6-be32-0518-4c26873c5dc9",
+        "gridData": {
+          "x": 24,
+          "y": 32,
+          "w": 24,
+          "h": 12,
+          "i": "4f435521-b3f6-be32-0518-4c26873c5dc9"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Queue Depth and Rejections Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "893d1400-cdbf-b21f-48b1-b0e98604a831",
+                    "accessors": [
+                      "e976855b-f978-6e5c-9596-70700fbfefb7",
+                      "dafc20a2-21a9-1560-3d32-082ef9c83e85"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\"\n| STATS queue_depth = SUM(COALESCE(`iis.request.queue.count`, 0)), rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "893d1400-cdbf-b21f-48b1-b0e98604a831": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\"\n| STATS queue_depth = SUM(COALESCE(`iis.request.queue.count`, 0)), rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "queue_depth",
+                          "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                          "label": "queue_depth",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "rej_rate",
+                          "columnId": "dafc20a2-21a9-1560-3d32-082ef9c83e85",
+                          "label": "rej_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "queue_depth",
+                          "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                          "label": "queue_depth",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "rej_rate",
+                          "columnId": "dafc20a2-21a9-1560-3d32-082ef9c83e85",
+                          "label": "rej_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "eee5aea0-a409-c924-2c9a-6904041a625c",
+        "gridData": {
+          "x": 0,
+          "y": 44,
+          "w": 12,
+          "h": 10,
+          "i": "eee5aea0-a409-c924-2c9a-6904041a625c"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Queue Depth Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "c8b86171-f1f3-d287-82ea-c416c4c60863",
+                    "accessors": [
+                      "e976855b-f978-6e5c-9596-70700fbfefb7"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "bottom"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "c8b86171-f1f3-d287-82ea-c416c4c60863": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "queue_depth",
+                          "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                          "label": "queue_depth",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "queue_depth",
+                          "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                          "label": "queue_depth",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "872b997d-1b64-79cb-596e-27e82d85296d",
+        "gridData": {
+          "x": 12,
+          "y": 44,
+          "w": 12,
+          "h": 10,
+          "i": "872b997d-1b64-79cb-596e-27e82d85296d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Rejections Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "a4bed244-493a-e788-e13b-f8d4920a2037",
+                    "accessors": [
+                      "dafc20a2-21a9-1560-3d32-082ef9c83e85"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "bottom"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "a4bed244-493a-e788-e13b-f8d4920a2037": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL\n| STATS rej_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rej_rate",
+                          "columnId": "dafc20a2-21a9-1560-3d32-082ef9c83e85",
+                          "label": "rej_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rej_rate",
+                          "columnId": "dafc20a2-21a9-1560-3d32-082ef9c83e85",
+                          "label": "rej_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "e75467ea-82ca-9f6b-ae93-e22957fe1697",
+        "gridData": {
+          "x": 24,
+          "y": 44,
+          "w": 24,
+          "h": 10,
+          "i": "e75467ea-82ca-9f6b-ae93-e22957fe1697"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Queue Age Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "9ea7ce9f-5bb4-72c5-5be9-c8b8f53b727b",
+                    "accessors": [
+                      "efce20bc-bdd4-19fc-3289-e7a670ec6e46"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL\n| STATS max_age = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "9ea7ce9f-5bb4-72c5-5be9-c8b8f53b727b": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL\n| STATS max_age = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "max_age",
+                          "columnId": "efce20bc-bdd4-19fc-3289-e7a670ec6e46",
+                          "label": "max_age",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "max_age",
+                          "columnId": "efce20bc-bdd4-19fc-3289-e7a670ec6e46",
+                          "label": "max_age",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "9a325fad-2e84-d2d6-4737-c9d5addbd26e",
+        "gridData": {
+          "x": 0,
+          "y": 54,
+          "w": 48,
+          "h": 3,
+          "i": "9a325fad-2e84-d2d6-4737-c9d5addbd26e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Traffic, Method Distribution & Network\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "c43a4883-7cb8-eb95-61e6-152104c9bd11",
+        "gridData": {
+          "x": 0,
+          "y": 57,
+          "w": 12,
+          "h": 10,
+          "i": "c43a4883-7cb8-eb95-61e6-152104c9bd11"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Request Method Distribution",
+            "visualizationType": "lnsPie",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "672deec4-9160-eea9-ef60-c7e7673edd20",
+                    "layerType": "data",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    },
+                    "primaryGroups": [
+                      "832a40a5-0d17-20cc-1799-0d4c98b841c4"
+                    ],
+                    "metrics": [
+                      "e43af042-3fa3-61be-f3d7-62e1baefc7e7"
+                    ],
+                    "numberDisplay": "percent",
+                    "categoryDisplay": "default",
+                    "legendDisplay": "default",
+                    "nestedLegend": false
+                  }
+                ],
+                "shape": "pie"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS total = SUM(INCREASE(`iis.request.count`)) BY attributes.request\n| SORT total DESC\n| LIMIT 10\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "672deec4-9160-eea9-ef60-c7e7673edd20": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL\n| STATS total = SUM(INCREASE(`iis.request.count`)) BY attributes.request\n| SORT total DESC\n| LIMIT 10\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "total",
+                          "columnId": "e43af042-3fa3-61be-f3d7-62e1baefc7e7",
+                          "label": "total",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "attributes.request",
+                          "columnId": "832a40a5-0d17-20cc-1799-0d4c98b841c4",
+                          "label": "attributes.request",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "total",
+                          "columnId": "e43af042-3fa3-61be-f3d7-62e1baefc7e7",
+                          "label": "total",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "attributes.request",
+                          "columnId": "832a40a5-0d17-20cc-1799-0d4c98b841c4",
+                          "label": "attributes.request",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "d72aacf8-ee68-d4a1-e5f1-dbf65ea1d497",
+        "gridData": {
+          "x": 12,
+          "y": 57,
+          "w": 24,
+          "h": 10,
+          "i": "d72aacf8-ee68-d4a1-e5f1-dbf65ea1d497"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Network Throughput by Direction",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "2e13466d-46b0-3fe7-b853-613b5d3f6c5e",
+                    "accessors": [
+                      "d17d0e31-7edb-b976-81cb-d9a16f07f2a2"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "fe86b495-7752-6f2d-44dc-203bce848544",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.io` IS NOT NULL\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.direction\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "2e13466d-46b0-3fe7-b853-613b5d3f6c5e": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.io` IS NOT NULL\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.direction\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "throughput",
+                          "columnId": "d17d0e31-7edb-b976-81cb-d9a16f07f2a2",
+                          "label": "throughput",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.direction",
+                          "columnId": "fe86b495-7752-6f2d-44dc-203bce848544",
+                          "label": "attributes.direction",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "throughput",
+                          "columnId": "d17d0e31-7edb-b976-81cb-d9a16f07f2a2",
+                          "label": "throughput",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "attributes.direction",
+                          "columnId": "fe86b495-7752-6f2d-44dc-203bce848544",
+                          "label": "attributes.direction",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "14976295-25a9-0b8c-cdc5-e98753bd2bbe",
+        "gridData": {
+          "x": 36,
+          "y": 57,
+          "w": 12,
+          "h": 10,
+          "i": "14976295-25a9-0b8c-cdc5-e98753bd2bbe"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Connection Attempts Rate",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "208be375-a11f-8910-a5ce-e993bdeb4a48",
+                    "accessors": [
+                      "0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "bottom"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.attempt.count` IS NOT NULL\n| STATS conn_rate = SUM(RATE(`iis.connection.attempt.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "208be375-a11f-8910-a5ce-e993bdeb4a48": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.attempt.count` IS NOT NULL\n| STATS conn_rate = SUM(RATE(`iis.connection.attempt.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "conn_rate",
+                          "columnId": "0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2",
+                          "label": "conn_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "conn_rate",
+                          "columnId": "0bf48cc0-9f4e-7cdb-d0e8-ff75a86955f2",
+                          "label": "conn_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "62953700-7a24-57d5-a2a0-ab0aa34c850a",
+        "gridData": {
+          "x": 0,
+          "y": 67,
+          "w": 24,
+          "h": 10,
+          "i": "62953700-7a24-57d5-a2a0-ab0aa34c850a"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Active Connections and Connection Attempts Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "af83e35f-7589-ecc6-71db-7e9e91d7300a",
+                    "accessors": [
+                      "e69a4803-c22b-cba0-e508-01c3fe86ec24"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND (`iis.connection.active` IS NOT NULL OR `iis.connection.attempt.count` IS NOT NULL)\n| EVAL conn = COALESCE(`iis.connection.active`, 0)\n| STATS connections = SUM(conn) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "af83e35f-7589-ecc6-71db-7e9e91d7300a": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND (`iis.connection.active` IS NOT NULL OR `iis.connection.attempt.count` IS NOT NULL)\n| EVAL conn = COALESCE(`iis.connection.active`, 0)\n| STATS connections = SUM(conn) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "e69a4803-c22b-cba0-e508-01c3fe86ec24",
+                          "label": "connections",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "e69a4803-c22b-cba0-e508-01c3fe86ec24",
+                          "label": "connections",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "937f0d95-1ed6-015e-58a6-47b6b543dae8",
+        "gridData": {
+          "x": 24,
+          "y": 67,
+          "w": 24,
+          "h": 10,
+          "i": "937f0d95-1ed6-015e-58a6-47b6b543dae8"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Active Threads Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "cd2de242-0e52-9c46-5093-3fe9b7f25a2d",
+                    "accessors": [
+                      "9285a34b-2f64-b4a4-a660-df6762b1a5ef"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cd2de242-0e52-9c46-5093-3fe9b7f25a2d": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "threads",
+                          "columnId": "9285a34b-2f64-b4a4-a660-df6762b1a5ef",
+                          "label": "threads",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "threads",
+                          "columnId": "9285a34b-2f64-b4a4-a660-df6762b1a5ef",
+                          "label": "threads",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "c601e964-d18c-2c8d-e202-057197d76666",
+        "gridData": {
+          "x": 0,
+          "y": 77,
+          "w": 24,
+          "h": 10,
+          "i": "c601e964-d18c-2c8d-e202-057197d76666"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Bandwidth Throttling Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "7e0bb619-2f97-53d1-f665-2da5bec7f452",
+                    "accessors": [
+                      "f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.blocked` IS NOT NULL\n| STATS blocked = SUM(RATE(`iis.network.blocked`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "7e0bb619-2f97-53d1-f665-2da5bec7f452": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.blocked` IS NOT NULL\n| STATS blocked = SUM(RATE(`iis.network.blocked`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "blocked",
+                          "columnId": "f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6",
+                          "label": "blocked",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "blocked",
+                          "columnId": "f00a3c3b-b0c6-5d8e-96cb-b57c94074cc6",
+                          "label": "blocked",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "33ec49e3-d414-5288-c27e-dd7c855b7ede",
+        "gridData": {
+          "x": 0,
+          "y": 87,
+          "w": 48,
+          "h": 3,
+          "i": "33ec49e3-d414-5288-c27e-dd7c855b7ede"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Top Sites & Application Pools\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "4b178876-d6bc-6817-cb95-9410be79a3d5",
+        "gridData": {
+          "x": 0,
+          "y": 90,
+          "w": 24,
+          "h": 15,
+          "i": "4b178876-d6bc-6817-cb95-9410be79a3d5"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Sites by Request Rate",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "9d9e8e9c-05ff-d7b4-37f4-67269da539f8",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "1146ad2e-b45b-c51e-a472-c2a5df85e06d",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\n| SORT req_rate DESC\n| LIMIT 20"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "1146ad2e-b45b-c51e-a472-c2a5df85e06d": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\n| SORT req_rate DESC\n| LIMIT 20"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                          "label": "Site",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "req_rate",
+                          "columnId": "9d9e8e9c-05ff-d7b4-37f4-67269da539f8",
+                          "label": "Requests/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                          "label": "Site",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "req_rate",
+                          "columnId": "9d9e8e9c-05ff-d7b4-37f4-67269da539f8",
+                          "label": "Requests/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "f5caab11-b09c-9683-20ca-e18a4a976389",
+        "gridData": {
+          "x": 24,
+          "y": 90,
+          "w": 24,
+          "h": 15,
+          "i": "f5caab11-b09c-9683-20ca-e18a4a976389"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Application Pools \u2014 State Summary",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "7c285696-c270-94aa-795d-ac176b29783d",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "383e53a9-74bd-03a4-5f81-ad611d89e4ab",
+                    "isTransposed": false,
+                    "isMetric": true
+                  },
+                  {
+                    "columnId": "769b48fc-2694-0312-2783-7980ecda30ca",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "ede5f01c-ef7b-064c-9b87-19ba855dec60",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND iis.application_pool IS NOT NULL\n| STATS state = MAX(`iis.application_pool.state`), queue = MAX(`iis.request.queue.count`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool\n| EVAL state_label = CASE( state == 1, \"Uninitialized\", state == 2, \"Initialized\", state == 3, \"Running\", state == 4, \"Disabling\", state == 5, \"Disabled\", state == 6, \"Shutdown Pending\", state == 7, \"Delete Pending\", \"Unknown\" )\n| SORT pool ASC"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ede5f01c-ef7b-064c-9b87-19ba855dec60": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND iis.application_pool IS NOT NULL\n| STATS state = MAX(`iis.application_pool.state`), queue = MAX(`iis.request.queue.count`), uptime = MAX(`iis.application_pool.uptime`) BY pool = iis.application_pool\n| EVAL state_label = CASE( state == 1, \"Uninitialized\", state == 2, \"Initialized\", state == 3, \"Running\", state == 4, \"Disabling\", state == 5, \"Disabled\", state == 6, \"Shutdown Pending\", state == 7, \"Delete Pending\", \"Unknown\" )\n| SORT pool ASC"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "pool",
+                          "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                          "label": "Application Pool",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "state_label",
+                          "columnId": "7c285696-c270-94aa-795d-ac176b29783d",
+                          "label": "State",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "queue",
+                          "columnId": "383e53a9-74bd-03a4-5f81-ad611d89e4ab",
+                          "label": "Queue Depth",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "uptime",
+                          "columnId": "769b48fc-2694-0312-2783-7980ecda30ca",
+                          "label": "Uptime (ms)",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "pool",
+                          "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                          "label": "Application Pool",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "state_label",
+                          "columnId": "7c285696-c270-94aa-795d-ac176b29783d",
+                          "label": "State",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "queue",
+                          "columnId": "383e53a9-74bd-03a4-5f81-ad611d89e4ab",
+                          "label": "Queue Depth",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "fieldName": "uptime",
+                          "columnId": "769b48fc-2694-0312-2783-7980ecda30ca",
+                          "label": "Uptime (ms)",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"iisreceiver.otel\"}},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"iisreceiver.otel\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "data_stream.dataset",
+              "field": "data_stream.dataset",
+              "params": {
+                "query": "iisreceiver.otel"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "iisreceiver.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": true,
     "timeFrom": "now-1h",
@@ -14,8 +3099,68 @@
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"ba14dd38-3256-313e-2eb9-8a73fea4ed25\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"ba14dd38-3256-313e-2eb9-8a73fea4ed25\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"resource.attributes.host.name\",\"title\":\"Host\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"a710b1ce-97f3-66d6-b2c5-09c5b73a4568\":{\"grow\":false,\"order\":1,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"a710b1ce-97f3-66d6-b2c5-09c5b73a4568\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"iis.site\",\"title\":\"Site\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"2aa79284-fddb-46b6-64a3-983d23b2dd43\":{\"grow\":false,\"order\":2,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2aa79284-fddb-46b6-64a3-983d23b2dd43\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"iis.application_pool\",\"title\":\"Application Pool\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "ba14dd38-3256-313e-2eb9-8a73fea4ed25": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "ba14dd38-3256-313e-2eb9-8a73fea4ed25",
+            "dataViewId": "metrics-*",
+            "fieldName": "resource.attributes.host.name",
+            "title": "Host",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "a710b1ce-97f3-66d6-b2c5-09c5b73a4568": {
+          "grow": false,
+          "order": 1,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "a710b1ce-97f3-66d6-b2c5-09c5b73a4568",
+            "dataViewId": "metrics-*",
+            "fieldName": "iis.site",
+            "title": "Site",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "2aa79284-fddb-46b6-64a3-983d23b2dd43": {
+          "grow": false,
+          "order": 2,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "2aa79284-fddb-46b6-64a3-983d23b2dd43",
+            "dataViewId": "metrics-*",
+            "fieldName": "iis.application_pool",
+            "title": "Application Pool",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/iis_otel/kibana/dashboard/iis_otel-sites.json
+++ b/packages/iis_otel/kibana/dashboard/iis_otel-sites.json
@@ -2,10 +2,1716 @@
   "attributes": {
     "title": "[IIS OTel] Sites & Pools",
     "description": "Per-site and per-application-pool breakdown of request rate, network throughput, connections, queue metrics, and rejections. Supports capacity planning and per-tenant analysis.",
-    "panelsJSON": "[{\"panelIndex\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\", \"gridData\": {\"x\": 0, \"y\": 0, \"w\": 48, \"h\": 2, \"i\": \"5ec9d4e9-3f1c-8f1e-41f0-eb022308081d\"}, \"type\": \"links\", \"embeddableConfig\": {\"enhancements\": {}, \"attributes\": {\"layout\": \"horizontal\", \"links\": [{\"id\": \"3af4ba12-6f83-488a-bdc9-0c7216a22d73\", \"order\": 0, \"label\": \"Overview\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard\"}, {\"id\": \"311e2098-d3cb-e8f4-bf13-b097739154c3\", \"order\": 1, \"label\": \"Sites & Pools\", \"type\": \"dashboardLink\", \"destinationRefName\": \"link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard\"}]}}}, {\"panelIndex\": \"0563dba8-e018-01bf-7e3c-91932750954e\", \"gridData\": {\"x\": 0, \"y\": 2, \"w\": 16, \"h\": 12, \"i\": \"0563dba8-e018-01bf-7e3c-91932750954e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## [IIS OTel] Sites & Pools\\n\\nThis dashboard provides per-site and per-application-pool breakdowns:\\n\\n- **Per-site** \\u2014 Request rate, network throughput, active connections\\n- **Per-pool** \\u2014 Queue depth, rejection rate, queue age, active threads\\n- **Detail tables** \\u2014 Top sites and pools by traffic and health\\n\\nUse the Host, Site, and Application Pool filters to narrow the view.\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"1c7012df-5cc7-34a1-5597-5373fcecbff6\", \"gridData\": {\"x\": 16, \"y\": 2, \"w\": 32, \"h\": 12, \"i\": \"1c7012df-5cc7-34a1-5597-5373fcecbff6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Request Rate by Site\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"0c465483-dfd4-e2d3-507f-67f1b821efaa\", \"accessors\": [\"3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS request_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"0c465483-dfd4-e2d3-507f-67f1b821efaa\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS request_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"request_rate\", \"columnId\": \"3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af\", \"label\": \"request_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"request_rate\", \"columnId\": \"3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af\", \"label\": \"request_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"6fbdbb87-fb45-c3da-aed7-bea514676e1f\", \"gridData\": {\"x\": 0, \"y\": 14, \"w\": 24, \"h\": 12, \"i\": \"6fbdbb87-fb45-c3da-aed7-bea514676e1f\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Network Throughput by Site\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"6ea955e7-32d8-1231-d0d9-a5040c1dd5f0\", \"accessors\": [\"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\"], \"layerType\": \"data\", \"seriesType\": \"area\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"area\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.io` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"6ea955e7-32d8-1231-d0d9-a5040c1dd5f0\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.network.io` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"throughput\", \"columnId\": \"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\", \"label\": \"throughput\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"throughput\", \"columnId\": \"d17d0e31-7edb-b976-81cb-d9a16f07f2a2\", \"label\": \"throughput\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"b9979009-5578-7141-2933-4fa0583cd882\", \"gridData\": {\"x\": 24, \"y\": 14, \"w\": 24, \"h\": 12, \"i\": \"b9979009-5578-7141-2933-4fa0583cd882\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Connections by Site\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"72f89635-d20b-efff-66a2-17c249116451\", \"accessors\": [\"e69a4803-c22b-cba0-e508-01c3fe86ec24\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.active` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS connections = SUM(`iis.connection.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"72f89635-d20b-efff-66a2-17c249116451\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.connection.active` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS connections = SUM(`iis.connection.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"connections\", \"columnId\": \"e69a4803-c22b-cba0-e508-01c3fe86ec24\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"connections\", \"columnId\": \"e69a4803-c22b-cba0-e508-01c3fe86ec24\", \"label\": \"connections\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.site\", \"columnId\": \"0e985310-7abc-5c01-8e04-de1541d1d5b6\", \"label\": \"iis.site\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"2c63b4bb-844a-bad3-6fff-536f2d1f4b6e\", \"gridData\": {\"x\": 0, \"y\": 26, \"w\": 48, \"h\": 3, \"i\": \"2c63b4bb-844a-bad3-6fff-536f2d1f4b6e\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Per-Application-Pool Metrics\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"ce3ef6aa-8bd3-f6bc-9314-b44e31080fb9\", \"gridData\": {\"x\": 0, \"y\": 29, \"w\": 24, \"h\": 12, \"i\": \"ce3ef6aa-8bd3-f6bc-9314-b44e31080fb9\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Depth by Pool\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"e30e9523-c233-3c51-155a-4582b0abed2d\", \"accessors\": [\"e976855b-f978-6e5c-9596-70700fbfefb7\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"e30e9523-c233-3c51-155a-4582b0abed2d\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"queue_depth\", \"columnId\": \"e976855b-f978-6e5c-9596-70700fbfefb7\", \"label\": \"queue_depth\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"05b2f9df-5188-db1e-2796-18cb493beef6\", \"gridData\": {\"x\": 24, \"y\": 29, \"w\": 24, \"h\": 12, \"i\": \"05b2f9df-5188-db1e-2796-18cb493beef6\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Rejection Rate by Pool\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"ff033aca-ef68-7e0f-4374-669704a4af74\", \"accessors\": [\"94c16f55-bfe3-3609-6bad-10f1b6d92e7c\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"ff033aca-ef68-7e0f-4374-669704a4af74\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"rejection_rate\", \"columnId\": \"94c16f55-bfe3-3609-6bad-10f1b6d92e7c\", \"label\": \"rejection_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"rejection_rate\", \"columnId\": \"94c16f55-bfe3-3609-6bad-10f1b6d92e7c\", \"label\": \"rejection_rate\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"7c4344c7-425f-c9c2-aa97-4009ea1b4b5d\", \"gridData\": {\"x\": 0, \"y\": 41, \"w\": 24, \"h\": 12, \"i\": \"7c4344c7-425f-c9c2-aa97-4009ea1b4b5d\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Queue Age by Pool\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"869b4ddf-26c4-1055-1214-36de11156f9e\", \"accessors\": [\"034b560f-b710-abfb-87aa-04700d0fac5e\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"splitAccessor\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS queue_age_ms = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"869b4ddf-26c4-1055-1214-36de11156f9e\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.age.max` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS queue_age_ms = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"queue_age_ms\", \"columnId\": \"034b560f-b710-abfb-87aa-04700d0fac5e\", \"label\": \"queue_age_ms\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"allColumns\": [{\"fieldName\": \"queue_age_ms\", \"columnId\": \"034b560f-b710-abfb-87aa-04700d0fac5e\", \"label\": \"queue_age_ms\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}, {\"fieldName\": \"iis.application_pool\", \"columnId\": \"52595828-5c38-4c1e-0add-e337fff6d573\", \"label\": \"iis.application_pool\", \"customLabel\": false}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"dd819480-c9aa-d638-ee8e-ff0aa6b3d934\", \"gridData\": {\"x\": 24, \"y\": 41, \"w\": 24, \"h\": 12, \"i\": \"dd819480-c9aa-d638-ee8e-ff0aa6b3d934\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Active Threads Over Time\", \"visualizationType\": \"lnsXY\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"layers\": [{\"layerId\": \"cd2de242-0e52-9c46-5093-3fe9b7f25a2d\", \"accessors\": [\"9285a34b-2f64-b4a4-a660-df6762b1a5ef\"], \"layerType\": \"data\", \"seriesType\": \"line\", \"xAccessor\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"position\": \"top\", \"showGridlines\": false, \"colorMapping\": {\"assignments\": [], \"specialAssignments\": [{\"rule\": {\"type\": \"other\"}, \"color\": {\"type\": \"loop\"}, \"touched\": false}], \"paletteId\": \"eui_amsterdam_color_blind\", \"colorMode\": {\"type\": \"categorical\"}}}], \"preferredSeriesType\": \"line\", \"legend\": {\"position\": \"right\"}, \"valueLabels\": \"hide\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"cd2de242-0e52-9c46-5093-3fe9b7f25a2d\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.thread.active` IS NOT NULL\\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\\n| SORT time_bucket ASC\\n\"}, \"columns\": [{\"fieldName\": \"threads\", \"columnId\": \"9285a34b-2f64-b4a4-a660-df6762b1a5ef\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"allColumns\": [{\"fieldName\": \"threads\", \"columnId\": \"9285a34b-2f64-b4a4-a660-df6762b1a5ef\", \"label\": \"threads\", \"customLabel\": false, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true}, {\"fieldName\": \"time_bucket\", \"columnId\": \"44714e97-119f-dc33-b7f7-4ce49cc5463f\", \"label\": \"time_bucket\", \"customLabel\": false, \"meta\": {\"type\": \"date\", \"esType\": \"date\"}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"25facd50-b4a8-7a8c-60c5-d653f5f8b3e9\", \"gridData\": {\"x\": 0, \"y\": 53, \"w\": 48, \"h\": 3, \"i\": \"25facd50-b4a8-7a8c-60c5-d653f5f8b3e9\"}, \"type\": \"visualization\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"savedVis\": {\"type\": \"markdown\", \"id\": \"\", \"title\": \"\", \"description\": \"\", \"params\": {\"fontSize\": 12, \"openLinksInNewTab\": false, \"markdown\": \"## Top Sites & Application Pools\\n\"}, \"uiState\": {}, \"data\": {\"aggs\": [], \"searchSource\": {\"query\": {\"query\": \"\", \"language\": \"kuery\"}, \"filter\": []}}}}}, {\"panelIndex\": \"0fffa92b-02c5-f0c4-d098-ba89a3915abb\", \"gridData\": {\"x\": 0, \"y\": 56, \"w\": 24, \"h\": 15, \"i\": \"0fffa92b-02c5-f0c4-d098-ba89a3915abb\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Sites by Request Count\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"be420b5c-0eaa-3390-b377-822f4d268b24\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"6afb878c-1dc6-f565-27b8-7b350df39dd1\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS total_requests = SUM(INCREASE(`iis.request.count`)) BY iis.site\\n| SORT total_requests DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"6afb878c-1dc6-f565-27b8-7b350df39dd1\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS total_requests = SUM(INCREASE(`iis.request.count`)) BY iis.site\\n| SORT total_requests DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"total_requests\", \"columnId\": \"be420b5c-0eaa-3390-b377-822f4d268b24\", \"label\": \"Total Requests\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"total_requests\", \"columnId\": \"be420b5c-0eaa-3390-b377-822f4d268b24\", \"label\": \"Total Requests\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"8e745e07-81c8-1aaf-6552-35e44b95ff33\", \"gridData\": {\"x\": 24, \"y\": 56, \"w\": 24, \"h\": 15, \"i\": \"8e745e07-81c8-1aaf-6552-35e44b95ff33\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Pools by Rejection Rate\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"9da88212-7b99-6af6-4b0e-060c74a32bba\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"4b4146c2-44db-ccfd-b6a0-33eb34faa0b0\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY iis.application_pool\\n| SORT rejection_rate DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"4b4146c2-44db-ccfd-b6a0-33eb34faa0b0\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY iis.application_pool\\n| SORT rejection_rate DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"iis.application_pool\", \"columnId\": \"9da88212-7b99-6af6-4b0e-060c74a32bba\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"rejection_rate\", \"columnId\": \"b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c\", \"label\": \"Rejections/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"allColumns\": [{\"fieldName\": \"iis.application_pool\", \"columnId\": \"9da88212-7b99-6af6-4b0e-060c74a32bba\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"rejection_rate\", \"columnId\": \"b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c\", \"label\": \"Rejections/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 2}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"e5bc9ecd-4d83-a600-8a4a-3667f9a37642\", \"gridData\": {\"x\": 0, \"y\": 71, \"w\": 24, \"h\": 15, \"i\": \"e5bc9ecd-4d83-a600-8a4a-3667f9a37642\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Sites by Request Rate\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"907abc74-5aaa-8841-ac4d-e2e37c13de57\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\\n| SORT req_rate DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"907abc74-5aaa-8841-ac4d-e2e37c13de57\": {\"query\": {\"esql\": \"TS metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\\n| SORT req_rate DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"req_rate\", \"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"allColumns\": [{\"fieldName\": \"iis.site\", \"columnId\": \"b01c5d5f-975d-a4bf-903a-a5409cd71b3b\", \"label\": \"Site\", \"customLabel\": true}, {\"fieldName\": \"req_rate\", \"columnId\": \"9d9e8e9c-05ff-d7b4-37f4-67269da539f8\", \"label\": \"Requests/sec\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 1}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}, {\"panelIndex\": \"3df009d1-4950-6747-bfa1-958aac238cbd\", \"gridData\": {\"x\": 24, \"y\": 71, \"w\": 24, \"h\": 15, \"i\": \"3df009d1-4950-6747-bfa1-958aac238cbd\"}, \"type\": \"lens\", \"embeddableConfig\": {\"enhancements\": {\"dynamicActions\": {\"events\": []}}, \"attributes\": {\"title\": \"Top Pools by Queue Depth\", \"visualizationType\": \"lnsDatatable\", \"type\": \"lens\", \"references\": [], \"state\": {\"visualization\": {\"columns\": [{\"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"isTransposed\": false, \"isMetric\": false}, {\"columnId\": \"679f83c2-0608-6f7b-366c-d6be08613c7e\", \"isTransposed\": false, \"isMetric\": true}], \"layerId\": \"1372e37d-1581-a2d4-ee1e-0b9385a98a54\", \"layerType\": \"data\"}, \"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS max_queue = MAX(`iis.request.queue.count`) BY pool = iis.application_pool\\n| SORT max_queue DESC\\n| LIMIT 50\"}, \"filters\": [], \"datasourceStates\": {\"textBased\": {\"layers\": {\"1372e37d-1581-a2d4-ee1e-0b9385a98a54\": {\"query\": {\"esql\": \"FROM metrics-iisreceiver.otel-*\\n| WHERE data_stream.dataset == \\\"iisreceiver.otel\\\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\\n| STATS max_queue = MAX(`iis.request.queue.count`) BY pool = iis.application_pool\\n| SORT max_queue DESC\\n| LIMIT 50\"}, \"columns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"max_queue\", \"columnId\": \"679f83c2-0608-6f7b-366c-d6be08613c7e\", \"label\": \"Max Queue Depth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"allColumns\": [{\"fieldName\": \"pool\", \"columnId\": \"d87e9d4f-7643-94be-d3a1-f766ec373f31\", \"label\": \"Application Pool\", \"customLabel\": true}, {\"fieldName\": \"max_queue\", \"columnId\": \"679f83c2-0608-6f7b-366c-d6be08613c7e\", \"label\": \"Max Queue Depth\", \"customLabel\": true, \"meta\": {\"type\": \"number\", \"esType\": \"long\"}, \"inMetricDimension\": true, \"params\": {\"format\": {\"id\": \"number\", \"params\": {\"decimals\": 0}}}}], \"timeField\": \"@timestamp\"}}}}, \"internalReferences\": [], \"adHocDataViews\": {}}}, \"syncTooltips\": false, \"syncColors\": false, \"syncCursor\": true, \"filters\": [], \"query\": {\"query\": \"\", \"language\": \"kuery\"}}}]",
-    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": [
+      {
+        "panelIndex": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 2,
+          "i": "5ec9d4e9-3f1c-8f1e-41f0-eb022308081d"
+        },
+        "type": "links",
+        "embeddableConfig": {
+          "enhancements": {},
+          "attributes": {
+            "layout": "horizontal",
+            "links": [
+              {
+                "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+                "order": 0,
+                "label": "Overview",
+                "type": "dashboardLink",
+                "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard"
+              },
+              {
+                "id": "311e2098-d3cb-e8f4-bf13-b097739154c3",
+                "order": 1,
+                "label": "Sites & Pools",
+                "type": "dashboardLink",
+                "destinationRefName": "link_311e2098-d3cb-e8f4-bf13-b097739154c3_dashboard"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "panelIndex": "0563dba8-e018-01bf-7e3c-91932750954e",
+        "gridData": {
+          "x": 0,
+          "y": 2,
+          "w": 16,
+          "h": 12,
+          "i": "0563dba8-e018-01bf-7e3c-91932750954e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## [IIS OTel] Sites & Pools\n\nThis dashboard provides per-site and per-application-pool breakdowns:\n\n- **Per-site** \u2014 Request rate, network throughput, active connections\n- **Per-pool** \u2014 Queue depth, rejection rate, queue age, active threads\n- **Detail tables** \u2014 Top sites and pools by traffic and health\n\nUse the Host, Site, and Application Pool filters to narrow the view.\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "1c7012df-5cc7-34a1-5597-5373fcecbff6",
+        "gridData": {
+          "x": 16,
+          "y": 2,
+          "w": 32,
+          "h": 12,
+          "i": "1c7012df-5cc7-34a1-5597-5373fcecbff6"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Request Rate by Site",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "0c465483-dfd4-e2d3-507f-67f1b821efaa",
+                    "accessors": [
+                      "3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS request_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "0c465483-dfd4-e2d3-507f-67f1b821efaa": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS request_rate = SUM(RATE(`iis.request.count`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "request_rate",
+                          "columnId": "3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af",
+                          "label": "request_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                          "label": "iis.site",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "request_rate",
+                          "columnId": "3fe83a4c-3cba-c2cb-0f7d-79bb2b6d09af",
+                          "label": "request_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                          "label": "iis.site",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "6fbdbb87-fb45-c3da-aed7-bea514676e1f",
+        "gridData": {
+          "x": 0,
+          "y": 14,
+          "w": 24,
+          "h": 12,
+          "i": "6fbdbb87-fb45-c3da-aed7-bea514676e1f"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Network Throughput by Site",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "6ea955e7-32d8-1231-d0d9-a5040c1dd5f0",
+                    "accessors": [
+                      "d17d0e31-7edb-b976-81cb-d9a16f07f2a2"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "area",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.io` IS NOT NULL AND iis.site IS NOT NULL\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "6ea955e7-32d8-1231-d0d9-a5040c1dd5f0": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.network.io` IS NOT NULL AND iis.site IS NOT NULL\n| STATS throughput = SUM(RATE(`iis.network.io`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "throughput",
+                          "columnId": "d17d0e31-7edb-b976-81cb-d9a16f07f2a2",
+                          "label": "throughput",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                          "label": "iis.site",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "throughput",
+                          "columnId": "d17d0e31-7edb-b976-81cb-d9a16f07f2a2",
+                          "label": "throughput",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                          "label": "iis.site",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "b9979009-5578-7141-2933-4fa0583cd882",
+        "gridData": {
+          "x": 24,
+          "y": 14,
+          "w": 24,
+          "h": 12,
+          "i": "b9979009-5578-7141-2933-4fa0583cd882"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Active Connections by Site",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "72f89635-d20b-efff-66a2-17c249116451",
+                    "accessors": [
+                      "e69a4803-c22b-cba0-e508-01c3fe86ec24"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.active` IS NOT NULL AND iis.site IS NOT NULL\n| STATS connections = SUM(`iis.connection.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "72f89635-d20b-efff-66a2-17c249116451": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.connection.active` IS NOT NULL AND iis.site IS NOT NULL\n| STATS connections = SUM(`iis.connection.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.site\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "e69a4803-c22b-cba0-e508-01c3fe86ec24",
+                          "label": "connections",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                          "label": "iis.site",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "connections",
+                          "columnId": "e69a4803-c22b-cba0-e508-01c3fe86ec24",
+                          "label": "connections",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "0e985310-7abc-5c01-8e04-de1541d1d5b6",
+                          "label": "iis.site",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "2c63b4bb-844a-bad3-6fff-536f2d1f4b6e",
+        "gridData": {
+          "x": 0,
+          "y": 26,
+          "w": 48,
+          "h": 3,
+          "i": "2c63b4bb-844a-bad3-6fff-536f2d1f4b6e"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Per-Application-Pool Metrics\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "ce3ef6aa-8bd3-f6bc-9314-b44e31080fb9",
+        "gridData": {
+          "x": 0,
+          "y": 29,
+          "w": 24,
+          "h": 12,
+          "i": "ce3ef6aa-8bd3-f6bc-9314-b44e31080fb9"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Queue Depth by Pool",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "e30e9523-c233-3c51-155a-4582b0abed2d",
+                    "accessors": [
+                      "e976855b-f978-6e5c-9596-70700fbfefb7"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "52595828-5c38-4c1e-0add-e337fff6d573",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e30e9523-c233-3c51-155a-4582b0abed2d": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS queue_depth = SUM(`iis.request.queue.count`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "queue_depth",
+                          "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                          "label": "queue_depth",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.application_pool",
+                          "columnId": "52595828-5c38-4c1e-0add-e337fff6d573",
+                          "label": "iis.application_pool",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "queue_depth",
+                          "columnId": "e976855b-f978-6e5c-9596-70700fbfefb7",
+                          "label": "queue_depth",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.application_pool",
+                          "columnId": "52595828-5c38-4c1e-0add-e337fff6d573",
+                          "label": "iis.application_pool",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "05b2f9df-5188-db1e-2796-18cb493beef6",
+        "gridData": {
+          "x": 24,
+          "y": 29,
+          "w": 24,
+          "h": 12,
+          "i": "05b2f9df-5188-db1e-2796-18cb493beef6"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Rejection Rate by Pool",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "ff033aca-ef68-7e0f-4374-669704a4af74",
+                    "accessors": [
+                      "94c16f55-bfe3-3609-6bad-10f1b6d92e7c"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "52595828-5c38-4c1e-0add-e337fff6d573",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "ff033aca-ef68-7e0f-4374-669704a4af74": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "94c16f55-bfe3-3609-6bad-10f1b6d92e7c",
+                          "label": "rejection_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.application_pool",
+                          "columnId": "52595828-5c38-4c1e-0add-e337fff6d573",
+                          "label": "iis.application_pool",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "94c16f55-bfe3-3609-6bad-10f1b6d92e7c",
+                          "label": "rejection_rate",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.application_pool",
+                          "columnId": "52595828-5c38-4c1e-0add-e337fff6d573",
+                          "label": "iis.application_pool",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "7c4344c7-425f-c9c2-aa97-4009ea1b4b5d",
+        "gridData": {
+          "x": 0,
+          "y": 41,
+          "w": 24,
+          "h": 12,
+          "i": "7c4344c7-425f-c9c2-aa97-4009ea1b4b5d"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Queue Age by Pool",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "869b4ddf-26c4-1055-1214-36de11156f9e",
+                    "accessors": [
+                      "034b560f-b710-abfb-87aa-04700d0fac5e"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "splitAccessor": "52595828-5c38-4c1e-0add-e337fff6d573",
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS queue_age_ms = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "869b4ddf-26c4-1055-1214-36de11156f9e": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.age.max` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS queue_age_ms = MAX(`iis.request.queue.age.max`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), iis.application_pool\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "queue_age_ms",
+                          "columnId": "034b560f-b710-abfb-87aa-04700d0fac5e",
+                          "label": "queue_age_ms",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.application_pool",
+                          "columnId": "52595828-5c38-4c1e-0add-e337fff6d573",
+                          "label": "iis.application_pool",
+                          "customLabel": false
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "queue_age_ms",
+                          "columnId": "034b560f-b710-abfb-87aa-04700d0fac5e",
+                          "label": "queue_age_ms",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        },
+                        {
+                          "fieldName": "iis.application_pool",
+                          "columnId": "52595828-5c38-4c1e-0add-e337fff6d573",
+                          "label": "iis.application_pool",
+                          "customLabel": false
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "dd819480-c9aa-d638-ee8e-ff0aa6b3d934",
+        "gridData": {
+          "x": 24,
+          "y": 41,
+          "w": 24,
+          "h": 12,
+          "i": "dd819480-c9aa-d638-ee8e-ff0aa6b3d934"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Active Threads Over Time",
+            "visualizationType": "lnsXY",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "layers": [
+                  {
+                    "layerId": "cd2de242-0e52-9c46-5093-3fe9b7f25a2d",
+                    "accessors": [
+                      "9285a34b-2f64-b4a4-a660-df6762b1a5ef"
+                    ],
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                    "position": "top",
+                    "showGridlines": false,
+                    "colorMapping": {
+                      "assignments": [],
+                      "specialAssignments": [
+                        {
+                          "rule": {
+                            "type": "other"
+                          },
+                          "color": {
+                            "type": "loop"
+                          },
+                          "touched": false
+                        }
+                      ],
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "colorMode": {
+                        "type": "categorical"
+                      }
+                    }
+                  }
+                ],
+                "preferredSeriesType": "line",
+                "legend": {
+                  "position": "right"
+                },
+                "valueLabels": "hide"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "cd2de242-0e52-9c46-5093-3fe9b7f25a2d": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.thread.active` IS NOT NULL\n| STATS threads = SUM(`iis.thread.active`) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC\n"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "threads",
+                          "columnId": "9285a34b-2f64-b4a4-a660-df6762b1a5ef",
+                          "label": "threads",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "threads",
+                          "columnId": "9285a34b-2f64-b4a4-a660-df6762b1a5ef",
+                          "label": "threads",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true
+                        },
+                        {
+                          "fieldName": "time_bucket",
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "label": "time_bucket",
+                          "customLabel": false,
+                          "meta": {
+                            "type": "date",
+                            "esType": "date"
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "25facd50-b4a8-7a8c-60c5-d653f5f8b3e9",
+        "gridData": {
+          "x": 0,
+          "y": 53,
+          "w": 48,
+          "h": 3,
+          "i": "25facd50-b4a8-7a8c-60c5-d653f5f8b3e9"
+        },
+        "type": "visualization",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "savedVis": {
+            "type": "markdown",
+            "id": "",
+            "title": "",
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "openLinksInNewTab": false,
+              "markdown": "## Top Sites & Application Pools\n"
+            },
+            "uiState": {},
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "query": {
+                  "query": "",
+                  "language": "kuery"
+                },
+                "filter": []
+              }
+            }
+          }
+        }
+      },
+      {
+        "panelIndex": "0fffa92b-02c5-f0c4-d098-ba89a3915abb",
+        "gridData": {
+          "x": 0,
+          "y": 56,
+          "w": 24,
+          "h": 15,
+          "i": "0fffa92b-02c5-f0c4-d098-ba89a3915abb"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Sites by Request Count",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "be420b5c-0eaa-3390-b377-822f4d268b24",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "6afb878c-1dc6-f565-27b8-7b350df39dd1",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS total_requests = SUM(INCREASE(`iis.request.count`)) BY iis.site\n| SORT total_requests DESC\n| LIMIT 50"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "6afb878c-1dc6-f565-27b8-7b350df39dd1": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS total_requests = SUM(INCREASE(`iis.request.count`)) BY iis.site\n| SORT total_requests DESC\n| LIMIT 50"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                          "label": "Site",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "total_requests",
+                          "columnId": "be420b5c-0eaa-3390-b377-822f4d268b24",
+                          "label": "Total Requests",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                          "label": "Site",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "total_requests",
+                          "columnId": "be420b5c-0eaa-3390-b377-822f4d268b24",
+                          "label": "Total Requests",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "8e745e07-81c8-1aaf-6552-35e44b95ff33",
+        "gridData": {
+          "x": 24,
+          "y": 56,
+          "w": 24,
+          "h": 15,
+          "i": "8e745e07-81c8-1aaf-6552-35e44b95ff33"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Pools by Rejection Rate",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "9da88212-7b99-6af6-4b0e-060c74a32bba",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "4b4146c2-44db-ccfd-b6a0-33eb34faa0b0",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY iis.application_pool\n| SORT rejection_rate DESC\n| LIMIT 50"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "4b4146c2-44db-ccfd-b6a0-33eb34faa0b0": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.rejected` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS rejection_rate = SUM(RATE(`iis.request.rejected`)) BY iis.application_pool\n| SORT rejection_rate DESC\n| LIMIT 50"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "iis.application_pool",
+                          "columnId": "9da88212-7b99-6af6-4b0e-060c74a32bba",
+                          "label": "Application Pool",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c",
+                          "label": "Rejections/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "iis.application_pool",
+                          "columnId": "9da88212-7b99-6af6-4b0e-060c74a32bba",
+                          "label": "Application Pool",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "rejection_rate",
+                          "columnId": "b4734893-eb5f-7f5d-b4fc-ebe59c5c1f9c",
+                          "label": "Rejections/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "e5bc9ecd-4d83-a600-8a4a-3667f9a37642",
+        "gridData": {
+          "x": 0,
+          "y": 71,
+          "w": 24,
+          "h": 15,
+          "i": "e5bc9ecd-4d83-a600-8a4a-3667f9a37642"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Sites by Request Rate",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "9d9e8e9c-05ff-d7b4-37f4-67269da539f8",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "907abc74-5aaa-8841-ac4d-e2e37c13de57",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\n| SORT req_rate DESC\n| LIMIT 50"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "907abc74-5aaa-8841-ac4d-e2e37c13de57": {
+                      "query": {
+                        "esql": "TS metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.count` IS NOT NULL AND iis.site IS NOT NULL\n| STATS req_rate = SUM(RATE(`iis.request.count`)) BY iis.site\n| SORT req_rate DESC\n| LIMIT 50"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                          "label": "Site",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "req_rate",
+                          "columnId": "9d9e8e9c-05ff-d7b4-37f4-67269da539f8",
+                          "label": "Requests/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "iis.site",
+                          "columnId": "b01c5d5f-975d-a4bf-903a-a5409cd71b3b",
+                          "label": "Site",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "req_rate",
+                          "columnId": "9d9e8e9c-05ff-d7b4-37f4-67269da539f8",
+                          "label": "Requests/sec",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      },
+      {
+        "panelIndex": "3df009d1-4950-6747-bfa1-958aac238cbd",
+        "gridData": {
+          "x": 24,
+          "y": 71,
+          "w": 24,
+          "h": 15,
+          "i": "3df009d1-4950-6747-bfa1-958aac238cbd"
+        },
+        "type": "lens",
+        "embeddableConfig": {
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "attributes": {
+            "title": "Top Pools by Queue Depth",
+            "visualizationType": "lnsDatatable",
+            "type": "lens",
+            "references": [],
+            "state": {
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                    "isTransposed": false,
+                    "isMetric": false
+                  },
+                  {
+                    "columnId": "679f83c2-0608-6f7b-366c-d6be08613c7e",
+                    "isTransposed": false,
+                    "isMetric": true
+                  }
+                ],
+                "layerId": "1372e37d-1581-a2d4-ee1e-0b9385a98a54",
+                "layerType": "data"
+              },
+              "query": {
+                "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS max_queue = MAX(`iis.request.queue.count`) BY pool = iis.application_pool\n| SORT max_queue DESC\n| LIMIT 50"
+              },
+              "filters": [],
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "1372e37d-1581-a2d4-ee1e-0b9385a98a54": {
+                      "query": {
+                        "esql": "FROM metrics-iisreceiver.otel-*\n| WHERE data_stream.dataset == \"iisreceiver.otel\" AND `iis.request.queue.count` IS NOT NULL AND iis.application_pool IS NOT NULL\n| STATS max_queue = MAX(`iis.request.queue.count`) BY pool = iis.application_pool\n| SORT max_queue DESC\n| LIMIT 50"
+                      },
+                      "columns": [
+                        {
+                          "fieldName": "pool",
+                          "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                          "label": "Application Pool",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "max_queue",
+                          "columnId": "679f83c2-0608-6f7b-366c-d6be08613c7e",
+                          "label": "Max Queue Depth",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "allColumns": [
+                        {
+                          "fieldName": "pool",
+                          "columnId": "d87e9d4f-7643-94be-d3a1-f766ec373f31",
+                          "label": "Application Pool",
+                          "customLabel": true
+                        },
+                        {
+                          "fieldName": "max_queue",
+                          "columnId": "679f83c2-0608-6f7b-366c-d6be08613c7e",
+                          "label": "Max Queue Depth",
+                          "customLabel": true,
+                          "meta": {
+                            "type": "number",
+                            "esType": "long"
+                          },
+                          "inMetricDimension": true,
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "internalReferences": [],
+              "adHocDataViews": {}
+            }
+          },
+          "syncTooltips": false,
+          "syncColors": false,
+          "syncCursor": true,
+          "filters": [],
+          "query": {
+            "query": "",
+            "language": "kuery"
+          }
+        }
+      }
+    ],
+    "optionsJSON": {
+      "useMargins": true,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "hidePanelTitles": false
+    },
     "kibanaSavedObjectMeta": {
-      "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"iisreceiver.otel\"}},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"iisreceiver.otel\"}}}],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "disabled": false,
+              "negate": false,
+              "alias": null,
+              "type": "phrase",
+              "key": "data_stream.dataset",
+              "field": "data_stream.dataset",
+              "params": {
+                "query": "iisreceiver.otel"
+              }
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "iisreceiver.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "query": "",
+          "language": "kuery"
+        }
+      }
     },
     "timeRestore": true,
     "timeFrom": "now-1h",
@@ -14,8 +1720,68 @@
     "controlGroupInput": {
       "chainingSystem": "HIERARCHICAL",
       "controlStyle": "oneLine",
-      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-      "panelsJSON": "{\"ba14dd38-3256-313e-2eb9-8a73fea4ed25\":{\"grow\":false,\"order\":0,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"ba14dd38-3256-313e-2eb9-8a73fea4ed25\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"resource.attributes.host.name\",\"title\":\"Host\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"a710b1ce-97f3-66d6-b2c5-09c5b73a4568\":{\"grow\":false,\"order\":1,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"a710b1ce-97f3-66d6-b2c5-09c5b73a4568\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"iis.site\",\"title\":\"Site\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}},\"2aa79284-fddb-46b6-64a3-983d23b2dd43\":{\"grow\":false,\"order\":2,\"width\":\"medium\",\"type\":\"optionsListControl\",\"explicitInput\":{\"id\":\"2aa79284-fddb-46b6-64a3-983d23b2dd43\",\"dataViewId\":\"metrics-*\",\"fieldName\":\"iis.application_pool\",\"title\":\"Application Pool\",\"searchTechnique\":\"prefix\",\"selectedOptions\":[],\"sort\":{\"by\":\"_count\",\"direction\":\"desc\"}}}}",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "ba14dd38-3256-313e-2eb9-8a73fea4ed25": {
+          "grow": false,
+          "order": 0,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "ba14dd38-3256-313e-2eb9-8a73fea4ed25",
+            "dataViewId": "metrics-*",
+            "fieldName": "resource.attributes.host.name",
+            "title": "Host",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "a710b1ce-97f3-66d6-b2c5-09c5b73a4568": {
+          "grow": false,
+          "order": 1,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "a710b1ce-97f3-66d6-b2c5-09c5b73a4568",
+            "dataViewId": "metrics-*",
+            "fieldName": "iis.site",
+            "title": "Site",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        },
+        "2aa79284-fddb-46b6-64a3-983d23b2dd43": {
+          "grow": false,
+          "order": 2,
+          "width": "medium",
+          "type": "optionsListControl",
+          "explicitInput": {
+            "id": "2aa79284-fddb-46b6-64a3-983d23b2dd43",
+            "dataViewId": "metrics-*",
+            "fieldName": "iis.application_pool",
+            "title": "Application Pool",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            }
+          }
+        }
+      },
       "showApplySelections": false
     }
   },

--- a/packages/kafka_otel/kibana/dashboard/kafka_otel-consumer-groups.json
+++ b/packages/kafka_otel/kibana/dashboard/kafka_otel-consumer-groups.json
@@ -1,1133 +1,1133 @@
 {
-    "attributes": {
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
+  "attributes": {
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "bef629a0-e1db-8bab-570b-ea16cd6e2fe0": {
+          "explicitInput": {
+            "dataViewId": "metrics-*",
+            "exclude": false,
+            "existsSelected": false,
+            "fieldName": "attributes.group",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
             },
-            "panelsJSON": {
-                "bef629a0-e1db-8bab-570b-ea16cd6e2fe0": {
-                    "explicitInput": {
-                        "dataViewId": "metrics-*",
-                        "exclude": false,
-                        "existsSelected": false,
-                        "fieldName": "attributes.group",
-                        "searchTechnique": "prefix",
-                        "selectedOptions": [],
-                        "sort": {
-                            "by": "_count",
-                            "direction": "desc"
-                        },
-                        "title": "Consumer Group"
-                    },
-                    "grow": false,
-                    "order": 0,
-                    "type": "optionsListControl",
-                    "width": "medium"
-                }
-            },
-            "showApplySelections": false
-        },
-        "description": "Granular consumer group analysis: lag by group, topic, and partition; member counts; offset progression. Drill-down for lag troubleshooting.",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "key": "data_stream.dataset",
-                            "negate": false,
-                            "params": {
-                                "query": "kafkametricsreceiver.otel"
-                            },
-                            "type": "phrase"
-                        },
-                        "query": {
-                            "match_phrase": {
-                                "data_stream.dataset": "kafkametricsreceiver.otel"
-                            }
-                        }
-                    }
-                ],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": false,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "layout": "horizontal",
-                    "links": [
-                        {
-                            "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
-                            "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
-                            "label": "Overview",
-                            "order": 0,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
-                            "id": "023dd0d5-85a5-7c2d-7761-09ac67eaf6b0",
-                            "label": "Consumer Groups",
-                            "order": 1,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
-                            "id": "9fa8a215-5ab9-a0b8-3ae7-50918026c5b2",
-                            "label": "Topics \u0026 Partitions",
-                            "order": 2,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
-                            "id": "55497914-9303-4f76-667d-ef92eaa42807",
-                            "label": "Replication Health",
-                            "order": 3,
-                            "type": "dashboardLink"
-                        }
-                    ]
-                },
-                "gridData": {
-                    "h": 2,
-                    "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
-                    "w": 48,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
-                "type": "links"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "45cd0b34-959d-2210-9ee7-72dd47e60c27": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "e158e6f5-7afb-7d24-06e5-86773dffab86",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.group",
-                                                    "label": "attributes.group"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "e158e6f5-7afb-7d24-06e5-86773dffab86",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.group",
-                                                    "label": "attributes.group"
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL AND attributes.group IS NOT NULL\n| STATS lag = SUM(kafka.consumer_group.lag_sum) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.group\n| SORT time_bucket ASC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL AND attributes.group IS NOT NULL\n| STATS lag = SUM(kafka.consumer_group.lag_sum) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.group\n| SORT time_bucket ASC"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "e158e6f5-7afb-7d24-06e5-86773dffab86"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "45cd0b34-959d-2210-9ee7-72dd47e60c27",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
-                                        "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Lag Sum Over Time by Group",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "b26be22d-d4aa-9e90-89e1-f21b256ff704",
-                    "w": 48,
-                    "x": 0,
-                    "y": 10
-                },
-                "panelIndex": "b26be22d-d4aa-9e90-89e1-f21b256ff704",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "11fc2557-1899-d3b2-9d74-2ffb545bbd27": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag_sum",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "401fba55-6155-5e77-50ee-10188f965a49",
-                                                    "customLabel": false,
-                                                    "fieldName": "group_topic",
-                                                    "label": "group_topic"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag_sum",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "401fba55-6155-5e77-50ee-10188f965a49",
-                                                    "customLabel": false,
-                                                    "fieldName": "group_topic",
-                                                    "label": "group_topic"
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL AND attributes.group IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS lag_sum = SUM(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| EVAL group_topic = CONCAT(attributes.group, \" / \", attributes.topic)\n| STATS lag_sum = SUM(lag_sum) BY group_topic\n| SORT lag_sum DESC\n| LIMIT 20"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL AND attributes.group IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS lag_sum = SUM(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| EVAL group_topic = CONCAT(attributes.group, \" / \", attributes.topic)\n| STATS lag_sum = SUM(lag_sum) BY group_topic\n| SORT lag_sum DESC\n| LIMIT 20"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d558689a-a066-bbc0-e59f-a93654972edb"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "11fc2557-1899-d3b2-9d74-2ffb545bbd27",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_unstacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "401fba55-6155-5e77-50ee-10188f965a49"
-                                    }
-                                ],
-                                "legend": {
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_unstacked",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Lag by Group and Topic (Top 20)",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "0008bfc9-aede-ae2b-09d2-2fe95f65702d",
-                    "w": 24,
-                    "x": 0,
-                    "y": 22
-                },
-                "panelIndex": "0008bfc9-aede-ae2b-09d2-2fe95f65702d",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "5e67d40f-c978-b23d-6eb8-3cf61800b9e7": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "a5dd5f3b-c637-31fb-ada6-9755aec98f04",
-                                                    "customLabel": true,
-                                                    "fieldName": "members",
-                                                    "inMetricDimension": true,
-                                                    "label": "Members",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.group",
-                                                    "label": "attributes.group"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "a5dd5f3b-c637-31fb-ada6-9755aec98f04",
-                                                    "customLabel": true,
-                                                    "fieldName": "members",
-                                                    "inMetricDimension": true,
-                                                    "label": "Members",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.group",
-                                                    "label": "attributes.group"
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL AND attributes.group IS NOT NULL\n| STATS members = MAX(LAST_OVER_TIME(kafka.consumer_group.members)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.group\n| SORT time_bucket ASC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL AND attributes.group IS NOT NULL\n| STATS members = MAX(LAST_OVER_TIME(kafka.consumer_group.members)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.group\n| SORT time_bucket ASC"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "a5dd5f3b-c637-31fb-ada6-9755aec98f04"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "5e67d40f-c978-b23d-6eb8-3cf61800b9e7",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
-                                        "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "line",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Consumer Group Members Over Time",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "763b19c3-6f02-6af9-e94d-7840b8f7e11f",
-                    "w": 24,
-                    "x": 24,
-                    "y": 22
-                },
-                "panelIndex": "763b19c3-6f02-6af9-e94d-7840b8f7e11f",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "f3799344-cabe-2cf2-15f6-654db9296dc0": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "89095d4b-5c3e-9755-6d1f-4a17fcdcd7e5",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.group",
-                                                    "label": "Group"
-                                                },
-                                                {
-                                                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "Topic"
-                                                },
-                                                {
-                                                    "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.partition",
-                                                    "label": "Partition"
-                                                },
-                                                {
-                                                    "columnId": "b3c8697c-707f-5e62-cf7d-49afdb037013",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "89095d4b-5c3e-9755-6d1f-4a17fcdcd7e5",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.group",
-                                                    "label": "Group"
-                                                },
-                                                {
-                                                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "Topic"
-                                                },
-                                                {
-                                                    "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.partition",
-                                                    "label": "Partition"
-                                                },
-                                                {
-                                                    "columnId": "b3c8697c-707f-5e62-cf7d-49afdb037013",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag IS NOT NULL AND attributes.group IS NOT NULL AND attributes.topic IS NOT NULL AND attributes.partition IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag) BY attributes.group, attributes.topic, attributes.partition\n| SORT lag DESC\n| LIMIT 50"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag IS NOT NULL AND attributes.group IS NOT NULL AND attributes.topic IS NOT NULL AND attributes.partition IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag) BY attributes.group, attributes.topic, attributes.partition\n| SORT lag DESC\n| LIMIT 50"
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "89095d4b-5c3e-9755-6d1f-4a17fcdcd7e5",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "b3c8697c-707f-5e62-cf7d-49afdb037013",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "f3799344-cabe-2cf2-15f6-654db9296dc0",
-                                "layerType": "data",
-                                "paging": {
-                                    "enabled": true,
-                                    "size": 15
-                                }
-                            }
-                        },
-                        "title": "Lag by Partition (Top 20 Partitions)",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 16,
-                    "i": "54375245-294f-cfa1-33c3-2dbf942a36d6",
-                    "w": 48,
-                    "x": 0,
-                    "y": 34
-                },
-                "panelIndex": "54375245-294f-cfa1-33c3-2dbf942a36d6",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "content": "## [Kafka OTel] Consumer Groups\n\nConsumer lag and offset drill-down:\n- Lag sum per group and topic\n- Lag by partition (hot partitions)\n- Member count per group\n- Offset position vs current partition offset\n"
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "540fc689-8453-4b28-ac92-167f1d8d23c3",
-                    "w": 16,
-                    "x": 0,
-                    "y": 2
-                },
-                "panelIndex": "540fc689-8453-4b28-ac92-167f1d8d23c3",
-                "type": "DASHBOARD_MARKDOWN"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "e39615e1-18c0-f840-8cf7-da9a26477e37": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "d130cae9-2511-fae1-6d1f-205113cd7694",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "Total Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "d130cae9-2511-fae1-6d1f-205113cd7694",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "Total Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS total_lag = SUM(kafka.consumer_group.lag_sum)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS total_lag = SUM(kafka.consumer_group.lag_sum)"
-                            },
-                            "visualization": {
-                                "layerId": "e39615e1-18c0-f840-8cf7-da9a26477e37",
-                                "layerType": "data",
-                                "metricAccessor": "d130cae9-2511-fae1-6d1f-205113cd7694",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Total Lag (Selected Group)",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "e1c6bdf6-5283-dbb2-0fde-d3662c6a1bb5",
-                    "w": 6,
-                    "x": 16,
-                    "y": 2
-                },
-                "panelIndex": "e1c6bdf6-5283-dbb2-0fde-d3662c6a1bb5",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "8a3a653b-d44c-e1ba-df8e-66e2e9b45da1": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "8f6ed4a6-1e75-9840-3599-25716ab4ddc9",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Groups with Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "8f6ed4a6-1e75-9840-3599-25716ab4ddc9",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Groups with Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = SUM(kafka.consumer_group.lag_sum) BY attributes.group\n| WHERE lag_sum \u003e 0\n| STATS count = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = SUM(kafka.consumer_group.lag_sum) BY attributes.group\n| WHERE lag_sum \u003e 0\n| STATS count = COUNT(*)"
-                            },
-                            "visualization": {
-                                "layerId": "8a3a653b-d44c-e1ba-df8e-66e2e9b45da1",
-                                "layerType": "data",
-                                "metricAccessor": "8f6ed4a6-1e75-9840-3599-25716ab4ddc9",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Groups with Lag",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "2c5a22f4-6bcd-8e7b-f30b-81b15e151622",
-                    "w": 6,
-                    "x": 22,
-                    "y": 2
-                },
-                "panelIndex": "2c5a22f4-6bcd-8e7b-f30b-81b15e151622",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "a15c4713-de6a-53f9-ce22-7b11cc23821d": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "f5458c8a-e44d-5e09-d71c-0fb2c0ffb648",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Empty Groups",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "f5458c8a-e44d-5e09-d71c-0fb2c0ffb648",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Empty Groups",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| WHERE members == 0\n| STATS count = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| WHERE members == 0\n| STATS count = COUNT(*)"
-                            },
-                            "visualization": {
-                                "layerId": "a15c4713-de6a-53f9-ce22-7b11cc23821d",
-                                "layerType": "data",
-                                "metricAccessor": "f5458c8a-e44d-5e09-d71c-0fb2c0ffb648",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Empty Groups",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "a6a91455-c973-82a6-1493-917fe4983754",
-                    "w": 6,
-                    "x": 28,
-                    "y": 2
-                },
-                "panelIndex": "a6a91455-c973-82a6-1493-917fe4983754",
-                "type": "lens"
-            }
-        ],
-        "timeFrom": "now-15m",
-        "timeRestore": true,
-        "timeTo": "now",
-        "title": "[Kafka OTel] Consumer Groups"
-    },
-    "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-03-13T13:08:21.384Z",
-    "id": "kafka_otel-consumer-groups",
-    "references": [
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_bef629a0-e1db-8bab-570b-ea16cd6e2fe0:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "kafka_otel-overview",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-consumer-groups",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-topics-partitions",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-replication",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
-            "type": "dashboard"
+            "title": "Consumer Group"
+          },
+          "grow": false,
+          "order": 0,
+          "type": "optionsListControl",
+          "width": "medium"
         }
+      },
+      "showApplySelections": false
+    },
+    "description": "Granular consumer group analysis: lag by group, topic, and partition; member counts; offset progression. Drill-down for lag troubleshooting.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "alias": null,
+              "disabled": false,
+              "field": "data_stream.dataset",
+              "key": "data_stream.dataset",
+              "negate": false,
+              "params": {
+                "query": "kafkametricsreceiver.otel"
+              },
+              "type": "phrase"
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "kafkametricsreceiver.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "language": "kuery",
+          "query": ""
+        }
+      }
+    },
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "enhancements": {},
+          "layout": "horizontal",
+          "links": [
+            {
+              "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
+              "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+              "label": "Overview",
+              "order": 0,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
+              "id": "023dd0d5-85a5-7c2d-7761-09ac67eaf6b0",
+              "label": "Consumer Groups",
+              "order": 1,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
+              "id": "9fa8a215-5ab9-a0b8-3ae7-50918026c5b2",
+              "label": "Topics & Partitions",
+              "order": 2,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
+              "id": "55497914-9303-4f76-667d-ef92eaa42807",
+              "label": "Replication Health",
+              "order": 3,
+              "type": "dashboardLink"
+            }
+          ]
+        },
+        "gridData": {
+          "h": 2,
+          "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+        "type": "links"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "45cd0b34-959d-2210-9ee7-72dd47e60c27": {
+                      "allColumns": [
+                        {
+                          "columnId": "e158e6f5-7afb-7d24-06e5-86773dffab86",
+                          "customLabel": true,
+                          "fieldName": "lag",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        },
+                        {
+                          "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
+                          "customLabel": false,
+                          "fieldName": "attributes.group",
+                          "label": "attributes.group"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "e158e6f5-7afb-7d24-06e5-86773dffab86",
+                          "customLabel": true,
+                          "fieldName": "lag",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        },
+                        {
+                          "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
+                          "customLabel": false,
+                          "fieldName": "attributes.group",
+                          "label": "attributes.group"
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL AND attributes.group IS NOT NULL\n| STATS lag = SUM(kafka.consumer_group.lag_sum) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.group\n| SORT time_bucket ASC"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL AND attributes.group IS NOT NULL\n| STATS lag = SUM(kafka.consumer_group.lag_sum) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.group\n| SORT time_bucket ASC"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "e158e6f5-7afb-7d24-06e5-86773dffab86"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "45cd0b34-959d-2210-9ee7-72dd47e60c27",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "splitAccessor": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "preferredSeriesType": "area",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Lag Sum Over Time by Group",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "i": "b26be22d-d4aa-9e90-89e1-f21b256ff704",
+          "w": 48,
+          "x": 0,
+          "y": 10
+        },
+        "panelIndex": "b26be22d-d4aa-9e90-89e1-f21b256ff704",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "11fc2557-1899-d3b2-9d74-2ffb545bbd27": {
+                      "allColumns": [
+                        {
+                          "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
+                          "customLabel": true,
+                          "fieldName": "lag_sum",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "401fba55-6155-5e77-50ee-10188f965a49",
+                          "customLabel": false,
+                          "fieldName": "group_topic",
+                          "label": "group_topic"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
+                          "customLabel": true,
+                          "fieldName": "lag_sum",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "401fba55-6155-5e77-50ee-10188f965a49",
+                          "customLabel": false,
+                          "fieldName": "group_topic",
+                          "label": "group_topic"
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL AND attributes.group IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS lag_sum = SUM(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| EVAL group_topic = CONCAT(attributes.group, \" / \", attributes.topic)\n| STATS lag_sum = SUM(lag_sum) BY group_topic\n| SORT lag_sum DESC\n| LIMIT 20"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL AND attributes.group IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS lag_sum = SUM(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| EVAL group_topic = CONCAT(attributes.group, \" / \", attributes.topic)\n| STATS lag_sum = SUM(lag_sum) BY group_topic\n| SORT lag_sum DESC\n| LIMIT 20"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "d558689a-a066-bbc0-e59f-a93654972edb"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "11fc2557-1899-d3b2-9d74-2ffb545bbd27",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_unstacked",
+                    "showGridlines": false,
+                    "xAccessor": "401fba55-6155-5e77-50ee-10188f965a49"
+                  }
+                ],
+                "legend": {
+                  "position": "right"
+                },
+                "preferredSeriesType": "bar_unstacked",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Lag by Group and Topic (Top 20)",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "i": "0008bfc9-aede-ae2b-09d2-2fe95f65702d",
+          "w": 24,
+          "x": 0,
+          "y": 22
+        },
+        "panelIndex": "0008bfc9-aede-ae2b-09d2-2fe95f65702d",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "5e67d40f-c978-b23d-6eb8-3cf61800b9e7": {
+                      "allColumns": [
+                        {
+                          "columnId": "a5dd5f3b-c637-31fb-ada6-9755aec98f04",
+                          "customLabel": true,
+                          "fieldName": "members",
+                          "inMetricDimension": true,
+                          "label": "Members",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        },
+                        {
+                          "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
+                          "customLabel": false,
+                          "fieldName": "attributes.group",
+                          "label": "attributes.group"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "a5dd5f3b-c637-31fb-ada6-9755aec98f04",
+                          "customLabel": true,
+                          "fieldName": "members",
+                          "inMetricDimension": true,
+                          "label": "Members",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        },
+                        {
+                          "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
+                          "customLabel": false,
+                          "fieldName": "attributes.group",
+                          "label": "attributes.group"
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL AND attributes.group IS NOT NULL\n| STATS members = MAX(LAST_OVER_TIME(kafka.consumer_group.members)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.group\n| SORT time_bucket ASC"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL AND attributes.group IS NOT NULL\n| STATS members = MAX(LAST_OVER_TIME(kafka.consumer_group.members)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend), attributes.group\n| SORT time_bucket ASC"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "a5dd5f3b-c637-31fb-ada6-9755aec98f04"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "5e67d40f-c978-b23d-6eb8-3cf61800b9e7",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "splitAccessor": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "preferredSeriesType": "line",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Consumer Group Members Over Time",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "i": "763b19c3-6f02-6af9-e94d-7840b8f7e11f",
+          "w": 24,
+          "x": 24,
+          "y": 22
+        },
+        "panelIndex": "763b19c3-6f02-6af9-e94d-7840b8f7e11f",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "f3799344-cabe-2cf2-15f6-654db9296dc0": {
+                      "allColumns": [
+                        {
+                          "columnId": "89095d4b-5c3e-9755-6d1f-4a17fcdcd7e5",
+                          "customLabel": true,
+                          "fieldName": "attributes.group",
+                          "label": "Group"
+                        },
+                        {
+                          "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                          "customLabel": true,
+                          "fieldName": "attributes.topic",
+                          "label": "Topic"
+                        },
+                        {
+                          "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
+                          "customLabel": true,
+                          "fieldName": "attributes.partition",
+                          "label": "Partition"
+                        },
+                        {
+                          "columnId": "b3c8697c-707f-5e62-cf7d-49afdb037013",
+                          "customLabel": true,
+                          "fieldName": "lag",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "89095d4b-5c3e-9755-6d1f-4a17fcdcd7e5",
+                          "customLabel": true,
+                          "fieldName": "attributes.group",
+                          "label": "Group"
+                        },
+                        {
+                          "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                          "customLabel": true,
+                          "fieldName": "attributes.topic",
+                          "label": "Topic"
+                        },
+                        {
+                          "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
+                          "customLabel": true,
+                          "fieldName": "attributes.partition",
+                          "label": "Partition"
+                        },
+                        {
+                          "columnId": "b3c8697c-707f-5e62-cf7d-49afdb037013",
+                          "customLabel": true,
+                          "fieldName": "lag",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag IS NOT NULL AND attributes.group IS NOT NULL AND attributes.topic IS NOT NULL AND attributes.partition IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag) BY attributes.group, attributes.topic, attributes.partition\n| SORT lag DESC\n| LIMIT 50"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag IS NOT NULL AND attributes.group IS NOT NULL AND attributes.topic IS NOT NULL AND attributes.partition IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag) BY attributes.group, attributes.topic, attributes.partition\n| SORT lag DESC\n| LIMIT 50"
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "89095d4b-5c3e-9755-6d1f-4a17fcdcd7e5",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "b3c8697c-707f-5e62-cf7d-49afdb037013",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "layerId": "f3799344-cabe-2cf2-15f6-654db9296dc0",
+                "layerType": "data",
+                "paging": {
+                  "enabled": true,
+                  "size": 15
+                }
+              }
+            },
+            "title": "Lag by Partition (Top 20 Partitions)",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 16,
+          "i": "54375245-294f-cfa1-33c3-2dbf942a36d6",
+          "w": 48,
+          "x": 0,
+          "y": 34
+        },
+        "panelIndex": "54375245-294f-cfa1-33c3-2dbf942a36d6",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "content": "## [Kafka OTel] Consumer Groups\n\nConsumer lag and offset drill-down:\n- Lag sum per group and topic\n- Lag by partition (hot partitions)\n- Member count per group\n- Offset position vs current partition offset\n"
+        },
+        "gridData": {
+          "h": 8,
+          "i": "540fc689-8453-4b28-ac92-167f1d8d23c3",
+          "w": 16,
+          "x": 0,
+          "y": 2
+        },
+        "panelIndex": "540fc689-8453-4b28-ac92-167f1d8d23c3",
+        "type": "DASHBOARD_MARKDOWN"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e39615e1-18c0-f840-8cf7-da9a26477e37": {
+                      "allColumns": [
+                        {
+                          "columnId": "d130cae9-2511-fae1-6d1f-205113cd7694",
+                          "customLabel": true,
+                          "fieldName": "total_lag",
+                          "inMetricDimension": true,
+                          "label": "Total Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "d130cae9-2511-fae1-6d1f-205113cd7694",
+                          "customLabel": true,
+                          "fieldName": "total_lag",
+                          "inMetricDimension": true,
+                          "label": "Total Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS total_lag = SUM(kafka.consumer_group.lag_sum)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS total_lag = SUM(kafka.consumer_group.lag_sum)"
+              },
+              "visualization": {
+                "layerId": "e39615e1-18c0-f840-8cf7-da9a26477e37",
+                "layerType": "data",
+                "metricAccessor": "d130cae9-2511-fae1-6d1f-205113cd7694",
+                "showBar": false
+              }
+            },
+            "title": "Total Lag (Selected Group)",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "e1c6bdf6-5283-dbb2-0fde-d3662c6a1bb5",
+          "w": 6,
+          "x": 16,
+          "y": 2
+        },
+        "panelIndex": "e1c6bdf6-5283-dbb2-0fde-d3662c6a1bb5",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "8a3a653b-d44c-e1ba-df8e-66e2e9b45da1": {
+                      "allColumns": [
+                        {
+                          "columnId": "8f6ed4a6-1e75-9840-3599-25716ab4ddc9",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Groups with Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "8f6ed4a6-1e75-9840-3599-25716ab4ddc9",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Groups with Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = SUM(kafka.consumer_group.lag_sum) BY attributes.group\n| WHERE lag_sum > 0\n| STATS count = COUNT(*)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = SUM(kafka.consumer_group.lag_sum) BY attributes.group\n| WHERE lag_sum > 0\n| STATS count = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "8a3a653b-d44c-e1ba-df8e-66e2e9b45da1",
+                "layerType": "data",
+                "metricAccessor": "8f6ed4a6-1e75-9840-3599-25716ab4ddc9",
+                "showBar": false
+              }
+            },
+            "title": "Groups with Lag",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "2c5a22f4-6bcd-8e7b-f30b-81b15e151622",
+          "w": 6,
+          "x": 22,
+          "y": 2
+        },
+        "panelIndex": "2c5a22f4-6bcd-8e7b-f30b-81b15e151622",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "a15c4713-de6a-53f9-ce22-7b11cc23821d": {
+                      "allColumns": [
+                        {
+                          "columnId": "f5458c8a-e44d-5e09-d71c-0fb2c0ffb648",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Empty Groups",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "f5458c8a-e44d-5e09-d71c-0fb2c0ffb648",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Empty Groups",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| WHERE members == 0\n| STATS count = COUNT(*)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| WHERE members == 0\n| STATS count = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "a15c4713-de6a-53f9-ce22-7b11cc23821d",
+                "layerType": "data",
+                "metricAccessor": "f5458c8a-e44d-5e09-d71c-0fb2c0ffb648",
+                "showBar": false
+              }
+            },
+            "title": "Empty Groups",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "a6a91455-c973-82a6-1493-917fe4983754",
+          "w": 6,
+          "x": 28,
+          "y": 2
+        },
+        "panelIndex": "a6a91455-c973-82a6-1493-917fe4983754",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.3.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "timeFrom": "now-15m",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "[Kafka OTel] Consumer Groups"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2026-03-13T13:08:21.384Z",
+  "id": "kafka_otel-consumer-groups",
+  "references": [
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_bef629a0-e1db-8bab-570b-ea16cd6e2fe0:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "kafka_otel-overview",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-consumer-groups",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-topics-partitions",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-replication",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
+      "type": "dashboard"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.3.0",
+  "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/kafka_otel/kibana/dashboard/kafka_otel-overview.json
+++ b/packages/kafka_otel/kibana/dashboard/kafka_otel-overview.json
@@ -1,1737 +1,1737 @@
 {
-    "attributes": {
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
-            },
-            "panelsJSON": {},
-            "showApplySelections": false
-        },
-        "description": "High-level Kafka cluster health: broker count, consumer lag, replication status, and consumer group membership. For ES superusers and administrators of production Kafka clusters.",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "key": "data_stream.dataset",
-                            "negate": false,
-                            "params": {
-                                "query": "kafkametricsreceiver.otel"
-                            },
-                            "type": "phrase"
-                        },
-                        "query": {
-                            "match_phrase": {
-                                "data_stream.dataset": "kafkametricsreceiver.otel"
-                            }
-                        }
-                    }
-                ],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": false,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "layout": "horizontal",
-                    "links": [
-                        {
-                            "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
-                            "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
-                            "label": "Overview",
-                            "order": 0,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
-                            "id": "023dd0d5-85a5-7c2d-7761-09ac67eaf6b0",
-                            "label": "Consumer Groups",
-                            "order": 1,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
-                            "id": "9fa8a215-5ab9-a0b8-3ae7-50918026c5b2",
-                            "label": "Topics \u0026 Partitions",
-                            "order": 2,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
-                            "id": "55497914-9303-4f76-667d-ef92eaa42807",
-                            "label": "Replication Health",
-                            "order": 3,
-                            "type": "dashboardLink"
-                        }
-                    ]
-                },
-                "gridData": {
-                    "h": 2,
-                    "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
-                    "w": 48,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
-                "type": "links"
-            },
-            {
-                "embeddableConfig": {
-                    "content": "## [Kafka OTel] Overview\n\nCluster health at a glance:\n- Broker count stability \n- Total consumer lag across all groups \n- Under-replicated partition count\n- Consumer groups with zero members\n- Topic and partition topology\n"
-                },
-                "gridData": {
-                    "h": 14,
-                    "i": "df3eb799-5e66-44d7-a23f-c02f83975463",
-                    "w": 16,
-                    "x": 0,
-                    "y": 2
-                },
-                "panelIndex": "df3eb799-5e66-44d7-a23f-c02f83975463",
-                "type": "DASHBOARD_MARKDOWN"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "e99c54bd-b190-d6b7-873e-bcf06fc90a89": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "23e41af3-757b-7be3-ba4a-da76eceba54d",
-                                                    "customLabel": true,
-                                                    "fieldName": "brokers",
-                                                    "inMetricDimension": true,
-                                                    "label": "Brokers",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "23e41af3-757b-7be3-ba4a-da76eceba54d",
-                                                    "customLabel": true,
-                                                    "fieldName": "brokers",
-                                                    "inMetricDimension": true,
-                                                    "label": "Brokers",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.brokers IS NOT NULL\n| STATS brokers = MAX(LAST_OVER_TIME(kafka.brokers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.brokers IS NOT NULL\n| STATS brokers = MAX(LAST_OVER_TIME(kafka.brokers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "23e41af3-757b-7be3-ba4a-da76eceba54d"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "e99c54bd-b190-d6b7-873e-bcf06fc90a89",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
-                                    }
-                                ],
-                                "legend": {
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "line",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Broker Count Over Time",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "337f7387-25ac-db8d-5d79-056975c75cfa",
-                    "w": 24,
-                    "x": 24,
-                    "y": 16
-                },
-                "panelIndex": "337f7387-25ac-db8d-5d79-056975c75cfa",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "250adb6c-a3ee-4bd7-9f5e-fe701530d2b6": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "total_lag",
-                                                    "customLabel": false,
-                                                    "fieldName": "total_lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "total_lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "time_bucket",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum)\n    BY attributes.group, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS total_lag = SUM(lag) BY time_bucket\n| SORT time_bucket ASC"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum)\n    BY attributes.group, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS total_lag = SUM(lag) BY time_bucket\n| SORT time_bucket ASC"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "Linear",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "total_lag"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "default",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "250adb6c-a3ee-4bd7-9f5e-fe701530d2b6",
-                                        "layerType": "data",
-                                        "seriesType": "bar_stacked",
-                                        "xAccessor": "time_bucket"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Bar vertical stacked",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum)\n    BY attributes.group, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS total_lag = SUM(lag) BY time_bucket\n| SORT time_bucket ASC"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "8501c161-0806-31e2-5944-808e14384b60",
-                    "w": 24,
-                    "x": 0,
-                    "y": 16
-                },
-                "panelIndex": "8501c161-0806-31e2-5944-808e14384b60",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "872c513d-dc21-2eda-22e5-f3bd06890338": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag_sum",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.group",
-                                                    "label": "attributes.group"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag_sum",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.group",
-                                                    "label": "Group"
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| SORT lag_sum DESC\n| LIMIT 10"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| SORT lag_sum DESC\n| LIMIT 10"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d558689a-a066-bbc0-e59f-a93654972edb"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "872c513d-dc21-2eda-22e5-f3bd06890338",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_unstacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "1e6904ec-2867-e558-ec9c-1e72297e1d42"
-                                    }
-                                ],
-                                "legend": {
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_unstacked",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Consumer Lag by Group (Top 10)",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| SORT lag_sum DESC\n| LIMIT 10"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "8d62801b-1e08-4ed1-5884-4ec779fe3071",
-                    "w": 24,
-                    "x": 24,
-                    "y": 26
-                },
-                "panelIndex": "8d62801b-1e08-4ed1-5884-4ec779fe3071",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "eb9ed4c0-5712-d669-1f4e-f10efd95d04f": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag_sum",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "attributes.topic"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
-                                                    "customLabel": true,
-                                                    "fieldName": "lag_sum",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "Topic"
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| STATS lag_sum = SUM(lag) BY attributes.topic\n| SORT lag_sum DESC\n| LIMIT 10"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| STATS lag_sum = SUM(lag) BY attributes.topic\n| SORT lag_sum DESC\n| LIMIT 10"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d558689a-a066-bbc0-e59f-a93654972edb"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "eb9ed4c0-5712-d669-1f4e-f10efd95d04f",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_unstacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "063c4976-1285-e229-5879-4c7845b3a305"
-                                    }
-                                ],
-                                "legend": {
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_unstacked",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Lag by Topic (Top 10)",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| STATS lag_sum = SUM(lag) BY attributes.topic\n| SORT lag_sum DESC\n| LIMIT 10"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "a705abae-d30a-7937-875b-40403bb2bc4d",
-                    "w": 24,
-                    "x": 0,
-                    "y": 26
-                },
-                "panelIndex": "a705abae-d30a-7937-875b-40403bb2bc4d",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [],
-                                    "layers": {
-                                        "ce83660d-89e1-6652-b22c-1929b9ca8907": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "0a824a41-1c38-2f32-e6fa-ef6ae5a714da",
-                                                    "customLabel": false,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "count",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "0333e3c9-fd19-5a50-5398-62047d6a082f",
-                                                    "customLabel": true,
-                                                    "fieldName": "member_status",
-                                                    "label": "Members"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "0a824a41-1c38-2f32-e6fa-ef6ae5a714da",
-                                                    "customLabel": false,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "count",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "0333e3c9-fd19-5a50-5398-62047d6a082f",
-                                                    "customLabel": true,
-                                                    "fieldName": "member_status",
-                                                    "label": "Members"
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| EVAL member_status = CASE(members == 0, \"0 (empty)\", members \u003e 0 AND members \u003c= 5, \"1-5\", members \u003e 5 AND members \u003c= 20, \"6-20\", \"20+\")\n| STATS count = COUNT(*) BY member_status\n| SORT count DESC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| EVAL member_status = CASE(members == 0, \"0 (empty)\", members \u003e 0 AND members \u003c= 5, \"1-5\", members \u003e 5 AND members \u003c= 20, \"6-20\", \"20+\")\n| STATS count = COUNT(*) BY member_status\n| SORT count DESC"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "categoryDisplay": "default",
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "ce83660d-89e1-6652-b22c-1929b9ca8907",
-                                        "layerType": "data",
-                                        "legendDisplay": "default",
-                                        "metrics": [
-                                            "0a824a41-1c38-2f32-e6fa-ef6ae5a714da"
-                                        ],
-                                        "nestedLegend": false,
-                                        "numberDisplay": "percent",
-                                        "primaryGroups": [
-                                            "0333e3c9-fd19-5a50-5398-62047d6a082f"
-                                        ]
-                                    }
-                                ],
-                                "shape": "donut"
-                            }
-                        },
-                        "title": "Consumer Groups by Member Count",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsPie"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| EVAL member_status = CASE(members == 0, \"0 (empty)\", members \u003e 0 AND members \u003c= 5, \"1-5\", members \u003e 5 AND members \u003c= 20, \"6-20\", \"20+\")\n| STATS count = COUNT(*) BY member_status\n| SORT count DESC"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "9596b3f6-9d9d-19a7-717d-8d03c78993f0",
-                    "w": 24,
-                    "x": 24,
-                    "y": 36
-                },
-                "panelIndex": "9596b3f6-9d9d-19a7-717d-8d03c78993f0",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "3d222337-2500-90ca-58d3-f9d9f71b0e0e": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under-Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under-Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under_replicated = replicas - in_sync\n| WHERE under_replicated \u003e 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under_replicated = replicas - in_sync\n| WHERE under_replicated \u003e 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "3d222337-2500-90ca-58d3-f9d9f71b0e0e",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
-                                    }
-                                ],
-                                "legend": {
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "line",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Under-Replicated Partitions Over Time",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under_replicated = replicas - in_sync\n| WHERE under_replicated \u003e 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "39e781fd-9d85-6080-613e-82b045d569d8",
-                    "w": 24,
-                    "x": 0,
-                    "y": 36
-                },
-                "panelIndex": "39e781fd-9d85-6080-613e-82b045d569d8",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [],
-                                    "layers": {
-                                        "b3a94ba1-f454-670a-8b15-1da5714da014": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "Topic"
-                                                },
-                                                {
-                                                    "columnId": "9ec30bb9-f1ad-3e91-d648-b2a42e6c3d54",
-                                                    "customLabel": true,
-                                                    "fieldName": "partitions",
-                                                    "inMetricDimension": true,
-                                                    "label": "Partitions",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "Topic"
-                                                },
-                                                {
-                                                    "columnId": "9ec30bb9-f1ad-3e91-d648-b2a42e6c3d54",
-                                                    "customLabel": true,
-                                                    "fieldName": "partitions",
-                                                    "inMetricDimension": true,
-                                                    "label": "Partitions",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 50"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 50"
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "9ec30bb9-f1ad-3e91-d648-b2a42e6c3d54",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "b3a94ba1-f454-670a-8b15-1da5714da014",
-                                "layerType": "data",
-                                "paging": {
-                                    "enabled": true,
-                                    "size": 10
-                                }
-                            }
-                        },
-                        "title": "Top Topics by Partition Count",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 50"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "i": "b63bc833-06c5-2db1-78eb-8a6050d03e82",
-                    "w": 48,
-                    "x": 0,
-                    "y": 46
-                },
-                "panelIndex": "b63bc833-06c5-2db1-78eb-8a6050d03e82",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "3e6bb59a-2113-23a6-b4f7-c799c58f1ef8": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "10814910-b993-a0ec-4ac6-bfe8717c7340",
-                                                    "customLabel": true,
-                                                    "fieldName": "unique_topics",
-                                                    "inMetricDimension": true,
-                                                    "label": "Topics",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "10814910-b993-a0ec-4ac6-bfe8717c7340",
-                                                    "customLabel": true,
-                                                    "fieldName": "unique_topics",
-                                                    "inMetricDimension": true,
-                                                    "label": "Topics",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "FROM metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS unique_topics = COUNT_DISTINCT(attributes.topic)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "FROM metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS unique_topics = COUNT_DISTINCT(attributes.topic)"
-                            },
-                            "visualization": {
-                                "layerId": "3e6bb59a-2113-23a6-b4f7-c799c58f1ef8",
-                                "layerType": "data",
-                                "metricAccessor": "10814910-b993-a0ec-4ac6-bfe8717c7340",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Topics",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 7,
-                    "i": "d58ba307-2059-1f9a-a37c-d14ded1f0cb3",
-                    "w": 8,
-                    "x": 16,
-                    "y": 9
-                },
-                "panelIndex": "d58ba307-2059-1f9a-a37c-d14ded1f0cb3",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "b81c7217-d768-aafd-e08b-c139d9d2e470": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "c22a46c7-913f-134e-4925-9f5a3cab4700",
-                                                    "customLabel": true,
-                                                    "fieldName": "brokers",
-                                                    "inMetricDimension": true,
-                                                    "label": "Brokers",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "c22a46c7-913f-134e-4925-9f5a3cab4700",
-                                                    "customLabel": true,
-                                                    "fieldName": "brokers",
-                                                    "inMetricDimension": true,
-                                                    "label": "Brokers",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.brokers IS NOT NULL\n| STATS brokers = MAX(kafka.brokers)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.brokers IS NOT NULL\n| STATS brokers = MAX(kafka.brokers)"
-                            },
-                            "visualization": {
-                                "layerId": "b81c7217-d768-aafd-e08b-c139d9d2e470",
-                                "layerType": "data",
-                                "metricAccessor": "c22a46c7-913f-134e-4925-9f5a3cab4700",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Brokers",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 7,
-                    "i": "faeae98a-2151-daad-4ddf-bc1c77ab52b7",
-                    "w": 8,
-                    "x": 16,
-                    "y": 2
-                },
-                "panelIndex": "faeae98a-2151-daad-4ddf-bc1c77ab52b7",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "e39615e1-18c0-f840-8cf7-da9a26477e37": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "d130cae9-2511-fae1-6d1f-205113cd7694",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "Total Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "d130cae9-2511-fae1-6d1f-205113cd7694",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_lag",
-                                                    "inMetricDimension": true,
-                                                    "label": "Total Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS latest_lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| STATS total_lag = SUM(latest_lag)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS latest_lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| STATS total_lag = SUM(latest_lag)"
-                            },
-                            "visualization": {
-                                "layerId": "e39615e1-18c0-f840-8cf7-da9a26477e37",
-                                "layerType": "data",
-                                "metricAccessor": "d130cae9-2511-fae1-6d1f-205113cd7694",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Total Lag",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS latest_lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| STATS total_lag = SUM(latest_lag)"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 7,
-                    "i": "70655726-6b18-411c-8545-46fe7bbdd21f",
-                    "w": 8,
-                    "x": 24,
-                    "y": 2
-                },
-                "panelIndex": "70655726-6b18-411c-8545-46fe7bbdd21f",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "075d34ec-90e5-4f08-8d8b-27b522052794": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "under_replicated_partitions",
-                                                    "customLabel": true,
-                                                    "fieldName": "under_replicated_partitions",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under replicated partitions",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas),\n        in_sync = MAX(kafka.partition.replicas_in_sync)\n  BY attributes.topic, attributes.partition\n| WHERE replicas \u003e in_sync\n| STATS under_replicated_partitions = COUNT(*)"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas),\n        in_sync = MAX(kafka.partition.replicas_in_sync)\n  BY attributes.topic, attributes.partition\n| WHERE replicas \u003e in_sync\n| STATS under_replicated_partitions = COUNT(*)"
-                            },
-                            "visualization": {
-                                "layerId": "075d34ec-90e5-4f08-8d8b-27b522052794",
-                                "layerType": "data",
-                                "metricAccessor": "under_replicated_partitions"
-                            }
-                        },
-                        "title": "under_replicated_partitions",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas),\n        in_sync = MAX(kafka.partition.replicas_in_sync)\n  BY attributes.topic, attributes.partition\n| WHERE replicas \u003e in_sync\n| STATS under_replicated_partitions = COUNT(*)"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 7,
-                    "i": "e079e0c2-d9b3-115b-ad94-cf389bbbacf7",
-                    "w": 8,
-                    "x": 32,
-                    "y": 2
-                },
-                "panelIndex": "e079e0c2-d9b3-115b-ad94-cf389bbbacf7",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "aab83e9b-efd5-e440-1550-be4a538cd27e": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "4e12562d-df82-f995-53d9-84a59bdc6d27",
-                                                    "customLabel": true,
-                                                    "fieldName": "empty_groups",
-                                                    "inMetricDimension": true,
-                                                    "label": "Empty Groups",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "4e12562d-df82-f995-53d9-84a59bdc6d27",
-                                                    "customLabel": true,
-                                                    "fieldName": "empty_groups",
-                                                    "inMetricDimension": true,
-                                                    "label": "Empty Groups",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| WHERE members == 0\n| STATS empty_groups = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| WHERE members == 0\n| STATS empty_groups = COUNT(*)"
-                            },
-                            "visualization": {
-                                "layerId": "aab83e9b-efd5-e440-1550-be4a538cd27e",
-                                "layerType": "data",
-                                "metricAccessor": "4e12562d-df82-f995-53d9-84a59bdc6d27",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Groups with No Members",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 7,
-                    "i": "44ee2a6f-1962-6f3e-07fe-7aad2781e9fe",
-                    "w": 8,
-                    "x": 24,
-                    "y": 9
-                },
-                "panelIndex": "44ee2a6f-1962-6f3e-07fe-7aad2781e9fe",
-                "type": "lens"
-            }
-        ],
-        "timeFrom": "now-15m",
-        "timeRestore": true,
-        "timeTo": "now",
-        "title": "[Kafka OTel] Overview"
+  "attributes": {
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {},
+      "showApplySelections": false
     },
-    "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-03-13T13:08:22.039Z",
-    "id": "kafka_otel-overview",
-    "references": [
-        {
-            "id": "kafka_otel-overview",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-consumer-groups",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-topics-partitions",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-replication",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
-            "type": "dashboard"
+    "description": "High-level Kafka cluster health: broker count, consumer lag, replication status, and consumer group membership. For ES superusers and administrators of production Kafka clusters.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "alias": null,
+              "disabled": false,
+              "field": "data_stream.dataset",
+              "key": "data_stream.dataset",
+              "negate": false,
+              "params": {
+                "query": "kafkametricsreceiver.otel"
+              },
+              "type": "phrase"
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "kafkametricsreceiver.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "language": "kuery",
+          "query": ""
         }
+      }
+    },
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "enhancements": {},
+          "layout": "horizontal",
+          "links": [
+            {
+              "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
+              "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+              "label": "Overview",
+              "order": 0,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
+              "id": "023dd0d5-85a5-7c2d-7761-09ac67eaf6b0",
+              "label": "Consumer Groups",
+              "order": 1,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
+              "id": "9fa8a215-5ab9-a0b8-3ae7-50918026c5b2",
+              "label": "Topics & Partitions",
+              "order": 2,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
+              "id": "55497914-9303-4f76-667d-ef92eaa42807",
+              "label": "Replication Health",
+              "order": 3,
+              "type": "dashboardLink"
+            }
+          ]
+        },
+        "gridData": {
+          "h": 2,
+          "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+        "type": "links"
+      },
+      {
+        "embeddableConfig": {
+          "content": "## [Kafka OTel] Overview\n\nCluster health at a glance:\n- Broker count stability \n- Total consumer lag across all groups \n- Under-replicated partition count\n- Consumer groups with zero members\n- Topic and partition topology\n"
+        },
+        "gridData": {
+          "h": 14,
+          "i": "df3eb799-5e66-44d7-a23f-c02f83975463",
+          "w": 16,
+          "x": 0,
+          "y": 2
+        },
+        "panelIndex": "df3eb799-5e66-44d7-a23f-c02f83975463",
+        "type": "DASHBOARD_MARKDOWN"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e99c54bd-b190-d6b7-873e-bcf06fc90a89": {
+                      "allColumns": [
+                        {
+                          "columnId": "23e41af3-757b-7be3-ba4a-da76eceba54d",
+                          "customLabel": true,
+                          "fieldName": "brokers",
+                          "inMetricDimension": true,
+                          "label": "Brokers",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "23e41af3-757b-7be3-ba4a-da76eceba54d",
+                          "customLabel": true,
+                          "fieldName": "brokers",
+                          "inMetricDimension": true,
+                          "label": "Brokers",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.brokers IS NOT NULL\n| STATS brokers = MAX(LAST_OVER_TIME(kafka.brokers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.brokers IS NOT NULL\n| STATS brokers = MAX(LAST_OVER_TIME(kafka.brokers)) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "23e41af3-757b-7be3-ba4a-da76eceba54d"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "e99c54bd-b190-d6b7-873e-bcf06fc90a89",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
+                  }
+                ],
+                "legend": {
+                  "position": "right"
+                },
+                "preferredSeriesType": "line",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Broker Count Over Time",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "337f7387-25ac-db8d-5d79-056975c75cfa",
+          "w": 24,
+          "x": 24,
+          "y": 16
+        },
+        "panelIndex": "337f7387-25ac-db8d-5d79-056975c75cfa",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "250adb6c-a3ee-4bd7-9f5e-fe701530d2b6": {
+                      "columns": [
+                        {
+                          "columnId": "total_lag",
+                          "customLabel": false,
+                          "fieldName": "total_lag",
+                          "inMetricDimension": true,
+                          "label": "total_lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          }
+                        },
+                        {
+                          "columnId": "time_bucket",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum)\n    BY attributes.group, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS total_lag = SUM(lag) BY time_bucket\n| SORT time_bucket ASC"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum)\n    BY attributes.group, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS total_lag = SUM(lag) BY time_bucket\n| SORT time_bucket ASC"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "fittingFunction": "Linear",
+                "gridlinesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "total_lag"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "default",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "250adb6c-a3ee-4bd7-9f5e-fe701530d2b6",
+                    "layerType": "data",
+                    "seriesType": "bar_stacked",
+                    "xAccessor": "time_bucket"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "preferredSeriesType": "bar_stacked",
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Bar vertical stacked",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum)\n    BY attributes.group, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS total_lag = SUM(lag) BY time_bucket\n| SORT time_bucket ASC"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "8501c161-0806-31e2-5944-808e14384b60",
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "panelIndex": "8501c161-0806-31e2-5944-808e14384b60",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "872c513d-dc21-2eda-22e5-f3bd06890338": {
+                      "allColumns": [
+                        {
+                          "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
+                          "customLabel": true,
+                          "fieldName": "lag_sum",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
+                          "customLabel": false,
+                          "fieldName": "attributes.group",
+                          "label": "attributes.group"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
+                          "customLabel": true,
+                          "fieldName": "lag_sum",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "1e6904ec-2867-e558-ec9c-1e72297e1d42",
+                          "customLabel": true,
+                          "fieldName": "attributes.group",
+                          "label": "Group"
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| SORT lag_sum DESC\n| LIMIT 10"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| SORT lag_sum DESC\n| LIMIT 10"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "d558689a-a066-bbc0-e59f-a93654972edb"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "872c513d-dc21-2eda-22e5-f3bd06890338",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_unstacked",
+                    "showGridlines": false,
+                    "xAccessor": "1e6904ec-2867-e558-ec9c-1e72297e1d42"
+                  }
+                ],
+                "legend": {
+                  "position": "right"
+                },
+                "preferredSeriesType": "bar_unstacked",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Consumer Lag by Group (Top 10)",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag_sum = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| SORT lag_sum DESC\n| LIMIT 10"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "8d62801b-1e08-4ed1-5884-4ec779fe3071",
+          "w": 24,
+          "x": 24,
+          "y": 26
+        },
+        "panelIndex": "8d62801b-1e08-4ed1-5884-4ec779fe3071",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "eb9ed4c0-5712-d669-1f4e-f10efd95d04f": {
+                      "allColumns": [
+                        {
+                          "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
+                          "customLabel": true,
+                          "fieldName": "lag_sum",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
+                          "customLabel": false,
+                          "fieldName": "attributes.topic",
+                          "label": "attributes.topic"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "d558689a-a066-bbc0-e59f-a93654972edb",
+                          "customLabel": true,
+                          "fieldName": "lag_sum",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
+                          "customLabel": true,
+                          "fieldName": "attributes.topic",
+                          "label": "Topic"
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| STATS lag_sum = SUM(lag) BY attributes.topic\n| SORT lag_sum DESC\n| LIMIT 10"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| STATS lag_sum = SUM(lag) BY attributes.topic\n| SORT lag_sum DESC\n| LIMIT 10"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "d558689a-a066-bbc0-e59f-a93654972edb"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "eb9ed4c0-5712-d669-1f4e-f10efd95d04f",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_unstacked",
+                    "showGridlines": false,
+                    "xAccessor": "063c4976-1285-e229-5879-4c7845b3a305"
+                  }
+                ],
+                "legend": {
+                  "position": "right"
+                },
+                "preferredSeriesType": "bar_unstacked",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Lag by Topic (Top 10)",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group, attributes.topic\n| STATS lag_sum = SUM(lag) BY attributes.topic\n| SORT lag_sum DESC\n| LIMIT 10"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "a705abae-d30a-7937-875b-40403bb2bc4d",
+          "w": 24,
+          "x": 0,
+          "y": 26
+        },
+        "panelIndex": "a705abae-d30a-7937-875b-40403bb2bc4d",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [],
+                  "layers": {
+                    "ce83660d-89e1-6652-b22c-1929b9ca8907": {
+                      "allColumns": [
+                        {
+                          "columnId": "0a824a41-1c38-2f32-e6fa-ef6ae5a714da",
+                          "customLabel": false,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "count",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          }
+                        },
+                        {
+                          "columnId": "0333e3c9-fd19-5a50-5398-62047d6a082f",
+                          "customLabel": true,
+                          "fieldName": "member_status",
+                          "label": "Members"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "0a824a41-1c38-2f32-e6fa-ef6ae5a714da",
+                          "customLabel": false,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "count",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          }
+                        },
+                        {
+                          "columnId": "0333e3c9-fd19-5a50-5398-62047d6a082f",
+                          "customLabel": true,
+                          "fieldName": "member_status",
+                          "label": "Members"
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| EVAL member_status = CASE(members == 0, \"0 (empty)\", members > 0 AND members <= 5, \"1-5\", members > 5 AND members <= 20, \"6-20\", \"20+\")\n| STATS count = COUNT(*) BY member_status\n| SORT count DESC"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| EVAL member_status = CASE(members == 0, \"0 (empty)\", members > 0 AND members <= 5, \"1-5\", members > 5 AND members <= 20, \"6-20\", \"20+\")\n| STATS count = COUNT(*) BY member_status\n| SORT count DESC"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "categoryDisplay": "default",
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "ce83660d-89e1-6652-b22c-1929b9ca8907",
+                    "layerType": "data",
+                    "legendDisplay": "default",
+                    "metrics": [
+                      "0a824a41-1c38-2f32-e6fa-ef6ae5a714da"
+                    ],
+                    "nestedLegend": false,
+                    "numberDisplay": "percent",
+                    "primaryGroups": [
+                      "0333e3c9-fd19-5a50-5398-62047d6a082f"
+                    ]
+                  }
+                ],
+                "shape": "donut"
+              }
+            },
+            "title": "Consumer Groups by Member Count",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsPie"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| EVAL member_status = CASE(members == 0, \"0 (empty)\", members > 0 AND members <= 5, \"1-5\", members > 5 AND members <= 20, \"6-20\", \"20+\")\n| STATS count = COUNT(*) BY member_status\n| SORT count DESC"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "9596b3f6-9d9d-19a7-717d-8d03c78993f0",
+          "w": 24,
+          "x": 24,
+          "y": 36
+        },
+        "panelIndex": "9596b3f6-9d9d-19a7-717d-8d03c78993f0",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "3d222337-2500-90ca-58d3-f9d9f71b0e0e": {
+                      "allColumns": [
+                        {
+                          "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Under-Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Under-Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under_replicated = replicas - in_sync\n| WHERE under_replicated > 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under_replicated = replicas - in_sync\n| WHERE under_replicated > 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "3d222337-2500-90ca-58d3-f9d9f71b0e0e",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
+                  }
+                ],
+                "legend": {
+                  "position": "right"
+                },
+                "preferredSeriesType": "line",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Under-Replicated Partitions Over Time",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under_replicated = replicas - in_sync\n| WHERE under_replicated > 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "39e781fd-9d85-6080-613e-82b045d569d8",
+          "w": 24,
+          "x": 0,
+          "y": 36
+        },
+        "panelIndex": "39e781fd-9d85-6080-613e-82b045d569d8",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [],
+                  "layers": {
+                    "b3a94ba1-f454-670a-8b15-1da5714da014": {
+                      "allColumns": [
+                        {
+                          "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                          "customLabel": true,
+                          "fieldName": "attributes.topic",
+                          "label": "Topic"
+                        },
+                        {
+                          "columnId": "9ec30bb9-f1ad-3e91-d648-b2a42e6c3d54",
+                          "customLabel": true,
+                          "fieldName": "partitions",
+                          "inMetricDimension": true,
+                          "label": "Partitions",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                          "customLabel": true,
+                          "fieldName": "attributes.topic",
+                          "label": "Topic"
+                        },
+                        {
+                          "columnId": "9ec30bb9-f1ad-3e91-d648-b2a42e6c3d54",
+                          "customLabel": true,
+                          "fieldName": "partitions",
+                          "inMetricDimension": true,
+                          "label": "Partitions",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 50"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 50"
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "9ec30bb9-f1ad-3e91-d648-b2a42e6c3d54",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "layerId": "b3a94ba1-f454-670a-8b15-1da5714da014",
+                "layerType": "data",
+                "paging": {
+                  "enabled": true,
+                  "size": 10
+                }
+              }
+            },
+            "title": "Top Topics by Partition Count",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 50"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 14,
+          "i": "b63bc833-06c5-2db1-78eb-8a6050d03e82",
+          "w": 48,
+          "x": 0,
+          "y": 46
+        },
+        "panelIndex": "b63bc833-06c5-2db1-78eb-8a6050d03e82",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "3e6bb59a-2113-23a6-b4f7-c799c58f1ef8": {
+                      "allColumns": [
+                        {
+                          "columnId": "10814910-b993-a0ec-4ac6-bfe8717c7340",
+                          "customLabel": true,
+                          "fieldName": "unique_topics",
+                          "inMetricDimension": true,
+                          "label": "Topics",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "10814910-b993-a0ec-4ac6-bfe8717c7340",
+                          "customLabel": true,
+                          "fieldName": "unique_topics",
+                          "inMetricDimension": true,
+                          "label": "Topics",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "FROM metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS unique_topics = COUNT_DISTINCT(attributes.topic)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "FROM metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS unique_topics = COUNT_DISTINCT(attributes.topic)"
+              },
+              "visualization": {
+                "layerId": "3e6bb59a-2113-23a6-b4f7-c799c58f1ef8",
+                "layerType": "data",
+                "metricAccessor": "10814910-b993-a0ec-4ac6-bfe8717c7340",
+                "showBar": false
+              }
+            },
+            "title": "Topics",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 7,
+          "i": "d58ba307-2059-1f9a-a37c-d14ded1f0cb3",
+          "w": 8,
+          "x": 16,
+          "y": 9
+        },
+        "panelIndex": "d58ba307-2059-1f9a-a37c-d14ded1f0cb3",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "b81c7217-d768-aafd-e08b-c139d9d2e470": {
+                      "allColumns": [
+                        {
+                          "columnId": "c22a46c7-913f-134e-4925-9f5a3cab4700",
+                          "customLabel": true,
+                          "fieldName": "brokers",
+                          "inMetricDimension": true,
+                          "label": "Brokers",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "c22a46c7-913f-134e-4925-9f5a3cab4700",
+                          "customLabel": true,
+                          "fieldName": "brokers",
+                          "inMetricDimension": true,
+                          "label": "Brokers",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.brokers IS NOT NULL\n| STATS brokers = MAX(kafka.brokers)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.brokers IS NOT NULL\n| STATS brokers = MAX(kafka.brokers)"
+              },
+              "visualization": {
+                "layerId": "b81c7217-d768-aafd-e08b-c139d9d2e470",
+                "layerType": "data",
+                "metricAccessor": "c22a46c7-913f-134e-4925-9f5a3cab4700",
+                "showBar": false
+              }
+            },
+            "title": "Brokers",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 7,
+          "i": "faeae98a-2151-daad-4ddf-bc1c77ab52b7",
+          "w": 8,
+          "x": 16,
+          "y": 2
+        },
+        "panelIndex": "faeae98a-2151-daad-4ddf-bc1c77ab52b7",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "e39615e1-18c0-f840-8cf7-da9a26477e37": {
+                      "allColumns": [
+                        {
+                          "columnId": "d130cae9-2511-fae1-6d1f-205113cd7694",
+                          "customLabel": true,
+                          "fieldName": "total_lag",
+                          "inMetricDimension": true,
+                          "label": "Total Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "d130cae9-2511-fae1-6d1f-205113cd7694",
+                          "customLabel": true,
+                          "fieldName": "total_lag",
+                          "inMetricDimension": true,
+                          "label": "Total Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS latest_lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| STATS total_lag = SUM(latest_lag)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS latest_lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| STATS total_lag = SUM(latest_lag)"
+              },
+              "visualization": {
+                "layerId": "e39615e1-18c0-f840-8cf7-da9a26477e37",
+                "layerType": "data",
+                "metricAccessor": "d130cae9-2511-fae1-6d1f-205113cd7694",
+                "showBar": false
+              }
+            },
+            "title": "Total Lag",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.lag_sum IS NOT NULL\n| STATS latest_lag = MAX(kafka.consumer_group.lag_sum) BY attributes.group\n| STATS total_lag = SUM(latest_lag)"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 7,
+          "i": "70655726-6b18-411c-8545-46fe7bbdd21f",
+          "w": 8,
+          "x": 24,
+          "y": 2
+        },
+        "panelIndex": "70655726-6b18-411c-8545-46fe7bbdd21f",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "075d34ec-90e5-4f08-8d8b-27b522052794": {
+                      "columns": [
+                        {
+                          "columnId": "under_replicated_partitions",
+                          "customLabel": true,
+                          "fieldName": "under_replicated_partitions",
+                          "inMetricDimension": true,
+                          "label": "Under replicated partitions",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas),\n        in_sync = MAX(kafka.partition.replicas_in_sync)\n  BY attributes.topic, attributes.partition\n| WHERE replicas > in_sync\n| STATS under_replicated_partitions = COUNT(*)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas),\n        in_sync = MAX(kafka.partition.replicas_in_sync)\n  BY attributes.topic, attributes.partition\n| WHERE replicas > in_sync\n| STATS under_replicated_partitions = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "075d34ec-90e5-4f08-8d8b-27b522052794",
+                "layerType": "data",
+                "metricAccessor": "under_replicated_partitions"
+              }
+            },
+            "title": "under_replicated_partitions",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas),\n        in_sync = MAX(kafka.partition.replicas_in_sync)\n  BY attributes.topic, attributes.partition\n| WHERE replicas > in_sync\n| STATS under_replicated_partitions = COUNT(*)"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 7,
+          "i": "e079e0c2-d9b3-115b-ad94-cf389bbbacf7",
+          "w": 8,
+          "x": 32,
+          "y": 2
+        },
+        "panelIndex": "e079e0c2-d9b3-115b-ad94-cf389bbbacf7",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "aab83e9b-efd5-e440-1550-be4a538cd27e": {
+                      "allColumns": [
+                        {
+                          "columnId": "4e12562d-df82-f995-53d9-84a59bdc6d27",
+                          "customLabel": true,
+                          "fieldName": "empty_groups",
+                          "inMetricDimension": true,
+                          "label": "Empty Groups",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "4e12562d-df82-f995-53d9-84a59bdc6d27",
+                          "customLabel": true,
+                          "fieldName": "empty_groups",
+                          "inMetricDimension": true,
+                          "label": "Empty Groups",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| WHERE members == 0\n| STATS empty_groups = COUNT(*)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.consumer_group.members IS NOT NULL\n| STATS members = MAX(kafka.consumer_group.members) BY attributes.group\n| WHERE members == 0\n| STATS empty_groups = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "aab83e9b-efd5-e440-1550-be4a538cd27e",
+                "layerType": "data",
+                "metricAccessor": "4e12562d-df82-f995-53d9-84a59bdc6d27",
+                "showBar": false
+              }
+            },
+            "title": "Groups with No Members",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 7,
+          "i": "44ee2a6f-1962-6f3e-07fe-7aad2781e9fe",
+          "w": 8,
+          "x": 24,
+          "y": 9
+        },
+        "panelIndex": "44ee2a6f-1962-6f3e-07fe-7aad2781e9fe",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.3.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "timeFrom": "now-15m",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "[Kafka OTel] Overview"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2026-03-13T13:08:22.039Z",
+  "id": "kafka_otel-overview",
+  "references": [
+    {
+      "id": "kafka_otel-overview",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-consumer-groups",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-topics-partitions",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-replication",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
+      "type": "dashboard"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.3.0",
+  "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/kafka_otel/kibana/dashboard/kafka_otel-replication.json
+++ b/packages/kafka_otel/kibana/dashboard/kafka_otel-replication.json
@@ -1,1184 +1,1184 @@
 {
-    "attributes": {
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
-            },
-            "panelsJSON": {},
-            "showApplySelections": false
-        },
-        "description": "Partition replication status: under-replicated partitions, replicas vs in-sync replicas. Critical for durability and failover readiness.",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "key": "data_stream.dataset",
-                            "negate": false,
-                            "params": {
-                                "query": "kafkametricsreceiver.otel"
-                            },
-                            "type": "phrase"
-                        },
-                        "query": {
-                            "match_phrase": {
-                                "data_stream.dataset": "kafkametricsreceiver.otel"
-                            }
-                        }
-                    }
-                ],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": false,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "layout": "horizontal",
-                    "links": [
-                        {
-                            "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
-                            "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
-                            "label": "Overview",
-                            "order": 0,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
-                            "id": "023dd0d5-85a5-7c2d-7761-09ac67eaf6b0",
-                            "label": "Consumer Groups",
-                            "order": 1,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
-                            "id": "9fa8a215-5ab9-a0b8-3ae7-50918026c5b2",
-                            "label": "Topics \u0026 Partitions",
-                            "order": 2,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
-                            "id": "55497914-9303-4f76-667d-ef92eaa42807",
-                            "label": "Replication Health",
-                            "order": 3,
-                            "type": "dashboardLink"
-                        }
-                    ]
-                },
-                "gridData": {
-                    "h": 2,
-                    "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
-                    "w": 48,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
-                "type": "links"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [],
-                                    "layers": {
-                                        "e44e1126-7706-ca01-baa6-ddfe20bd5ca5": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "bab9e7f2-9932-c7ad-2603-40d12400a8b3",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_replicas",
-                                                    "inMetricDimension": true,
-                                                    "label": "Total Replicas",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "6558c703-0734-17f2-61c1-96aaf453232f",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_in_sync",
-                                                    "inMetricDimension": true,
-                                                    "label": "In-Sync Replicas",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "bab9e7f2-9932-c7ad-2603-40d12400a8b3",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_replicas",
-                                                    "inMetricDimension": true,
-                                                    "label": "Total Replicas",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "6558c703-0734-17f2-61c1-96aaf453232f",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_in_sync",
-                                                    "inMetricDimension": true,
-                                                    "label": "In-Sync Replicas",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": false,
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS total_replicas = SUM(kafka.partition.replicas), total_in_sync = SUM(kafka.partition.replicas_in_sync) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS total_replicas = SUM(kafka.partition.replicas), total_in_sync = SUM(kafka.partition.replicas_in_sync) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "bab9e7f2-9932-c7ad-2603-40d12400a8b3",
-                                            "6558c703-0734-17f2-61c1-96aaf453232f"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "e44e1126-7706-ca01-baa6-ddfe20bd5ca5",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "line",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Replicas vs In-Sync Over Time",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS total_replicas = SUM(kafka.partition.replicas), total_in_sync = SUM(kafka.partition.replicas_in_sync) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "31df3bee-2b39-938c-d9eb-20a7ac175622",
-                    "w": 48,
-                    "x": 0,
-                    "y": 10
-                },
-                "panelIndex": "31df3bee-2b39-938c-d9eb-20a7ac175622",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "b96b79b3-13ad-7ca0-42ac-ed09e84b587c": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under-Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under-Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under = replicas - in_sync\n| WHERE under \u003e 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under = replicas - in_sync\n| WHERE under \u003e 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "b96b79b3-13ad-7ca0-42ac-ed09e84b587c",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area_unstacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
-                                    }
-                                ],
-                                "legend": {
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area_unstacked",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Under-Replicated Partitions Over Time",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "f8479993-f528-841f-dad2-759da0ee9822",
-                    "w": 24,
-                    "x": 0,
-                    "y": 22
-                },
-                "panelIndex": "f8479993-f528-841f-dad2-759da0ee9822",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "9466d20c-3452-4508-282e-e74550ce4f92": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under-Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "attributes.topic"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under-Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "attributes.topic"
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - in_sync\n| WHERE under \u003e 0\n| STATS count = COUNT(*) BY attributes.topic\n| SORT count DESC\n| LIMIT 15"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - in_sync\n| WHERE under \u003e 0\n| STATS count = COUNT(*) BY attributes.topic\n| SORT count DESC\n| LIMIT 15"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "9466d20c-3452-4508-282e-e74550ce4f92",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_unstacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "063c4976-1285-e229-5879-4c7845b3a305"
-                                    }
-                                ],
-                                "legend": {
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_unstacked",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Under-Replicated by Topic",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "112c1348-849f-a36e-1d4d-04fd04ea123a",
-                    "w": 24,
-                    "x": 24,
-                    "y": 22
-                },
-                "panelIndex": "112c1348-849f-a36e-1d4d-04fd04ea123a",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [],
-                                    "layers": {
-                                        "ff8e5d68-6996-e652-92aa-4720fc505004": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "Topic"
-                                                },
-                                                {
-                                                    "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.partition",
-                                                    "label": "Partition"
-                                                },
-                                                {
-                                                    "columnId": "269fb707-8b90-ac74-b6de-2a8906ed4ea7",
-                                                    "customLabel": true,
-                                                    "fieldName": "replicas",
-                                                    "inMetricDimension": true,
-                                                    "label": "Replicas",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "930cae77-8074-a681-0e5c-ff05374cf3f4",
-                                                    "customLabel": true,
-                                                    "fieldName": "replicas_in_sync",
-                                                    "inMetricDimension": true,
-                                                    "label": "In Sync",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "acbdfd08-4029-1dff-7701-e4660c34c292",
-                                                    "customLabel": true,
-                                                    "fieldName": "under",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "Topic"
-                                                },
-                                                {
-                                                    "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.partition",
-                                                    "label": "Partition"
-                                                },
-                                                {
-                                                    "columnId": "269fb707-8b90-ac74-b6de-2a8906ed4ea7",
-                                                    "customLabel": true,
-                                                    "fieldName": "replicas",
-                                                    "inMetricDimension": true,
-                                                    "label": "Replicas",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "930cae77-8074-a681-0e5c-ff05374cf3f4",
-                                                    "customLabel": true,
-                                                    "fieldName": "replicas_in_sync",
-                                                    "inMetricDimension": true,
-                                                    "label": "In Sync",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "acbdfd08-4029-1dff-7701-e4660c34c292",
-                                                    "customLabel": true,
-                                                    "fieldName": "under",
-                                                    "inMetricDimension": true,
-                                                    "label": "Lag",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), replicas_in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - replicas_in_sync\n| WHERE under \u003e 0\n| SORT under DESC\n| LIMIT 100"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), replicas_in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - replicas_in_sync\n| WHERE under \u003e 0\n| SORT under DESC\n| LIMIT 100"
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
-                                        "isMetric": false,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "269fb707-8b90-ac74-b6de-2a8906ed4ea7",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "930cae77-8074-a681-0e5c-ff05374cf3f4",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "acbdfd08-4029-1dff-7701-e4660c34c292",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    }
-                                ],
-                                "layerId": "ff8e5d68-6996-e652-92aa-4720fc505004",
-                                "layerType": "data",
-                                "paging": {
-                                    "enabled": true,
-                                    "size": 15
-                                }
-                            }
-                        },
-                        "title": "Under-Replicated Partitions (Detail)",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), replicas_in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - replicas_in_sync\n| WHERE under \u003e 0\n| SORT under DESC\n| LIMIT 100"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 16,
-                    "i": "db770a88-0c37-5cc4-b43a-f03e1b72188e",
-                    "w": 48,
-                    "x": 0,
-                    "y": 32
-                },
-                "panelIndex": "db770a88-0c37-5cc4-b43a-f03e1b72188e",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "content": "## [Kafka OTel] Replication Health\n\nReplication fidelity and ISR status:\n- Under-replicated partitions (replicas \u003e replicas_in_sync)\n- Partitions by replication factor\n- Replicas vs in-sync over time\n"
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "61c6a463-d87d-4ea4-8a9f-db9a34b5a4ab",
-                    "w": 16,
-                    "x": 0,
-                    "y": 2
-                },
-                "panelIndex": "61c6a463-d87d-4ea4-8a9f-db9a34b5a4ab",
-                "type": "DASHBOARD_MARKDOWN"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "39e9a9d3-cac5-f19f-47de-57accacd9e43": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "d307701e-3996-e1e7-8228-41f0116f3b9a",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under-Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "d307701e-3996-e1e7-8228-41f0116f3b9a",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Under-Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - in_sync\n| WHERE under \u003e 0\n| STATS count = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - in_sync\n| WHERE under \u003e 0\n| STATS count = COUNT(*)"
-                            },
-                            "visualization": {
-                                "layerId": "39e9a9d3-cac5-f19f-47de-57accacd9e43",
-                                "layerType": "data",
-                                "metricAccessor": "d307701e-3996-e1e7-8228-41f0116f3b9a",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Under-Replicated Partitions",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "247bddfc-fb6f-d194-5ef4-03a05bad33fc",
-                    "w": 6,
-                    "x": 16,
-                    "y": 2
-                },
-                "panelIndex": "247bddfc-fb6f-d194-5ef4-03a05bad33fc",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "9ba1ce47-1dbf-a2cc-f3fd-fff3e0466a7a": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "ebf49ab5-e75f-9735-4a9e-df45969de903",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Fully Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "ebf49ab5-e75f-9735-4a9e-df45969de903",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Fully Replicated",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| WHERE replicas == in_sync\n| STATS count = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| WHERE replicas == in_sync\n| STATS count = COUNT(*)"
-                            },
-                            "visualization": {
-                                "layerId": "9ba1ce47-1dbf-a2cc-f3fd-fff3e0466a7a",
-                                "layerType": "data",
-                                "metricAccessor": "ebf49ab5-e75f-9735-4a9e-df45969de903",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Fully Replicated Partitions",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "b983b5c4-67ef-f54a-0abb-37d484488037",
-                    "w": 6,
-                    "x": 22,
-                    "y": 2
-                },
-                "panelIndex": "b983b5c4-67ef-f54a-0abb-37d484488037",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [],
-                                    "layers": {
-                                        "1863654e-48c7-ec6f-2b80-7359f738e6bb": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "7c33a018-7162-ca7c-ca16-ad22bd5aa405",
-                                                    "customLabel": true,
-                                                    "fieldName": "unique_rf",
-                                                    "inMetricDimension": true,
-                                                    "label": "Distinct RF Values",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "7c33a018-7162-ca7c-ca16-ad22bd5aa405",
-                                                    "customLabel": true,
-                                                    "fieldName": "unique_rf",
-                                                    "inMetricDimension": true,
-                                                    "label": "Distinct Replication Factor",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL\n| STATS unique_rf = COUNT_DISTINCT(kafka.partition.replicas)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL\n| STATS unique_rf = COUNT_DISTINCT(kafka.partition.replicas)"
-                            },
-                            "visualization": {
-                                "layerId": "1863654e-48c7-ec6f-2b80-7359f738e6bb",
-                                "layerType": "data",
-                                "metricAccessor": "7c33a018-7162-ca7c-ca16-ad22bd5aa405",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Replication Factor Distribution",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL\n| STATS unique_rf = COUNT_DISTINCT(kafka.partition.replicas)"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "94032886-0c09-9b13-cf2a-687838afafb7",
-                    "w": 6,
-                    "x": 28,
-                    "y": 2
-                },
-                "panelIndex": "94032886-0c09-9b13-cf2a-687838afafb7",
-                "type": "lens"
-            }
-        ],
-        "timeFrom": "now-15m",
-        "timeRestore": true,
-        "timeTo": "now",
-        "title": "[Kafka OTel] Replication Health"
+  "attributes": {
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {},
+      "showApplySelections": false
     },
-    "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-03-13T13:08:23.044Z",
-    "id": "kafka_otel-replication",
-    "references": [
-        {
-            "id": "kafka_otel-overview",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-consumer-groups",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-topics-partitions",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-replication",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
-            "type": "dashboard"
+    "description": "Partition replication status: under-replicated partitions, replicas vs in-sync replicas. Critical for durability and failover readiness.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "alias": null,
+              "disabled": false,
+              "field": "data_stream.dataset",
+              "key": "data_stream.dataset",
+              "negate": false,
+              "params": {
+                "query": "kafkametricsreceiver.otel"
+              },
+              "type": "phrase"
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "kafkametricsreceiver.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "language": "kuery",
+          "query": ""
         }
+      }
+    },
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "enhancements": {},
+          "layout": "horizontal",
+          "links": [
+            {
+              "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
+              "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+              "label": "Overview",
+              "order": 0,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
+              "id": "023dd0d5-85a5-7c2d-7761-09ac67eaf6b0",
+              "label": "Consumer Groups",
+              "order": 1,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
+              "id": "9fa8a215-5ab9-a0b8-3ae7-50918026c5b2",
+              "label": "Topics & Partitions",
+              "order": 2,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
+              "id": "55497914-9303-4f76-667d-ef92eaa42807",
+              "label": "Replication Health",
+              "order": 3,
+              "type": "dashboardLink"
+            }
+          ]
+        },
+        "gridData": {
+          "h": 2,
+          "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+        "type": "links"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [],
+                  "layers": {
+                    "e44e1126-7706-ca01-baa6-ddfe20bd5ca5": {
+                      "allColumns": [
+                        {
+                          "columnId": "bab9e7f2-9932-c7ad-2603-40d12400a8b3",
+                          "customLabel": true,
+                          "fieldName": "total_replicas",
+                          "inMetricDimension": true,
+                          "label": "Total Replicas",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "6558c703-0734-17f2-61c1-96aaf453232f",
+                          "customLabel": true,
+                          "fieldName": "total_in_sync",
+                          "inMetricDimension": true,
+                          "label": "In-Sync Replicas",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "bab9e7f2-9932-c7ad-2603-40d12400a8b3",
+                          "customLabel": true,
+                          "fieldName": "total_replicas",
+                          "inMetricDimension": true,
+                          "label": "Total Replicas",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "6558c703-0734-17f2-61c1-96aaf453232f",
+                          "customLabel": true,
+                          "fieldName": "total_in_sync",
+                          "inMetricDimension": true,
+                          "label": "In-Sync Replicas",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": false,
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS total_replicas = SUM(kafka.partition.replicas), total_in_sync = SUM(kafka.partition.replicas_in_sync) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS total_replicas = SUM(kafka.partition.replicas), total_in_sync = SUM(kafka.partition.replicas_in_sync) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "bab9e7f2-9932-c7ad-2603-40d12400a8b3",
+                      "6558c703-0734-17f2-61c1-96aaf453232f"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "e44e1126-7706-ca01-baa6-ddfe20bd5ca5",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "preferredSeriesType": "line",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Replicas vs In-Sync Over Time",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS total_replicas = SUM(kafka.partition.replicas), total_in_sync = SUM(kafka.partition.replicas_in_sync) BY time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| SORT time_bucket ASC"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "i": "31df3bee-2b39-938c-d9eb-20a7ac175622",
+          "w": 48,
+          "x": 0,
+          "y": 10
+        },
+        "panelIndex": "31df3bee-2b39-938c-d9eb-20a7ac175622",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "b96b79b3-13ad-7ca0-42ac-ed09e84b587c": {
+                      "allColumns": [
+                        {
+                          "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Under-Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Under-Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under = replicas - in_sync\n| WHERE under > 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| EVAL under = replicas - in_sync\n| WHERE under > 0\n| STATS count = COUNT(*) BY time_bucket\n| SORT time_bucket ASC"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "b96b79b3-13ad-7ca0-42ac-ed09e84b587c",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area_unstacked",
+                    "showGridlines": false,
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
+                  }
+                ],
+                "legend": {
+                  "position": "right"
+                },
+                "preferredSeriesType": "area_unstacked",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Under-Replicated Partitions Over Time",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "f8479993-f528-841f-dad2-759da0ee9822",
+          "w": 24,
+          "x": 0,
+          "y": 22
+        },
+        "panelIndex": "f8479993-f528-841f-dad2-759da0ee9822",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "9466d20c-3452-4508-282e-e74550ce4f92": {
+                      "allColumns": [
+                        {
+                          "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Under-Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
+                          "customLabel": false,
+                          "fieldName": "attributes.topic",
+                          "label": "attributes.topic"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Under-Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
+                          "customLabel": false,
+                          "fieldName": "attributes.topic",
+                          "label": "attributes.topic"
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - in_sync\n| WHERE under > 0\n| STATS count = COUNT(*) BY attributes.topic\n| SORT count DESC\n| LIMIT 15"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - in_sync\n| WHERE under > 0\n| STATS count = COUNT(*) BY attributes.topic\n| SORT count DESC\n| LIMIT 15"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "24ba3808-12cd-2357-6c7a-c2b4dda7b6e9"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "9466d20c-3452-4508-282e-e74550ce4f92",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_unstacked",
+                    "showGridlines": false,
+                    "xAccessor": "063c4976-1285-e229-5879-4c7845b3a305"
+                  }
+                ],
+                "legend": {
+                  "position": "right"
+                },
+                "preferredSeriesType": "bar_unstacked",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Under-Replicated by Topic",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "112c1348-849f-a36e-1d4d-04fd04ea123a",
+          "w": 24,
+          "x": 24,
+          "y": 22
+        },
+        "panelIndex": "112c1348-849f-a36e-1d4d-04fd04ea123a",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [],
+                  "layers": {
+                    "ff8e5d68-6996-e652-92aa-4720fc505004": {
+                      "allColumns": [
+                        {
+                          "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                          "customLabel": true,
+                          "fieldName": "attributes.topic",
+                          "label": "Topic"
+                        },
+                        {
+                          "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
+                          "customLabel": true,
+                          "fieldName": "attributes.partition",
+                          "label": "Partition"
+                        },
+                        {
+                          "columnId": "269fb707-8b90-ac74-b6de-2a8906ed4ea7",
+                          "customLabel": true,
+                          "fieldName": "replicas",
+                          "inMetricDimension": true,
+                          "label": "Replicas",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "930cae77-8074-a681-0e5c-ff05374cf3f4",
+                          "customLabel": true,
+                          "fieldName": "replicas_in_sync",
+                          "inMetricDimension": true,
+                          "label": "In Sync",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "acbdfd08-4029-1dff-7701-e4660c34c292",
+                          "customLabel": true,
+                          "fieldName": "under",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                          "customLabel": true,
+                          "fieldName": "attributes.topic",
+                          "label": "Topic"
+                        },
+                        {
+                          "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
+                          "customLabel": true,
+                          "fieldName": "attributes.partition",
+                          "label": "Partition"
+                        },
+                        {
+                          "columnId": "269fb707-8b90-ac74-b6de-2a8906ed4ea7",
+                          "customLabel": true,
+                          "fieldName": "replicas",
+                          "inMetricDimension": true,
+                          "label": "Replicas",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "930cae77-8074-a681-0e5c-ff05374cf3f4",
+                          "customLabel": true,
+                          "fieldName": "replicas_in_sync",
+                          "inMetricDimension": true,
+                          "label": "In Sync",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "acbdfd08-4029-1dff-7701-e4660c34c292",
+                          "customLabel": true,
+                          "fieldName": "under",
+                          "inMetricDimension": true,
+                          "label": "Lag",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), replicas_in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - replicas_in_sync\n| WHERE under > 0\n| SORT under DESC\n| LIMIT 100"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), replicas_in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - replicas_in_sync\n| WHERE under > 0\n| SORT under DESC\n| LIMIT 100"
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "6a59d2b3-c989-6ade-16cc-80efb2986df5",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "ea1e47b9-f018-e7d0-14bb-62ae1b496f21",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "269fb707-8b90-ac74-b6de-2a8906ed4ea7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "930cae77-8074-a681-0e5c-ff05374cf3f4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "acbdfd08-4029-1dff-7701-e4660c34c292",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "layerId": "ff8e5d68-6996-e652-92aa-4720fc505004",
+                "layerType": "data",
+                "paging": {
+                  "enabled": true,
+                  "size": 15
+                }
+              }
+            },
+            "title": "Under-Replicated Partitions (Detail)",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), replicas_in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - replicas_in_sync\n| WHERE under > 0\n| SORT under DESC\n| LIMIT 100"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 16,
+          "i": "db770a88-0c37-5cc4-b43a-f03e1b72188e",
+          "w": 48,
+          "x": 0,
+          "y": 32
+        },
+        "panelIndex": "db770a88-0c37-5cc4-b43a-f03e1b72188e",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "content": "## [Kafka OTel] Replication Health\n\nReplication fidelity and ISR status:\n- Under-replicated partitions (replicas > replicas_in_sync)\n- Partitions by replication factor\n- Replicas vs in-sync over time\n"
+        },
+        "gridData": {
+          "h": 8,
+          "i": "61c6a463-d87d-4ea4-8a9f-db9a34b5a4ab",
+          "w": 16,
+          "x": 0,
+          "y": 2
+        },
+        "panelIndex": "61c6a463-d87d-4ea4-8a9f-db9a34b5a4ab",
+        "type": "DASHBOARD_MARKDOWN"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "39e9a9d3-cac5-f19f-47de-57accacd9e43": {
+                      "allColumns": [
+                        {
+                          "columnId": "d307701e-3996-e1e7-8228-41f0116f3b9a",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Under-Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "d307701e-3996-e1e7-8228-41f0116f3b9a",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Under-Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - in_sync\n| WHERE under > 0\n| STATS count = COUNT(*)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| EVAL under = replicas - in_sync\n| WHERE under > 0\n| STATS count = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "39e9a9d3-cac5-f19f-47de-57accacd9e43",
+                "layerType": "data",
+                "metricAccessor": "d307701e-3996-e1e7-8228-41f0116f3b9a",
+                "showBar": false
+              }
+            },
+            "title": "Under-Replicated Partitions",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "247bddfc-fb6f-d194-5ef4-03a05bad33fc",
+          "w": 6,
+          "x": 16,
+          "y": 2
+        },
+        "panelIndex": "247bddfc-fb6f-d194-5ef4-03a05bad33fc",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "9ba1ce47-1dbf-a2cc-f3fd-fff3e0466a7a": {
+                      "allColumns": [
+                        {
+                          "columnId": "ebf49ab5-e75f-9735-4a9e-df45969de903",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Fully Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "ebf49ab5-e75f-9735-4a9e-df45969de903",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Fully Replicated",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| WHERE replicas == in_sync\n| STATS count = COUNT(*)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL AND kafka.partition.replicas_in_sync IS NOT NULL\n| STATS replicas = MAX(kafka.partition.replicas), in_sync = MAX(kafka.partition.replicas_in_sync) BY attributes.topic, attributes.partition\n| WHERE replicas == in_sync\n| STATS count = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "9ba1ce47-1dbf-a2cc-f3fd-fff3e0466a7a",
+                "layerType": "data",
+                "metricAccessor": "ebf49ab5-e75f-9735-4a9e-df45969de903",
+                "showBar": false
+              }
+            },
+            "title": "Fully Replicated Partitions",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "b983b5c4-67ef-f54a-0abb-37d484488037",
+          "w": 6,
+          "x": 22,
+          "y": 2
+        },
+        "panelIndex": "b983b5c4-67ef-f54a-0abb-37d484488037",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [],
+                  "layers": {
+                    "1863654e-48c7-ec6f-2b80-7359f738e6bb": {
+                      "allColumns": [
+                        {
+                          "columnId": "7c33a018-7162-ca7c-ca16-ad22bd5aa405",
+                          "customLabel": true,
+                          "fieldName": "unique_rf",
+                          "inMetricDimension": true,
+                          "label": "Distinct RF Values",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "7c33a018-7162-ca7c-ca16-ad22bd5aa405",
+                          "customLabel": true,
+                          "fieldName": "unique_rf",
+                          "inMetricDimension": true,
+                          "label": "Distinct Replication Factor",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL\n| STATS unique_rf = COUNT_DISTINCT(kafka.partition.replicas)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL\n| STATS unique_rf = COUNT_DISTINCT(kafka.partition.replicas)"
+              },
+              "visualization": {
+                "layerId": "1863654e-48c7-ec6f-2b80-7359f738e6bb",
+                "layerType": "data",
+                "metricAccessor": "7c33a018-7162-ca7c-ca16-ad22bd5aa405",
+                "showBar": false
+              }
+            },
+            "title": "Replication Factor Distribution",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.replicas IS NOT NULL\n| STATS unique_rf = COUNT_DISTINCT(kafka.partition.replicas)"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "94032886-0c09-9b13-cf2a-687838afafb7",
+          "w": 6,
+          "x": 28,
+          "y": 2
+        },
+        "panelIndex": "94032886-0c09-9b13-cf2a-687838afafb7",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.3.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "timeFrom": "now-15m",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "[Kafka OTel] Replication Health"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2026-03-13T13:08:23.044Z",
+  "id": "kafka_otel-replication",
+  "references": [
+    {
+      "id": "kafka_otel-overview",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-consumer-groups",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-topics-partitions",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-replication",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
+      "type": "dashboard"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.3.0",
+  "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/kafka_otel/kibana/dashboard/kafka_otel-topics-partitions.json
+++ b/packages/kafka_otel/kibana/dashboard/kafka_otel-topics-partitions.json
@@ -1,1011 +1,1011 @@
 {
-    "attributes": {
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
+  "attributes": {
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "6ff6dd5b-251c-52e3-0c52-5b8a12b7f57c": {
+          "explicitInput": {
+            "dataViewId": "metrics-*",
+            "exclude": false,
+            "existsSelected": false,
+            "fieldName": "attributes.topic",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
             },
-            "panelsJSON": {
-                "6ff6dd5b-251c-52e3-0c52-5b8a12b7f57c": {
-                    "explicitInput": {
-                        "dataViewId": "metrics-*",
-                        "exclude": false,
-                        "existsSelected": false,
-                        "fieldName": "attributes.topic",
-                        "searchTechnique": "prefix",
-                        "selectedOptions": [],
-                        "sort": {
-                            "by": "_count",
-                            "direction": "desc"
-                        },
-                        "title": "Topic"
-                    },
-                    "grow": false,
-                    "order": 0,
-                    "type": "optionsListControl",
-                    "width": "medium"
-                }
-            },
-            "showApplySelections": false
-        },
-        "description": "Topic and partition topology: partition counts, current/oldest offsets, retained message volume. Capacity and throughput-inference views.",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "key": "data_stream.dataset",
-                            "negate": false,
-                            "params": {
-                                "query": "kafkametricsreceiver.otel"
-                            },
-                            "type": "phrase"
-                        },
-                        "query": {
-                            "match_phrase": {
-                                "data_stream.dataset": "kafkametricsreceiver.otel"
-                            }
-                        }
-                    }
-                ],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
-            }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": false,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "layout": "horizontal",
-                    "links": [
-                        {
-                            "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
-                            "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
-                            "label": "Overview",
-                            "order": 0,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
-                            "id": "023dd0d5-85a5-7c2d-7761-09ac67eaf6b0",
-                            "label": "Consumer Groups",
-                            "order": 1,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
-                            "id": "9fa8a215-5ab9-a0b8-3ae7-50918026c5b2",
-                            "label": "Topics \u0026 Partitions",
-                            "order": 2,
-                            "type": "dashboardLink"
-                        },
-                        {
-                            "destinationRefName": "link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
-                            "id": "55497914-9303-4f76-667d-ef92eaa42807",
-                            "label": "Replication Health",
-                            "order": 3,
-                            "type": "dashboardLink"
-                        }
-                    ]
-                },
-                "gridData": {
-                    "h": 2,
-                    "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
-                    "w": 48,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
-                "type": "links"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "9a14adb3-b7fb-1aa8-9730-5148f77877cc": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "417f2ad1-ca12-03aa-20a0-c7ac0c1c7c09",
-                                                    "customLabel": true,
-                                                    "fieldName": "current_offset",
-                                                    "inMetricDimension": true,
-                                                    "label": "Current Offset",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "attributes.topic"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "417f2ad1-ca12-03aa-20a0-c7ac0c1c7c09",
-                                                    "customLabel": true,
-                                                    "fieldName": "current_offset",
-                                                    "inMetricDimension": true,
-                                                    "label": "Current Offset",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
-                                                    "customLabel": false,
-                                                    "fieldName": "time_bucket",
-                                                    "label": "time_bucket",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "attributes.topic"
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS current_offset = SUM(offset) BY time_bucket, attributes.topic\n| SORT time_bucket ASC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS current_offset = SUM(offset) BY time_bucket, attributes.topic\n| SORT time_bucket ASC"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "417f2ad1-ca12-03aa-20a0-c7ac0c1c7c09"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "9a14adb3-b7fb-1aa8-9730-5148f77877cc",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "063c4976-1285-e229-5879-4c7845b3a305",
-                                        "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "line",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Current Offset Over Time by Topic (Top 5)",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS current_offset = SUM(offset) BY time_bucket, attributes.topic\n| SORT time_bucket ASC"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "b836c91f-4241-6f51-99c0-679ca2057d5d",
-                    "w": 24,
-                    "x": 0,
-                    "y": 10
-                },
-                "panelIndex": "b836c91f-4241-6f51-99c0-679ca2057d5d",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "e9a36c5d-89ef-c3ce-c4f3-a9b26fa76d0c": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "ab3b6e17-770a-fdf6-67ea-96c16204c681",
-                                                    "customLabel": true,
-                                                    "fieldName": "partitions",
-                                                    "inMetricDimension": true,
-                                                    "label": "Partitions",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "attributes.topic"
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "ab3b6e17-770a-fdf6-67ea-96c16204c681",
-                                                    "customLabel": true,
-                                                    "fieldName": "partitions",
-                                                    "inMetricDimension": true,
-                                                    "label": "Partitions",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.topic",
-                                                    "label": "attributes.topic"
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 15"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 15"
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "ab3b6e17-770a-fdf6-67ea-96c16204c681"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "e9a36c5d-89ef-c3ce-c4f3-a9b26fa76d0c",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_unstacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "063c4976-1285-e229-5879-4c7845b3a305"
-                                    }
-                                ],
-                                "legend": {
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_unstacked",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Partitions by Topic",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "0cf216bf-79df-78e3-7d18-7b8b1751796b",
-                    "w": 24,
-                    "x": 24,
-                    "y": 10
-                },
-                "panelIndex": "0cf216bf-79df-78e3-7d18-7b8b1751796b",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "76639bb3-1c51-4140-9a16-590d9c926f95": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "current_offset",
-                                                    "customLabel": false,
-                                                    "fieldName": "current_offset",
-                                                    "inMetricDimension": true,
-                                                    "label": "current_offset",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "attributes.topic",
-                                                    "customLabel": false,
-                                                    "fieldName": "attributes.topic",
-                                                    "inMetricDimension": true,
-                                                    "label": "attributes.topic",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "oldest_offset",
-                                                    "customLabel": false,
-                                                    "fieldName": "oldest_offset",
-                                                    "inMetricDimension": true,
-                                                    "label": "oldest_offset",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "attributes.topic",
-                                                    "customLabel": true,
-                                                    "fieldName": "attributes.topic",
-                                                    "inMetricDimension": true,
-                                                    "label": "Topic",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "current_offset",
-                                                    "customLabel": true,
-                                                    "fieldName": "current_offset",
-                                                    "inMetricDimension": true,
-                                                    "label": "Current offset",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "oldest_offset",
-                                                    "customLabel": true,
-                                                    "fieldName": "oldest_offset",
-                                                    "inMetricDimension": true,
-                                                    "label": "Oldest offset",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND kafka.partition.oldest_offset IS NOT NULL\n| STATS current_offset = MAX(kafka.partition.current_offset),\n        oldest_offset = MAX(kafka.partition.oldest_offset)\n    BY attributes.topic, attributes.partition\n| EVAL retained = current_offset - oldest_offset\n| SORT attributes.topic ASC, attributes.partition ASC\n| LIMIT 100"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND kafka.partition.oldest_offset IS NOT NULL\n| STATS current_offset = MAX(kafka.partition.current_offset),\n        oldest_offset = MAX(kafka.partition.oldest_offset)\n    BY attributes.topic, attributes.partition\n| EVAL retained = current_offset - oldest_offset\n| SORT attributes.topic ASC, attributes.partition ASC\n| LIMIT 100"
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "current_offset",
-                                        "isMetric": true,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "attributes.topic"
-                                    },
-                                    {
-                                        "columnId": "oldest_offset"
-                                    }
-                                ],
-                                "layerId": "76639bb3-1c51-4140-9a16-590d9c926f95",
-                                "layerType": "data"
-                            }
-                        },
-                        "title": "Table current_offset \u0026 attributes.topic \u0026 oldest_offset",
-                        "version": 1,
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND kafka.partition.oldest_offset IS NOT NULL\n| STATS current_offset = MAX(kafka.partition.current_offset),\n        oldest_offset = MAX(kafka.partition.oldest_offset)\n    BY attributes.topic, attributes.partition\n| EVAL retained = current_offset - oldest_offset\n| SORT attributes.topic ASC, attributes.partition ASC\n| LIMIT 100"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false,
-                    "title": "Partition offset details"
-                },
-                "gridData": {
-                    "h": 16,
-                    "i": "afca5714-d06b-0294-c1e4-585399c49276",
-                    "w": 48,
-                    "x": 0,
-                    "y": 20
-                },
-                "panelIndex": "afca5714-d06b-0294-c1e4-585399c49276",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "content": "## [Kafka OTel] Topics \u0026 Partitions\n\nTopic and partition metrics:\n- Partition count per topic\n- Current and oldest offsets\n- Retained message volume (current − oldest)\n- Replication factor and in-sync replicas\n"
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "9dd3c375-d9d2-42fd-b7b7-66771d78aba2",
-                    "w": 16,
-                    "x": 0,
-                    "y": 2
-                },
-                "panelIndex": "9dd3c375-d9d2-42fd-b7b7-66771d78aba2",
-                "type": "DASHBOARD_MARKDOWN"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "20b4415f-ec76-da18-4e74-0243bf0a97f0": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "77f244db-1f42-d9dd-b062-fdd4424d721a",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_partitions",
-                                                    "inMetricDimension": true,
-                                                    "label": "Partitions",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "77f244db-1f42-d9dd-b062-fdd4424d721a",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_partitions",
-                                                    "inMetricDimension": true,
-                                                    "label": "Partitions",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions_per_topic = MAX(kafka.topic.partitions) BY attributes.topic\n| STATS total_partitions = SUM(partitions_per_topic)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions_per_topic = MAX(kafka.topic.partitions) BY attributes.topic\n| STATS total_partitions = SUM(partitions_per_topic)"
-                            },
-                            "visualization": {
-                                "layerId": "20b4415f-ec76-da18-4e74-0243bf0a97f0",
-                                "layerType": "data",
-                                "metricAccessor": "77f244db-1f42-d9dd-b062-fdd4424d721a",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Total Partitions",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "358fc677-0838-eaca-1034-8e71f11f3c87",
-                    "w": 8,
-                    "x": 16,
-                    "y": 2
-                },
-                "panelIndex": "358fc677-0838-eaca-1034-8e71f11f3c87",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "textBased": {
-                                    "layers": {
-                                        "543cbc77-b170-32b1-b9c4-91f2913a1cf0": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "db496111-5508-6e4d-777f-353cc4f5de16",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Topics",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "db496111-5508-6e4d-777f-353cc4f5de16",
-                                                    "customLabel": true,
-                                                    "fieldName": "count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Topics",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "query": {
-                                                "esql": "FROM metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS count = COUNT_DISTINCT(attributes.topic)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "FROM metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS count = COUNT_DISTINCT(attributes.topic)"
-                            },
-                            "visualization": {
-                                "layerId": "543cbc77-b170-32b1-b9c4-91f2913a1cf0",
-                                "layerType": "data",
-                                "metricAccessor": "db496111-5508-6e4d-777f-353cc4f5de16",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Topics",
-                        "type": "lens",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "9b4e3882-0024-4ac3-6247-a6a7305119d2",
-                    "w": 7,
-                    "x": 24,
-                    "y": 2
-                },
-                "panelIndex": "9b4e3882-0024-4ac3-6247-a6a7305119d2",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                    "managed": false,
-                                    "name": "metrics-kafkametricsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "title": "metrics-kafkametricsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "title": "metrics-kafkametricsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "796b7623-176a-7b81-7cef-061ef18a4cc5": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "ab6bf359-3151-0400-d27c-61dee033202f",
-                                                    "customLabel": true,
-                                                    "fieldName": "total",
-                                                    "inMetricDimension": true,
-                                                    "label": "Current Offset Sum",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
-                                                {
-                                                    "columnId": "ab6bf359-3151-0400-d27c-61dee033202f",
-                                                    "customLabel": true,
-                                                    "fieldName": "total",
-                                                    "inMetricDimension": true,
-                                                    "label": "Current Offset Sum",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
-                                            "query": {
-                                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset) BY attributes.topic, attributes.partition\n| STATS total = SUM(offset)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset) BY attributes.topic, attributes.partition\n| STATS total = SUM(offset)"
-                            },
-                            "visualization": {
-                                "layerId": "796b7623-176a-7b81-7cef-061ef18a4cc5",
-                                "layerType": "data",
-                                "metricAccessor": "ab6bf359-3151-0400-d27c-61dee033202f",
-                                "showBar": false
-                            }
-                        },
-                        "title": "Current Offset (Sum)",
-                        "version": 1,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset) BY attributes.topic, attributes.partition\n| STATS total = SUM(offset)"
-                    },
-                    "syncColors": false,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "d1fa145a-5261-2021-3f36-e1105dc0bd48",
-                    "w": 7,
-                    "x": 31,
-                    "y": 2
-                },
-                "panelIndex": "d1fa145a-5261-2021-3f36-e1105dc0bd48",
-                "type": "lens"
-            }
-        ],
-        "timeFrom": "now-15m",
-        "timeRestore": true,
-        "timeTo": "now",
-        "title": "[Kafka OTel] Topics \u0026 Partitions"
-    },
-    "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-03-13T13:08:24.075Z",
-    "id": "kafka_otel-topics-partitions",
-    "references": [
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_6ff6dd5b-251c-52e3-0c52-5b8a12b7f57c:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "kafka_otel-overview",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-consumer-groups",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-topics-partitions",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kafka_otel-replication",
-            "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
-            "type": "dashboard"
+            "title": "Topic"
+          },
+          "grow": false,
+          "order": 0,
+          "type": "optionsListControl",
+          "width": "medium"
         }
+      },
+      "showApplySelections": false
+    },
+    "description": "Topic and partition topology: partition counts, current/oldest offsets, retained message volume. Capacity and throughput-inference views.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "alias": null,
+              "disabled": false,
+              "field": "data_stream.dataset",
+              "key": "data_stream.dataset",
+              "negate": false,
+              "params": {
+                "query": "kafkametricsreceiver.otel"
+              },
+              "type": "phrase"
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "kafkametricsreceiver.otel"
+              }
+            }
+          }
+        ],
+        "query": {
+          "language": "kuery",
+          "query": ""
+        }
+      }
+    },
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": false,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "enhancements": {},
+          "layout": "horizontal",
+          "links": [
+            {
+              "destinationRefName": "link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
+              "id": "3af4ba12-6f83-488a-bdc9-0c7216a22d73",
+              "label": "Overview",
+              "order": 0,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
+              "id": "023dd0d5-85a5-7c2d-7761-09ac67eaf6b0",
+              "label": "Consumer Groups",
+              "order": 1,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
+              "id": "9fa8a215-5ab9-a0b8-3ae7-50918026c5b2",
+              "label": "Topics & Partitions",
+              "order": 2,
+              "type": "dashboardLink"
+            },
+            {
+              "destinationRefName": "link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
+              "id": "55497914-9303-4f76-667d-ef92eaa42807",
+              "label": "Replication Health",
+              "order": 3,
+              "type": "dashboardLink"
+            }
+          ]
+        },
+        "gridData": {
+          "h": 2,
+          "i": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "91144e9b-fac7-b44d-0b1d-8339201b83cb",
+        "type": "links"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "9a14adb3-b7fb-1aa8-9730-5148f77877cc": {
+                      "allColumns": [
+                        {
+                          "columnId": "417f2ad1-ca12-03aa-20a0-c7ac0c1c7c09",
+                          "customLabel": true,
+                          "fieldName": "current_offset",
+                          "inMetricDimension": true,
+                          "label": "Current Offset",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        },
+                        {
+                          "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
+                          "customLabel": false,
+                          "fieldName": "attributes.topic",
+                          "label": "attributes.topic"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "417f2ad1-ca12-03aa-20a0-c7ac0c1c7c09",
+                          "customLabel": true,
+                          "fieldName": "current_offset",
+                          "inMetricDimension": true,
+                          "label": "Current Offset",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "44714e97-119f-dc33-b7f7-4ce49cc5463f",
+                          "customLabel": false,
+                          "fieldName": "time_bucket",
+                          "label": "time_bucket",
+                          "meta": {
+                            "esType": "date",
+                            "type": "date"
+                          }
+                        },
+                        {
+                          "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
+                          "customLabel": false,
+                          "fieldName": "attributes.topic",
+                          "label": "attributes.topic"
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS current_offset = SUM(offset) BY time_bucket, attributes.topic\n| SORT time_bucket ASC"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS current_offset = SUM(offset) BY time_bucket, attributes.topic\n| SORT time_bucket ASC"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "417f2ad1-ca12-03aa-20a0-c7ac0c1c7c09"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "9a14adb3-b7fb-1aa8-9730-5148f77877cc",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "splitAccessor": "063c4976-1285-e229-5879-4c7845b3a305",
+                    "xAccessor": "44714e97-119f-dc33-b7f7-4ce49cc5463f"
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right"
+                },
+                "preferredSeriesType": "line",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Current Offset Over Time by Topic (Top 5)",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND attributes.topic IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset)\n    BY attributes.topic, attributes.partition, time_bucket = BUCKET(@timestamp, 20, ?_tstart, ?_tend)\n| STATS current_offset = SUM(offset) BY time_bucket, attributes.topic\n| SORT time_bucket ASC"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "b836c91f-4241-6f51-99c0-679ca2057d5d",
+          "w": 24,
+          "x": 0,
+          "y": 10
+        },
+        "panelIndex": "b836c91f-4241-6f51-99c0-679ca2057d5d",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "e9a36c5d-89ef-c3ce-c4f3-a9b26fa76d0c": {
+                      "allColumns": [
+                        {
+                          "columnId": "ab3b6e17-770a-fdf6-67ea-96c16204c681",
+                          "customLabel": true,
+                          "fieldName": "partitions",
+                          "inMetricDimension": true,
+                          "label": "Partitions",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
+                          "customLabel": false,
+                          "fieldName": "attributes.topic",
+                          "label": "attributes.topic"
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "ab3b6e17-770a-fdf6-67ea-96c16204c681",
+                          "customLabel": true,
+                          "fieldName": "partitions",
+                          "inMetricDimension": true,
+                          "label": "Partitions",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "063c4976-1285-e229-5879-4c7845b3a305",
+                          "customLabel": false,
+                          "fieldName": "attributes.topic",
+                          "label": "attributes.topic"
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 15"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions = MAX(kafka.topic.partitions) BY attributes.topic\n| SORT partitions DESC\n| LIMIT 15"
+              },
+              "visualization": {
+                "layers": [
+                  {
+                    "accessors": [
+                      "ab3b6e17-770a-fdf6-67ea-96c16204c681"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "eui_amsterdam_color_blind",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "e9a36c5d-89ef-c3ce-c4f3-a9b26fa76d0c",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_unstacked",
+                    "showGridlines": false,
+                    "xAccessor": "063c4976-1285-e229-5879-4c7845b3a305"
+                  }
+                ],
+                "legend": {
+                  "position": "right"
+                },
+                "preferredSeriesType": "bar_unstacked",
+                "valueLabels": "hide"
+              }
+            },
+            "title": "Partitions by Topic",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 10,
+          "i": "0cf216bf-79df-78e3-7d18-7b8b1751796b",
+          "w": 24,
+          "x": 24,
+          "y": 10
+        },
+        "panelIndex": "0cf216bf-79df-78e3-7d18-7b8b1751796b",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "76639bb3-1c51-4140-9a16-590d9c926f95": {
+                      "allColumns": [
+                        {
+                          "columnId": "current_offset",
+                          "customLabel": false,
+                          "fieldName": "current_offset",
+                          "inMetricDimension": true,
+                          "label": "current_offset",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          }
+                        },
+                        {
+                          "columnId": "attributes.topic",
+                          "customLabel": false,
+                          "fieldName": "attributes.topic",
+                          "inMetricDimension": true,
+                          "label": "attributes.topic",
+                          "meta": {
+                            "esType": "keyword",
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "columnId": "oldest_offset",
+                          "customLabel": false,
+                          "fieldName": "oldest_offset",
+                          "inMetricDimension": true,
+                          "label": "oldest_offset",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "attributes.topic",
+                          "customLabel": true,
+                          "fieldName": "attributes.topic",
+                          "inMetricDimension": true,
+                          "label": "Topic",
+                          "meta": {
+                            "esType": "keyword",
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "columnId": "current_offset",
+                          "customLabel": true,
+                          "fieldName": "current_offset",
+                          "inMetricDimension": true,
+                          "label": "Current offset",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "columnId": "oldest_offset",
+                          "customLabel": true,
+                          "fieldName": "oldest_offset",
+                          "inMetricDimension": true,
+                          "label": "Oldest offset",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND kafka.partition.oldest_offset IS NOT NULL\n| STATS current_offset = MAX(kafka.partition.current_offset),\n        oldest_offset = MAX(kafka.partition.oldest_offset)\n    BY attributes.topic, attributes.partition\n| EVAL retained = current_offset - oldest_offset\n| SORT attributes.topic ASC, attributes.partition ASC\n| LIMIT 100"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND kafka.partition.oldest_offset IS NOT NULL\n| STATS current_offset = MAX(kafka.partition.current_offset),\n        oldest_offset = MAX(kafka.partition.oldest_offset)\n    BY attributes.topic, attributes.partition\n| EVAL retained = current_offset - oldest_offset\n| SORT attributes.topic ASC, attributes.partition ASC\n| LIMIT 100"
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "current_offset",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "attributes.topic"
+                  },
+                  {
+                    "columnId": "oldest_offset"
+                  }
+                ],
+                "layerId": "76639bb3-1c51-4140-9a16-590d9c926f95",
+                "layerType": "data"
+              }
+            },
+            "title": "Table current_offset & attributes.topic & oldest_offset",
+            "version": 1,
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL AND kafka.partition.oldest_offset IS NOT NULL\n| STATS current_offset = MAX(kafka.partition.current_offset),\n        oldest_offset = MAX(kafka.partition.oldest_offset)\n    BY attributes.topic, attributes.partition\n| EVAL retained = current_offset - oldest_offset\n| SORT attributes.topic ASC, attributes.partition ASC\n| LIMIT 100"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false,
+          "title": "Partition offset details"
+        },
+        "gridData": {
+          "h": 16,
+          "i": "afca5714-d06b-0294-c1e4-585399c49276",
+          "w": 48,
+          "x": 0,
+          "y": 20
+        },
+        "panelIndex": "afca5714-d06b-0294-c1e4-585399c49276",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "content": "## [Kafka OTel] Topics & Partitions\n\nTopic and partition metrics:\n- Partition count per topic\n- Current and oldest offsets\n- Retained message volume (current \u2212 oldest)\n- Replication factor and in-sync replicas\n"
+        },
+        "gridData": {
+          "h": 8,
+          "i": "9dd3c375-d9d2-42fd-b7b7-66771d78aba2",
+          "w": 16,
+          "x": 0,
+          "y": 2
+        },
+        "panelIndex": "9dd3c375-d9d2-42fd-b7b7-66771d78aba2",
+        "type": "DASHBOARD_MARKDOWN"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "20b4415f-ec76-da18-4e74-0243bf0a97f0": {
+                      "allColumns": [
+                        {
+                          "columnId": "77f244db-1f42-d9dd-b062-fdd4424d721a",
+                          "customLabel": true,
+                          "fieldName": "total_partitions",
+                          "inMetricDimension": true,
+                          "label": "Partitions",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "77f244db-1f42-d9dd-b062-fdd4424d721a",
+                          "customLabel": true,
+                          "fieldName": "total_partitions",
+                          "inMetricDimension": true,
+                          "label": "Partitions",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions_per_topic = MAX(kafka.topic.partitions) BY attributes.topic\n| STATS total_partitions = SUM(partitions_per_topic)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS partitions_per_topic = MAX(kafka.topic.partitions) BY attributes.topic\n| STATS total_partitions = SUM(partitions_per_topic)"
+              },
+              "visualization": {
+                "layerId": "20b4415f-ec76-da18-4e74-0243bf0a97f0",
+                "layerType": "data",
+                "metricAccessor": "77f244db-1f42-d9dd-b062-fdd4424d721a",
+                "showBar": false
+              }
+            },
+            "title": "Total Partitions",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "358fc677-0838-eaca-1034-8e71f11f3c87",
+          "w": 8,
+          "x": 16,
+          "y": 2
+        },
+        "panelIndex": "358fc677-0838-eaca-1034-8e71f11f3c87",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "543cbc77-b170-32b1-b9c4-91f2913a1cf0": {
+                      "allColumns": [
+                        {
+                          "columnId": "db496111-5508-6e4d-777f-353cc4f5de16",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Topics",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "db496111-5508-6e4d-777f-353cc4f5de16",
+                          "customLabel": true,
+                          "fieldName": "count",
+                          "inMetricDimension": true,
+                          "label": "Topics",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "query": {
+                        "esql": "FROM metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS count = COUNT_DISTINCT(attributes.topic)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "esql": "FROM metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.topic.partitions IS NOT NULL\n| STATS count = COUNT_DISTINCT(attributes.topic)"
+              },
+              "visualization": {
+                "layerId": "543cbc77-b170-32b1-b9c4-91f2913a1cf0",
+                "layerType": "data",
+                "metricAccessor": "db496111-5508-6e4d-777f-353cc4f5de16",
+                "showBar": false
+              }
+            },
+            "title": "Topics",
+            "type": "lens",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "9b4e3882-0024-4ac3-6247-a6a7305119d2",
+          "w": 7,
+          "x": 24,
+          "y": 2
+        },
+        "panelIndex": "9b4e3882-0024-4ac3-6247-a6a7305119d2",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldFormats": {},
+                  "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                  "managed": false,
+                  "name": "metrics-kafkametricsreceiver.otel-*",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-kafkametricsreceiver.otel-*",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "indexPatternRefs": [
+                    {
+                      "id": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "title": "metrics-kafkametricsreceiver.otel-*"
+                    }
+                  ],
+                  "layers": {
+                    "796b7623-176a-7b81-7cef-061ef18a4cc5": {
+                      "allColumns": [
+                        {
+                          "columnId": "ab6bf359-3151-0400-d27c-61dee033202f",
+                          "customLabel": true,
+                          "fieldName": "total",
+                          "inMetricDimension": true,
+                          "label": "Current Offset Sum",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "columns": [
+                        {
+                          "columnId": "ab6bf359-3151-0400-d27c-61dee033202f",
+                          "customLabel": true,
+                          "fieldName": "total",
+                          "inMetricDimension": true,
+                          "label": "Current Offset Sum",
+                          "meta": {
+                            "esType": "long",
+                            "type": "number"
+                          },
+                          "params": {
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "compact": true,
+                                "decimals": 2
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "index": "89c7f8ea9a864540349517969cfe38b3d7f12a57c2a1936c97e1844d6c571192",
+                      "query": {
+                        "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset) BY attributes.topic, attributes.partition\n| STATS total = SUM(offset)"
+                      },
+                      "timeField": "@timestamp"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "needsRefresh": false,
+              "query": {
+                "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset) BY attributes.topic, attributes.partition\n| STATS total = SUM(offset)"
+              },
+              "visualization": {
+                "layerId": "796b7623-176a-7b81-7cef-061ef18a4cc5",
+                "layerType": "data",
+                "metricAccessor": "ab6bf359-3151-0400-d27c-61dee033202f",
+                "showBar": false
+              }
+            },
+            "title": "Current Offset (Sum)",
+            "version": 1,
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "esql": "TS metrics-kafkametricsreceiver.otel-*\n| WHERE data_stream.dataset == \"kafkametricsreceiver.otel\"\n| WHERE kafka.partition.current_offset IS NOT NULL\n| STATS offset = MAX(kafka.partition.current_offset) BY attributes.topic, attributes.partition\n| STATS total = SUM(offset)"
+          },
+          "syncColors": false,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 8,
+          "i": "d1fa145a-5261-2021-3f36-e1105dc0bd48",
+          "w": 7,
+          "x": 31,
+          "y": 2
+        },
+        "panelIndex": "d1fa145a-5261-2021-3f36-e1105dc0bd48",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.3.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "timeFrom": "now-15m",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "[Kafka OTel] Topics & Partitions"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2026-03-13T13:08:24.075Z",
+  "id": "kafka_otel-topics-partitions",
+  "references": [
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_6ff6dd5b-251c-52e3-0c52-5b8a12b7f57c:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "kafka_otel-overview",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_3af4ba12-6f83-488a-bdc9-0c7216a22d73_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-consumer-groups",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_023dd0d5-85a5-7c2d-7761-09ac67eaf6b0_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-topics-partitions",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_9fa8a215-5ab9-a0b8-3ae7-50918026c5b2_dashboard",
+      "type": "dashboard"
+    },
+    {
+      "id": "kafka_otel-replication",
+      "name": "91144e9b-fac7-b44d-0b1d-8339201b83cb:link_55497914-9303-4f76-667d-ef92eaa42807_dashboard",
+      "type": "dashboard"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.3.0",
+  "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/nginx_otel/kibana/dashboard/nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890.json
+++ b/packages/nginx_otel/kibana/dashboard/nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890.json
@@ -1,2168 +1,2168 @@
 {
-    "attributes": {
-        "description": "Golden signals overview: errors, throughput, and saturation for Nginx.",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "data_stream.dataset",
-                            "negate": false,
-                            "params": [
-                                "nginx.access.otel",
-                                "nginx.error.otel",
-                                "nginxreceiver.otel"
-                            ],
-                            "type": "phrases"
-                        },
-                        "query": {
-                            "bool": {
-                                "minimum_should_match": 1,
-                                "should": [
-                                    {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "nginx.access.otel"
-                                        }
-                                    },
-                                    {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "nginx.error.otel"
-                                        }
-                                    },
-                                    {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "nginxreceiver.otel"
-                                        }
-                                    }
-                                ]
-                            }
-                        }
+  "attributes": {
+    "description": "Golden signals overview: errors, throughput, and saturation for Nginx.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "alias": null,
+              "disabled": false,
+              "field": "data_stream.dataset",
+              "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+              "key": "data_stream.dataset",
+              "negate": false,
+              "params": [
+                "nginx.access.otel",
+                "nginx.error.otel",
+                "nginxreceiver.otel"
+              ],
+              "type": "phrases"
+            },
+            "query": {
+              "bool": {
+                "minimum_should_match": 1,
+                "should": [
+                  {
+                    "match_phrase": {
+                      "data_stream.dataset": "nginx.access.otel"
                     }
-                ],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
+                  },
+                  {
+                    "match_phrase": {
+                      "data_stream.dataset": "nginx.error.otel"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "data_stream.dataset": "nginxreceiver.otel"
+                    }
+                  }
+                ]
+              }
             }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": true,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "**[Request Health](/app/dashboards#/view/nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890)** | **[Server Internals](/app/dashboards#/view/nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901)** | **[Traffic & Capacity](/app/dashboards#/view/nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012)**",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    },
-                    "hidePanelTitles": true
-                },
-                "gridData": {
-                    "h": 3,
-                    "w": 48,
-                    "x": 0,
-                    "y": 0,
-                    "i": "cb81b350-f7bb-4fea-914e-8836c9b2c17b"
-                },
-                "panelIndex": "cb81b350-f7bb-4fea-914e-8836c9b2c17b",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "## Request Health\n\nMonitor NGINX golden signals \u2014 errors, throughput, and saturation \u2014 at a glance.\n\n- **Errors**: 4xx client and 5xx server error rates from access logs\n- **Error logs**: Severity breakdown from NGINX error log\n- **Throughput**: Request rate derived from stub_status metrics\n- **Saturation**: Connection states and dropped connections\n- **Accepts & Handled**: Connection processing rates",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    },
-                    "hidePanelTitles": true
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 16,
-                    "x": 0,
-                    "y": 3,
-                    "i": "7068f8d3-a6d6-40ca-8918-4c3c3517a53b"
-                },
-                "panelIndex": "7068f8d3-a6d6-40ca-8918-4c3c3517a53b",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-a2f86c3f-3809-417d-b63c-34ad9cd255c2",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "a2f86c3f-3809-417d-b63c-34ad9cd255c2": {
-                                            "columnOrder": [
-                                                "eaae6a91-ff39-412e-8e6e-35fcd0f83b13"
-                                            ],
-                                            "columns": {
-                                                "eaae6a91-ff39-412e-8e6e-35fcd0f83b13": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "5xx Errors",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 500"
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "a2f86c3f-3809-417d-b63c-34ad9cd255c2",
-                                "layerType": "data",
-                                "metricAccessor": "eaae6a91-ff39-412e-8e6e-35fcd0f83b13",
-                                "subtitle": "Server errors",
-                                "color": "#E7664C"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 12,
-                    "x": 16,
-                    "y": 3,
-                    "i": "7b536f08-5375-4d5d-a470-aac7f857058f"
-                },
-                "panelIndex": "7b536f08-5375-4d5d-a470-aac7f857058f",
-                "title": "5xx Errors",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-9bbb590b-41bd-4ead-9068-2b6f4c0bc830",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "9bbb590b-41bd-4ead-9068-2b6f4c0bc830": {
-                                            "columnOrder": [
-                                                "184e0322-dee0-4673-85a3-3904f579bcbb"
-                                            ],
-                                            "columns": {
-                                                "184e0322-dee0-4673-85a3-3904f579bcbb": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "4xx Errors",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 400 AND attributes.http.response.status_code < 500"
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "9bbb590b-41bd-4ead-9068-2b6f4c0bc830",
-                                "layerType": "data",
-                                "metricAccessor": "184e0322-dee0-4673-85a3-3904f579bcbb",
-                                "subtitle": "Client errors",
-                                "color": "#F1D86F"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 12,
-                    "x": 28,
-                    "y": 3,
-                    "i": "b9641f0d-abb4-4bce-909a-ff7325169239"
-                },
-                "panelIndex": "b9641f0d-abb4-4bce-909a-ff7325169239",
-                "title": "4xx Errors",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-09e7c791-fda3-44ac-bd99-42cf69effef6",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "09e7c791-fda3-44ac-bd99-42cf69effef6": {
-                                            "columnOrder": [
-                                                "ec41721a-08a7-4968-9003-56143720f52e"
-                                            ],
-                                            "columns": {
-                                                "ec41721a-08a7-4968-9003-56143720f52e": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Requests",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "09e7c791-fda3-44ac-bd99-42cf69effef6",
-                                "layerType": "data",
-                                "metricAccessor": "ec41721a-08a7-4968-9003-56143720f52e",
-                                "subtitle": "Access log events",
-                                "color": "#54B399"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 8,
-                    "x": 40,
-                    "y": 3,
-                    "i": "93abfc07-dee9-4c02-959a-0a06ef6692b7"
-                },
-                "panelIndex": "93abfc07-dee9-4c02-959a-0a06ef6692b7",
-                "title": "Total Requests",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-abe7a68f-73d0-404e-8448-0a9980d1ad9d",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "abe7a68f-73d0-404e-8448-0a9980d1ad9d": {
-                                            "columnOrder": [
-                                                "e71e7657-9c93-4187-9466-3b6695e0cc4f"
-                                            ],
-                                            "columns": {
-                                                "e71e7657-9c93-4187-9466-3b6695e0cc4f": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Active",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"active\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "layerId": "abe7a68f-73d0-404e-8448-0a9980d1ad9d",
-                                "layerType": "data",
-                                "metricAccessor": "e71e7657-9c93-4187-9466-3b6695e0cc4f",
-                                "subtitle": "Current active",
-                                "color": "#6092C0"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 16,
-                    "x": 16,
-                    "y": 9,
-                    "i": "86991c7a-553b-4a9d-bce2-d0f7fee1186a"
-                },
-                "panelIndex": "86991c7a-553b-4a9d-bce2-d0f7fee1186a",
-                "title": "Active Connections",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-7ae14f01-0b29-45b2-a9ea-87d9e3d1de52",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "7ae14f01-0b29-45b2-a9ea-87d9e3d1de52": {
-                                            "columnOrder": [
-                                                "2aa944ac-cd41-4b17-9cb2-681739f566fd"
-                                            ],
-                                            "columns": {
-                                                "2aa944ac-cd41-4b17-9cb2-681739f566fd": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Hosts",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "host.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "layerId": "7ae14f01-0b29-45b2-a9ea-87d9e3d1de52",
-                                "layerType": "data",
-                                "metricAccessor": "2aa944ac-cd41-4b17-9cb2-681739f566fd",
-                                "subtitle": "Reporting instances",
-                                "color": "#54B399"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 16,
-                    "x": 32,
-                    "y": 9,
-                    "i": "21b3eea7-90d2-4e1f-b92b-24377276c2c9"
-                },
-                "panelIndex": "21b3eea7-90d2-4e1f-b92b-24377276c2c9",
-                "title": "Hosts Up",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-177f8f8b-1a22-46c9-bb06-8b1153e01e16",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "177f8f8b-1a22-46c9-bb06-8b1153e01e16": {
-                                            "columnOrder": [
-                                                "9b453486-37e9-4e23-ac9a-9ea50f163d5f",
-                                                "a9abc6df-1f1c-47c8-a36f-c264826ba28a",
-                                                "e31bd075-4bad-4cac-8949-f359a09877bf",
-                                                "948ecfc8-17d0-4902-ba9c-490ab6eece01",
-                                                "102d0342-ee01-4ce7-83b1-bf57a395d4ec"
-                                            ],
-                                            "columns": {
-                                                "9b453486-37e9-4e23-ac9a-9ea50f163d5f": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "a9abc6df-1f1c-47c8-a36f-c264826ba28a": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "2xx",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 200 AND attributes.http.response.status_code < 300"
-                                                    }
-                                                },
-                                                "e31bd075-4bad-4cac-8949-f359a09877bf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "3xx",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 300 AND attributes.http.response.status_code < 400"
-                                                    }
-                                                },
-                                                "948ecfc8-17d0-4902-ba9c-490ab6eece01": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "4xx",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 400 AND attributes.http.response.status_code < 500"
-                                                    }
-                                                },
-                                                "102d0342-ee01-4ce7-83b1-bf57a395d4ec": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "5xx",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 500"
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "a9abc6df-1f1c-47c8-a36f-c264826ba28a",
-                                            "e31bd075-4bad-4cac-8949-f359a09877bf",
-                                            "948ecfc8-17d0-4902-ba9c-490ab6eece01",
-                                            "102d0342-ee01-4ce7-83b1-bf57a395d4ec"
-                                        ],
-                                        "layerId": "177f8f8b-1a22-46c9-bb06-8b1153e01e16",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_stacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "9b453486-37e9-4e23-ac9a-9ea50f163d5f",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#54B399",
-                                                "forAccessor": "a9abc6df-1f1c-47c8-a36f-c264826ba28a"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#6092C0",
-                                                "forAccessor": "e31bd075-4bad-4cac-8949-f359a09877bf"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#F1D86F",
-                                                "forAccessor": "948ecfc8-17d0-4902-ba9c-490ab6eece01"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#E7664C",
-                                                "forAccessor": "102d0342-ee01-4ce7-83b1-bf57a395d4ec"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Requests"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "w": 30,
-                    "x": 0,
-                    "y": 16,
-                    "i": "9fe6620f-ce33-471c-af95-24e39f2e36a2"
-                },
-                "panelIndex": "9fe6620f-ce33-471c-af95-24e39f2e36a2",
-                "title": "Requests by Status Code Over Time",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-09be7f12-cf6f-4cb8-8528-1f238e0ab210",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "09be7f12-cf6f-4cb8-8528-1f238e0ab210": {
-                                            "columnOrder": [
-                                                "cc37834a-bdeb-4acd-831c-bc013e3ec21c",
-                                                "562e121f-1447-4f57-8f62-83287f6495ea"
-                                            ],
-                                            "columns": {
-                                                "cc37834a-bdeb-4acd-831c-bc013e3ec21c": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Status Code",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "562e121f-1447-4f57-8f62-83287f6495ea"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.http.response.status_code"
-                                                },
-                                                "562e121f-1447-4f57-8f62-83287f6495ea": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Requests",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "shape": "donut",
-                                "layers": [
-                                    {
-                                        "layerId": "09be7f12-cf6f-4cb8-8528-1f238e0ab210",
-                                        "layerType": "data",
-                                        "primaryGroups": [
-                                            "cc37834a-bdeb-4acd-831c-bc013e3ec21c"
-                                        ],
-                                        "metrics": [
-                                            "562e121f-1447-4f57-8f62-83287f6495ea"
-                                        ],
-                                        "numberDisplay": "percent",
-                                        "categoryDisplay": "default",
-                                        "legendDisplay": "default",
-                                        "legendPosition": "right",
-                                        "nestedLegend": false,
-                                        "truncateLegend": true,
-                                        "percentDecimals": 1
-                                    }
-                                ]
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsPie"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "w": 18,
-                    "x": 30,
-                    "y": 16,
-                    "i": "a45a5f1e-bb8d-4e99-8bf3-d717f622ef4c"
-                },
-                "panelIndex": "a45a5f1e-bb8d-4e99-8bf3-d717f622ef4c",
-                "title": "Status Code Distribution",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-48cf591f-e80c-49d3-99e1-0271c5855291",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "48cf591f-e80c-49d3-99e1-0271c5855291": {
-                                            "columnOrder": [
-                                                "bf31d46c-6e42-4535-ac0f-199b36693f74",
-                                                "7212c2fe-4599-4aa3-9f22-c2ea85fca30c",
-                                                "d82f5fd2-77cd-4ad7-9825-a5f93accf87d",
-                                                "420d600c-cd3a-4030-935b-73cf32ea2847",
-                                                "a63fefa8-695a-4a16-91db-f89dbb0ec728"
-                                            ],
-                                            "columns": {
-                                                "bf31d46c-6e42-4535-ac0f-199b36693f74": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "d82f5fd2-77cd-4ad7-9825-a5f93accf87d": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "error",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.log.level: \"error\""
-                                                    }
-                                                },
-                                                "7212c2fe-4599-4aa3-9f22-c2ea85fca30c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "crit",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.log.level: \"crit\""
-                                                    }
-                                                },
-                                                "420d600c-cd3a-4030-935b-73cf32ea2847": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "warn",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.log.level: \"warn\""
-                                                    }
-                                                },
-                                                "a63fefa8-695a-4a16-91db-f89dbb0ec728": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "other",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "NOT attributes.log.level: \"error\" AND NOT attributes.log.level: \"crit\" AND NOT attributes.log.level: \"warn\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.error.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "7212c2fe-4599-4aa3-9f22-c2ea85fca30c",
-                                            "d82f5fd2-77cd-4ad7-9825-a5f93accf87d",
-                                            "420d600c-cd3a-4030-935b-73cf32ea2847",
-                                            "a63fefa8-695a-4a16-91db-f89dbb0ec728"
-                                        ],
-                                        "layerId": "48cf591f-e80c-49d3-99e1-0271c5855291",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_stacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "bf31d46c-6e42-4535-ac0f-199b36693f74",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#E7664C",
-                                                "forAccessor": "7212c2fe-4599-4aa3-9f22-c2ea85fca30c"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#F1D86F",
-                                                "forAccessor": "d82f5fd2-77cd-4ad7-9825-a5f93accf87d"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#D6BF57",
-                                                "forAccessor": "420d600c-cd3a-4030-935b-73cf32ea2847"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#B9A888",
-                                                "forAccessor": "a63fefa8-695a-4a16-91db-f89dbb0ec728"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Error log events"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.error.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 0,
-                    "y": 30,
-                    "i": "14018edd-8c86-48db-8604-70a2db7bbd97"
-                },
-                "panelIndex": "14018edd-8c86-48db-8604-70a2db7bbd97",
-                "title": "Error Logs by Severity Over Time",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-409e826d-e109-4ce9-9605-089db6438e5b",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "409e826d-e109-4ce9-9605-089db6438e5b": {
-                                            "columnOrder": [
-                                                "42ee337a-159e-4209-84fc-823b6c4d982f",
-                                                "1293e1a7-0c72-45bd-8c8c-0569bab51f9c",
-                                                "f75356ee-10a5-4f14-b913-3db476b0dfb4"
-                                            ],
-                                            "columns": {
-                                                "42ee337a-159e-4209-84fc-823b6c4d982f": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Severity",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "f75356ee-10a5-4f14-b913-3db476b0dfb4"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.log.level"
-                                                },
-                                                "1293e1a7-0c72-45bd-8c8c-0569bab51f9c": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Process ID",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "f75356ee-10a5-4f14-b913-3db476b0dfb4"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.process.pid"
-                                                },
-                                                "f75356ee-10a5-4f14-b913-3db476b0dfb4": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.error.otel"
-                            },
-                            "visualization": {
-                                "layerId": "409e826d-e109-4ce9-9605-089db6438e5b",
-                                "layerType": "data",
-                                "columns": [
-                                    {
-                                        "columnId": "42ee337a-159e-4209-84fc-823b6c4d982f",
-                                        "isTransposed": false,
-                                        "hidden": false,
-                                        "alignment": "left",
-                                        "colorMode": "cell"
-                                    },
-                                    {
-                                        "columnId": "1293e1a7-0c72-45bd-8c8c-0569bab51f9c",
-                                        "isTransposed": false,
-                                        "hidden": false,
-                                        "alignment": "left",
-                                        "colorMode": "none"
-                                    },
-                                    {
-                                        "columnId": "f75356ee-10a5-4f14-b913-3db476b0dfb4",
-                                        "isTransposed": false,
-                                        "hidden": false,
-                                        "alignment": "right",
-                                        "colorMode": "none"
-                                    }
-                                ],
-                                "headerRowHeight": "auto",
-                                "headerRowHeightLines": 1,
-                                "rowHeight": "auto",
-                                "rowHeightLines": 2,
-                                "paging": {
-                                    "size": 10,
-                                    "enabled": true
-                                }
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.error.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 24,
-                    "y": 30,
-                    "i": "9eda7980-af33-4a14-abdd-42b97cb12b9b"
-                },
-                "panelIndex": "9eda7980-af33-4a14-abdd-42b97cb12b9b",
-                "title": "Error Counts by Severity",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-4890398c-a9f8-4d67-afdf-23e9d258040d",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "4890398c-a9f8-4d67-afdf-23e9d258040d": {
-                                            "columnOrder": [
-                                                "8fcf7a93-21ba-45c6-9035-7a4e6e08dcab",
-                                                "34c8bc32-9ede-48fa-a9af-689091004ec8",
-                                                "6b042de4-f6d5-482a-b3ec-d19d2ade368e"
-                                            ],
-                                            "columns": {
-                                                "8fcf7a93-21ba-45c6-9035-7a4e6e08dcab": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "34c8bc32-9ede-48fa-a9af-689091004ec8": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Max requests",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.requests"
-                                                },
-                                                "6b042de4-f6d5-482a-b3ec-d19d2ade368e": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Request rate",
-                                                    "operationType": "differences",
-                                                    "params": {},
-                                                    "references": [
-                                                        "34c8bc32-9ede-48fa-a9af-689091004ec8"
-                                                    ],
-                                                    "scale": "ratio"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "6b042de4-f6d5-482a-b3ec-d19d2ade368e"
-                                        ],
-                                        "layerId": "4890398c-a9f8-4d67-afdf-23e9d258040d",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "xAccessor": "8fcf7a93-21ba-45c6-9035-7a4e6e08dcab",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#54B399",
-                                                "forAccessor": "6b042de4-f6d5-482a-b3ec-d19d2ade368e"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "area",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Requests / interval"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 0,
-                    "y": 43,
-                    "i": "ab035c70-1d55-4a65-9764-6ac04ef9b886"
-                },
-                "panelIndex": "ab035c70-1d55-4a65-9764-6ac04ef9b886",
-                "title": "Request Rate (from metrics)",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-e401e152-99f5-4987-a544-a9c9f17e7186",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "e401e152-99f5-4987-a544-a9c9f17e7186": {
-                                            "columnOrder": [
-                                                "053c392d-ed05-4275-8378-1d0983b3fbee",
-                                                "aecfc35a-c458-4178-b5a4-70794b642434",
-                                                "66f0445c-9d28-4f58-8a2f-1bd04a3a24a1",
-                                                "cd1d53ff-0235-4717-9ced-1355dfbeb530",
-                                                "1066ed14-2167-4f65-b485-0a4c9d2d12df",
-                                                "34cb88f9-5b2a-41e4-951b-16fc56d5b646",
-                                                "5405622e-10d3-4256-9270-ef008a0e0587"
-                                            ],
-                                            "columns": {
-                                                "053c392d-ed05-4275-8378-1d0983b3fbee": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "aecfc35a-c458-4178-b5a4-70794b642434": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Accepts rate",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "formula": "differences(max(nginx.connections_accepted))",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "references": [
-                                                        "cd1d53ff-0235-4717-9ced-1355dfbeb530"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null
-                                                },
-                                                "66f0445c-9d28-4f58-8a2f-1bd04a3a24a1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Part of Accepts rate",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_accepted",
-                                                    "timeScale": null,
-                                                    "timeShift": null
-                                                },
-                                                "cd1d53ff-0235-4717-9ced-1355dfbeb530": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Part of Accepts rate",
-                                                    "operationType": "differences",
-                                                    "params": null,
-                                                    "references": [
-                                                        "66f0445c-9d28-4f58-8a2f-1bd04a3a24a1"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null,
-                                                    "timeShift": null
-                                                },
-                                                "1066ed14-2167-4f65-b485-0a4c9d2d12df": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Handled rate",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "formula": "differences(max(nginx.connections_handled))",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "references": [
-                                                        "5405622e-10d3-4256-9270-ef008a0e0587"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null
-                                                },
-                                                "34cb88f9-5b2a-41e4-951b-16fc56d5b646": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Part of Handled rate",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_handled",
-                                                    "timeScale": null,
-                                                    "timeShift": null
-                                                },
-                                                "5405622e-10d3-4256-9270-ef008a0e0587": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Part of Handled rate",
-                                                    "operationType": "differences",
-                                                    "params": null,
-                                                    "references": [
-                                                        "34cb88f9-5b2a-41e4-951b-16fc56d5b646"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null,
-                                                    "timeShift": null
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "aecfc35a-c458-4178-b5a4-70794b642434",
-                                            "1066ed14-2167-4f65-b485-0a4c9d2d12df"
-                                        ],
-                                        "layerId": "e401e152-99f5-4987-a544-a9c9f17e7186",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "053c392d-ed05-4275-8378-1d0983b3fbee",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#68bc00",
-                                                "forAccessor": "aecfc35a-c458-4178-b5a4-70794b642434"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#009ce0",
-                                                "forAccessor": "1066ed14-2167-4f65-b485-0a4c9d2d12df"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Rate"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 24,
-                    "y": 43,
-                    "i": "40f53647-39b7-4415-89b2-4f44059d235b"
-                },
-                "panelIndex": "40f53647-39b7-4415-89b2-4f44059d235b",
-                "title": "Accepts & Handled Rate",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-abc57c18-f2d8-4b4d-94cc-8bfef7d2cab3",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "abc57c18-f2d8-4b4d-94cc-8bfef7d2cab3": {
-                                            "columnOrder": [
-                                                "58bb5485-b57f-4a63-afcb-3db2e3a31445",
-                                                "7495cffe-4717-40ab-9986-629321f88307",
-                                                "b98e5adf-85d2-45d2-ab7f-60f859cee1d2",
-                                                "7a259b3c-8f46-4949-a8eb-39cc932f3afe",
-                                                "19d21813-791f-42b0-9301-56355a6e0234"
-                                            ],
-                                            "columns": {
-                                                "58bb5485-b57f-4a63-afcb-3db2e3a31445": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "7495cffe-4717-40ab-9986-629321f88307": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Active",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"active\""
-                                                    }
-                                                },
-                                                "b98e5adf-85d2-45d2-ab7f-60f859cee1d2": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Reading",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"reading\""
-                                                    }
-                                                },
-                                                "7a259b3c-8f46-4949-a8eb-39cc932f3afe": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Writing",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"writing\""
-                                                    }
-                                                },
-                                                "19d21813-791f-42b0-9301-56355a6e0234": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Waiting",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"waiting\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "7495cffe-4717-40ab-9986-629321f88307",
-                                            "b98e5adf-85d2-45d2-ab7f-60f859cee1d2",
-                                            "7a259b3c-8f46-4949-a8eb-39cc932f3afe",
-                                            "19d21813-791f-42b0-9301-56355a6e0234"
-                                        ],
-                                        "layerId": "abc57c18-f2d8-4b4d-94cc-8bfef7d2cab3",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "58bb5485-b57f-4a63-afcb-3db2e3a31445",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#E7664C",
-                                                "forAccessor": "7495cffe-4717-40ab-9986-629321f88307"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#68bc00",
-                                                "forAccessor": "b98e5adf-85d2-45d2-ab7f-60f859cee1d2"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#009ce0",
-                                                "forAccessor": "7a259b3c-8f46-4949-a8eb-39cc932f3afe"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#F1D86F",
-                                                "forAccessor": "19d21813-791f-42b0-9301-56355a6e0234"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Connections"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 0,
-                    "y": 56,
-                    "i": "6a18acb7-8ed1-441e-b651-8b1734b0c8ad"
-                },
-                "panelIndex": "6a18acb7-8ed1-441e-b651-8b1734b0c8ad",
-                "title": "Connection States Over Time",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-d96209bb-5150-4555-8d69-cf8b37b2470a",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "d96209bb-5150-4555-8d69-cf8b37b2470a": {
-                                            "columnOrder": [
-                                                "131ae73a-abcf-450a-874d-bbcf5dd2a1a6",
-                                                "1db69200-d1c3-4750-b6d3-12cba2fe8f2b",
-                                                "0631b26d-53dd-447f-b414-54eea352691b",
-                                                "5e57bd06-f36f-4ebd-8245-5c802b383260",
-                                                "9d400a0f-bfb5-490d-9c7f-0881034476fe"
-                                            ],
-                                            "columns": {
-                                                "131ae73a-abcf-450a-874d-bbcf5dd2a1a6": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "1db69200-d1c3-4750-b6d3-12cba2fe8f2b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Drops",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "formula": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "references": [
-                                                        "9d400a0f-bfb5-490d-9c7f-0881034476fe"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null
-                                                },
-                                                "0631b26d-53dd-447f-b414-54eea352691b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Drops",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_accepted"
-                                                },
-                                                "5e57bd06-f36f-4ebd-8245-5c802b383260": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Drops",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_handled"
-                                                },
-                                                "9d400a0f-bfb5-490d-9c7f-0881034476fe": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Drops",
-                                                    "operationType": "math",
-                                                    "params": {
-                                                        "tinymathAst": {
-                                                            "args": [
-                                                                "0631b26d-53dd-447f-b414-54eea352691b",
-                                                                "5e57bd06-f36f-4ebd-8245-5c802b383260"
-                                                            ],
-                                                            "location": {
-                                                                "max": 62,
-                                                                "min": 0
-                                                            },
-                                                            "name": "subtract",
-                                                            "text": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
-                                                            "type": "function"
-                                                        }
-                                                    },
-                                                    "references": [
-                                                        "0631b26d-53dd-447f-b414-54eea352691b",
-                                                        "5e57bd06-f36f-4ebd-8245-5c802b383260"
-                                                    ],
-                                                    "scale": "ratio"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "1db69200-d1c3-4750-b6d3-12cba2fe8f2b"
-                                        ],
-                                        "layerId": "d96209bb-5150-4555-8d69-cf8b37b2470a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "xAccessor": "131ae73a-abcf-450a-874d-bbcf5dd2a1a6",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#E7664C",
-                                                "forAccessor": "1db69200-d1c3-4750-b6d3-12cba2fe8f2b"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "area",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Dropped connections"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 24,
-                    "y": 56,
-                    "i": "2a24a599-7fe8-49c3-8c44-0641a408f6b9"
-                },
-                "panelIndex": "2a24a599-7fe8-49c3-8c44-0641a408f6b9",
-                "title": "Dropped Connections",
-                "type": "lens"
-            }
+          }
         ],
-        "timeRestore": false,
-        "title": "[Nginx OTel] Request Health",
-        "version": 3,
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
-            },
-            "panelsJSON": {
-                "5435c9ae-583b-493d-8adc-ea6b6a387595": {
-                    "explicitInput": {
-                        "dataViewId": "metrics-*",
-                        "fieldName": "host.name",
-                        "searchTechnique": "prefix",
-                        "selectedOptions": [],
-                        "singleSelect": true,
-                        "sort": {
-                            "by": "_count",
-                            "direction": "desc"
-                        },
-                        "title": "Nginx instance"
-                    },
-                    "grow": true,
-                    "order": 0,
-                    "type": "optionsListControl",
-                    "width": "medium"
-                }
-            },
-            "showApplySelections": false
+        "query": {
+          "language": "kuery",
+          "query": ""
         }
+      }
     },
-    "coreMigrationVersion": "8.8.0",
-    "id": "nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "managed": false,
-    "references": [
-        {
-            "id": "logs-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "savedVis": {
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "filter": [],
+                "query": {
+                  "language": "kuery",
+                  "query": ""
+                }
+              }
+            },
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "markdown": "**[Request Health](/app/dashboards#/view/nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890)** | **[Server Internals](/app/dashboards#/view/nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901)** | **[Traffic & Capacity](/app/dashboards#/view/nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012)**",
+              "openLinksInNewTab": false
+            },
+            "title": "",
+            "type": "markdown",
+            "uiState": {}
+          },
+          "hidePanelTitles": true
         },
-        {
-            "id": "logs-*",
-            "name": "7b536f08-5375-4d5d-a470-aac7f857058f:indexpattern-datasource-layer-a2f86c3f-3809-417d-b63c-34ad9cd255c2",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 3,
+          "w": 48,
+          "x": 0,
+          "y": 0,
+          "i": "cb81b350-f7bb-4fea-914e-8836c9b2c17b"
         },
-        {
-            "id": "logs-*",
-            "name": "b9641f0d-abb4-4bce-909a-ff7325169239:indexpattern-datasource-layer-9bbb590b-41bd-4ead-9068-2b6f4c0bc830",
-            "type": "index-pattern"
+        "panelIndex": "cb81b350-f7bb-4fea-914e-8836c9b2c17b",
+        "type": "visualization"
+      },
+      {
+        "embeddableConfig": {
+          "savedVis": {
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "filter": [],
+                "query": {
+                  "language": "kuery",
+                  "query": ""
+                }
+              }
+            },
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "markdown": "## Request Health\n\nMonitor NGINX golden signals \u2014 errors, throughput, and saturation \u2014 at a glance.\n\n- **Errors**: 4xx client and 5xx server error rates from access logs\n- **Error logs**: Severity breakdown from NGINX error log\n- **Throughput**: Request rate derived from stub_status metrics\n- **Saturation**: Connection states and dropped connections\n- **Accepts & Handled**: Connection processing rates",
+              "openLinksInNewTab": false
+            },
+            "title": "",
+            "type": "markdown",
+            "uiState": {}
+          },
+          "hidePanelTitles": true
         },
-        {
-            "id": "logs-*",
-            "name": "93abfc07-dee9-4c02-959a-0a06ef6692b7:indexpattern-datasource-layer-09e7c791-fda3-44ac-bd99-42cf69effef6",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 12,
+          "w": 16,
+          "x": 0,
+          "y": 3,
+          "i": "7068f8d3-a6d6-40ca-8918-4c3c3517a53b"
         },
-        {
-            "id": "metrics-*",
-            "name": "86991c7a-553b-4a9d-bce2-d0f7fee1186a:indexpattern-datasource-layer-abe7a68f-73d0-404e-8448-0a9980d1ad9d",
-            "type": "index-pattern"
+        "panelIndex": "7068f8d3-a6d6-40ca-8918-4c3c3517a53b",
+        "type": "visualization"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-a2f86c3f-3809-417d-b63c-34ad9cd255c2",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "a2f86c3f-3809-417d-b63c-34ad9cd255c2": {
+                      "columnOrder": [
+                        "eaae6a91-ff39-412e-8e6e-35fcd0f83b13"
+                      ],
+                      "columns": {
+                        "eaae6a91-ff39-412e-8e6e-35fcd0f83b13": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "5xx Errors",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 500"
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "layerId": "a2f86c3f-3809-417d-b63c-34ad9cd255c2",
+                "layerType": "data",
+                "metricAccessor": "eaae6a91-ff39-412e-8e6e-35fcd0f83b13",
+                "subtitle": "Server errors",
+                "color": "#E7664C"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "21b3eea7-90d2-4e1f-b92b-24377276c2c9:indexpattern-datasource-layer-7ae14f01-0b29-45b2-a9ea-87d9e3d1de52",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 12,
+          "x": 16,
+          "y": 3,
+          "i": "7b536f08-5375-4d5d-a470-aac7f857058f"
         },
-        {
-            "id": "logs-*",
-            "name": "9fe6620f-ce33-471c-af95-24e39f2e36a2:indexpattern-datasource-layer-177f8f8b-1a22-46c9-bb06-8b1153e01e16",
-            "type": "index-pattern"
+        "panelIndex": "7b536f08-5375-4d5d-a470-aac7f857058f",
+        "title": "5xx Errors",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-9bbb590b-41bd-4ead-9068-2b6f4c0bc830",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "9bbb590b-41bd-4ead-9068-2b6f4c0bc830": {
+                      "columnOrder": [
+                        "184e0322-dee0-4673-85a3-3904f579bcbb"
+                      ],
+                      "columns": {
+                        "184e0322-dee0-4673-85a3-3904f579bcbb": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "4xx Errors",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 400 AND attributes.http.response.status_code < 500"
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "layerId": "9bbb590b-41bd-4ead-9068-2b6f4c0bc830",
+                "layerType": "data",
+                "metricAccessor": "184e0322-dee0-4673-85a3-3904f579bcbb",
+                "subtitle": "Client errors",
+                "color": "#F1D86F"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "logs-*",
-            "name": "a45a5f1e-bb8d-4e99-8bf3-d717f622ef4c:indexpattern-datasource-layer-09be7f12-cf6f-4cb8-8528-1f238e0ab210",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 12,
+          "x": 28,
+          "y": 3,
+          "i": "b9641f0d-abb4-4bce-909a-ff7325169239"
         },
-        {
-            "id": "logs-*",
-            "name": "14018edd-8c86-48db-8604-70a2db7bbd97:indexpattern-datasource-layer-48cf591f-e80c-49d3-99e1-0271c5855291",
-            "type": "index-pattern"
+        "panelIndex": "b9641f0d-abb4-4bce-909a-ff7325169239",
+        "title": "4xx Errors",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-09e7c791-fda3-44ac-bd99-42cf69effef6",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "09e7c791-fda3-44ac-bd99-42cf69effef6": {
+                      "columnOrder": [
+                        "ec41721a-08a7-4968-9003-56143720f52e"
+                      ],
+                      "columns": {
+                        "ec41721a-08a7-4968-9003-56143720f52e": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Requests",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "layerId": "09e7c791-fda3-44ac-bd99-42cf69effef6",
+                "layerType": "data",
+                "metricAccessor": "ec41721a-08a7-4968-9003-56143720f52e",
+                "subtitle": "Access log events",
+                "color": "#54B399"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "logs-*",
-            "name": "9eda7980-af33-4a14-abdd-42b97cb12b9b:indexpattern-datasource-layer-409e826d-e109-4ce9-9605-089db6438e5b",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 8,
+          "x": 40,
+          "y": 3,
+          "i": "93abfc07-dee9-4c02-959a-0a06ef6692b7"
         },
-        {
-            "id": "metrics-*",
-            "name": "ab035c70-1d55-4a65-9764-6ac04ef9b886:indexpattern-datasource-layer-4890398c-a9f8-4d67-afdf-23e9d258040d",
-            "type": "index-pattern"
+        "panelIndex": "93abfc07-dee9-4c02-959a-0a06ef6692b7",
+        "title": "Total Requests",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-abe7a68f-73d0-404e-8448-0a9980d1ad9d",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "abe7a68f-73d0-404e-8448-0a9980d1ad9d": {
+                      "columnOrder": [
+                        "e71e7657-9c93-4187-9466-3b6695e0cc4f"
+                      ],
+                      "columns": {
+                        "e71e7657-9c93-4187-9466-3b6695e0cc4f": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Active",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"active\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "layerId": "abe7a68f-73d0-404e-8448-0a9980d1ad9d",
+                "layerType": "data",
+                "metricAccessor": "e71e7657-9c93-4187-9466-3b6695e0cc4f",
+                "subtitle": "Current active",
+                "color": "#6092C0"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "40f53647-39b7-4415-89b2-4f44059d235b:indexpattern-datasource-layer-e401e152-99f5-4987-a544-a9c9f17e7186",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 16,
+          "x": 16,
+          "y": 9,
+          "i": "86991c7a-553b-4a9d-bce2-d0f7fee1186a"
         },
-        {
-            "id": "metrics-*",
-            "name": "6a18acb7-8ed1-441e-b651-8b1734b0c8ad:indexpattern-datasource-layer-abc57c18-f2d8-4b4d-94cc-8bfef7d2cab3",
-            "type": "index-pattern"
+        "panelIndex": "86991c7a-553b-4a9d-bce2-d0f7fee1186a",
+        "title": "Active Connections",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-7ae14f01-0b29-45b2-a9ea-87d9e3d1de52",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "7ae14f01-0b29-45b2-a9ea-87d9e3d1de52": {
+                      "columnOrder": [
+                        "2aa944ac-cd41-4b17-9cb2-681739f566fd"
+                      ],
+                      "columns": {
+                        "2aa944ac-cd41-4b17-9cb2-681739f566fd": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Hosts",
+                          "operationType": "unique_count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "host.name"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "layerId": "7ae14f01-0b29-45b2-a9ea-87d9e3d1de52",
+                "layerType": "data",
+                "metricAccessor": "2aa944ac-cd41-4b17-9cb2-681739f566fd",
+                "subtitle": "Reporting instances",
+                "color": "#54B399"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "2a24a599-7fe8-49c3-8c44-0641a408f6b9:indexpattern-datasource-layer-d96209bb-5150-4555-8d69-cf8b37b2470a",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 16,
+          "x": 32,
+          "y": 9,
+          "i": "21b3eea7-90d2-4e1f-b92b-24377276c2c9"
         },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_5435c9ae-583b-493d-8adc-ea6b6a387595:optionsListDataView",
-            "type": "index-pattern"
-        }
+        "panelIndex": "21b3eea7-90d2-4e1f-b92b-24377276c2c9",
+        "title": "Hosts Up",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-177f8f8b-1a22-46c9-bb06-8b1153e01e16",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "177f8f8b-1a22-46c9-bb06-8b1153e01e16": {
+                      "columnOrder": [
+                        "9b453486-37e9-4e23-ac9a-9ea50f163d5f",
+                        "a9abc6df-1f1c-47c8-a36f-c264826ba28a",
+                        "e31bd075-4bad-4cac-8949-f359a09877bf",
+                        "948ecfc8-17d0-4902-ba9c-490ab6eece01",
+                        "102d0342-ee01-4ce7-83b1-bf57a395d4ec"
+                      ],
+                      "columns": {
+                        "9b453486-37e9-4e23-ac9a-9ea50f163d5f": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "a9abc6df-1f1c-47c8-a36f-c264826ba28a": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "2xx",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 200 AND attributes.http.response.status_code < 300"
+                          }
+                        },
+                        "e31bd075-4bad-4cac-8949-f359a09877bf": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "3xx",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 300 AND attributes.http.response.status_code < 400"
+                          }
+                        },
+                        "948ecfc8-17d0-4902-ba9c-490ab6eece01": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "4xx",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 400 AND attributes.http.response.status_code < 500"
+                          }
+                        },
+                        "102d0342-ee01-4ce7-83b1-bf57a395d4ec": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "5xx",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 500"
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "a9abc6df-1f1c-47c8-a36f-c264826ba28a",
+                      "e31bd075-4bad-4cac-8949-f359a09877bf",
+                      "948ecfc8-17d0-4902-ba9c-490ab6eece01",
+                      "102d0342-ee01-4ce7-83b1-bf57a395d4ec"
+                    ],
+                    "layerId": "177f8f8b-1a22-46c9-bb06-8b1153e01e16",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_stacked",
+                    "showGridlines": false,
+                    "xAccessor": "9b453486-37e9-4e23-ac9a-9ea50f163d5f",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#54B399",
+                        "forAccessor": "a9abc6df-1f1c-47c8-a36f-c264826ba28a"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#6092C0",
+                        "forAccessor": "e31bd075-4bad-4cac-8949-f359a09877bf"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#F1D86F",
+                        "forAccessor": "948ecfc8-17d0-4902-ba9c-490ab6eece01"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#E7664C",
+                        "forAccessor": "102d0342-ee01-4ce7-83b1-bf57a395d4ec"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "bar_stacked",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Requests"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 14,
+          "w": 30,
+          "x": 0,
+          "y": 16,
+          "i": "9fe6620f-ce33-471c-af95-24e39f2e36a2"
+        },
+        "panelIndex": "9fe6620f-ce33-471c-af95-24e39f2e36a2",
+        "title": "Requests by Status Code Over Time",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-09be7f12-cf6f-4cb8-8528-1f238e0ab210",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "09be7f12-cf6f-4cb8-8528-1f238e0ab210": {
+                      "columnOrder": [
+                        "cc37834a-bdeb-4acd-831c-bc013e3ec21c",
+                        "562e121f-1447-4f57-8f62-83287f6495ea"
+                      ],
+                      "columns": {
+                        "cc37834a-bdeb-4acd-831c-bc013e3ec21c": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Status Code",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "562e121f-1447-4f57-8f62-83287f6495ea"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.http.response.status_code"
+                        },
+                        "562e121f-1447-4f57-8f62-83287f6495ea": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Requests",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "shape": "donut",
+                "layers": [
+                  {
+                    "layerId": "09be7f12-cf6f-4cb8-8528-1f238e0ab210",
+                    "layerType": "data",
+                    "primaryGroups": [
+                      "cc37834a-bdeb-4acd-831c-bc013e3ec21c"
+                    ],
+                    "metrics": [
+                      "562e121f-1447-4f57-8f62-83287f6495ea"
+                    ],
+                    "numberDisplay": "percent",
+                    "categoryDisplay": "default",
+                    "legendDisplay": "default",
+                    "legendPosition": "right",
+                    "nestedLegend": false,
+                    "truncateLegend": true,
+                    "percentDecimals": 1
+                  }
+                ]
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsPie"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 14,
+          "w": 18,
+          "x": 30,
+          "y": 16,
+          "i": "a45a5f1e-bb8d-4e99-8bf3-d717f622ef4c"
+        },
+        "panelIndex": "a45a5f1e-bb8d-4e99-8bf3-d717f622ef4c",
+        "title": "Status Code Distribution",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-48cf591f-e80c-49d3-99e1-0271c5855291",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "48cf591f-e80c-49d3-99e1-0271c5855291": {
+                      "columnOrder": [
+                        "bf31d46c-6e42-4535-ac0f-199b36693f74",
+                        "7212c2fe-4599-4aa3-9f22-c2ea85fca30c",
+                        "d82f5fd2-77cd-4ad7-9825-a5f93accf87d",
+                        "420d600c-cd3a-4030-935b-73cf32ea2847",
+                        "a63fefa8-695a-4a16-91db-f89dbb0ec728"
+                      ],
+                      "columns": {
+                        "bf31d46c-6e42-4535-ac0f-199b36693f74": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "d82f5fd2-77cd-4ad7-9825-a5f93accf87d": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "error",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.log.level: \"error\""
+                          }
+                        },
+                        "7212c2fe-4599-4aa3-9f22-c2ea85fca30c": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "crit",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.log.level: \"crit\""
+                          }
+                        },
+                        "420d600c-cd3a-4030-935b-73cf32ea2847": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "warn",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.log.level: \"warn\""
+                          }
+                        },
+                        "a63fefa8-695a-4a16-91db-f89dbb0ec728": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "other",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "NOT attributes.log.level: \"error\" AND NOT attributes.log.level: \"crit\" AND NOT attributes.log.level: \"warn\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.error.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "7212c2fe-4599-4aa3-9f22-c2ea85fca30c",
+                      "d82f5fd2-77cd-4ad7-9825-a5f93accf87d",
+                      "420d600c-cd3a-4030-935b-73cf32ea2847",
+                      "a63fefa8-695a-4a16-91db-f89dbb0ec728"
+                    ],
+                    "layerId": "48cf591f-e80c-49d3-99e1-0271c5855291",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_stacked",
+                    "showGridlines": false,
+                    "xAccessor": "bf31d46c-6e42-4535-ac0f-199b36693f74",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#E7664C",
+                        "forAccessor": "7212c2fe-4599-4aa3-9f22-c2ea85fca30c"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#F1D86F",
+                        "forAccessor": "d82f5fd2-77cd-4ad7-9825-a5f93accf87d"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#D6BF57",
+                        "forAccessor": "420d600c-cd3a-4030-935b-73cf32ea2847"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#B9A888",
+                        "forAccessor": "a63fefa8-695a-4a16-91db-f89dbb0ec728"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "bar_stacked",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Error log events"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.error.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 30,
+          "i": "14018edd-8c86-48db-8604-70a2db7bbd97"
+        },
+        "panelIndex": "14018edd-8c86-48db-8604-70a2db7bbd97",
+        "title": "Error Logs by Severity Over Time",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-409e826d-e109-4ce9-9605-089db6438e5b",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "409e826d-e109-4ce9-9605-089db6438e5b": {
+                      "columnOrder": [
+                        "42ee337a-159e-4209-84fc-823b6c4d982f",
+                        "1293e1a7-0c72-45bd-8c8c-0569bab51f9c",
+                        "f75356ee-10a5-4f14-b913-3db476b0dfb4"
+                      ],
+                      "columns": {
+                        "42ee337a-159e-4209-84fc-823b6c4d982f": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Severity",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "f75356ee-10a5-4f14-b913-3db476b0dfb4"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.log.level"
+                        },
+                        "1293e1a7-0c72-45bd-8c8c-0569bab51f9c": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Process ID",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "f75356ee-10a5-4f14-b913-3db476b0dfb4"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.process.pid"
+                        },
+                        "f75356ee-10a5-4f14-b913-3db476b0dfb4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Count",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.error.otel"
+              },
+              "visualization": {
+                "layerId": "409e826d-e109-4ce9-9605-089db6438e5b",
+                "layerType": "data",
+                "columns": [
+                  {
+                    "columnId": "42ee337a-159e-4209-84fc-823b6c4d982f",
+                    "isTransposed": false,
+                    "hidden": false,
+                    "alignment": "left",
+                    "colorMode": "cell"
+                  },
+                  {
+                    "columnId": "1293e1a7-0c72-45bd-8c8c-0569bab51f9c",
+                    "isTransposed": false,
+                    "hidden": false,
+                    "alignment": "left",
+                    "colorMode": "none"
+                  },
+                  {
+                    "columnId": "f75356ee-10a5-4f14-b913-3db476b0dfb4",
+                    "isTransposed": false,
+                    "hidden": false,
+                    "alignment": "right",
+                    "colorMode": "none"
+                  }
+                ],
+                "headerRowHeight": "auto",
+                "headerRowHeightLines": 1,
+                "rowHeight": "auto",
+                "rowHeightLines": 2,
+                "paging": {
+                  "size": 10,
+                  "enabled": true
+                }
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.error.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 24,
+          "y": 30,
+          "i": "9eda7980-af33-4a14-abdd-42b97cb12b9b"
+        },
+        "panelIndex": "9eda7980-af33-4a14-abdd-42b97cb12b9b",
+        "title": "Error Counts by Severity",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-4890398c-a9f8-4d67-afdf-23e9d258040d",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "4890398c-a9f8-4d67-afdf-23e9d258040d": {
+                      "columnOrder": [
+                        "8fcf7a93-21ba-45c6-9035-7a4e6e08dcab",
+                        "34c8bc32-9ede-48fa-a9af-689091004ec8",
+                        "6b042de4-f6d5-482a-b3ec-d19d2ade368e"
+                      ],
+                      "columns": {
+                        "8fcf7a93-21ba-45c6-9035-7a4e6e08dcab": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "34c8bc32-9ede-48fa-a9af-689091004ec8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Max requests",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.requests"
+                        },
+                        "6b042de4-f6d5-482a-b3ec-d19d2ade368e": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Request rate",
+                          "operationType": "differences",
+                          "params": {},
+                          "references": [
+                            "34c8bc32-9ede-48fa-a9af-689091004ec8"
+                          ],
+                          "scale": "ratio"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "6b042de4-f6d5-482a-b3ec-d19d2ade368e"
+                    ],
+                    "layerId": "4890398c-a9f8-4d67-afdf-23e9d258040d",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "xAccessor": "8fcf7a93-21ba-45c6-9035-7a4e6e08dcab",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#54B399",
+                        "forAccessor": "6b042de4-f6d5-482a-b3ec-d19d2ade368e"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "area",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Requests / interval"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 43,
+          "i": "ab035c70-1d55-4a65-9764-6ac04ef9b886"
+        },
+        "panelIndex": "ab035c70-1d55-4a65-9764-6ac04ef9b886",
+        "title": "Request Rate (from metrics)",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-e401e152-99f5-4987-a544-a9c9f17e7186",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "e401e152-99f5-4987-a544-a9c9f17e7186": {
+                      "columnOrder": [
+                        "053c392d-ed05-4275-8378-1d0983b3fbee",
+                        "aecfc35a-c458-4178-b5a4-70794b642434",
+                        "66f0445c-9d28-4f58-8a2f-1bd04a3a24a1",
+                        "cd1d53ff-0235-4717-9ced-1355dfbeb530",
+                        "1066ed14-2167-4f65-b485-0a4c9d2d12df",
+                        "34cb88f9-5b2a-41e4-951b-16fc56d5b646",
+                        "5405622e-10d3-4256-9270-ef008a0e0587"
+                      ],
+                      "columns": {
+                        "053c392d-ed05-4275-8378-1d0983b3fbee": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "aecfc35a-c458-4178-b5a4-70794b642434": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Accepts rate",
+                          "operationType": "formula",
+                          "params": {
+                            "formula": "differences(max(nginx.connections_accepted))",
+                            "isFormulaBroken": false
+                          },
+                          "reducedTimeRange": null,
+                          "references": [
+                            "cd1d53ff-0235-4717-9ced-1355dfbeb530"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null
+                        },
+                        "66f0445c-9d28-4f58-8a2f-1bd04a3a24a1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Part of Accepts rate",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "reducedTimeRange": null,
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_accepted",
+                          "timeScale": null,
+                          "timeShift": null
+                        },
+                        "cd1d53ff-0235-4717-9ced-1355dfbeb530": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Part of Accepts rate",
+                          "operationType": "differences",
+                          "params": null,
+                          "references": [
+                            "66f0445c-9d28-4f58-8a2f-1bd04a3a24a1"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null,
+                          "timeShift": null
+                        },
+                        "1066ed14-2167-4f65-b485-0a4c9d2d12df": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Handled rate",
+                          "operationType": "formula",
+                          "params": {
+                            "formula": "differences(max(nginx.connections_handled))",
+                            "isFormulaBroken": false
+                          },
+                          "reducedTimeRange": null,
+                          "references": [
+                            "5405622e-10d3-4256-9270-ef008a0e0587"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null
+                        },
+                        "34cb88f9-5b2a-41e4-951b-16fc56d5b646": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Part of Handled rate",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "reducedTimeRange": null,
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_handled",
+                          "timeScale": null,
+                          "timeShift": null
+                        },
+                        "5405622e-10d3-4256-9270-ef008a0e0587": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Part of Handled rate",
+                          "operationType": "differences",
+                          "params": null,
+                          "references": [
+                            "34cb88f9-5b2a-41e4-951b-16fc56d5b646"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null,
+                          "timeShift": null
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "aecfc35a-c458-4178-b5a4-70794b642434",
+                      "1066ed14-2167-4f65-b485-0a4c9d2d12df"
+                    ],
+                    "layerId": "e401e152-99f5-4987-a544-a9c9f17e7186",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "053c392d-ed05-4275-8378-1d0983b3fbee",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#68bc00",
+                        "forAccessor": "aecfc35a-c458-4178-b5a4-70794b642434"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#009ce0",
+                        "forAccessor": "1066ed14-2167-4f65-b485-0a4c9d2d12df"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "line",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Rate"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 24,
+          "y": 43,
+          "i": "40f53647-39b7-4415-89b2-4f44059d235b"
+        },
+        "panelIndex": "40f53647-39b7-4415-89b2-4f44059d235b",
+        "title": "Accepts & Handled Rate",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-abc57c18-f2d8-4b4d-94cc-8bfef7d2cab3",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "abc57c18-f2d8-4b4d-94cc-8bfef7d2cab3": {
+                      "columnOrder": [
+                        "58bb5485-b57f-4a63-afcb-3db2e3a31445",
+                        "7495cffe-4717-40ab-9986-629321f88307",
+                        "b98e5adf-85d2-45d2-ab7f-60f859cee1d2",
+                        "7a259b3c-8f46-4949-a8eb-39cc932f3afe",
+                        "19d21813-791f-42b0-9301-56355a6e0234"
+                      ],
+                      "columns": {
+                        "58bb5485-b57f-4a63-afcb-3db2e3a31445": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "7495cffe-4717-40ab-9986-629321f88307": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Active",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"active\""
+                          }
+                        },
+                        "b98e5adf-85d2-45d2-ab7f-60f859cee1d2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Reading",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"reading\""
+                          }
+                        },
+                        "7a259b3c-8f46-4949-a8eb-39cc932f3afe": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Writing",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"writing\""
+                          }
+                        },
+                        "19d21813-791f-42b0-9301-56355a6e0234": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Waiting",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"waiting\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "7495cffe-4717-40ab-9986-629321f88307",
+                      "b98e5adf-85d2-45d2-ab7f-60f859cee1d2",
+                      "7a259b3c-8f46-4949-a8eb-39cc932f3afe",
+                      "19d21813-791f-42b0-9301-56355a6e0234"
+                    ],
+                    "layerId": "abc57c18-f2d8-4b4d-94cc-8bfef7d2cab3",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "58bb5485-b57f-4a63-afcb-3db2e3a31445",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#E7664C",
+                        "forAccessor": "7495cffe-4717-40ab-9986-629321f88307"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#68bc00",
+                        "forAccessor": "b98e5adf-85d2-45d2-ab7f-60f859cee1d2"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#009ce0",
+                        "forAccessor": "7a259b3c-8f46-4949-a8eb-39cc932f3afe"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#F1D86F",
+                        "forAccessor": "19d21813-791f-42b0-9301-56355a6e0234"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "line",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Connections"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 56,
+          "i": "6a18acb7-8ed1-441e-b651-8b1734b0c8ad"
+        },
+        "panelIndex": "6a18acb7-8ed1-441e-b651-8b1734b0c8ad",
+        "title": "Connection States Over Time",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-d96209bb-5150-4555-8d69-cf8b37b2470a",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "d96209bb-5150-4555-8d69-cf8b37b2470a": {
+                      "columnOrder": [
+                        "131ae73a-abcf-450a-874d-bbcf5dd2a1a6",
+                        "1db69200-d1c3-4750-b6d3-12cba2fe8f2b",
+                        "0631b26d-53dd-447f-b414-54eea352691b",
+                        "5e57bd06-f36f-4ebd-8245-5c802b383260",
+                        "9d400a0f-bfb5-490d-9c7f-0881034476fe"
+                      ],
+                      "columns": {
+                        "131ae73a-abcf-450a-874d-bbcf5dd2a1a6": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "1db69200-d1c3-4750-b6d3-12cba2fe8f2b": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Drops",
+                          "operationType": "formula",
+                          "params": {
+                            "formula": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
+                            "isFormulaBroken": false
+                          },
+                          "reducedTimeRange": null,
+                          "references": [
+                            "9d400a0f-bfb5-490d-9c7f-0881034476fe"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null
+                        },
+                        "0631b26d-53dd-447f-b414-54eea352691b": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Drops",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_accepted"
+                        },
+                        "5e57bd06-f36f-4ebd-8245-5c802b383260": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Drops",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_handled"
+                        },
+                        "9d400a0f-bfb5-490d-9c7f-0881034476fe": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Drops",
+                          "operationType": "math",
+                          "params": {
+                            "tinymathAst": {
+                              "args": [
+                                "0631b26d-53dd-447f-b414-54eea352691b",
+                                "5e57bd06-f36f-4ebd-8245-5c802b383260"
+                              ],
+                              "location": {
+                                "max": 62,
+                                "min": 0
+                              },
+                              "name": "subtract",
+                              "text": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
+                              "type": "function"
+                            }
+                          },
+                          "references": [
+                            "0631b26d-53dd-447f-b414-54eea352691b",
+                            "5e57bd06-f36f-4ebd-8245-5c802b383260"
+                          ],
+                          "scale": "ratio"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "1db69200-d1c3-4750-b6d3-12cba2fe8f2b"
+                    ],
+                    "layerId": "d96209bb-5150-4555-8d69-cf8b37b2470a",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "xAccessor": "131ae73a-abcf-450a-874d-bbcf5dd2a1a6",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#E7664C",
+                        "forAccessor": "1db69200-d1c3-4750-b6d3-12cba2fe8f2b"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "area",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Dropped connections"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 24,
+          "y": 56,
+          "i": "2a24a599-7fe8-49c3-8c44-0641a408f6b9"
+        },
+        "panelIndex": "2a24a599-7fe8-49c3-8c44-0641a408f6b9",
+        "title": "Dropped Connections",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.2.0"
+    "timeRestore": false,
+    "title": "[Nginx OTel] Request Health",
+    "version": 3,
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "5435c9ae-583b-493d-8adc-ea6b6a387595": {
+          "explicitInput": {
+            "dataViewId": "metrics-*",
+            "fieldName": "host.name",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "singleSelect": true,
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            },
+            "title": "Nginx instance"
+          },
+          "grow": true,
+          "order": 0,
+          "type": "optionsListControl",
+          "width": "medium"
+        }
+      },
+      "showApplySelections": false
+    }
+  },
+  "coreMigrationVersion": "8.8.0",
+  "id": "nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "managed": false,
+  "references": [
+    {
+      "id": "logs-*",
+      "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "7b536f08-5375-4d5d-a470-aac7f857058f:indexpattern-datasource-layer-a2f86c3f-3809-417d-b63c-34ad9cd255c2",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "b9641f0d-abb4-4bce-909a-ff7325169239:indexpattern-datasource-layer-9bbb590b-41bd-4ead-9068-2b6f4c0bc830",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "93abfc07-dee9-4c02-959a-0a06ef6692b7:indexpattern-datasource-layer-09e7c791-fda3-44ac-bd99-42cf69effef6",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "86991c7a-553b-4a9d-bce2-d0f7fee1186a:indexpattern-datasource-layer-abe7a68f-73d0-404e-8448-0a9980d1ad9d",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "21b3eea7-90d2-4e1f-b92b-24377276c2c9:indexpattern-datasource-layer-7ae14f01-0b29-45b2-a9ea-87d9e3d1de52",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "9fe6620f-ce33-471c-af95-24e39f2e36a2:indexpattern-datasource-layer-177f8f8b-1a22-46c9-bb06-8b1153e01e16",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "a45a5f1e-bb8d-4e99-8bf3-d717f622ef4c:indexpattern-datasource-layer-09be7f12-cf6f-4cb8-8528-1f238e0ab210",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "14018edd-8c86-48db-8604-70a2db7bbd97:indexpattern-datasource-layer-48cf591f-e80c-49d3-99e1-0271c5855291",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "9eda7980-af33-4a14-abdd-42b97cb12b9b:indexpattern-datasource-layer-409e826d-e109-4ce9-9605-089db6438e5b",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "ab035c70-1d55-4a65-9764-6ac04ef9b886:indexpattern-datasource-layer-4890398c-a9f8-4d67-afdf-23e9d258040d",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "40f53647-39b7-4415-89b2-4f44059d235b:indexpattern-datasource-layer-e401e152-99f5-4987-a544-a9c9f17e7186",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "6a18acb7-8ed1-441e-b651-8b1734b0c8ad:indexpattern-datasource-layer-abc57c18-f2d8-4b4d-94cc-8bfef7d2cab3",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "2a24a599-7fe8-49c3-8c44-0641a408f6b9:indexpattern-datasource-layer-d96209bb-5150-4555-8d69-cf8b37b2470a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_5435c9ae-583b-493d-8adc-ea6b6a387595:optionsListDataView",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.2.0"
 }

--- a/packages/nginx_otel/kibana/dashboard/nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901.json
+++ b/packages/nginx_otel/kibana/dashboard/nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901.json
@@ -1,1787 +1,1787 @@
 {
-    "attributes": {
-        "description": "Connection states, request processing, and capacity for Nginx.",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "data_stream.dataset",
-                            "negate": false,
-                            "params": {
-                                "query": "nginxreceiver.otel"
-                            },
-                            "type": "phrase"
-                        },
-                        "query": {
-                            "match_phrase": {
-                                "data_stream.dataset": "nginxreceiver.otel"
-                            }
-                        }
-                    }
-                ],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
+  "attributes": {
+    "description": "Connection states, request processing, and capacity for Nginx.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "alias": null,
+              "disabled": false,
+              "field": "data_stream.dataset",
+              "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+              "key": "data_stream.dataset",
+              "negate": false,
+              "params": {
+                "query": "nginxreceiver.otel"
+              },
+              "type": "phrase"
+            },
+            "query": {
+              "match_phrase": {
+                "data_stream.dataset": "nginxreceiver.otel"
+              }
             }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": true,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "**[Request Health](/app/dashboards#/view/nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890)** | **[Server Internals](/app/dashboards#/view/nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901)** | **[Traffic & Capacity](/app/dashboards#/view/nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012)**",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    },
-                    "hidePanelTitles": true
-                },
-                "gridData": {
-                    "h": 3,
-                    "w": 48,
-                    "x": 0,
-                    "y": 0,
-                    "i": "4abca524-da8e-4815-905d-c53f31e91497"
-                },
-                "panelIndex": "4abca524-da8e-4815-905d-c53f31e91497",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "## Server Internals\n\nDeep-dive into NGINX connection handling and request processing internals.\n\n- **Connection states**: Active, reading, writing, waiting breakdown\n- **New connections**: Accept and handled rates over time\n- **Request processing**: Cumulative request counter and request rate\n- **Connection drops**: Dropped connections trend (accepted \u2212 handled)\n- **Processed connections**: Cumulative handled connections",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    },
-                    "hidePanelTitles": true
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 16,
-                    "x": 0,
-                    "y": 3,
-                    "i": "37a590c1-330e-4bc8-94cd-75d4d847bcfd"
-                },
-                "panelIndex": "37a590c1-330e-4bc8-94cd-75d4d847bcfd",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-af12e3d4-71cb-4ba1-b6d2-287aacd5fe66",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "af12e3d4-71cb-4ba1-b6d2-287aacd5fe66": {
-                                            "columnOrder": [
-                                                "149e6fe3-facf-46b1-8b7b-fdded94a55cb"
-                                            ],
-                                            "columns": {
-                                                "149e6fe3-facf-46b1-8b7b-fdded94a55cb": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Active",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"active\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "af12e3d4-71cb-4ba1-b6d2-287aacd5fe66",
-                                "layerType": "data",
-                                "metricAccessor": "149e6fe3-facf-46b1-8b7b-fdded94a55cb",
-                                "subtitle": "Connections",
-                                "color": "#E7664C"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 12,
-                    "x": 16,
-                    "y": 3,
-                    "i": "870785a3-baa3-40f3-8a77-46c400167350"
-                },
-                "panelIndex": "870785a3-baa3-40f3-8a77-46c400167350",
-                "title": "Active",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-b02205c6-9993-48ca-abc0-75e3a23e99fa",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "b02205c6-9993-48ca-abc0-75e3a23e99fa": {
-                                            "columnOrder": [
-                                                "3a089c9b-6726-46df-b661-94655442d6de"
-                                            ],
-                                            "columns": {
-                                                "3a089c9b-6726-46df-b661-94655442d6de": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Reading",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"reading\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "b02205c6-9993-48ca-abc0-75e3a23e99fa",
-                                "layerType": "data",
-                                "metricAccessor": "3a089c9b-6726-46df-b661-94655442d6de",
-                                "subtitle": "Connections",
-                                "color": "#68bc00"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 10,
-                    "x": 28,
-                    "y": 3,
-                    "i": "ed9ded7e-684a-49dc-9fa2-1aac3e02bc73"
-                },
-                "panelIndex": "ed9ded7e-684a-49dc-9fa2-1aac3e02bc73",
-                "title": "Reading",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-dbc23c65-b8b7-420d-b13d-f72f5ed7e4be",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "dbc23c65-b8b7-420d-b13d-f72f5ed7e4be": {
-                                            "columnOrder": [
-                                                "8b5cb0e2-ef6a-49a3-9050-6f2056376f72"
-                                            ],
-                                            "columns": {
-                                                "8b5cb0e2-ef6a-49a3-9050-6f2056376f72": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Writing",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"writing\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "dbc23c65-b8b7-420d-b13d-f72f5ed7e4be",
-                                "layerType": "data",
-                                "metricAccessor": "8b5cb0e2-ef6a-49a3-9050-6f2056376f72",
-                                "subtitle": "Connections",
-                                "color": "#009ce0"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 10,
-                    "x": 38,
-                    "y": 3,
-                    "i": "1b4e1e6c-411a-4951-83b3-6358f3194272"
-                },
-                "panelIndex": "1b4e1e6c-411a-4951-83b3-6358f3194272",
-                "title": "Writing",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-0f89b7b1-1727-4620-804c-73522cf15576",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "0f89b7b1-1727-4620-804c-73522cf15576": {
-                                            "columnOrder": [
-                                                "68340915-bbe5-4d26-8443-f543787d3e4e"
-                                            ],
-                                            "columns": {
-                                                "68340915-bbe5-4d26-8443-f543787d3e4e": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Waiting",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"waiting\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "0f89b7b1-1727-4620-804c-73522cf15576",
-                                "layerType": "data",
-                                "metricAccessor": "68340915-bbe5-4d26-8443-f543787d3e4e",
-                                "subtitle": "Connections",
-                                "color": "#F1D86F"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 16,
-                    "x": 16,
-                    "y": 9,
-                    "i": "8afdfb31-a041-4fb4-b44c-b50624537f99"
-                },
-                "panelIndex": "8afdfb31-a041-4fb4-b44c-b50624537f99",
-                "title": "Waiting",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-271bea05-b2cb-4aea-af79-3342b29c0e08",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "271bea05-b2cb-4aea-af79-3342b29c0e08": {
-                                            "columnOrder": [
-                                                "10f5c3e9-9dc3-4017-b1d1-04da7276c013",
-                                                "507b9b0f-e39b-406d-b613-12a07a049948",
-                                                "d7dee9af-9a17-4854-871c-96057cf837c6",
-                                                "d234fb51-b1e5-454b-94ef-810c074bc46b"
-                                            ],
-                                            "columns": {
-                                                "10f5c3e9-9dc3-4017-b1d1-04da7276c013": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Dropped",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "formula": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "references": [
-                                                        "d234fb51-b1e5-454b-94ef-810c074bc46b"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null
-                                                },
-                                                "507b9b0f-e39b-406d-b613-12a07a049948": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Dropped",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_accepted"
-                                                },
-                                                "d7dee9af-9a17-4854-871c-96057cf837c6": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Dropped",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_handled"
-                                                },
-                                                "d234fb51-b1e5-454b-94ef-810c074bc46b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Dropped",
-                                                    "operationType": "math",
-                                                    "params": {
-                                                        "tinymathAst": {
-                                                            "args": [
-                                                                "507b9b0f-e39b-406d-b613-12a07a049948",
-                                                                "d7dee9af-9a17-4854-871c-96057cf837c6"
-                                                            ],
-                                                            "location": {
-                                                                "max": 62,
-                                                                "min": 0
-                                                            },
-                                                            "name": "subtract",
-                                                            "text": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
-                                                            "type": "function"
-                                                        }
-                                                    },
-                                                    "references": [
-                                                        "507b9b0f-e39b-406d-b613-12a07a049948",
-                                                        "d7dee9af-9a17-4854-871c-96057cf837c6"
-                                                    ],
-                                                    "scale": "ratio"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "271bea05-b2cb-4aea-af79-3342b29c0e08",
-                                "layerType": "data",
-                                "metricAccessor": "10f5c3e9-9dc3-4017-b1d1-04da7276c013",
-                                "subtitle": "Connections (cumulative)",
-                                "color": "#E7664C"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 16,
-                    "x": 32,
-                    "y": 9,
-                    "i": "f93f861c-9f56-4814-97fd-86aa37c855bf"
-                },
-                "panelIndex": "f93f861c-9f56-4814-97fd-86aa37c855bf",
-                "title": "Dropped",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-8cf405fe-226a-4811-b487-793240216219",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "8cf405fe-226a-4811-b487-793240216219": {
-                                            "columnOrder": [
-                                                "4e287efc-f10a-4d57-99cb-75ef00f26f85",
-                                                "81fa1dd9-5001-4d72-8b47-fdf934c04e7b",
-                                                "756dedaa-18b7-4971-afc6-52b715982812",
-                                                "59d73222-bedb-4c9c-a828-96c3084a904b",
-                                                "03fcd0d3-576d-4531-af61-e419504e4136"
-                                            ],
-                                            "columns": {
-                                                "4e287efc-f10a-4d57-99cb-75ef00f26f85": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "81fa1dd9-5001-4d72-8b47-fdf934c04e7b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Active",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"active\""
-                                                    }
-                                                },
-                                                "756dedaa-18b7-4971-afc6-52b715982812": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Reading",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"reading\""
-                                                    }
-                                                },
-                                                "59d73222-bedb-4c9c-a828-96c3084a904b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Writing",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"writing\""
-                                                    }
-                                                },
-                                                "03fcd0d3-576d-4531-af61-e419504e4136": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Waiting",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"waiting\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "81fa1dd9-5001-4d72-8b47-fdf934c04e7b",
-                                            "756dedaa-18b7-4971-afc6-52b715982812",
-                                            "59d73222-bedb-4c9c-a828-96c3084a904b",
-                                            "03fcd0d3-576d-4531-af61-e419504e4136"
-                                        ],
-                                        "layerId": "8cf405fe-226a-4811-b487-793240216219",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "4e287efc-f10a-4d57-99cb-75ef00f26f85",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#E7664C",
-                                                "forAccessor": "81fa1dd9-5001-4d72-8b47-fdf934c04e7b"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#68bc00",
-                                                "forAccessor": "756dedaa-18b7-4971-afc6-52b715982812"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#009ce0",
-                                                "forAccessor": "59d73222-bedb-4c9c-a828-96c3084a904b"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#F1D86F",
-                                                "forAccessor": "03fcd0d3-576d-4531-af61-e419504e4136"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Connections"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "w": 24,
-                    "x": 0,
-                    "y": 16,
-                    "i": "979f25e8-475b-4509-8303-24d1043bc5d2"
-                },
-                "panelIndex": "979f25e8-475b-4509-8303-24d1043bc5d2",
-                "title": "Connection States Over Time",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-e5c4051e-cf18-4ee0-8a7b-559d38c8c844",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "e5c4051e-cf18-4ee0-8a7b-559d38c8c844": {
-                                            "columnOrder": [
-                                                "7ee24693-9a73-4bac-95cf-99fd0578ab35",
-                                                "9b536489-0ad5-4079-8169-bfb636d5be19",
-                                                "cc5af50c-eee3-41f9-bfda-9e4c8c84c753",
-                                                "e87873f1-6559-421e-9dc4-c69d42a9a2a9",
-                                                "6d312e2b-c98a-439b-830d-7c0486a82e2d",
-                                                "bb60c8d7-a9b2-4ca1-8e40-5a6047d5b761",
-                                                "48b37fb2-01dc-4d1a-9796-1868118fef6a"
-                                            ],
-                                            "columns": {
-                                                "7ee24693-9a73-4bac-95cf-99fd0578ab35": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "9b536489-0ad5-4079-8169-bfb636d5be19": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Accepts rate",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "formula": "differences(max(nginx.connections_accepted))",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "references": [
-                                                        "e87873f1-6559-421e-9dc4-c69d42a9a2a9"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null
-                                                },
-                                                "cc5af50c-eee3-41f9-bfda-9e4c8c84c753": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Part of Accepts rate",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_accepted",
-                                                    "timeScale": null,
-                                                    "timeShift": null
-                                                },
-                                                "e87873f1-6559-421e-9dc4-c69d42a9a2a9": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Part of Accepts rate",
-                                                    "operationType": "differences",
-                                                    "params": null,
-                                                    "references": [
-                                                        "cc5af50c-eee3-41f9-bfda-9e4c8c84c753"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null,
-                                                    "timeShift": null
-                                                },
-                                                "6d312e2b-c98a-439b-830d-7c0486a82e2d": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Handled rate",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "formula": "differences(max(nginx.connections_handled))",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "references": [
-                                                        "48b37fb2-01dc-4d1a-9796-1868118fef6a"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null
-                                                },
-                                                "bb60c8d7-a9b2-4ca1-8e40-5a6047d5b761": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Part of Handled rate",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_handled",
-                                                    "timeScale": null,
-                                                    "timeShift": null
-                                                },
-                                                "48b37fb2-01dc-4d1a-9796-1868118fef6a": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Part of Handled rate",
-                                                    "operationType": "differences",
-                                                    "params": null,
-                                                    "references": [
-                                                        "bb60c8d7-a9b2-4ca1-8e40-5a6047d5b761"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null,
-                                                    "timeShift": null
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "9b536489-0ad5-4079-8169-bfb636d5be19",
-                                            "6d312e2b-c98a-439b-830d-7c0486a82e2d"
-                                        ],
-                                        "layerId": "e5c4051e-cf18-4ee0-8a7b-559d38c8c844",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "7ee24693-9a73-4bac-95cf-99fd0578ab35",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#68bc00",
-                                                "forAccessor": "9b536489-0ad5-4079-8169-bfb636d5be19"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#009ce0",
-                                                "forAccessor": "6d312e2b-c98a-439b-830d-7c0486a82e2d"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Rate"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "w": 24,
-                    "x": 24,
-                    "y": 16,
-                    "i": "242dea05-0775-462f-ac25-aaaee8951cfc"
-                },
-                "panelIndex": "242dea05-0775-462f-ac25-aaaee8951cfc",
-                "title": "New Connections / Interval",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-8472c28f-df16-4a3d-8c27-8bfb6ddbb5f3",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "8472c28f-df16-4a3d-8c27-8bfb6ddbb5f3": {
-                                            "columnOrder": [
-                                                "39836493-7490-4767-a04c-15e6c534c403",
-                                                "f9606b26-198f-4ac2-a7da-8e3751a8a1d9"
-                                            ],
-                                            "columns": {
-                                                "39836493-7490-4767-a04c-15e6c534c403": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "f9606b26-198f-4ac2-a7da-8e3751a8a1d9": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Total",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.requests"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "emphasizeFitting": true,
-                                "fittingFunction": "Linear",
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "f9606b26-198f-4ac2-a7da-8e3751a8a1d9"
-                                        ],
-                                        "layerId": "8472c28f-df16-4a3d-8c27-8bfb6ddbb5f3",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "39836493-7490-4767-a04c-15e6c534c403",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "forAccessor": "f9606b26-198f-4ac2-a7da-8e3751a8a1d9"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Requests (cumulative)"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 0,
-                    "y": 31,
-                    "i": "25937e0e-f4ac-487c-94a1-b1dc5226b8b7"
-                },
-                "panelIndex": "25937e0e-f4ac-487c-94a1-b1dc5226b8b7",
-                "title": "Total Requests (cumulative)",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-05ecac70-2127-4799-8c06-4720538ed52e",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "05ecac70-2127-4799-8c06-4720538ed52e": {
-                                            "columnOrder": [
-                                                "275057f5-874d-4fab-9a5d-5272f522469c",
-                                                "61632657-47e7-4733-96aa-881d97e48129",
-                                                "302fa9db-8d38-4252-a176-4dccedb59884"
-                                            ],
-                                            "columns": {
-                                                "275057f5-874d-4fab-9a5d-5272f522469c": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "61632657-47e7-4733-96aa-881d97e48129": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Max requests",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.requests"
-                                                },
-                                                "302fa9db-8d38-4252-a176-4dccedb59884": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Request rate",
-                                                    "operationType": "differences",
-                                                    "params": {},
-                                                    "references": [
-                                                        "61632657-47e7-4733-96aa-881d97e48129"
-                                                    ],
-                                                    "scale": "ratio"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "302fa9db-8d38-4252-a176-4dccedb59884"
-                                        ],
-                                        "layerId": "05ecac70-2127-4799-8c06-4720538ed52e",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "xAccessor": "275057f5-874d-4fab-9a5d-5272f522469c",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#54B399",
-                                                "forAccessor": "302fa9db-8d38-4252-a176-4dccedb59884"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "area",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yLeftScale": "linear",
-                                "yTitle": "Requests / interval"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 24,
-                    "y": 31,
-                    "i": "d96a9655-1883-4ae8-8522-667ddc56fb9f"
-                },
-                "panelIndex": "d96a9655-1883-4ae8-8522-667ddc56fb9f",
-                "title": "Request Rate",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-74c9d698-e423-4ea8-a29d-cc30dd8aaddd",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "74c9d698-e423-4ea8-a29d-cc30dd8aaddd": {
-                                            "columnOrder": [
-                                                "f78ac1b1-2237-4aca-8d8d-f1b149220e0e",
-                                                "38d45b95-c100-4b3d-9557-bb6c6402d278",
-                                                "a41fc0aa-9fb3-4166-b6f4-9d2455a5e5b1",
-                                                "61497af8-cca9-4b6e-80e5-263778d1c8b7",
-                                                "b3c66ca3-0bf4-47aa-a8e8-8368a817f9cf"
-                                            ],
-                                            "columns": {
-                                                "f78ac1b1-2237-4aca-8d8d-f1b149220e0e": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "38d45b95-c100-4b3d-9557-bb6c6402d278": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": null,
-                                                    "isBucketed": false,
-                                                    "label": "Drops",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "formula": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "reducedTimeRange": null,
-                                                    "references": [
-                                                        "b3c66ca3-0bf4-47aa-a8e8-8368a817f9cf"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": null
-                                                },
-                                                "a41fc0aa-9fb3-4166-b6f4-9d2455a5e5b1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Drops",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_accepted"
-                                                },
-                                                "61497af8-cca9-4b6e-80e5-263778d1c8b7": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Drops",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_handled"
-                                                },
-                                                "b3c66ca3-0bf4-47aa-a8e8-8368a817f9cf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of Drops",
-                                                    "operationType": "math",
-                                                    "params": {
-                                                        "tinymathAst": {
-                                                            "args": [
-                                                                "a41fc0aa-9fb3-4166-b6f4-9d2455a5e5b1",
-                                                                "61497af8-cca9-4b6e-80e5-263778d1c8b7"
-                                                            ],
-                                                            "location": {
-                                                                "max": 62,
-                                                                "min": 0
-                                                            },
-                                                            "name": "subtract",
-                                                            "text": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
-                                                            "type": "function"
-                                                        }
-                                                    },
-                                                    "references": [
-                                                        "a41fc0aa-9fb3-4166-b6f4-9d2455a5e5b1",
-                                                        "61497af8-cca9-4b6e-80e5-263778d1c8b7"
-                                                    ],
-                                                    "scale": "ratio"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "38d45b95-c100-4b3d-9557-bb6c6402d278"
-                                        ],
-                                        "layerId": "74c9d698-e423-4ea8-a29d-cc30dd8aaddd",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "xAccessor": "f78ac1b1-2237-4aca-8d8d-f1b149220e0e",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#E7664C",
-                                                "forAccessor": "38d45b95-c100-4b3d-9557-bb6c6402d278"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "area",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Dropped connections"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 0,
-                    "y": 44,
-                    "i": "b6e60068-8359-404d-a3b7-f1bc69fdd34c"
-                },
-                "panelIndex": "b6e60068-8359-404d-a3b7-f1bc69fdd34c",
-                "title": "Dropped Connections Over Time",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-8160efbe-6863-4d2c-8e64-af3f823f0b89",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "8160efbe-6863-4d2c-8e64-af3f823f0b89": {
-                                            "columnOrder": [
-                                                "d862c3d3-d6d9-49f5-a04b-429c22448b55",
-                                                "a67b2664-c6b2-484d-8317-24c020949c8f"
-                                            ],
-                                            "columns": {
-                                                "d862c3d3-d6d9-49f5-a04b-429c22448b55": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "a67b2664-c6b2-484d-8317-24c020949c8f": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Processed",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_handled"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "emphasizeFitting": true,
-                                "fittingFunction": "Linear",
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "a67b2664-c6b2-484d-8317-24c020949c8f"
-                                        ],
-                                        "layerId": "8160efbe-6863-4d2c-8e64-af3f823f0b89",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "d862c3d3-d6d9-49f5-a04b-429c22448b55",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "forAccessor": "a67b2664-c6b2-484d-8317-24c020949c8f"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Handled connections (cumulative)"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": ""
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 24,
-                    "y": 44,
-                    "i": "fc5d5001-be9e-4c19-bf5f-41808192c6c7"
-                },
-                "panelIndex": "fc5d5001-be9e-4c19-bf5f-41808192c6c7",
-                "title": "Processed Connections (cumulative)",
-                "type": "lens"
-            }
+          }
         ],
-        "timeRestore": false,
-        "title": "[Nginx OTel] Server Internals",
-        "version": 3,
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
-            },
-            "panelsJSON": {
-                "07e5bc41-06c9-480e-942f-4765110fbabe": {
-                    "explicitInput": {
-                        "dataViewId": "metrics-*",
-                        "fieldName": "host.name",
-                        "searchTechnique": "prefix",
-                        "selectedOptions": [],
-                        "singleSelect": true,
-                        "sort": {
-                            "by": "_count",
-                            "direction": "desc"
-                        },
-                        "title": "Nginx instance"
-                    },
-                    "grow": true,
-                    "order": 0,
-                    "type": "optionsListControl",
-                    "width": "medium"
-                }
-            },
-            "showApplySelections": false
+        "query": {
+          "language": "kuery",
+          "query": ""
         }
+      }
     },
-    "coreMigrationVersion": "8.8.0",
-    "id": "nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901",
-    "managed": false,
-    "references": [
-        {
-            "id": "logs-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "savedVis": {
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "filter": [],
+                "query": {
+                  "language": "kuery",
+                  "query": ""
+                }
+              }
+            },
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "markdown": "**[Request Health](/app/dashboards#/view/nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890)** | **[Server Internals](/app/dashboards#/view/nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901)** | **[Traffic & Capacity](/app/dashboards#/view/nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012)**",
+              "openLinksInNewTab": false
+            },
+            "title": "",
+            "type": "markdown",
+            "uiState": {}
+          },
+          "hidePanelTitles": true
         },
-        {
-            "id": "metrics-*",
-            "name": "870785a3-baa3-40f3-8a77-46c400167350:indexpattern-datasource-layer-af12e3d4-71cb-4ba1-b6d2-287aacd5fe66",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 3,
+          "w": 48,
+          "x": 0,
+          "y": 0,
+          "i": "4abca524-da8e-4815-905d-c53f31e91497"
         },
-        {
-            "id": "metrics-*",
-            "name": "ed9ded7e-684a-49dc-9fa2-1aac3e02bc73:indexpattern-datasource-layer-b02205c6-9993-48ca-abc0-75e3a23e99fa",
-            "type": "index-pattern"
+        "panelIndex": "4abca524-da8e-4815-905d-c53f31e91497",
+        "type": "visualization"
+      },
+      {
+        "embeddableConfig": {
+          "savedVis": {
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "filter": [],
+                "query": {
+                  "language": "kuery",
+                  "query": ""
+                }
+              }
+            },
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "markdown": "## Server Internals\n\nDeep-dive into NGINX connection handling and request processing internals.\n\n- **Connection states**: Active, reading, writing, waiting breakdown\n- **New connections**: Accept and handled rates over time\n- **Request processing**: Cumulative request counter and request rate\n- **Connection drops**: Dropped connections trend (accepted \u2212 handled)\n- **Processed connections**: Cumulative handled connections",
+              "openLinksInNewTab": false
+            },
+            "title": "",
+            "type": "markdown",
+            "uiState": {}
+          },
+          "hidePanelTitles": true
         },
-        {
-            "id": "metrics-*",
-            "name": "1b4e1e6c-411a-4951-83b3-6358f3194272:indexpattern-datasource-layer-dbc23c65-b8b7-420d-b13d-f72f5ed7e4be",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 12,
+          "w": 16,
+          "x": 0,
+          "y": 3,
+          "i": "37a590c1-330e-4bc8-94cd-75d4d847bcfd"
         },
-        {
-            "id": "metrics-*",
-            "name": "8afdfb31-a041-4fb4-b44c-b50624537f99:indexpattern-datasource-layer-0f89b7b1-1727-4620-804c-73522cf15576",
-            "type": "index-pattern"
+        "panelIndex": "37a590c1-330e-4bc8-94cd-75d4d847bcfd",
+        "type": "visualization"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-af12e3d4-71cb-4ba1-b6d2-287aacd5fe66",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "af12e3d4-71cb-4ba1-b6d2-287aacd5fe66": {
+                      "columnOrder": [
+                        "149e6fe3-facf-46b1-8b7b-fdded94a55cb"
+                      ],
+                      "columns": {
+                        "149e6fe3-facf-46b1-8b7b-fdded94a55cb": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Active",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"active\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "layerId": "af12e3d4-71cb-4ba1-b6d2-287aacd5fe66",
+                "layerType": "data",
+                "metricAccessor": "149e6fe3-facf-46b1-8b7b-fdded94a55cb",
+                "subtitle": "Connections",
+                "color": "#E7664C"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "f93f861c-9f56-4814-97fd-86aa37c855bf:indexpattern-datasource-layer-271bea05-b2cb-4aea-af79-3342b29c0e08",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 12,
+          "x": 16,
+          "y": 3,
+          "i": "870785a3-baa3-40f3-8a77-46c400167350"
         },
-        {
-            "id": "metrics-*",
-            "name": "979f25e8-475b-4509-8303-24d1043bc5d2:indexpattern-datasource-layer-8cf405fe-226a-4811-b487-793240216219",
-            "type": "index-pattern"
+        "panelIndex": "870785a3-baa3-40f3-8a77-46c400167350",
+        "title": "Active",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-b02205c6-9993-48ca-abc0-75e3a23e99fa",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "b02205c6-9993-48ca-abc0-75e3a23e99fa": {
+                      "columnOrder": [
+                        "3a089c9b-6726-46df-b661-94655442d6de"
+                      ],
+                      "columns": {
+                        "3a089c9b-6726-46df-b661-94655442d6de": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Reading",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"reading\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "layerId": "b02205c6-9993-48ca-abc0-75e3a23e99fa",
+                "layerType": "data",
+                "metricAccessor": "3a089c9b-6726-46df-b661-94655442d6de",
+                "subtitle": "Connections",
+                "color": "#68bc00"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "242dea05-0775-462f-ac25-aaaee8951cfc:indexpattern-datasource-layer-e5c4051e-cf18-4ee0-8a7b-559d38c8c844",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 10,
+          "x": 28,
+          "y": 3,
+          "i": "ed9ded7e-684a-49dc-9fa2-1aac3e02bc73"
         },
-        {
-            "id": "metrics-*",
-            "name": "25937e0e-f4ac-487c-94a1-b1dc5226b8b7:indexpattern-datasource-layer-8472c28f-df16-4a3d-8c27-8bfb6ddbb5f3",
-            "type": "index-pattern"
+        "panelIndex": "ed9ded7e-684a-49dc-9fa2-1aac3e02bc73",
+        "title": "Reading",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-dbc23c65-b8b7-420d-b13d-f72f5ed7e4be",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "dbc23c65-b8b7-420d-b13d-f72f5ed7e4be": {
+                      "columnOrder": [
+                        "8b5cb0e2-ef6a-49a3-9050-6f2056376f72"
+                      ],
+                      "columns": {
+                        "8b5cb0e2-ef6a-49a3-9050-6f2056376f72": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Writing",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"writing\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "layerId": "dbc23c65-b8b7-420d-b13d-f72f5ed7e4be",
+                "layerType": "data",
+                "metricAccessor": "8b5cb0e2-ef6a-49a3-9050-6f2056376f72",
+                "subtitle": "Connections",
+                "color": "#009ce0"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "d96a9655-1883-4ae8-8522-667ddc56fb9f:indexpattern-datasource-layer-05ecac70-2127-4799-8c06-4720538ed52e",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 10,
+          "x": 38,
+          "y": 3,
+          "i": "1b4e1e6c-411a-4951-83b3-6358f3194272"
         },
-        {
-            "id": "metrics-*",
-            "name": "b6e60068-8359-404d-a3b7-f1bc69fdd34c:indexpattern-datasource-layer-74c9d698-e423-4ea8-a29d-cc30dd8aaddd",
-            "type": "index-pattern"
+        "panelIndex": "1b4e1e6c-411a-4951-83b3-6358f3194272",
+        "title": "Writing",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-0f89b7b1-1727-4620-804c-73522cf15576",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "0f89b7b1-1727-4620-804c-73522cf15576": {
+                      "columnOrder": [
+                        "68340915-bbe5-4d26-8443-f543787d3e4e"
+                      ],
+                      "columns": {
+                        "68340915-bbe5-4d26-8443-f543787d3e4e": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Waiting",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"waiting\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "layerId": "0f89b7b1-1727-4620-804c-73522cf15576",
+                "layerType": "data",
+                "metricAccessor": "68340915-bbe5-4d26-8443-f543787d3e4e",
+                "subtitle": "Connections",
+                "color": "#F1D86F"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "fc5d5001-be9e-4c19-bf5f-41808192c6c7:indexpattern-datasource-layer-8160efbe-6863-4d2c-8e64-af3f823f0b89",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 6,
+          "w": 16,
+          "x": 16,
+          "y": 9,
+          "i": "8afdfb31-a041-4fb4-b44c-b50624537f99"
         },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_07e5bc41-06c9-480e-942f-4765110fbabe:optionsListDataView",
-            "type": "index-pattern"
-        }
+        "panelIndex": "8afdfb31-a041-4fb4-b44c-b50624537f99",
+        "title": "Waiting",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-271bea05-b2cb-4aea-af79-3342b29c0e08",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "271bea05-b2cb-4aea-af79-3342b29c0e08": {
+                      "columnOrder": [
+                        "10f5c3e9-9dc3-4017-b1d1-04da7276c013",
+                        "507b9b0f-e39b-406d-b613-12a07a049948",
+                        "d7dee9af-9a17-4854-871c-96057cf837c6",
+                        "d234fb51-b1e5-454b-94ef-810c074bc46b"
+                      ],
+                      "columns": {
+                        "10f5c3e9-9dc3-4017-b1d1-04da7276c013": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Dropped",
+                          "operationType": "formula",
+                          "params": {
+                            "formula": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
+                            "isFormulaBroken": false
+                          },
+                          "reducedTimeRange": null,
+                          "references": [
+                            "d234fb51-b1e5-454b-94ef-810c074bc46b"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null
+                        },
+                        "507b9b0f-e39b-406d-b613-12a07a049948": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Dropped",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_accepted"
+                        },
+                        "d7dee9af-9a17-4854-871c-96057cf837c6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Dropped",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_handled"
+                        },
+                        "d234fb51-b1e5-454b-94ef-810c074bc46b": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Dropped",
+                          "operationType": "math",
+                          "params": {
+                            "tinymathAst": {
+                              "args": [
+                                "507b9b0f-e39b-406d-b613-12a07a049948",
+                                "d7dee9af-9a17-4854-871c-96057cf837c6"
+                              ],
+                              "location": {
+                                "max": 62,
+                                "min": 0
+                              },
+                              "name": "subtract",
+                              "text": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
+                              "type": "function"
+                            }
+                          },
+                          "references": [
+                            "507b9b0f-e39b-406d-b613-12a07a049948",
+                            "d7dee9af-9a17-4854-871c-96057cf837c6"
+                          ],
+                          "scale": "ratio"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "layerId": "271bea05-b2cb-4aea-af79-3342b29c0e08",
+                "layerType": "data",
+                "metricAccessor": "10f5c3e9-9dc3-4017-b1d1-04da7276c013",
+                "subtitle": "Connections (cumulative)",
+                "color": "#E7664C"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 6,
+          "w": 16,
+          "x": 32,
+          "y": 9,
+          "i": "f93f861c-9f56-4814-97fd-86aa37c855bf"
+        },
+        "panelIndex": "f93f861c-9f56-4814-97fd-86aa37c855bf",
+        "title": "Dropped",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-8cf405fe-226a-4811-b487-793240216219",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "8cf405fe-226a-4811-b487-793240216219": {
+                      "columnOrder": [
+                        "4e287efc-f10a-4d57-99cb-75ef00f26f85",
+                        "81fa1dd9-5001-4d72-8b47-fdf934c04e7b",
+                        "756dedaa-18b7-4971-afc6-52b715982812",
+                        "59d73222-bedb-4c9c-a828-96c3084a904b",
+                        "03fcd0d3-576d-4531-af61-e419504e4136"
+                      ],
+                      "columns": {
+                        "4e287efc-f10a-4d57-99cb-75ef00f26f85": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "81fa1dd9-5001-4d72-8b47-fdf934c04e7b": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Active",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"active\""
+                          }
+                        },
+                        "756dedaa-18b7-4971-afc6-52b715982812": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Reading",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"reading\""
+                          }
+                        },
+                        "59d73222-bedb-4c9c-a828-96c3084a904b": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Writing",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"writing\""
+                          }
+                        },
+                        "03fcd0d3-576d-4531-af61-e419504e4136": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Waiting",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 1
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"waiting\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "81fa1dd9-5001-4d72-8b47-fdf934c04e7b",
+                      "756dedaa-18b7-4971-afc6-52b715982812",
+                      "59d73222-bedb-4c9c-a828-96c3084a904b",
+                      "03fcd0d3-576d-4531-af61-e419504e4136"
+                    ],
+                    "layerId": "8cf405fe-226a-4811-b487-793240216219",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "4e287efc-f10a-4d57-99cb-75ef00f26f85",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#E7664C",
+                        "forAccessor": "81fa1dd9-5001-4d72-8b47-fdf934c04e7b"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#68bc00",
+                        "forAccessor": "756dedaa-18b7-4971-afc6-52b715982812"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#009ce0",
+                        "forAccessor": "59d73222-bedb-4c9c-a828-96c3084a904b"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#F1D86F",
+                        "forAccessor": "03fcd0d3-576d-4531-af61-e419504e4136"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "line",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Connections"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 14,
+          "w": 24,
+          "x": 0,
+          "y": 16,
+          "i": "979f25e8-475b-4509-8303-24d1043bc5d2"
+        },
+        "panelIndex": "979f25e8-475b-4509-8303-24d1043bc5d2",
+        "title": "Connection States Over Time",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-e5c4051e-cf18-4ee0-8a7b-559d38c8c844",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "e5c4051e-cf18-4ee0-8a7b-559d38c8c844": {
+                      "columnOrder": [
+                        "7ee24693-9a73-4bac-95cf-99fd0578ab35",
+                        "9b536489-0ad5-4079-8169-bfb636d5be19",
+                        "cc5af50c-eee3-41f9-bfda-9e4c8c84c753",
+                        "e87873f1-6559-421e-9dc4-c69d42a9a2a9",
+                        "6d312e2b-c98a-439b-830d-7c0486a82e2d",
+                        "bb60c8d7-a9b2-4ca1-8e40-5a6047d5b761",
+                        "48b37fb2-01dc-4d1a-9796-1868118fef6a"
+                      ],
+                      "columns": {
+                        "7ee24693-9a73-4bac-95cf-99fd0578ab35": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "9b536489-0ad5-4079-8169-bfb636d5be19": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Accepts rate",
+                          "operationType": "formula",
+                          "params": {
+                            "formula": "differences(max(nginx.connections_accepted))",
+                            "isFormulaBroken": false
+                          },
+                          "reducedTimeRange": null,
+                          "references": [
+                            "e87873f1-6559-421e-9dc4-c69d42a9a2a9"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null
+                        },
+                        "cc5af50c-eee3-41f9-bfda-9e4c8c84c753": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Part of Accepts rate",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "reducedTimeRange": null,
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_accepted",
+                          "timeScale": null,
+                          "timeShift": null
+                        },
+                        "e87873f1-6559-421e-9dc4-c69d42a9a2a9": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Part of Accepts rate",
+                          "operationType": "differences",
+                          "params": null,
+                          "references": [
+                            "cc5af50c-eee3-41f9-bfda-9e4c8c84c753"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null,
+                          "timeShift": null
+                        },
+                        "6d312e2b-c98a-439b-830d-7c0486a82e2d": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Handled rate",
+                          "operationType": "formula",
+                          "params": {
+                            "formula": "differences(max(nginx.connections_handled))",
+                            "isFormulaBroken": false
+                          },
+                          "reducedTimeRange": null,
+                          "references": [
+                            "48b37fb2-01dc-4d1a-9796-1868118fef6a"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null
+                        },
+                        "bb60c8d7-a9b2-4ca1-8e40-5a6047d5b761": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Part of Handled rate",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "reducedTimeRange": null,
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_handled",
+                          "timeScale": null,
+                          "timeShift": null
+                        },
+                        "48b37fb2-01dc-4d1a-9796-1868118fef6a": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Part of Handled rate",
+                          "operationType": "differences",
+                          "params": null,
+                          "references": [
+                            "bb60c8d7-a9b2-4ca1-8e40-5a6047d5b761"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null,
+                          "timeShift": null
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "9b536489-0ad5-4079-8169-bfb636d5be19",
+                      "6d312e2b-c98a-439b-830d-7c0486a82e2d"
+                    ],
+                    "layerId": "e5c4051e-cf18-4ee0-8a7b-559d38c8c844",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "7ee24693-9a73-4bac-95cf-99fd0578ab35",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#68bc00",
+                        "forAccessor": "9b536489-0ad5-4079-8169-bfb636d5be19"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#009ce0",
+                        "forAccessor": "6d312e2b-c98a-439b-830d-7c0486a82e2d"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "line",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Rate"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 14,
+          "w": 24,
+          "x": 24,
+          "y": 16,
+          "i": "242dea05-0775-462f-ac25-aaaee8951cfc"
+        },
+        "panelIndex": "242dea05-0775-462f-ac25-aaaee8951cfc",
+        "title": "New Connections / Interval",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-8472c28f-df16-4a3d-8c27-8bfb6ddbb5f3",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "8472c28f-df16-4a3d-8c27-8bfb6ddbb5f3": {
+                      "columnOrder": [
+                        "39836493-7490-4767-a04c-15e6c534c403",
+                        "f9606b26-198f-4ac2-a7da-8e3751a8a1d9"
+                      ],
+                      "columns": {
+                        "39836493-7490-4767-a04c-15e6c534c403": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "f9606b26-198f-4ac2-a7da-8e3751a8a1d9": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.requests"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "emphasizeFitting": true,
+                "fittingFunction": "Linear",
+                "layers": [
+                  {
+                    "accessors": [
+                      "f9606b26-198f-4ac2-a7da-8e3751a8a1d9"
+                    ],
+                    "layerId": "8472c28f-df16-4a3d-8c27-8bfb6ddbb5f3",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "39836493-7490-4767-a04c-15e6c534c403",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "f9606b26-198f-4ac2-a7da-8e3751a8a1d9"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "line",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Requests (cumulative)"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 31,
+          "i": "25937e0e-f4ac-487c-94a1-b1dc5226b8b7"
+        },
+        "panelIndex": "25937e0e-f4ac-487c-94a1-b1dc5226b8b7",
+        "title": "Total Requests (cumulative)",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-05ecac70-2127-4799-8c06-4720538ed52e",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "05ecac70-2127-4799-8c06-4720538ed52e": {
+                      "columnOrder": [
+                        "275057f5-874d-4fab-9a5d-5272f522469c",
+                        "61632657-47e7-4733-96aa-881d97e48129",
+                        "302fa9db-8d38-4252-a176-4dccedb59884"
+                      ],
+                      "columns": {
+                        "275057f5-874d-4fab-9a5d-5272f522469c": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "61632657-47e7-4733-96aa-881d97e48129": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Max requests",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.requests"
+                        },
+                        "302fa9db-8d38-4252-a176-4dccedb59884": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Request rate",
+                          "operationType": "differences",
+                          "params": {},
+                          "references": [
+                            "61632657-47e7-4733-96aa-881d97e48129"
+                          ],
+                          "scale": "ratio"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "302fa9db-8d38-4252-a176-4dccedb59884"
+                    ],
+                    "layerId": "05ecac70-2127-4799-8c06-4720538ed52e",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "xAccessor": "275057f5-874d-4fab-9a5d-5272f522469c",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#54B399",
+                        "forAccessor": "302fa9db-8d38-4252-a176-4dccedb59884"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "area",
+                "title": "",
+                "valueLabels": "hide",
+                "yLeftScale": "linear",
+                "yTitle": "Requests / interval"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 24,
+          "y": 31,
+          "i": "d96a9655-1883-4ae8-8522-667ddc56fb9f"
+        },
+        "panelIndex": "d96a9655-1883-4ae8-8522-667ddc56fb9f",
+        "title": "Request Rate",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-74c9d698-e423-4ea8-a29d-cc30dd8aaddd",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "74c9d698-e423-4ea8-a29d-cc30dd8aaddd": {
+                      "columnOrder": [
+                        "f78ac1b1-2237-4aca-8d8d-f1b149220e0e",
+                        "38d45b95-c100-4b3d-9557-bb6c6402d278",
+                        "a41fc0aa-9fb3-4166-b6f4-9d2455a5e5b1",
+                        "61497af8-cca9-4b6e-80e5-263778d1c8b7",
+                        "b3c66ca3-0bf4-47aa-a8e8-8368a817f9cf"
+                      ],
+                      "columns": {
+                        "f78ac1b1-2237-4aca-8d8d-f1b149220e0e": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "38d45b95-c100-4b3d-9557-bb6c6402d278": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "filter": null,
+                          "isBucketed": false,
+                          "label": "Drops",
+                          "operationType": "formula",
+                          "params": {
+                            "formula": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
+                            "isFormulaBroken": false
+                          },
+                          "reducedTimeRange": null,
+                          "references": [
+                            "b3c66ca3-0bf4-47aa-a8e8-8368a817f9cf"
+                          ],
+                          "scale": "ratio",
+                          "timeScale": null
+                        },
+                        "a41fc0aa-9fb3-4166-b6f4-9d2455a5e5b1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Drops",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_accepted"
+                        },
+                        "61497af8-cca9-4b6e-80e5-263778d1c8b7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Drops",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_handled"
+                        },
+                        "b3c66ca3-0bf4-47aa-a8e8-8368a817f9cf": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Part of Drops",
+                          "operationType": "math",
+                          "params": {
+                            "tinymathAst": {
+                              "args": [
+                                "a41fc0aa-9fb3-4166-b6f4-9d2455a5e5b1",
+                                "61497af8-cca9-4b6e-80e5-263778d1c8b7"
+                              ],
+                              "location": {
+                                "max": 62,
+                                "min": 0
+                              },
+                              "name": "subtract",
+                              "text": "max(nginx.connections_accepted)-max(nginx.connections_handled)",
+                              "type": "function"
+                            }
+                          },
+                          "references": [
+                            "a41fc0aa-9fb3-4166-b6f4-9d2455a5e5b1",
+                            "61497af8-cca9-4b6e-80e5-263778d1c8b7"
+                          ],
+                          "scale": "ratio"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "fittingFunction": "None",
+                "layers": [
+                  {
+                    "accessors": [
+                      "38d45b95-c100-4b3d-9557-bb6c6402d278"
+                    ],
+                    "layerId": "74c9d698-e423-4ea8-a29d-cc30dd8aaddd",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "xAccessor": "f78ac1b1-2237-4aca-8d8d-f1b149220e0e",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#E7664C",
+                        "forAccessor": "38d45b95-c100-4b3d-9557-bb6c6402d278"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "area",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Dropped connections"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 44,
+          "i": "b6e60068-8359-404d-a3b7-f1bc69fdd34c"
+        },
+        "panelIndex": "b6e60068-8359-404d-a3b7-f1bc69fdd34c",
+        "title": "Dropped Connections Over Time",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-8160efbe-6863-4d2c-8e64-af3f823f0b89",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "8160efbe-6863-4d2c-8e64-af3f823f0b89": {
+                      "columnOrder": [
+                        "d862c3d3-d6d9-49f5-a04b-429c22448b55",
+                        "a67b2664-c6b2-484d-8317-24c020949c8f"
+                      ],
+                      "columns": {
+                        "d862c3d3-d6d9-49f5-a04b-429c22448b55": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "a67b2664-c6b2-484d-8317-24c020949c8f": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Processed",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_handled"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "emphasizeFitting": true,
+                "fittingFunction": "Linear",
+                "layers": [
+                  {
+                    "accessors": [
+                      "a67b2664-c6b2-484d-8317-24c020949c8f"
+                    ],
+                    "layerId": "8160efbe-6863-4d2c-8e64-af3f823f0b89",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "line",
+                    "showGridlines": false,
+                    "xAccessor": "d862c3d3-d6d9-49f5-a04b-429c22448b55",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "a67b2664-c6b2-484d-8317-24c020949c8f"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "line",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Handled connections (cumulative)"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": ""
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 24,
+          "y": 44,
+          "i": "fc5d5001-be9e-4c19-bf5f-41808192c6c7"
+        },
+        "panelIndex": "fc5d5001-be9e-4c19-bf5f-41808192c6c7",
+        "title": "Processed Connections (cumulative)",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.2.0"
+    "timeRestore": false,
+    "title": "[Nginx OTel] Server Internals",
+    "version": 3,
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "07e5bc41-06c9-480e-942f-4765110fbabe": {
+          "explicitInput": {
+            "dataViewId": "metrics-*",
+            "fieldName": "host.name",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "singleSelect": true,
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            },
+            "title": "Nginx instance"
+          },
+          "grow": true,
+          "order": 0,
+          "type": "optionsListControl",
+          "width": "medium"
+        }
+      },
+      "showApplySelections": false
+    }
+  },
+  "coreMigrationVersion": "8.8.0",
+  "id": "nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "managed": false,
+  "references": [
+    {
+      "id": "logs-*",
+      "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "870785a3-baa3-40f3-8a77-46c400167350:indexpattern-datasource-layer-af12e3d4-71cb-4ba1-b6d2-287aacd5fe66",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "ed9ded7e-684a-49dc-9fa2-1aac3e02bc73:indexpattern-datasource-layer-b02205c6-9993-48ca-abc0-75e3a23e99fa",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "1b4e1e6c-411a-4951-83b3-6358f3194272:indexpattern-datasource-layer-dbc23c65-b8b7-420d-b13d-f72f5ed7e4be",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "8afdfb31-a041-4fb4-b44c-b50624537f99:indexpattern-datasource-layer-0f89b7b1-1727-4620-804c-73522cf15576",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "f93f861c-9f56-4814-97fd-86aa37c855bf:indexpattern-datasource-layer-271bea05-b2cb-4aea-af79-3342b29c0e08",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "979f25e8-475b-4509-8303-24d1043bc5d2:indexpattern-datasource-layer-8cf405fe-226a-4811-b487-793240216219",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "242dea05-0775-462f-ac25-aaaee8951cfc:indexpattern-datasource-layer-e5c4051e-cf18-4ee0-8a7b-559d38c8c844",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "25937e0e-f4ac-487c-94a1-b1dc5226b8b7:indexpattern-datasource-layer-8472c28f-df16-4a3d-8c27-8bfb6ddbb5f3",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "d96a9655-1883-4ae8-8522-667ddc56fb9f:indexpattern-datasource-layer-05ecac70-2127-4799-8c06-4720538ed52e",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "b6e60068-8359-404d-a3b7-f1bc69fdd34c:indexpattern-datasource-layer-74c9d698-e423-4ea8-a29d-cc30dd8aaddd",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "fc5d5001-be9e-4c19-bf5f-41808192c6c7:indexpattern-datasource-layer-8160efbe-6863-4d2c-8e64-af3f823f0b89",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "controlGroup_07e5bc41-06c9-480e-942f-4765110fbabe:optionsListDataView",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.2.0"
 }

--- a/packages/nginx_otel/kibana/dashboard/nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012.json
+++ b/packages/nginx_otel/kibana/dashboard/nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012.json
@@ -1,1768 +1,1768 @@
 {
-    "attributes": {
-        "description": "Traffic analysis, request patterns, and capacity planning for Nginx.",
-        "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {
-                "filter": [
-                    {
-                        "$state": {
-                            "store": "appState"
-                        },
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                            "key": "data_stream.dataset",
-                            "negate": false,
-                            "params": [
-                                "nginx.access.otel",
-                                "nginxreceiver.otel"
-                            ],
-                            "type": "phrases"
-                        },
-                        "query": {
-                            "bool": {
-                                "minimum_should_match": 1,
-                                "should": [
-                                    {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "nginx.access.otel"
-                                        }
-                                    },
-                                    {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "nginxreceiver.otel"
-                                        }
-                                    }
-                                ]
-                            }
-                        }
+  "attributes": {
+    "description": "Traffic analysis, request patterns, and capacity planning for Nginx.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [
+          {
+            "$state": {
+              "store": "appState"
+            },
+            "meta": {
+              "alias": null,
+              "disabled": false,
+              "field": "data_stream.dataset",
+              "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+              "key": "data_stream.dataset",
+              "negate": false,
+              "params": [
+                "nginx.access.otel",
+                "nginxreceiver.otel"
+              ],
+              "type": "phrases"
+            },
+            "query": {
+              "bool": {
+                "minimum_should_match": 1,
+                "should": [
+                  {
+                    "match_phrase": {
+                      "data_stream.dataset": "nginx.access.otel"
                     }
-                ],
-                "query": {
-                    "language": "kuery",
-                    "query": ""
-                }
+                  },
+                  {
+                    "match_phrase": {
+                      "data_stream.dataset": "nginxreceiver.otel"
+                    }
+                  }
+                ]
+              }
             }
-        },
-        "optionsJSON": {
-            "hidePanelTitles": false,
-            "syncColors": true,
-            "syncCursor": true,
-            "syncTooltips": false,
-            "useMargins": true
-        },
-        "panelsJSON": [
-            {
-                "embeddableConfig": {
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "**[Request Health](/app/dashboards#/view/nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890)** | **[Server Internals](/app/dashboards#/view/nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901)** | **[Traffic & Capacity](/app/dashboards#/view/nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012)**",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    },
-                    "hidePanelTitles": true
-                },
-                "gridData": {
-                    "h": 3,
-                    "w": 48,
-                    "x": 0,
-                    "y": 0,
-                    "i": "d4d496c3-fb2c-4901-ad5c-5be618412cf5"
-                },
-                "panelIndex": "d4d496c3-fb2c-4901-ad5c-5be618412cf5",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "## Traffic & Capacity\n\nAnalyze NGINX traffic patterns and plan for capacity.\n\n- **Status codes**: Response code distribution over time\n- **Top URLs**: Busiest endpoints with error counts\n- **Top clients**: Highest-volume source IPs\n- **HTTP methods & versions**: Request method and protocol mix\n- **Capacity metrics**: Active connections, requests, and throughput trends",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    },
-                    "hidePanelTitles": true
-                },
-                "gridData": {
-                    "h": 15,
-                    "w": 16,
-                    "x": 0,
-                    "y": 3,
-                    "i": "909060f1-eb4f-4ddc-abc5-da4af7438ced"
-                },
-                "panelIndex": "909060f1-eb4f-4ddc-abc5-da4af7438ced",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-40fe387e-0718-4e8f-9791-6ad142985be4",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "40fe387e-0718-4e8f-9791-6ad142985be4": {
-                                            "columnOrder": [
-                                                "8ddbd58c-2cc2-414a-b0c5-a4ee32fc5137",
-                                                "d7fd291e-e7ee-4254-8678-4c8d783bc9a3",
-                                                "7709125e-7e26-46db-96f7-2ce49e440112",
-                                                "db3d9038-2932-4eff-b414-dc88916cadef",
-                                                "886bedad-c0ab-4a3d-953e-48de6eba5cca"
-                                            ],
-                                            "columns": {
-                                                "8ddbd58c-2cc2-414a-b0c5-a4ee32fc5137": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "d7fd291e-e7ee-4254-8678-4c8d783bc9a3": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "2xx",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 200 AND attributes.http.response.status_code < 300"
-                                                    }
-                                                },
-                                                "7709125e-7e26-46db-96f7-2ce49e440112": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "3xx",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 300 AND attributes.http.response.status_code < 400"
-                                                    }
-                                                },
-                                                "db3d9038-2932-4eff-b414-dc88916cadef": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "4xx",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 400 AND attributes.http.response.status_code < 500"
-                                                    }
-                                                },
-                                                "886bedad-c0ab-4a3d-953e-48de6eba5cca": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "5xx",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 500"
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "d7fd291e-e7ee-4254-8678-4c8d783bc9a3",
-                                            "7709125e-7e26-46db-96f7-2ce49e440112",
-                                            "db3d9038-2932-4eff-b414-dc88916cadef",
-                                            "886bedad-c0ab-4a3d-953e-48de6eba5cca"
-                                        ],
-                                        "layerId": "40fe387e-0718-4e8f-9791-6ad142985be4",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_stacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "8ddbd58c-2cc2-414a-b0c5-a4ee32fc5137",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#54B399",
-                                                "forAccessor": "d7fd291e-e7ee-4254-8678-4c8d783bc9a3"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#6092C0",
-                                                "forAccessor": "7709125e-7e26-46db-96f7-2ce49e440112"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#F1D86F",
-                                                "forAccessor": "db3d9038-2932-4eff-b414-dc88916cadef"
-                                            },
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#E7664C",
-                                                "forAccessor": "886bedad-c0ab-4a3d-953e-48de6eba5cca"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Requests"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "w": 20,
-                    "x": 16,
-                    "y": 4,
-                    "i": "67fbb1a1-7da2-4bf4-a776-106e36e10cba"
-                },
-                "panelIndex": "67fbb1a1-7da2-4bf4-a776-106e36e10cba",
-                "title": "Requests by Status Code Over Time",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-cdd1a33f-d9c9-48ae-818e-c3b3488f0276",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "cdd1a33f-d9c9-48ae-818e-c3b3488f0276": {
-                                            "columnOrder": [
-                                                "50d28854-4d57-4462-8dad-320122a675f1",
-                                                "350ff3e4-aeb8-4405-8c75-ae2ab2448b81"
-                                            ],
-                                            "columns": {
-                                                "50d28854-4d57-4462-8dad-320122a675f1": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Status Code",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "350ff3e4-aeb8-4405-8c75-ae2ab2448b81"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.http.response.status_code"
-                                                },
-                                                "350ff3e4-aeb8-4405-8c75-ae2ab2448b81": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Requests",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "shape": "donut",
-                                "layers": [
-                                    {
-                                        "layerId": "cdd1a33f-d9c9-48ae-818e-c3b3488f0276",
-                                        "layerType": "data",
-                                        "primaryGroups": [
-                                            "50d28854-4d57-4462-8dad-320122a675f1"
-                                        ],
-                                        "metrics": [
-                                            "350ff3e4-aeb8-4405-8c75-ae2ab2448b81"
-                                        ],
-                                        "numberDisplay": "percent",
-                                        "categoryDisplay": "default",
-                                        "legendDisplay": "default",
-                                        "legendPosition": "right",
-                                        "nestedLegend": false,
-                                        "truncateLegend": true,
-                                        "percentDecimals": 1
-                                    }
-                                ]
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsPie"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "w": 12,
-                    "x": 36,
-                    "y": 4,
-                    "i": "01ea25ca-bfee-4d9e-b03d-2fe6dca27a7d"
-                },
-                "panelIndex": "01ea25ca-bfee-4d9e-b03d-2fe6dca27a7d",
-                "title": "Status Code Distribution",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-d06f6cdc-b47c-4ac3-93cb-01e6247acf6c",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "d06f6cdc-b47c-4ac3-93cb-01e6247acf6c": {
-                                            "columnOrder": [
-                                                "febc201a-d989-40be-8d9a-330f7f1cce2a",
-                                                "286fcdf5-2916-4f60-951d-8b79e2cf03f8",
-                                                "e5af91e2-6806-4553-9806-26fc8ec9432d"
-                                            ],
-                                            "columns": {
-                                                "febc201a-d989-40be-8d9a-330f7f1cce2a": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "URL Path",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "286fcdf5-2916-4f60-951d-8b79e2cf03f8"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 20
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.url.original"
-                                                },
-                                                "286fcdf5-2916-4f60-951d-8b79e2cf03f8": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Requests",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "e5af91e2-6806-4553-9806-26fc8ec9432d": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "5xx Errors",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "attributes.http.response.status_code >= 500"
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "layerId": "d06f6cdc-b47c-4ac3-93cb-01e6247acf6c",
-                                "layerType": "data",
-                                "columns": [
-                                    {
-                                        "columnId": "febc201a-d989-40be-8d9a-330f7f1cce2a",
-                                        "isTransposed": false,
-                                        "hidden": false,
-                                        "alignment": "left",
-                                        "colorMode": "none",
-                                        "width": 350
-                                    },
-                                    {
-                                        "columnId": "286fcdf5-2916-4f60-951d-8b79e2cf03f8",
-                                        "isTransposed": false,
-                                        "hidden": false,
-                                        "alignment": "right",
-                                        "colorMode": "none"
-                                    },
-                                    {
-                                        "columnId": "e5af91e2-6806-4553-9806-26fc8ec9432d",
-                                        "isTransposed": false,
-                                        "hidden": false,
-                                        "alignment": "right",
-                                        "colorMode": "cell"
-                                    }
-                                ],
-                                "headerRowHeight": "auto",
-                                "headerRowHeightLines": 1,
-                                "rowHeight": "auto",
-                                "rowHeightLines": 2,
-                                "paging": {
-                                    "size": 10,
-                                    "enabled": true
-                                }
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "w": 48,
-                    "x": 0,
-                    "y": 18,
-                    "i": "73ba8255-41d6-472e-9c8c-cbad3c47e49f"
-                },
-                "panelIndex": "73ba8255-41d6-472e-9c8c-cbad3c47e49f",
-                "title": "Top URLs by Request Count",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-8393de96-6bb5-47ea-8dad-f410b78889fa",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "8393de96-6bb5-47ea-8dad-f410b78889fa": {
-                                            "columnOrder": [
-                                                "6f92c588-fe46-44a6-b182-3af9c3060220",
-                                                "07c419ce-72da-41d4-acdb-0d68051ba4b7"
-                                            ],
-                                            "columns": {
-                                                "6f92c588-fe46-44a6-b182-3af9c3060220": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Client IP",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "07c419ce-72da-41d4-acdb-0d68051ba4b7"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.source.address"
-                                                },
-                                                "07c419ce-72da-41d4-acdb-0d68051ba4b7": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Requests",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "07c419ce-72da-41d4-acdb-0d68051ba4b7"
-                                        ],
-                                        "layerId": "8393de96-6bb5-47ea-8dad-f410b78889fa",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "xAccessor": "6f92c588-fe46-44a6-b182-3af9c3060220",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#6092C0",
-                                                "forAccessor": "07c419ce-72da-41d4-acdb-0d68051ba4b7"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "bottom"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "title": "",
-                                "valueLabels": "show",
-                                "yTitle": "Requests"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 0,
-                    "y": 32,
-                    "i": "4cb7bdc4-04cb-4055-a446-00f536d1ecbe"
-                },
-                "panelIndex": "4cb7bdc4-04cb-4055-a446-00f536d1ecbe",
-                "title": "Top Clients by Request Count",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-fc03c168-05e5-47d7-a9d1-0af707a4348c",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "fc03c168-05e5-47d7-a9d1-0af707a4348c": {
-                                            "columnOrder": [
-                                                "f5a951e4-2a43-4f79-9c88-a1fca1b1ac98",
-                                                "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8"
-                                            ],
-                                            "columns": {
-                                                "f5a951e4-2a43-4f79-9c88-a1fca1b1ac98": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "HTTP Method",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.http.request.method"
-                                                },
-                                                "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Requests",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8"
-                                        ],
-                                        "layerId": "fc03c168-05e5-47d7-a9d1-0af707a4348c",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "xAccessor": "f5a951e4-2a43-4f79-9c88-a1fca1b1ac98",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#54B399",
-                                                "forAccessor": "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "bottom"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "title": "",
-                                "valueLabels": "show",
-                                "yTitle": "Requests"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 24,
-                    "y": 32,
-                    "i": "e33d06c5-711e-43c0-9a1f-a96a52d25d66"
-                },
-                "panelIndex": "e33d06c5-711e-43c0-9a1f-a96a52d25d66",
-                "title": "Requests by HTTP Method",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-541ccc80-99b9-4cf2-a9f3-14f654783716",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "541ccc80-99b9-4cf2-a9f3-14f654783716": {
-                                            "columnOrder": [
-                                                "98b27a7a-48e5-4435-a326-888ae16f30ed",
-                                                "1af7c859-fdda-45d7-a5f6-bde9de515a2d"
-                                            ],
-                                            "columns": {
-                                                "98b27a7a-48e5-4435-a326-888ae16f30ed": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "User Agent",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "1af7c859-fdda-45d7-a5f6-bde9de515a2d"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.user_agent.name"
-                                                },
-                                                "1af7c859-fdda-45d7-a5f6-bde9de515a2d": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Requests",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "1af7c859-fdda-45d7-a5f6-bde9de515a2d"
-                                        ],
-                                        "layerId": "541ccc80-99b9-4cf2-a9f3-14f654783716",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "xAccessor": "98b27a7a-48e5-4435-a326-888ae16f30ed",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#D36086",
-                                                "forAccessor": "1af7c859-fdda-45d7-a5f6-bde9de515a2d"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "bottom"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "title": "",
-                                "valueLabels": "show",
-                                "yTitle": "Requests"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 0,
-                    "y": 44,
-                    "i": "494e2fe5-5443-4d7b-af31-ad4d6884a4b2"
-                },
-                "panelIndex": "494e2fe5-5443-4d7b-af31-ad4d6884a4b2",
-                "title": "Top User Agents",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-2b46c402-b5f3-40b7-baae-91c61cedf566",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "logs-*",
-                                    "layers": {
-                                        "2b46c402-b5f3-40b7-baae-91c61cedf566": {
-                                            "columnOrder": [
-                                                "f0972673-1031-4668-8dbf-de822f097c2b",
-                                                "9ce1b391-cd97-4be6-8d22-f1f848a636ea"
-                                            ],
-                                            "columns": {
-                                                "f0972673-1031-4668-8dbf-de822f097c2b": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "HTTP Version",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "type": "column",
-                                                            "columnId": "9ce1b391-cd97-4be6-8d22-f1f848a636ea"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "attributes.http.version"
-                                                },
-                                                "9ce1b391-cd97-4be6-8d22-f1f848a636ea": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Requests",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginx.access.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "9ce1b391-cd97-4be6-8d22-f1f848a636ea"
-                                        ],
-                                        "layerId": "2b46c402-b5f3-40b7-baae-91c61cedf566",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "xAccessor": "f0972673-1031-4668-8dbf-de822f097c2b",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#B9A888",
-                                                "forAccessor": "9ce1b391-cd97-4be6-8d22-f1f848a636ea"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "bottom"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "title": "",
-                                "valueLabels": "show",
-                                "yTitle": "Requests"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginx.access.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 12,
-                    "w": 24,
-                    "x": 24,
-                    "y": 44,
-                    "i": "1456b8fc-3140-4413-a9d5-c896cb83816a"
-                },
-                "panelIndex": "1456b8fc-3140-4413-a9d5-c896cb83816a",
-                "title": "Requests by HTTP Version",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-5d980795-abca-4b16-872b-15fd98ae9c6a",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "5d980795-abca-4b16-872b-15fd98ae9c6a": {
-                                            "columnOrder": [
-                                                "a509e4df-ad84-4977-ab68-19a8a1356194"
-                                            ],
-                                            "columns": {
-                                                "a509e4df-ad84-4977-ab68-19a8a1356194": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Active Connections",
-                                                    "operationType": "average",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_current",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "state: \"active\""
-                                                    }
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "layerId": "5d980795-abca-4b16-872b-15fd98ae9c6a",
-                                "layerType": "data",
-                                "metricAccessor": "a509e4df-ad84-4977-ab68-19a8a1356194",
-                                "subtitle": "Current",
-                                "color": "#6092C0"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 12,
-                    "x": 0,
-                    "y": 57,
-                    "i": "60a5ad7f-0e1a-4f7f-b563-3d056445799f"
-                },
-                "panelIndex": "60a5ad7f-0e1a-4f7f-b563-3d056445799f",
-                "title": "Active Connections",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-6de54442-a2d4-4708-92f2-6c752050ccd7",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "6de54442-a2d4-4708-92f2-6c752050ccd7": {
-                                            "columnOrder": [
-                                                "9b4b3a6a-afc1-40e8-becd-27b058830a47"
-                                            ],
-                                            "columns": {
-                                                "9b4b3a6a-afc1-40e8-becd-27b058830a47": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Total Requests",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.requests"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "layerId": "6de54442-a2d4-4708-92f2-6c752050ccd7",
-                                "layerType": "data",
-                                "metricAccessor": "9b4b3a6a-afc1-40e8-becd-27b058830a47",
-                                "subtitle": "Cumulative",
-                                "color": "#54B399"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 12,
-                    "x": 12,
-                    "y": 57,
-                    "i": "d85a1677-3752-4102-a8a9-6eb9d6cfcb0a"
-                },
-                "panelIndex": "d85a1677-3752-4102-a8a9-6eb9d6cfcb0a",
-                "title": "Total Requests",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-d1a22c3d-480c-4f0b-9d95-5344cb956c09",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "d1a22c3d-480c-4f0b-9d95-5344cb956c09": {
-                                            "columnOrder": [
-                                                "c65291e7-697f-4201-bef4-586cbc1ac1d9"
-                                            ],
-                                            "columns": {
-                                                "c65291e7-697f-4201-bef4-586cbc1ac1d9": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Total Accepted",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_accepted"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "layerId": "d1a22c3d-480c-4f0b-9d95-5344cb956c09",
-                                "layerType": "data",
-                                "metricAccessor": "c65291e7-697f-4201-bef4-586cbc1ac1d9",
-                                "subtitle": "Cumulative connections",
-                                "color": "#68bc00"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 12,
-                    "x": 24,
-                    "y": 57,
-                    "i": "b08782f3-85b1-4223-a64d-877f234115cf"
-                },
-                "panelIndex": "b08782f3-85b1-4223-a64d-877f234115cf",
-                "title": "Total Accepted",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-85fa3542-c02a-4c5e-8862-86ff0e0dedec",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "85fa3542-c02a-4c5e-8862-86ff0e0dedec": {
-                                            "columnOrder": [
-                                                "f7faf435-f470-4f91-9ff8-b118641c40f6"
-                                            ],
-                                            "columns": {
-                                                "f7faf435-f470-4f91-9ff8-b118641c40f6": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Total Handled",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.connections_handled"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "layerId": "85fa3542-c02a-4c5e-8862-86ff0e0dedec",
-                                "layerType": "data",
-                                "metricAccessor": "f7faf435-f470-4f91-9ff8-b118641c40f6",
-                                "subtitle": "Cumulative connections",
-                                "color": "#009ce0"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": true,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "w": 12,
-                    "x": 36,
-                    "y": 57,
-                    "i": "89ce4ea8-729c-4bd9-9201-df3d8d52f2ab"
-                },
-                "panelIndex": "89ce4ea8-729c-4bd9-9201-df3d8d52f2ab",
-                "title": "Total Handled",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-37957781-40af-4806-ab2f-716c309f5a7c",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "37957781-40af-4806-ab2f-716c309f5a7c": {
-                                            "columnOrder": [
-                                                "35b919dd-ab6f-4445-b457-10e967388f19",
-                                                "7739085e-db28-4cb6-8b50-b755d3f75afa",
-                                                "fecf8374-efd1-4cb1-8bb5-131f7b7a7e68"
-                                            ],
-                                            "columns": {
-                                                "35b919dd-ab6f-4445-b457-10e967388f19": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "7739085e-db28-4cb6-8b50-b755d3f75afa": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Max requests",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "nginx.requests"
-                                                },
-                                                "fecf8374-efd1-4cb1-8bb5-131f7b7a7e68": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Request rate",
-                                                    "operationType": "differences",
-                                                    "params": {},
-                                                    "references": [
-                                                        "7739085e-db28-4cb6-8b50-b755d3f75afa"
-                                                    ],
-                                                    "scale": "ratio"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset: nginxreceiver.otel"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "fecf8374-efd1-4cb1-8bb5-131f7b7a7e68"
-                                        ],
-                                        "layerId": "37957781-40af-4806-ab2f-716c309f5a7c",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "xAccessor": "35b919dd-ab6f-4445-b457-10e967388f19",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#54B399",
-                                                "forAccessor": "fecf8374-efd1-4cb1-8bb5-131f7b7a7e68"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendStats": [
-                                        "currentAndLastValue"
-                                    ],
-                                    "position": "bottom",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "area",
-                                "title": "",
-                                "valueLabels": "hide",
-                                "yTitle": "Requests / interval"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "filters": [],
-                    "hidePanelTitles": false,
-                    "query": {
-                        "language": "kuery",
-                        "query": "data_stream.dataset: nginxreceiver.otel"
-                    },
-                    "syncColors": true,
-                    "syncCursor": true,
-                    "syncTooltips": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "w": 48,
-                    "x": 0,
-                    "y": 63,
-                    "i": "dc94770b-1517-4f0f-b9fa-494bf2661429"
-                },
-                "panelIndex": "dc94770b-1517-4f0f-b9fa-494bf2661429",
-                "title": "Request Rate Trend",
-                "type": "lens"
-            }
+          }
         ],
-        "timeRestore": false,
-        "title": "[Nginx OTel] Traffic & Capacity",
-        "version": 3,
-        "controlGroupInput": {
-            "chainingSystem": "HIERARCHICAL",
-            "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
-            },
-            "panelsJSON": {
-                "f8cf6e8e-b7aa-4cf6-a4ad-1952e3847b1d": {
-                    "explicitInput": {
-                        "dataViewId": "logs-*",
-                        "fieldName": "host.name",
-                        "searchTechnique": "prefix",
-                        "selectedOptions": [],
-                        "singleSelect": true,
-                        "sort": {
-                            "by": "_count",
-                            "direction": "desc"
-                        },
-                        "title": "Nginx instance"
-                    },
-                    "grow": true,
-                    "order": 0,
-                    "type": "optionsListControl",
-                    "width": "medium"
-                }
-            },
-            "showApplySelections": false
+        "query": {
+          "language": "kuery",
+          "query": ""
         }
+      }
     },
-    "coreMigrationVersion": "8.8.0",
-    "id": "nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012",
-    "managed": false,
-    "references": [
-        {
-            "id": "logs-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
+    "optionsJSON": {
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": false,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "savedVis": {
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "filter": [],
+                "query": {
+                  "language": "kuery",
+                  "query": ""
+                }
+              }
+            },
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "markdown": "**[Request Health](/app/dashboards#/view/nginx_otel-a1b2c3d4-e5f6-7890-abcd-ef1234567890)** | **[Server Internals](/app/dashboards#/view/nginx_otel-b2c3d4e5-f6a7-8901-bcde-f12345678901)** | **[Traffic & Capacity](/app/dashboards#/view/nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012)**",
+              "openLinksInNewTab": false
+            },
+            "title": "",
+            "type": "markdown",
+            "uiState": {}
+          },
+          "hidePanelTitles": true
         },
-        {
-            "id": "logs-*",
-            "name": "67fbb1a1-7da2-4bf4-a776-106e36e10cba:indexpattern-datasource-layer-40fe387e-0718-4e8f-9791-6ad142985be4",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 3,
+          "w": 48,
+          "x": 0,
+          "y": 0,
+          "i": "d4d496c3-fb2c-4901-ad5c-5be618412cf5"
         },
-        {
-            "id": "logs-*",
-            "name": "01ea25ca-bfee-4d9e-b03d-2fe6dca27a7d:indexpattern-datasource-layer-cdd1a33f-d9c9-48ae-818e-c3b3488f0276",
-            "type": "index-pattern"
+        "panelIndex": "d4d496c3-fb2c-4901-ad5c-5be618412cf5",
+        "type": "visualization"
+      },
+      {
+        "embeddableConfig": {
+          "savedVis": {
+            "data": {
+              "aggs": [],
+              "searchSource": {
+                "filter": [],
+                "query": {
+                  "language": "kuery",
+                  "query": ""
+                }
+              }
+            },
+            "description": "",
+            "params": {
+              "fontSize": 12,
+              "markdown": "## Traffic & Capacity\n\nAnalyze NGINX traffic patterns and plan for capacity.\n\n- **Status codes**: Response code distribution over time\n- **Top URLs**: Busiest endpoints with error counts\n- **Top clients**: Highest-volume source IPs\n- **HTTP methods & versions**: Request method and protocol mix\n- **Capacity metrics**: Active connections, requests, and throughput trends",
+              "openLinksInNewTab": false
+            },
+            "title": "",
+            "type": "markdown",
+            "uiState": {}
+          },
+          "hidePanelTitles": true
         },
-        {
-            "id": "logs-*",
-            "name": "73ba8255-41d6-472e-9c8c-cbad3c47e49f:indexpattern-datasource-layer-d06f6cdc-b47c-4ac3-93cb-01e6247acf6c",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 15,
+          "w": 16,
+          "x": 0,
+          "y": 3,
+          "i": "909060f1-eb4f-4ddc-abc5-da4af7438ced"
         },
-        {
-            "id": "logs-*",
-            "name": "4cb7bdc4-04cb-4055-a446-00f536d1ecbe:indexpattern-datasource-layer-8393de96-6bb5-47ea-8dad-f410b78889fa",
-            "type": "index-pattern"
+        "panelIndex": "909060f1-eb4f-4ddc-abc5-da4af7438ced",
+        "type": "visualization"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-40fe387e-0718-4e8f-9791-6ad142985be4",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "40fe387e-0718-4e8f-9791-6ad142985be4": {
+                      "columnOrder": [
+                        "8ddbd58c-2cc2-414a-b0c5-a4ee32fc5137",
+                        "d7fd291e-e7ee-4254-8678-4c8d783bc9a3",
+                        "7709125e-7e26-46db-96f7-2ce49e440112",
+                        "db3d9038-2932-4eff-b414-dc88916cadef",
+                        "886bedad-c0ab-4a3d-953e-48de6eba5cca"
+                      ],
+                      "columns": {
+                        "8ddbd58c-2cc2-414a-b0c5-a4ee32fc5137": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "d7fd291e-e7ee-4254-8678-4c8d783bc9a3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "2xx",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 200 AND attributes.http.response.status_code < 300"
+                          }
+                        },
+                        "7709125e-7e26-46db-96f7-2ce49e440112": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "3xx",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 300 AND attributes.http.response.status_code < 400"
+                          }
+                        },
+                        "db3d9038-2932-4eff-b414-dc88916cadef": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "4xx",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 400 AND attributes.http.response.status_code < 500"
+                          }
+                        },
+                        "886bedad-c0ab-4a3d-953e-48de6eba5cca": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "5xx",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 500"
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "d7fd291e-e7ee-4254-8678-4c8d783bc9a3",
+                      "7709125e-7e26-46db-96f7-2ce49e440112",
+                      "db3d9038-2932-4eff-b414-dc88916cadef",
+                      "886bedad-c0ab-4a3d-953e-48de6eba5cca"
+                    ],
+                    "layerId": "40fe387e-0718-4e8f-9791-6ad142985be4",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_stacked",
+                    "showGridlines": false,
+                    "xAccessor": "8ddbd58c-2cc2-414a-b0c5-a4ee32fc5137",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#54B399",
+                        "forAccessor": "d7fd291e-e7ee-4254-8678-4c8d783bc9a3"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#6092C0",
+                        "forAccessor": "7709125e-7e26-46db-96f7-2ce49e440112"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#F1D86F",
+                        "forAccessor": "db3d9038-2932-4eff-b414-dc88916cadef"
+                      },
+                      {
+                        "axisMode": "left",
+                        "color": "#E7664C",
+                        "forAccessor": "886bedad-c0ab-4a3d-953e-48de6eba5cca"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "position": "right",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "bar_stacked",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Requests"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "logs-*",
-            "name": "e33d06c5-711e-43c0-9a1f-a96a52d25d66:indexpattern-datasource-layer-fc03c168-05e5-47d7-a9d1-0af707a4348c",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 14,
+          "w": 20,
+          "x": 16,
+          "y": 4,
+          "i": "67fbb1a1-7da2-4bf4-a776-106e36e10cba"
         },
-        {
-            "id": "logs-*",
-            "name": "494e2fe5-5443-4d7b-af31-ad4d6884a4b2:indexpattern-datasource-layer-541ccc80-99b9-4cf2-a9f3-14f654783716",
-            "type": "index-pattern"
+        "panelIndex": "67fbb1a1-7da2-4bf4-a776-106e36e10cba",
+        "title": "Requests by Status Code Over Time",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-cdd1a33f-d9c9-48ae-818e-c3b3488f0276",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "cdd1a33f-d9c9-48ae-818e-c3b3488f0276": {
+                      "columnOrder": [
+                        "50d28854-4d57-4462-8dad-320122a675f1",
+                        "350ff3e4-aeb8-4405-8c75-ae2ab2448b81"
+                      ],
+                      "columns": {
+                        "50d28854-4d57-4462-8dad-320122a675f1": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Status Code",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "350ff3e4-aeb8-4405-8c75-ae2ab2448b81"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.http.response.status_code"
+                        },
+                        "350ff3e4-aeb8-4405-8c75-ae2ab2448b81": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Requests",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "shape": "donut",
+                "layers": [
+                  {
+                    "layerId": "cdd1a33f-d9c9-48ae-818e-c3b3488f0276",
+                    "layerType": "data",
+                    "primaryGroups": [
+                      "50d28854-4d57-4462-8dad-320122a675f1"
+                    ],
+                    "metrics": [
+                      "350ff3e4-aeb8-4405-8c75-ae2ab2448b81"
+                    ],
+                    "numberDisplay": "percent",
+                    "categoryDisplay": "default",
+                    "legendDisplay": "default",
+                    "legendPosition": "right",
+                    "nestedLegend": false,
+                    "truncateLegend": true,
+                    "percentDecimals": 1
+                  }
+                ]
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsPie"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "logs-*",
-            "name": "1456b8fc-3140-4413-a9d5-c896cb83816a:indexpattern-datasource-layer-2b46c402-b5f3-40b7-baae-91c61cedf566",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 14,
+          "w": 12,
+          "x": 36,
+          "y": 4,
+          "i": "01ea25ca-bfee-4d9e-b03d-2fe6dca27a7d"
         },
-        {
-            "id": "metrics-*",
-            "name": "60a5ad7f-0e1a-4f7f-b563-3d056445799f:indexpattern-datasource-layer-5d980795-abca-4b16-872b-15fd98ae9c6a",
-            "type": "index-pattern"
+        "panelIndex": "01ea25ca-bfee-4d9e-b03d-2fe6dca27a7d",
+        "title": "Status Code Distribution",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-d06f6cdc-b47c-4ac3-93cb-01e6247acf6c",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "d06f6cdc-b47c-4ac3-93cb-01e6247acf6c": {
+                      "columnOrder": [
+                        "febc201a-d989-40be-8d9a-330f7f1cce2a",
+                        "286fcdf5-2916-4f60-951d-8b79e2cf03f8",
+                        "e5af91e2-6806-4553-9806-26fc8ec9432d"
+                      ],
+                      "columns": {
+                        "febc201a-d989-40be-8d9a-330f7f1cce2a": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "URL Path",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "286fcdf5-2916-4f60-951d-8b79e2cf03f8"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.url.original"
+                        },
+                        "286fcdf5-2916-4f60-951d-8b79e2cf03f8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Requests",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        },
+                        "e5af91e2-6806-4553-9806-26fc8ec9432d": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "5xx Errors",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "attributes.http.response.status_code >= 500"
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "layerId": "d06f6cdc-b47c-4ac3-93cb-01e6247acf6c",
+                "layerType": "data",
+                "columns": [
+                  {
+                    "columnId": "febc201a-d989-40be-8d9a-330f7f1cce2a",
+                    "isTransposed": false,
+                    "hidden": false,
+                    "alignment": "left",
+                    "colorMode": "none",
+                    "width": 350
+                  },
+                  {
+                    "columnId": "286fcdf5-2916-4f60-951d-8b79e2cf03f8",
+                    "isTransposed": false,
+                    "hidden": false,
+                    "alignment": "right",
+                    "colorMode": "none"
+                  },
+                  {
+                    "columnId": "e5af91e2-6806-4553-9806-26fc8ec9432d",
+                    "isTransposed": false,
+                    "hidden": false,
+                    "alignment": "right",
+                    "colorMode": "cell"
+                  }
+                ],
+                "headerRowHeight": "auto",
+                "headerRowHeightLines": 1,
+                "rowHeight": "auto",
+                "rowHeightLines": 2,
+                "paging": {
+                  "size": 10,
+                  "enabled": true
+                }
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsDatatable"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "d85a1677-3752-4102-a8a9-6eb9d6cfcb0a:indexpattern-datasource-layer-6de54442-a2d4-4708-92f2-6c752050ccd7",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 14,
+          "w": 48,
+          "x": 0,
+          "y": 18,
+          "i": "73ba8255-41d6-472e-9c8c-cbad3c47e49f"
         },
-        {
-            "id": "metrics-*",
-            "name": "b08782f3-85b1-4223-a64d-877f234115cf:indexpattern-datasource-layer-d1a22c3d-480c-4f0b-9d95-5344cb956c09",
-            "type": "index-pattern"
+        "panelIndex": "73ba8255-41d6-472e-9c8c-cbad3c47e49f",
+        "title": "Top URLs by Request Count",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-8393de96-6bb5-47ea-8dad-f410b78889fa",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "8393de96-6bb5-47ea-8dad-f410b78889fa": {
+                      "columnOrder": [
+                        "6f92c588-fe46-44a6-b182-3af9c3060220",
+                        "07c419ce-72da-41d4-acdb-0d68051ba4b7"
+                      ],
+                      "columns": {
+                        "6f92c588-fe46-44a6-b182-3af9c3060220": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "Client IP",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "07c419ce-72da-41d4-acdb-0d68051ba4b7"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.source.address"
+                        },
+                        "07c419ce-72da-41d4-acdb-0d68051ba4b7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Requests",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "07c419ce-72da-41d4-acdb-0d68051ba4b7"
+                    ],
+                    "layerId": "8393de96-6bb5-47ea-8dad-f410b78889fa",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "xAccessor": "6f92c588-fe46-44a6-b182-3af9c3060220",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#6092C0",
+                        "forAccessor": "07c419ce-72da-41d4-acdb-0d68051ba4b7"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "bottom"
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "title": "",
+                "valueLabels": "show",
+                "yTitle": "Requests"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "metrics-*",
-            "name": "89ce4ea8-729c-4bd9-9201-df3d8d52f2ab:indexpattern-datasource-layer-85fa3542-c02a-4c5e-8862-86ff0e0dedec",
-            "type": "index-pattern"
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 32,
+          "i": "4cb7bdc4-04cb-4055-a446-00f536d1ecbe"
         },
-        {
-            "id": "metrics-*",
-            "name": "dc94770b-1517-4f0f-b9fa-494bf2661429:indexpattern-datasource-layer-37957781-40af-4806-ab2f-716c309f5a7c",
-            "type": "index-pattern"
+        "panelIndex": "4cb7bdc4-04cb-4055-a446-00f536d1ecbe",
+        "title": "Top Clients by Request Count",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-fc03c168-05e5-47d7-a9d1-0af707a4348c",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "fc03c168-05e5-47d7-a9d1-0af707a4348c": {
+                      "columnOrder": [
+                        "f5a951e4-2a43-4f79-9c88-a1fca1b1ac98",
+                        "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8"
+                      ],
+                      "columns": {
+                        "f5a951e4-2a43-4f79-9c88-a1fca1b1ac98": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "HTTP Method",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.http.request.method"
+                        },
+                        "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Requests",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8"
+                    ],
+                    "layerId": "fc03c168-05e5-47d7-a9d1-0af707a4348c",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "xAccessor": "f5a951e4-2a43-4f79-9c88-a1fca1b1ac98",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#54B399",
+                        "forAccessor": "54532791-0d89-4a1d-ba3f-8ddf14bbd5e8"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "bottom"
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "title": "",
+                "valueLabels": "show",
+                "yTitle": "Requests"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
         },
-        {
-            "id": "logs-*",
-            "name": "controlGroup_f8cf6e8e-b7aa-4cf6-a4ad-1952e3847b1d:optionsListDataView",
-            "type": "index-pattern"
-        }
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 24,
+          "y": 32,
+          "i": "e33d06c5-711e-43c0-9a1f-a96a52d25d66"
+        },
+        "panelIndex": "e33d06c5-711e-43c0-9a1f-a96a52d25d66",
+        "title": "Requests by HTTP Method",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-541ccc80-99b9-4cf2-a9f3-14f654783716",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "541ccc80-99b9-4cf2-a9f3-14f654783716": {
+                      "columnOrder": [
+                        "98b27a7a-48e5-4435-a326-888ae16f30ed",
+                        "1af7c859-fdda-45d7-a5f6-bde9de515a2d"
+                      ],
+                      "columns": {
+                        "98b27a7a-48e5-4435-a326-888ae16f30ed": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "User Agent",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "1af7c859-fdda-45d7-a5f6-bde9de515a2d"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.user_agent.name"
+                        },
+                        "1af7c859-fdda-45d7-a5f6-bde9de515a2d": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Requests",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "1af7c859-fdda-45d7-a5f6-bde9de515a2d"
+                    ],
+                    "layerId": "541ccc80-99b9-4cf2-a9f3-14f654783716",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "xAccessor": "98b27a7a-48e5-4435-a326-888ae16f30ed",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#D36086",
+                        "forAccessor": "1af7c859-fdda-45d7-a5f6-bde9de515a2d"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "bottom"
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "title": "",
+                "valueLabels": "show",
+                "yTitle": "Requests"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 44,
+          "i": "494e2fe5-5443-4d7b-af31-ad4d6884a4b2"
+        },
+        "panelIndex": "494e2fe5-5443-4d7b-af31-ad4d6884a4b2",
+        "title": "Top User Agents",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "logs-*",
+                "name": "indexpattern-datasource-layer-2b46c402-b5f3-40b7-baae-91c61cedf566",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "logs-*",
+                  "layers": {
+                    "2b46c402-b5f3-40b7-baae-91c61cedf566": {
+                      "columnOrder": [
+                        "f0972673-1031-4668-8dbf-de822f097c2b",
+                        "9ce1b391-cd97-4be6-8d22-f1f848a636ea"
+                      ],
+                      "columns": {
+                        "f0972673-1031-4668-8dbf-de822f097c2b": {
+                          "customLabel": true,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "HTTP Version",
+                          "operationType": "terms",
+                          "params": {
+                            "exclude": [],
+                            "excludeIsRegex": false,
+                            "include": [],
+                            "includeIsRegex": false,
+                            "missingBucket": false,
+                            "orderBy": {
+                              "type": "column",
+                              "columnId": "9ce1b391-cd97-4be6-8d22-f1f848a636ea"
+                            },
+                            "orderDirection": "desc",
+                            "otherBucket": true,
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "scale": "ordinal",
+                          "sourceField": "attributes.http.version"
+                        },
+                        "9ce1b391-cd97-4be6-8d22-f1f848a636ea": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Requests",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "___records___"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "logs-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginx.access.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "9ce1b391-cd97-4be6-8d22-f1f848a636ea"
+                    ],
+                    "layerId": "2b46c402-b5f3-40b7-baae-91c61cedf566",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "bar_horizontal",
+                    "showGridlines": false,
+                    "xAccessor": "f0972673-1031-4668-8dbf-de822f097c2b",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#B9A888",
+                        "forAccessor": "9ce1b391-cd97-4be6-8d22-f1f848a636ea"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": false,
+                  "position": "bottom"
+                },
+                "preferredSeriesType": "bar_horizontal",
+                "title": "",
+                "valueLabels": "show",
+                "yTitle": "Requests"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginx.access.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 12,
+          "w": 24,
+          "x": 24,
+          "y": 44,
+          "i": "1456b8fc-3140-4413-a9d5-c896cb83816a"
+        },
+        "panelIndex": "1456b8fc-3140-4413-a9d5-c896cb83816a",
+        "title": "Requests by HTTP Version",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-5d980795-abca-4b16-872b-15fd98ae9c6a",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "5d980795-abca-4b16-872b-15fd98ae9c6a": {
+                      "columnOrder": [
+                        "a509e4df-ad84-4977-ab68-19a8a1356194"
+                      ],
+                      "columns": {
+                        "a509e4df-ad84-4977-ab68-19a8a1356194": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Active Connections",
+                          "operationType": "average",
+                          "params": {
+                            "emptyAsNull": true,
+                            "format": {
+                              "id": "number",
+                              "params": {
+                                "decimals": 0
+                              }
+                            }
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_current",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "state: \"active\""
+                          }
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "layerId": "5d980795-abca-4b16-872b-15fd98ae9c6a",
+                "layerType": "data",
+                "metricAccessor": "a509e4df-ad84-4977-ab68-19a8a1356194",
+                "subtitle": "Current",
+                "color": "#6092C0"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 6,
+          "w": 12,
+          "x": 0,
+          "y": 57,
+          "i": "60a5ad7f-0e1a-4f7f-b563-3d056445799f"
+        },
+        "panelIndex": "60a5ad7f-0e1a-4f7f-b563-3d056445799f",
+        "title": "Active Connections",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-6de54442-a2d4-4708-92f2-6c752050ccd7",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "6de54442-a2d4-4708-92f2-6c752050ccd7": {
+                      "columnOrder": [
+                        "9b4b3a6a-afc1-40e8-becd-27b058830a47"
+                      ],
+                      "columns": {
+                        "9b4b3a6a-afc1-40e8-becd-27b058830a47": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Requests",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.requests"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "layerId": "6de54442-a2d4-4708-92f2-6c752050ccd7",
+                "layerType": "data",
+                "metricAccessor": "9b4b3a6a-afc1-40e8-becd-27b058830a47",
+                "subtitle": "Cumulative",
+                "color": "#54B399"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 6,
+          "w": 12,
+          "x": 12,
+          "y": 57,
+          "i": "d85a1677-3752-4102-a8a9-6eb9d6cfcb0a"
+        },
+        "panelIndex": "d85a1677-3752-4102-a8a9-6eb9d6cfcb0a",
+        "title": "Total Requests",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-d1a22c3d-480c-4f0b-9d95-5344cb956c09",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "d1a22c3d-480c-4f0b-9d95-5344cb956c09": {
+                      "columnOrder": [
+                        "c65291e7-697f-4201-bef4-586cbc1ac1d9"
+                      ],
+                      "columns": {
+                        "c65291e7-697f-4201-bef4-586cbc1ac1d9": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Accepted",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_accepted"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "layerId": "d1a22c3d-480c-4f0b-9d95-5344cb956c09",
+                "layerType": "data",
+                "metricAccessor": "c65291e7-697f-4201-bef4-586cbc1ac1d9",
+                "subtitle": "Cumulative connections",
+                "color": "#68bc00"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 6,
+          "w": 12,
+          "x": 24,
+          "y": 57,
+          "i": "b08782f3-85b1-4223-a64d-877f234115cf"
+        },
+        "panelIndex": "b08782f3-85b1-4223-a64d-877f234115cf",
+        "title": "Total Accepted",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-85fa3542-c02a-4c5e-8862-86ff0e0dedec",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "85fa3542-c02a-4c5e-8862-86ff0e0dedec": {
+                      "columnOrder": [
+                        "f7faf435-f470-4f91-9ff8-b118641c40f6"
+                      ],
+                      "columns": {
+                        "f7faf435-f470-4f91-9ff8-b118641c40f6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Handled",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.connections_handled"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "layerId": "85fa3542-c02a-4c5e-8862-86ff0e0dedec",
+                "layerType": "data",
+                "metricAccessor": "f7faf435-f470-4f91-9ff8-b118641c40f6",
+                "subtitle": "Cumulative connections",
+                "color": "#009ce0"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsMetric"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": true,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 6,
+          "w": 12,
+          "x": 36,
+          "y": 57,
+          "i": "89ce4ea8-729c-4bd9-9201-df3d8d52f2ab"
+        },
+        "panelIndex": "89ce4ea8-729c-4bd9-9201-df3d8d52f2ab",
+        "title": "Total Handled",
+        "type": "lens"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "metrics-*",
+                "name": "indexpattern-datasource-layer-37957781-40af-4806-ab2f-716c309f5a7c",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "currentIndexPatternId": "metrics-*",
+                  "layers": {
+                    "37957781-40af-4806-ab2f-716c309f5a7c": {
+                      "columnOrder": [
+                        "35b919dd-ab6f-4445-b457-10e967388f19",
+                        "7739085e-db28-4cb6-8b50-b755d3f75afa",
+                        "fecf8374-efd1-4cb1-8bb5-131f7b7a7e68"
+                      ],
+                      "columns": {
+                        "35b919dd-ab6f-4445-b457-10e967388f19": {
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "@timestamp",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": true,
+                            "includeEmptyRows": true,
+                            "interval": "auto"
+                          },
+                          "scale": "interval",
+                          "sourceField": "@timestamp"
+                        },
+                        "7739085e-db28-4cb6-8b50-b755d3f75afa": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Max requests",
+                          "operationType": "max",
+                          "params": {
+                            "emptyAsNull": true
+                          },
+                          "scale": "ratio",
+                          "sourceField": "nginx.requests"
+                        },
+                        "fecf8374-efd1-4cb1-8bb5-131f7b7a7e68": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Request rate",
+                          "operationType": "differences",
+                          "params": {},
+                          "references": [
+                            "7739085e-db28-4cb6-8b50-b755d3f75afa"
+                          ],
+                          "scale": "ratio"
+                        }
+                      },
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": "data_stream.dataset: nginxreceiver.otel"
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "fecf8374-efd1-4cb1-8bb5-131f7b7a7e68"
+                    ],
+                    "layerId": "37957781-40af-4806-ab2f-716c309f5a7c",
+                    "layerType": "data",
+                    "position": "top",
+                    "seriesType": "area",
+                    "showGridlines": false,
+                    "xAccessor": "35b919dd-ab6f-4445-b457-10e967388f19",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "color": "#54B399",
+                        "forAccessor": "fecf8374-efd1-4cb1-8bb5-131f7b7a7e68"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "legendStats": [
+                    "currentAndLastValue"
+                  ],
+                  "position": "bottom",
+                  "showSingleSeries": true
+                },
+                "preferredSeriesType": "area",
+                "title": "",
+                "valueLabels": "hide",
+                "yTitle": "Requests / interval"
+              }
+            },
+            "title": "",
+            "type": "lens",
+            "visualizationType": "lnsXY"
+          },
+          "enhancements": {
+            "dynamicActions": {
+              "events": []
+            }
+          },
+          "filters": [],
+          "hidePanelTitles": false,
+          "query": {
+            "language": "kuery",
+            "query": "data_stream.dataset: nginxreceiver.otel"
+          },
+          "syncColors": true,
+          "syncCursor": true,
+          "syncTooltips": false
+        },
+        "gridData": {
+          "h": 14,
+          "w": 48,
+          "x": 0,
+          "y": 63,
+          "i": "dc94770b-1517-4f0f-b9fa-494bf2661429"
+        },
+        "panelIndex": "dc94770b-1517-4f0f-b9fa-494bf2661429",
+        "title": "Request Rate Trend",
+        "type": "lens"
+      }
     ],
-    "type": "dashboard",
-    "typeMigrationVersion": "10.2.0"
+    "timeRestore": false,
+    "title": "[Nginx OTel] Traffic & Capacity",
+    "version": 3,
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": {
+        "ignoreFilters": false,
+        "ignoreQuery": false,
+        "ignoreTimerange": false,
+        "ignoreValidations": false
+      },
+      "panelsJSON": {
+        "f8cf6e8e-b7aa-4cf6-a4ad-1952e3847b1d": {
+          "explicitInput": {
+            "dataViewId": "logs-*",
+            "fieldName": "host.name",
+            "searchTechnique": "prefix",
+            "selectedOptions": [],
+            "singleSelect": true,
+            "sort": {
+              "by": "_count",
+              "direction": "desc"
+            },
+            "title": "Nginx instance"
+          },
+          "grow": true,
+          "order": 0,
+          "type": "optionsListControl",
+          "width": "medium"
+        }
+      },
+      "showApplySelections": false
+    }
+  },
+  "coreMigrationVersion": "8.8.0",
+  "id": "nginx_otel-c3d4e5f6-a7b8-9012-cdef-123456789012",
+  "managed": false,
+  "references": [
+    {
+      "id": "logs-*",
+      "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "67fbb1a1-7da2-4bf4-a776-106e36e10cba:indexpattern-datasource-layer-40fe387e-0718-4e8f-9791-6ad142985be4",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "01ea25ca-bfee-4d9e-b03d-2fe6dca27a7d:indexpattern-datasource-layer-cdd1a33f-d9c9-48ae-818e-c3b3488f0276",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "73ba8255-41d6-472e-9c8c-cbad3c47e49f:indexpattern-datasource-layer-d06f6cdc-b47c-4ac3-93cb-01e6247acf6c",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "4cb7bdc4-04cb-4055-a446-00f536d1ecbe:indexpattern-datasource-layer-8393de96-6bb5-47ea-8dad-f410b78889fa",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "e33d06c5-711e-43c0-9a1f-a96a52d25d66:indexpattern-datasource-layer-fc03c168-05e5-47d7-a9d1-0af707a4348c",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "494e2fe5-5443-4d7b-af31-ad4d6884a4b2:indexpattern-datasource-layer-541ccc80-99b9-4cf2-a9f3-14f654783716",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "1456b8fc-3140-4413-a9d5-c896cb83816a:indexpattern-datasource-layer-2b46c402-b5f3-40b7-baae-91c61cedf566",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "60a5ad7f-0e1a-4f7f-b563-3d056445799f:indexpattern-datasource-layer-5d980795-abca-4b16-872b-15fd98ae9c6a",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "d85a1677-3752-4102-a8a9-6eb9d6cfcb0a:indexpattern-datasource-layer-6de54442-a2d4-4708-92f2-6c752050ccd7",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "b08782f3-85b1-4223-a64d-877f234115cf:indexpattern-datasource-layer-d1a22c3d-480c-4f0b-9d95-5344cb956c09",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "89ce4ea8-729c-4bd9-9201-df3d8d52f2ab:indexpattern-datasource-layer-85fa3542-c02a-4c5e-8862-86ff0e0dedec",
+      "type": "index-pattern"
+    },
+    {
+      "id": "metrics-*",
+      "name": "dc94770b-1517-4f0f-b9fa-494bf2661429:indexpattern-datasource-layer-37957781-40af-4806-ab2f-716c309f5a7c",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logs-*",
+      "name": "controlGroup_f8cf6e8e-b7aa-4cf6-a4ad-1952e3847b1d:optionsListDataView",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "10.2.0"
 }


### PR DESCRIPTION
## Summary
- normalize generated OTel dashboard JSON files by unstringifying embedded JSON blobs
- keep this PR strictly JSON-only (no YAML or compiler-behavior changes)
- make follow-up compiler-upgrade diffs easier to review by reducing string-encoded payload noise

this will be the new behavior of the compiler starting in 0.3.2 when `--format` is set to `elastic-integrations`

## Test plan
- [x] Cherry-picked only the JSON normalization commit onto a clean branch from `main`
- [x] Verified PR diff contains only files under `packages/*_otel/kibana/dashboard/*.json`
- [x] Verified branch contains a single commit


Made with [Cursor](https://cursor.com)