### PR TITLE
[UDP] Use the logs.ecs index instead of logs

### DIFF
--- a/packages/udp/agent/input/udp.yml.hbs
+++ b/packages/udp/agent/input/udp.yml.hbs
@@ -1,5 +1,5 @@
 {{#if use_logs_stream}}
-index: logs
+index: logs.ecs
 {{else}}
 data_stream:
   dataset: {{data_stream.dataset}}

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "2.5.0"
+  changes:
+    - description: 'Use the `logs.ecs` index instead of `logs` when "Use logs data stream" is enabled.'
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18017
 - version: "2.4.0"
   changes:
     - description: Improved documentation with detailed setup instructions, troubleshooting guidance, and knowledge base service info.

--- a/packages/udp/manifest.yml
+++ b/packages/udp/manifest.yml
@@ -3,10 +3,10 @@ name: udp
 title: Custom UDP Logs
 description: Collect raw UDP data from listening UDP port with Elastic Agent.
 type: input
-version: "2.4.0"
+version: "2.5.0"
 conditions:
   kibana:
-    version: "^9.2.0"
+    version: "^9.4.0"
 categories:
   - custom
   - custom_logs
@@ -40,7 +40,7 @@ policy_templates:
         type: bool
         title: Use the "logs" data stream
         description: |
-          Enabling this will send all the ingested data to the "logs" data stream. This feature requires Elasticsearch 9.2.0 or later and is disabled by default. If enabled the Dataset name option is ignored. "Write to logs streams" option must be enabled in the output settings for this to work.
+          Enabling this will send all the ingested data to the "logs.ecs" data stream. This feature requires Elasticsearch 9.4.0 or later and is disabled by default. If enabled the Dataset name option is ignored. "Write to logs streams" option must be enabled in the output settings for this to work.
         required: false
         show_user: true
         default: false


### PR DESCRIPTION
## Proposed commit message

Use the logs.ecs index instead of logs

When "Use logs data stream" is enabled, we now write to the `logs.ecs` data stream.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Built this altered integration package with `elastic-package build`
2. Then run the registry with `elastic-package stack up --version 9.4.0-SNAPSHOT`
3. Create an agent policy with the altered integration (note `2.5.0` version):

<img width="1656" height="466" alt="Screenshot 2026-03-24 at 15 28 31" src="https://github.com/user-attachments/assets/9cc1b5ea-890f-4bf1-a524-b916442cba2b" />
<img width="903" height="796" alt="Screenshot 2026-03-24 at 15 29 29" src="https://github.com/user-attachments/assets/0faecd43-df56-43b2-9be9-9b3772192494" />

4. Create a new Fleet output which is allowed to write to data streams:

<img width="1824" height="948" alt="Screenshot 2026-03-24 at 16 05 02" src="https://github.com/user-attachments/assets/30baeda7-bf74-4dd7-b4e8-9f9759d84987" />

5. Select this new output in the policy settings:

<img width="1828" height="950" alt="Screenshot 2026-03-24 at 16 05 49" src="https://github.com/user-attachments/assets/7708dbc6-a5d8-4898-b0c1-f65976c46b9b" />

7. Install an agent locally (I used 9.3.2, does not have to be 9.4.0): 

```sh
sudo ./elastic-agent install --develop
```

8. Enroll the installed agent with:

```sh
sudo elastic-development-agent enroll --url=https://fleet-server:8220 --enrollment-token=<token> --insecure
```

<img width="804" height="910" alt="Screenshot 2026-03-24 at 16 08 08" src="https://github.com/user-attachments/assets/509c9918-d450-4e76-9d9d-8f6bf55df425" />


9. Check that the test logs got ingested into the `logs.ecs` index:

First write to the UDP port:

```sh
echo -e "line one\nline two\nline three" | nc -u localhost 8989
```

Then check Discover:

<img width="1441" height="903" alt="Screenshot 2026-03-24 at 16 10 37" src="https://github.com/user-attachments/assets/e24bbfa9-736a-4219-835a-c4a8a5898529" />
<img width="1909" height="691" alt="Screenshot 2026-03-24 at 16 11 32" src="https://github.com/user-attachments/assets/85640dfb-ec33-49f6-8e10-ead5dc6dca91" />

We can also inspect the computed filestream configuration in the agent diagnostics:

beat-rendered-config.yml
```yaml
apm: {}
features:
    features:
        fqdn:
            enabled: false
inputs:
    - host: localhost:8989
      id: udp-udp.udp-3f2f43f9-7600-49eb-8ad1-ffbd6cb8947a
      index: logs.ecs
      max_message_size: 10KiB
      processors:
        - add_fields:
            fields:
                input_id: udp-udp-3f2f43f9-7600-49eb-8ad1-ffbd6cb8947a
            target: '@metadata'
        - add_fields:
            fields:
                dataset: udp.udp
                namespace: default
                type: logs
            target: data_stream
        - add_fields:
            fields:
                dataset: udp.udp
            target: event
        - add_fields:
            fields:
                stream_id: udp-udp.udp-3f2f43f9-7600-49eb-8ad1-ffbd6cb8947a
            target: '@metadata'
        - add_fields:
            fields:
                id: 0742a0f9-05b5-4e20-a609-2f42ba0688a4
                snapshot: false
                version: 9.3.2
            target: elastic_agent
        - add_fields:
            fields:
                id: 0742a0f9-05b5-4e20-a609-2f42ba0688a4
            target: agent
      type: udp
outputs:
    elasticsearch:
        api_key: <REDACTED>
        bulk_max_size: 1600
        compression_level: 1
        hosts:
            - https://elasticsearch:9200
        idle_connection_timeout: 3s
        preset: balanced
        queue:
            mem:
                events: 3200
                flush:
                    min_events: 1600
                    timeout: 10s
        ssl:
            ca_trusted_fingerprint: <REDACTED>
            certificate: <REDACTED>
            certificate_authorities: []
        type: elasticsearch
        worker: 1
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/17664