### PR TITLE
[TCP] Use the logs.ecs index instead of logs

### DIFF
--- a/packages/tcp/agent/input/tcp.yml.hbs
+++ b/packages/tcp/agent/input/tcp.yml.hbs
@@ -1,5 +1,5 @@
 {{#if use_logs_stream}}
-index: logs
+index: logs.ecs
 {{else}}
 data_stream:
   dataset: {{data_stream.dataset}}

--- a/packages/tcp/changelog.yml
+++ b/packages/tcp/changelog.yml
@@ -1,3 +1,8 @@
+- version: "2.3.0"
+  changes:
+    - description: 'Use the `logs.ecs` index instead of `logs` when "Use logs data stream" is enabled.'
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18018
 - version: "2.2.0"
   changes:
     - description: Update integration documentation.

--- a/packages/tcp/manifest.yml
+++ b/packages/tcp/manifest.yml
@@ -3,10 +3,10 @@ name: tcp
 title: Custom TCP Logs
 description: Collect raw TCP data from listening TCP port with Elastic Agent.
 type: input
-version: "2.2.0"
+version: "2.3.0"
 conditions:
   kibana:
-    version: "^9.2.0"
+    version: "^9.4.0"
 categories:
   - custom
   - custom_logs
@@ -38,7 +38,7 @@ policy_templates:
         type: bool
         title: Use the "logs" data stream
         description: |
-          Enabling this will send all the ingested data to the "logs" data stream. This feature requires Elasticsearch 9.2.0 or later and is disabled by default. If enabled the Dataset name option is ignored. "Write to logs streams" option must be enabled in the output settings for this to work.
+          Enabling this will send all the ingested data to the "logs.ecs" data stream. This feature requires Elasticsearch 9.4.0 or later and is disabled by default. If enabled the Dataset name option is ignored. "Write to logs streams" option must be enabled in the output settings for this to work.
         required: false
         show_user: true
         default: false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Use the logs.ecs index instead of logs

When "Use logs data stream" is enabled, we now write to the `logs.ecs` data stream.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
~~- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~~


## How to test this PR locally

1. Built this altered integration package with `elastic-package build`
2. Then run the registry with `elastic-package stack up --version 9.4.0-SNAPSHOT`
3. Create an agent policy with the altered integration (note `2.3.0` version):

<img width="1572" height="513" alt="Screenshot 2026-03-24 at 16 36 32" src="https://github.com/user-attachments/assets/8af3bbb8-2b71-4070-9305-4a5cd25b2d11" />
<img width="763" height="816" alt="Screenshot 2026-03-24 at 16 43 16" src="https://github.com/user-attachments/assets/ec0923a2-05d4-4101-8135-32708cb10f69" />

4. Create a new Fleet output which is allowed to write to data streams:

<img width="804" height="902" alt="Screenshot 2026-03-24 at 16 38 53" src="https://github.com/user-attachments/assets/aaa23373-ec27-4ea6-9017-34ba64dfe288" />


5. Select this new output in the policy settings:

<img width="1869" height="950" alt="Screenshot 2026-03-24 at 16 39 19" src="https://github.com/user-attachments/assets/dc5a29f9-28b3-4b4f-96a4-0ebb0460c58e" />

7. Install an agent locally (I used 9.3.2, does not have to be 9.4.0): 

```sh
sudo ./elastic-agent install --develop
```

8. Enroll the installed agent with:

```sh
sudo elastic-development-agent enroll --url=https://fleet-server:8220 --enrollment-token=<token> --insecure
```

9. Check that the test logs got ingested into the `logs.ecs` index:

First write to the TCP port:

```sh
echo -e "line one\nline two\nline three" | nc localhost 9696
```

Then check Discover:

<img width="1444" height="860" alt="Screenshot 2026-03-24 at 17 37 19" src="https://github.com/user-attachments/assets/04973508-3fd1-4157-bb70-6a3866ee72f3" />
<img width="1918" height="962" alt="Screenshot 2026-03-24 at 17 37 44" src="https://github.com/user-attachments/assets/9bb483a8-14c1-405b-8228-c043ec7ea93d" />

We can also inspect the computed filestream configuration in the agent diagnostics:

beat-rendered-config.yml
```yaml
apm: {}
features:
    features:
        fqdn:
            enabled: false
inputs:
    - host: localhost:9696
      id: tcp-tcp.tcp-d056d39c-a2f0-475c-b362-25af09abdd2e
      index: logs.ecs
      processors:
        - add_fields:
            fields:
                input_id: tcp-tcp-d056d39c-a2f0-475c-b362-25af09abdd2e
            target: '@metadata'
        - add_fields:
            fields:
                dataset: tcp.tcp
                namespace: default
                type: logs
            target: data_stream
        - add_fields:
            fields:
                dataset: tcp.tcp
            target: event
        - add_fields:
            fields:
                stream_id: tcp-tcp.tcp-d056d39c-a2f0-475c-b362-25af09abdd2e
            target: '@metadata'
        - add_fields:
            fields:
                id: af6f8b76-0783-4f60-a3e8-f7974fa84864
                snapshot: false
                version: 9.3.2
            target: elastic_agent
        - add_fields:
            fields:
                id: af6f8b76-0783-4f60-a3e8-f7974fa84864
            target: agent
      type: tcp
outputs:
    elasticsearch:
        api_key: <REDACTED>
        bulk_max_size: 1600
        compression_level: 1
        hosts:
            - https://elasticsearch:9200
        idle_connection_timeout: 3s
        preset: balanced
        queue:
            mem:
                events: 3200
                flush:
                    min_events: 1600
                    timeout: 10s
        ssl:
            ca_trusted_fingerprint: <REDACTED>
            certificate: <REDACTED>
            certificate_authorities: []
        type: elasticsearch
        worker: 1

```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/17664