### PR TITLE
Update YAML dashboard validation docs/workflow for kb-dashboard 0.4.1

### DIFF
--- a/.github/workflows/validate-yaml-dashboards.requirements.txt
+++ b/.github/workflows/validate-yaml-dashboards.requirements.txt
@@ -1,2 +1,2 @@
-kb-dashboard-cli==0.4.0 --hash=sha256:4e79c3ee94f779fd4d573b0ffbd0454b13d3f14ec6b4269a5e588cc453848c8b
-kb-dashboard-lint==0.4.0 --hash=sha256:96ce1dfb895fcbc853a2e0726a3d9192273c071a09a5d63e0b951fa252859f70
+kb-dashboard-cli==0.4.1 --hash=sha256:dc35aec2dea9370b1597d0b1d6545d55aaf4aaf5bd5fe49fecde91570a95465a
+kb-dashboard-lint==0.4.1 --hash=sha256:8cf3b3129f1ae174f37d6c9a55be895ed1afe255e07cbc7ba6289793f527bb3b

--- a/.github/workflows/validate-yaml-dashboards.yml
+++ b/.github/workflows/validate-yaml-dashboards.yml
@@ -84,12 +84,12 @@ jobs:
             
             # First, show all linting results (warnings, info, errors)
             echo "Linting results:"
-            uvx --with-requirements "$KB_DASHBOARD_REQUIREMENTS" --from kb-dashboard-lint==0.4.0 kb-dashboard-lint check \
+            uvx --with-requirements "$KB_DASHBOARD_REQUIREMENTS" --from kb-dashboard-lint==0.4.1 kb-dashboard-lint check \
                 --input-file "$yaml_file" || true
             echo ""
             
             # Then check specifically for warnings/errors (this will exit non-zero on warnings or errors)
-            if ! uvx --with-requirements "$KB_DASHBOARD_REQUIREMENTS" --from kb-dashboard-lint==0.4.0 kb-dashboard-lint check \
+            if ! uvx --with-requirements "$KB_DASHBOARD_REQUIREMENTS" --from kb-dashboard-lint==0.4.1 kb-dashboard-lint check \
                 --input-file "$yaml_file" \
                 --severity-threshold warning > /dev/null 2>&1; then
               echo "❌ ERROR: Linting found warnings or errors in $yaml_file"
@@ -129,11 +129,11 @@ jobs:
             echo "Checking schema upgrade requirements: $yaml_file"
             echo "=========================================="
             
-            if ! uvx --with-requirements "$KB_DASHBOARD_REQUIREMENTS" --from kb-dashboard-cli==0.4.0 kb-dashboard upgrade \
+            if ! uvx --with-requirements "$KB_DASHBOARD_REQUIREMENTS" --from kb-dashboard-cli==0.4.1 kb-dashboard upgrade \
                 --input-file "$yaml_file" \
                 --fail-on-change > /dev/null 2>&1; then
               echo "❌ ERROR: $yaml_file requires schema upgrade. Run:"
-              echo "  uvx --with-requirements $KB_DASHBOARD_REQUIREMENTS --from kb-dashboard-cli==0.4.0 kb-dashboard upgrade --input-file $yaml_file --write"
+              echo "  uvx --with-requirements $KB_DASHBOARD_REQUIREMENTS --from kb-dashboard-cli==0.4.1 kb-dashboard upgrade --input-file $yaml_file --write"
               UPGRADE_FAILED=1
             else
               echo "✅ No schema upgrade required for $yaml_file"
@@ -179,7 +179,7 @@ jobs:
             # (capped at 125). It only checks files produced by the compiler, so
             # non-compiled (pre-existing) JSON dashboards are ignored.
             set +e
-            uvx --with-requirements "$KB_DASHBOARD_REQUIREMENTS" --from kb-dashboard-cli==0.4.0 kb-dashboard compile \
+            uvx --with-requirements "$KB_DASHBOARD_REQUIREMENTS" --from kb-dashboard-cli==0.4.1 kb-dashboard compile \
                 --input-dir "$input_dir" \
                 --output-dir "$output_dir" \
                 --format elastic-integrations \
@@ -198,7 +198,7 @@ jobs:
               echo ""
               echo "The YAML source and committed JSON are out of sync."
               echo "Please recompile with:"
-              echo "  uvx --with-requirements $KB_DASHBOARD_REQUIREMENTS --from kb-dashboard-cli==0.4.0 kb-dashboard compile --input-dir $input_dir --output-dir $output_dir --format elastic-integrations"
+              echo "  uvx --with-requirements $KB_DASHBOARD_REQUIREMENTS --from kb-dashboard-cli==0.4.1 kb-dashboard compile --input-dir $input_dir --output-dir $output_dir --format elastic-integrations"
               echo ""
               VALIDATION_FAILED=1
             fi

