### PR TITLE
[Filestream] Use the `logs.ecs` index instead of `logs`

### DIFF
--- a/packages/filestream/agent/input/filestream.yml.hbs
+++ b/packages/filestream/agent/input/filestream.yml.hbs
@@ -1,5 +1,5 @@
 {{#if use_logs_stream}}
-index: logs
+index: logs.ecs
 {{else}}
 
 data_stream:

--- a/packages/filestream/changelog.yml
+++ b/packages/filestream/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.0"
+  changes:
+    - description: 'Use the `logs.ecs` index instead of `logs` when "Use logs data stream" is enabled.'
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/17909
 - version: "2.3.3"
   changes:
     - description: Remove duplicated ECS mappings from package template

--- a/packages/filestream/manifest.yml
+++ b/packages/filestream/manifest.yml
@@ -3,10 +3,10 @@ name: filestream
 title: Custom Logs (Filestream)
 description: Collect log data using filestream with Elastic Agent.
 type: input
-version: 2.3.3
+version: 2.4.0
 conditions:
   kibana:
-    version: "^9.2.0"
+    version: "^9.4.0"
 categories:
   - custom
   - custom_logs
@@ -40,9 +40,9 @@ policy_templates:
           When enabled, filestream will decompress GZIP-compressed files (.gz) as they are read. For full details, see the [documentation](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files). If enabled, you **must** also remove the '\.gz$' pattern from the "Exclude Files" setting to ensure `.gz` files are ingested. Available for Elastic Agent 9.2.0 in beta and for Elastic Agent 9.3.0 or newer in GA.
       - name: use_logs_stream
         type: bool
-        title: Use the "logs" data stream
+        title: Use the "logs.ecs" data stream
         description: |
-          When enabled, data ingested by this integration is written to the "logs" data stream. **The 'Ingest Pipeline' and the configured 'Dataset name' are ignored**. You also need to [Turn on wired streams](https://www.elastic.co/docs/solutions/observability/streams/wired-streams#streams-wired-streams-enable) in Streams [Settings](/app/streams) and to enable **Allow agents to write to Streams** for the output policy in the Fleet [Settings](/app/fleet/settings) tab. [Learn more](https://www.elastic.co/docs/solutions/observability/streams/wired-streams).
+          When enabled, data ingested by this integration is written to the "logs.ecs" data stream. **The 'Ingest Pipeline' and the configured 'Dataset name' are ignored**. You also need to [Turn on wired streams](https://www.elastic.co/docs/solutions/observability/streams/wired-streams#streams-wired-streams-enable) in Streams [Settings](/app/streams) and to enable **Allow agents to write to Streams** for the output policy in the Fleet [Settings](/app/fleet/settings) tab. [Learn more](https://www.elastic.co/docs/solutions/observability/streams/wired-streams).
         required: false
         show_user: true
         default: false


### PR DESCRIPTION
## Proposed commit message

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

1. Built this altered integration package with `elastic-package build`
2. Then run the registry with `elastic-package stack up --version 9.4.0-SNAPSHOT`
3. Create an agent policy with the altered integration (note `2.4.0` version):

<img width="1157" height="466" alt="Screenshot 2026-03-19 at 17 34 24" src="https://github.com/user-attachments/assets/58ba8e08-62eb-4af3-b714-5ee508e86306" />
<img width="768" height="689" alt="Screenshot 2026-03-19 at 17 36 41" src="https://github.com/user-attachments/assets/8443fcd9-fafc-47de-82f2-db8026f3ea16" />

4. Create a new Fleet output which is allowed to write to data streams:

<img width="1873" height="950" alt="Screenshot 2026-03-19 at 17 41 55" src="https://github.com/user-attachments/assets/1757309e-5159-4b92-8960-671d7a7ab429" />

5. Select this new output in the policy settings:

<img width="1671" height="946" alt="Screenshot 2026-03-19 at 18 02 34" src="https://github.com/user-attachments/assets/553a0d21-7193-44a6-92a0-bcd76bfaee23" />

6. Install an agent locally (I used 9.3.2, does not have to be 9.4.0): 

```sh
sudo ./elastic-agent install --develop
```

7. Enroll the installed agent with:

```sh
sudo elastic-development-agent enroll --url=https://fleet-server:8220 --enrollment-token=<token> --insecure
```

<img width="1821" height="953" alt="Screenshot 2026-03-19 at 17 51 20" src="https://github.com/user-attachments/assets/e47ecb8a-bc59-4d30-84cf-4398683e8f69" />

8. Check that the test logs got ingested into the `logs.ecs` index:

<img width="1903" height="951" alt="Screenshot 2026-03-19 at 17 52 00" src="https://github.com/user-attachments/assets/c2eb6837-734b-4c58-9d24-812d0383ce91" />
<img width="1917" height="951" alt="Screenshot 2026-03-19 at 17 52 48" src="https://github.com/user-attachments/assets/bc0d5259-0f9e-4560-9cdf-7996b9591707" />

We can also inspect the computed filestream configuration in the agent diagnostics:

beat-rendered-config.yml
```yaml
apm: {}
features:
    features:
        fqdn:
            enabled: false
inputs:
    - clean_inactive: -1
      file_identity:
        fingerprint: null
      id: filestream-filestream.filestream-546d6aa6-3510-4e7c-83fd-c9e8bf21155f
      index: logs.ecs
      paths:
        - /logs/*.log
      processors:
        - add_fields:
            fields:
                input_id: filestream-filestream-546d6aa6-3510-4e7c-83fd-c9e8bf21155f
            target: '@metadata'
        - add_fields:
            fields:
                dataset: filestream.filestream
                namespace: default
                type: logs
            target: data_stream
        - add_fields:
            fields:
                dataset: filestream.filestream
            target: event
        - add_fields:
            fields:
                stream_id: filestream-filestream.filestream-546d6aa6-3510-4e7c-83fd-c9e8bf21155f
            target: '@metadata'
        - add_fields:
            fields:
                id: 6335dc4d-c911-49cf-8ff7-9ff98f7ff161
                snapshot: false
                version: 9.3.2
            target: elastic_agent
        - add_fields:
            fields:
                id: 6335dc4d-c911-49cf-8ff7-9ff98f7ff161
            target: agent
      prospector:
        scanner:
            exclude_files:
                - \.gz$
            fingerprint:
                enabled: true
                length: 1024
                offset: 0
            recursive_glob: true
      type: filestream
outputs:
    elasticsearch:
        api_key: <REDACTED>
        bulk_max_size: 1600
        compression_level: 1
        hosts:
            - https://elasticsearch:9200
        idle_connection_timeout: 3s
        preset: balanced
        queue:
            mem:
                events: 3200
                flush:
                    min_events: 1600
                    timeout: 10s
        ssl:
            ca_trusted_fingerprint: <REDACTED>
            certificate: <REDACTED>
            certificate_authorities: []
        type: elasticsearch
        worker: 1
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/17664