### PR TITLE
[test] Minor doc edits to test validate-package-docs workflow

### DIFF
--- a/packages/1password/docs/README.md
+++ b/packages/1password/docs/README.md
@@ -1,6 +1,6 @@
 # 1Password Events Reporting
 
-With [1Password Business](https://support.1password.com/explore/business/), you can send your account activity to your security information and event management (SIEM) system, using the 1Password Events API. 
+With [1Password Business](https://support.1password.com/explore/business/), you can send your account activity to your security information and event management (SIEM) system, using the 1Password Events API.
 
 Get reports about 1Password activity, such as sign-in attempts and item usage, while you manage all your company’s applications and services from a central location.
 

--- a/packages/nginx/docs/README.md
+++ b/packages/nginx/docs/README.md
@@ -1,6 +1,6 @@
 # Nginx Integration
 
-The Nginx integration allows you to monitor [Nginx](https://nginx.org/) servers. Time series [index mode](https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html) enabled for metrics data stream.
+The Nginx integration allows you to monitor [Nginx](https://nginx.org/) servers. Time series [index mode](https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html) is enabled for the metrics data stream.
 
 Use the Nginx integration to collect metrics and logs from your server.
 Then visualize that data in Kibana, use the Machine Learning app to find unusual activity in HTTP access logs,

--- a/packages/redis/docs/README.md
+++ b/packages/redis/docs/README.md
@@ -4,8 +4,7 @@ This integration periodically fetches logs and metrics from [Redis](https://redi
 
 ## Compatibility
 
-The `log` and `slowlog` datasets were tested with logs from Redis versions 1.2.6, 2.4.6, and 3.0.2, so we expect
-compatibility with any version 1.x, 2.x, or 3.x.
+The `log` and `slowlog` datasets were tested with logs from Redis versions 1.2.6, 2.4.6, and 3.0.2, so we expect compatibility with any version 1.x, 2.x, or 3.x.
 
 The `info`, `key` and `keyspace` datasets were tested with Redis 3.2.12, 4.0.11 and 5.0-rc4, and are expected to work
 with all versions `>= 3.0`.


### PR DESCRIPTION
## Summary

Trivial doc edits to 3 packages to test the `Validate Package Docs (docs-builder)` workflow:
- `1password`: trim trailing whitespace
- `nginx`: minor wording fix
- `redis`: unwrap line

## Expected

The `Validate Package Docs (docs-builder)` check should appear and run successfully against these 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)