### PR TITLE
docs: fix broken localhost links and "Datasream" typo in manifests

### DIFF
--- a/packages/istio/data_stream/access_logs/manifest.yml
+++ b/packages/istio/data_stream/access_logs/manifest.yml
@@ -31,7 +31,7 @@ streams:
         default: false
       - name: condition
         title: Condition
-        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](http://localhost:8000/guide/providers.html#kubernetes-provider) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
+        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](https://www.elastic.co/guide/en/fleet/current/kubernetes-provider.html) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
         type: text
         multi: false
         required: true

--- a/packages/istio/data_stream/proxy_metrics/manifest.yml
+++ b/packages/istio/data_stream/proxy_metrics/manifest.yml
@@ -33,7 +33,7 @@ streams:
           - /stats/prometheus
       - name: condition
         title: Condition
-        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](http://localhost:8000/guide/providers.html#kubernetes-provider) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
+        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](https://www.elastic.co/guide/en/fleet/current/kubernetes-provider.html) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
         type: text
         multi: false
         required: true

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -169,7 +169,7 @@ streams:
           #   key: value
       - name: data_stream.dataset
         type: text
-        title: 'Datasream Dataset name'
+        title: 'Data stream dataset name'
         description: Name of Datastream dataset
         multi: false
         default: prometheus.collector

--- a/packages/prometheus/data_stream/query/manifest.yml
+++ b/packages/prometheus/data_stream/query/manifest.yml
@@ -118,7 +118,7 @@ streams:
         default: false
       - name: data_stream.dataset
         type: text
-        title: 'Datasream Dataset name'
+        title: 'Data stream dataset name'
         description: Name of Datastream dataset
         multi: false
         default: prometheus.query

--- a/packages/prometheus/data_stream/remote_write/manifest.yml
+++ b/packages/prometheus/data_stream/remote_write/manifest.yml
@@ -91,7 +91,7 @@ streams:
         default: []
       - name: data_stream.dataset
         type: text
-        title: 'Datasream Dataset name'
+        title: 'Data stream dataset name'
         description: Name of Datastream dataset
         multi: false
         default: prometheus.remote_write

--- a/packages/swimlane/data_stream/swimlane_api/manifest.yml
+++ b/packages/swimlane/data_stream/swimlane_api/manifest.yml
@@ -42,7 +42,7 @@ streams:
         default: auto
       - name: condition
         title: Condition
-        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](http://localhost:8000/guide/providers.html#kubernetes-provider) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
+        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](https://www.elastic.co/guide/en/fleet/current/kubernetes-provider.html) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
         type: text
         multi: false
         required: false

--- a/packages/swimlane/data_stream/tenant_api/manifest.yml
+++ b/packages/swimlane/data_stream/tenant_api/manifest.yml
@@ -42,7 +42,7 @@ streams:
         default: auto
       - name: condition
         title: Condition
-        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](http://localhost:8000/guide/providers.html#kubernetes-provider) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
+        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](https://www.elastic.co/guide/en/fleet/current/kubernetes-provider.html) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
         type: text
         multi: false
         required: false

--- a/packages/swimlane/data_stream/turbine_api/manifest.yml
+++ b/packages/swimlane/data_stream/turbine_api/manifest.yml
@@ -42,7 +42,7 @@ streams:
         default: auto
       - name: condition
         title: Condition
-        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](http://localhost:8000/guide/providers.html#kubernetes-provider) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
+        description: Condition to filter when to apply this datastream. Refer to [Kubernetes provider](https://www.elastic.co/guide/en/fleet/current/kubernetes-provider.html) to find the available keys and to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.
         type: text
         multi: false
         required: false


### PR DESCRIPTION
Fix two families of user-facing text issues:

1. **Broken localhost links** (5 files): Replace `http://localhost:8000/guide/providers.html#kubernetes-provider` with the public docs URL `https://www.elastic.co/guide/en/fleet/current/kubernetes-provider.html` in Istio and Swimlane manifest descriptions.

2. **"Datasream" typo** (3 files): Fix `Datasream Dataset name` → `Data stream dataset name` in Prometheus manifest titles.

Closes #17969