### PR TITLE
[test] Validate package docs with isolated docs-builder

### DIFF
--- a/.github/workflows/validate-package-docs.yml
+++ b/.github/workflows/validate-package-docs.yml
@@ -22,8 +22,10 @@ jobs:
 
       - name: Find changed package docs
         id: changed-docs
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD \
+          FILES=$(git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD \
             | grep '^packages/.*/docs/[^/]*\.md$' \
             | grep -v '_dev/build/' || true)
           echo "files<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Reworked the `Validate Package Docs` workflow to run docs-builder in a fully isolated `.validate/` directory (with `git init`), preventing it from discovering `docs/docset.yml` or scanning unrelated repo markdown files
- Lowercases filenames before validation (docs-builder requirement)
- Includes `cross_links` in the generated docset (`beats`, `docs-content`, `ecs`, `elasticsearch`, `integrations`) so cross-repo references resolve correctly
- Uses `docker run` directly instead of the action, giving full control over the build context
- Adds test edits to `1password`, `nginx`, `aws` package docs to trigger the check

## Expected behavior

The `Validate Package Docs (docs-builder)` check should run against only the three changed package docs without errors from `docs/extend/` or other repo files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)