### PR TITLE
[ci] Add blocking PR check for package docs using docs-builder

### DIFF
--- a/.github/workflows/validate-package-docs.yml
+++ b/.github/workflows/validate-package-docs.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'packages/**/docs/*.md'
+      - 'packages/*/docs/*.md'
+      - 'packages/*/*/docs/*.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate-package-docs.yml` — a new blocking PR check that runs `elastic/docs-builder` (metadata-only + strict mode) against any `packages/**/docs/*.md` files changed in a PR
- Generates a temporary `docset.yml` at the repo root listing only the changed files, so no static manifest needs to be maintained
- Excludes `_dev/build/` paths (those contain `{{ fields }}` template syntax not valid for docs-builder)
- Exits early if no package docs changed, so unrelated PRs pay zero cost

## Why

Vale linting already runs but is non-blocking (`fail_on_error: false`). Badly formatted Markdown or invalid docs-builder directives can slip into `packages/*/docs/README.md` files and break downstream consumers (EPR / `integration-docs` repo) silently. This check catches those issues at PR time.

## Test plan

- [ ] Open a PR modifying a `packages/*/docs/README.md` with intentionally broken Markdown — confirm `Validate Package Docs (docs-builder)` check appears and fails
- [ ] Fix the Markdown — confirm the check passes
- [ ] Open a PR touching only non-docs files — confirm the check is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)