### PR TITLE
fix(qualys_vmdr): use join for ID_SET in KB response error path

### DIFF
--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.17.1"
+  changes:
+    - description: Fix intermittent evaluation error in asset_host_detection when the knowledge base API response is missing expected ID values.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/17932
 - version: "6.17.0"
   changes:
     - description: Add navigation links across all dashboards.
@@ -24,7 +29,7 @@
       link: https://github.com/elastic/integrations/pull/16727
 - version: "6.14.1"
   changes:
-    - description: Update XSD schema name to match Host Detection API v5.0 response. 
+    - description: Update XSD schema name to match Host Detection API v5.0 response.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/16623
 - version: "6.14.0"

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/agent/stream/input.yml.hbs
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/agent/stream/input.yml.hbs
@@ -241,7 +241,7 @@ program: |
                       "events": [{
                         "message": {
                           "KNOWLEDGE_BASE": {
-                            "response_error": "response IDs values are missing: " + string(kb_body.?doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.ID_SET.orValue([])),
+                            "response_error": "response IDs values are missing: " + kb_body.?doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.ID_SET.orValue([]).join(" "),
                           },
                           "interval_start": state.interval.start,
                           "interval_id": state.interval.id,

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "6.17.0"
+version: "6.17.1"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
The CEL expression at line 244 calls string() on the result
of ID_SET.orValue([]) which is a list. When the knowledge
base API response is missing expected ID values, this path
triggers string(list) which has no overload.

Replace string() with join(" ") to properly convert the list
to a string for the error message
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

