### PR TITLE
[prisma_access] Add changelog and version bump for v1.7.0

### DIFF
--- a/packages/prisma_access/changelog.yml
+++ b/packages/prisma_access/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Remove agent-side replace processors for CEF hyphen workaround, reducing unnecessary allocations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/17986
 - version: "1.6.2"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/prisma_access/manifest.yml
+++ b/packages/prisma_access/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: prisma_access
 title: Palo Alto Prisma Access
-version: "1.6.2"
+version: "1.7.0"
 description: Collect logs from Palo Alto Prisma Access with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

## Proposed commit message

```
The changelog entry and version bump were omitted from #17986.
```

I had added the changelog entry, but failed to push it for the last PR. 🤕 

## Related issues

- Relates #17986