--- a/docs/yaml_dashboards.md
+++ b/docs/yaml_dashboards.md
@@ -45,10 +45,10 @@ The compiler is distributed as a Python package and runs using [uv](https://gith
 REQS=.github/workflows/validate-yaml-dashboards.requirements.txt
 
 # Compile dashboards (no persistent install needed)
-uvx --with-requirements "$REQS" --from kb-dashboard-cli==0.4.0 kb-dashboard compile --help
+uvx --with-requirements "$REQS" --from kb-dashboard-cli==0.4.1 kb-dashboard compile --help
 
 # Lint dashboards
-uvx --with-requirements "$REQS" --from kb-dashboard-lint==0.4.0 kb-dashboard-lint check --help
+uvx --with-requirements "$REQS" --from kb-dashboard-lint==0.4.1 kb-dashboard-lint check --help
 ```
 
 The pinned package hashes live in `.github/workflows/validate-yaml-dashboards.requirements.txt`. Keep this file updated when bumping compiler versions.
@@ -59,12 +59,12 @@ If you are migrating older YAML dashboards from `0.2.7`, use the built-in upgrad
 REQS=.github/workflows/validate-yaml-dashboards.requirements.txt
 
 # Check if upgrades are needed (no files written)
-uvx --with-requirements "$REQS" --from kb-dashboard-cli==0.4.0 kb-dashboard upgrade \
+uvx --with-requirements "$REQS" --from kb-dashboard-cli==0.4.1 kb-dashboard upgrade \
     --input-dir _dev/shared/kibana \
     --fail-on-change
 
 # Apply upgrades in place
-uvx --with-requirements "$REQS" --from kb-dashboard-cli==0.4.0 kb-dashboard upgrade \
+uvx --with-requirements "$REQS" --from kb-dashboard-cli==0.4.1 kb-dashboard upgrade \
     --input-dir _dev/shared/kibana \
     --write
 ```
@@ -123,11 +123,11 @@ cd packages/my_package
 REQS=../../.github/workflows/validate-yaml-dashboards.requirements.txt
 
 # Lint the YAML
-uvx --with-requirements "$REQS" --from kb-dashboard-lint==0.4.0 kb-dashboard-lint check \
+uvx --with-requirements "$REQS" --from kb-dashboard-lint==0.4.1 kb-dashboard-lint check \
     --input-file _dev/shared/kibana/overview.yaml
 
 # Compile YAML to Elastic integration JSON
-uvx --with-requirements "$REQS" --from kb-dashboard-cli==0.4.0 kb-dashboard compile \
+uvx --with-requirements "$REQS" --from kb-dashboard-cli==0.4.1 kb-dashboard compile \
     --input-dir _dev/shared/kibana \
     --output-dir kibana/dashboard \
     --format "elastic-integrations"
@@ -147,16 +147,16 @@ The compiler bundles all schema documentation, examples, and workflow guides. Us
 
 ```bash
 # Output the complete documentation (schema, examples, style guides) to stdout
-uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.0 kb-dashboard docs llms-full
+uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.1 kb-dashboard docs llms-full
 
 # Copy to clipboard (macOS)
-uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.0 kb-dashboard docs llms-full | pbcopy
+uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.1 kb-dashboard docs llms-full | pbcopy
 
 # List available workflow guides
-uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.0 kb-dashboard docs list-guides
+uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.1 kb-dashboard docs list-guides
 
 # Output a specific guide
-uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.0 kb-dashboard docs guide dashboard-style-guide
+uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.1 kb-dashboard docs guide dashboard-style-guide
 ```
 
 Feed the `llms-full` output to the LLM as context. It contains the full schema reference, panel type documentation, complete examples, and workflow guides. Run `kb-dashboard docs list-guides` to see all available guides. Currently bundled guides include:
@@ -207,13 +207,13 @@ After the LLM produces a YAML file:
 1. **Lint it** to catch schema issues:
 
    ```bash
-   uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-lint==0.4.0 kb-dashboard-lint check --input-file dashboard.yaml
+   uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-lint==0.4.1 kb-dashboard-lint check --input-file dashboard.yaml
    ```
 
 2. **Compile it** to verify it produces valid integration JSON:
 
    ```bash
-   uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.0 kb-dashboard compile \
+   uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.1 kb-dashboard compile \
        --input-file dashboard.yaml \
        --output-dir /tmp/output \
        --format "elastic-integrations"
@@ -222,7 +222,7 @@ After the LLM produces a YAML file:
 3. If you have kibana running, you can **Upload it** to your running Kibana instance to visually verify:
 
    ```bash
-   uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.0 kb-dashboard compile \
+   uvx --with-requirements .github/workflows/validate-yaml-dashboards.requirements.txt --from kb-dashboard-cli==0.4.1 kb-dashboard compile \
        --input-file dashboard.yaml \
        --upload \
        --kibana-url http://localhost:5601 \


### PR DESCRIPTION
## Summary
- bump YAML dashboard tool pins to `kb-dashboard-cli==0.4.1` and `kb-dashboard-lint==0.4.1`, including updated SHA256 hashes in `.github/workflows/validate-yaml-dashboards.requirements.txt`