### PR TITLE
Fix broken links and image paths in security-service-integrations docs

### DIFF
--- a/packages/azure_blob_storage/changelog.yml
+++ b/packages/azure_blob_storage/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "2.3.0"
   changes:
     - description: Add RBAC based authentication for azure blob storage input.

--- a/packages/azure_blob_storage/changelog.yml
+++ b/packages/azure_blob_storage/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "2.3.0"
   changes:
     - description: Add RBAC based authentication for azure blob storage input.

--- a/packages/azure_blob_storage/docs/README.md
+++ b/packages/azure_blob_storage/docs/README.md
@@ -23,4 +23,4 @@ Assuming you have Azure Blob Containers already set up and account credentials a
 This integration includes the ECS Dynamic Template, all fields that follow the ECS Schema will get assigned the correct index field mapping and do not need to be added manually.
 
 ## Ingest Pipelines
-Custom ingest pipelines may be added by adding the name to the pipeline configuration option, creating custom ingest pipelines can be done either through the API or the [Ingest Node Pipeline UI](/app/management/ingest/ingest_pipelines/).
+Custom ingest pipelines may be added by adding the name to the pipeline configuration option, creating custom ingest pipelines can be done either through the API or the [Ingest Node Pipeline UI](docs-content://reference/ingestion-tools/enrich-processor/ingest-pipelines.md).

--- a/packages/azure_blob_storage/manifest.yml
+++ b/packages/azure_blob_storage/manifest.yml
@@ -3,7 +3,7 @@ name: azure_blob_storage
 title: Custom Azure Blob Storage Input
 description: Collect log data from configured Azure Blob Storage Container with Elastic Agent.
 type: input
-version: "2.3.0"
+version: "2.3.1"
 conditions:
   kibana:
     version: "^8.16.0 || ^9.0.0"
@@ -123,6 +123,7 @@ policy_templates:
         title: Containers
         description: >
           This attribute contains the details about a specific container like, name, number_of_workers, poll, poll_interval etc. The attribute 'name' is specific to a container as it describes the container name, while the fields number_of_workers, poll, poll_interval can exist both at the container level and at the global level.  If you have already defined the attributes globally, then you can only specify the container name in this yaml config. If you want to override any specific attribute for a container, then, you can define it here. Any attribute defined in the yaml will override the global definitions.  Please see the relevant [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html#attrib-containers) for further information.
+
         required: true
         show_user: true
         default: |
@@ -144,6 +145,7 @@ policy_templates:
           # - regex: "event/"
         description: >
           If the container will have events that correspond to files that this integration shouldn’t process, file_selectors can be used to limit the files that are downloaded.  This is a list of selectors which is made up of regex patters. The regex should match the container filepath.  Regexes use [RE2 syntax](https://pkg.go.dev/regexp/syntax). Files that don’t match one of the regexes will not be processed.
+
       - name: timestamp_epoch
         type: integer
         title: Timestamp Epoch
@@ -158,6 +160,7 @@ policy_templates:
         show_user: false
         description: >
           If the file-set using this input expects to receive multiple messages bundled under a specific field or an array of objects then the config option for 'expand_event_list_from_field' can be specified. This setting will be able to split the messages under the group value into separate events. This can be specified at the global level or at the container level. For more info please refer to the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html#attrib-expand_event_list_from_field).
+
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/bitdefender/_dev/build/docs/README.md
+++ b/packages/bitdefender/_dev/build/docs/README.md
@@ -35,9 +35,9 @@ The integration can also collect the push notification configuration and statist
 3. Click on "BitDefender GravityZone" integration from the search results.
 4. Click on **Add BitDefender GravityZone** button to add BitDefender GravityZone integration.
 
-![Example Integration Configuration](../img/bitdefender-integration-configuration-1.png)
+![Example Integration Configuration](.../img/bitdefender-integration-configuration-1.png)
 
-![Example Integration Configuration](../img/bitdefender-integration-configuration-2.png)
+![Example Integration Configuration](.../img/bitdefender-integration-configuration-2.png)
 
 ### Create a BitDefender GravityZone API key that can configure a push notification service
 
@@ -49,21 +49,21 @@ Bear in mind the API key will be associated to the account you create it from. A
 
 Navigate to your account details within the GravityZone portal. If you have sufficient privileges you will see the "API keys" section near the bottom of the page. Click "Add" here.
 
-![Example Configuration 1](../img/bitdefender-gravityzone-api-key-1.png)
+![Example Configuration 1](.../img/bitdefender-gravityzone-api-key-1.png)
 
 Give the API key a description and tick the "Event Push Service API" box at minimum.
 
 NOTE: If you intend to use the API key for other API calls you may need to tick other boxes.
 
-![Example Configuration 2](../img/bitdefender-gravityzone-api-key-2.png)
+![Example Configuration 2](.../img/bitdefender-gravityzone-api-key-2.png)
 
 Click the Key value that is shown in blue.
 
-![Example Configuration 3](../img/bitdefender-gravityzone-api-key-3.png)
+![Example Configuration 3](.../img/bitdefender-gravityzone-api-key-3.png)
 
 Click the clipboard icon to copy the API key to your PC's clipboard.
 
-![Example Configuration 4](../img/bitdefender-gravityzone-api-key-4.png)
+![Example Configuration 4](.../img/bitdefender-gravityzone-api-key-4.png)
 
 ### Creating the push notification configuration via BitDefender GravityZone API
 
@@ -135,11 +135,11 @@ There are two dashboards available as part of the integration,
 
 "[BitDefender GravityZone] Push Notifications", which provides a summary of push notifications received within the search window.
 
-![Push Notifications Dashboard](./img/bitdefender-dashboard-push-notifications.png)
+![Push Notifications Dashboard](../img/bitdefender-dashboard-push-notifications.png)
 
 "[BitDefender GravityZone] Configuration State & Statistics", which provides graphs and other visualisations related push notification service state and statistics available within the search window.
 
-![Configuration State & Statistics Dashboard](./img/bitdefender-dashboard-push-config-and-stats.png)
+![Configuration State & Statistics Dashboard](../img/bitdefender-dashboard-push-config-and-stats.png)
 
 ## Data stream
 

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.1"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "2.7.0"
   changes:
     - description: Update the BitDefender Integration documentation.

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "2.7.0"
   changes:
     - description: Update the BitDefender Integration documentation.

--- a/packages/bitdefender/docs/README.md
+++ b/packages/bitdefender/docs/README.md
@@ -35,9 +35,9 @@ The integration can also collect the push notification configuration and statist
 3. Click on "BitDefender GravityZone" integration from the search results.
 4. Click on **Add BitDefender GravityZone** button to add BitDefender GravityZone integration.
 
-![Example Integration Configuration](../img/bitdefender-integration-configuration-1.png)
+![Example Integration Configuration](.../img/bitdefender-integration-configuration-1.png)
 
-![Example Integration Configuration](../img/bitdefender-integration-configuration-2.png)
+![Example Integration Configuration](.../img/bitdefender-integration-configuration-2.png)
 
 ### Create a BitDefender GravityZone API key that can configure a push notification service
 
@@ -49,21 +49,21 @@ Bear in mind the API key will be associated to the account you create it from. A
 
 Navigate to your account details within the GravityZone portal. If you have sufficient privileges you will see the "API keys" section near the bottom of the page. Click "Add" here.
 
-![Example Configuration 1](../img/bitdefender-gravityzone-api-key-1.png)
+![Example Configuration 1](.../img/bitdefender-gravityzone-api-key-1.png)
 
 Give the API key a description and tick the "Event Push Service API" box at minimum.
 
 NOTE: If you intend to use the API key for other API calls you may need to tick other boxes.
 
-![Example Configuration 2](../img/bitdefender-gravityzone-api-key-2.png)
+![Example Configuration 2](.../img/bitdefender-gravityzone-api-key-2.png)
 
 Click the Key value that is shown in blue.
 
-![Example Configuration 3](../img/bitdefender-gravityzone-api-key-3.png)
+![Example Configuration 3](.../img/bitdefender-gravityzone-api-key-3.png)
 
 Click the clipboard icon to copy the API key to your PC's clipboard.
 
-![Example Configuration 4](../img/bitdefender-gravityzone-api-key-4.png)
+![Example Configuration 4](.../img/bitdefender-gravityzone-api-key-4.png)
 
 ### Creating the push notification configuration via BitDefender GravityZone API
 
@@ -135,11 +135,11 @@ There are two dashboards available as part of the integration,
 
 "[BitDefender GravityZone] Push Notifications", which provides a summary of push notifications received within the search window.
 
-![Push Notifications Dashboard](./img/bitdefender-dashboard-push-notifications.png)
+![Push Notifications Dashboard](../img/bitdefender-dashboard-push-notifications.png)
 
 "[BitDefender GravityZone] Configuration State & Statistics", which provides graphs and other visualisations related push notification service state and statistics available within the search window.
 
-![Configuration State & Statistics Dashboard](./img/bitdefender-dashboard-push-config-and-stats.png)
+![Configuration State & Statistics Dashboard](../img/bitdefender-dashboard-push-config-and-stats.png)
 
 ## Data stream
 

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: bitdefender
 title: "BitDefender"
-version: "2.7.0"
+version: "2.7.1"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"

--- a/packages/cybereason/_dev/build/docs/README.md
+++ b/packages/cybereason/_dev/build/docs/README.md
@@ -24,7 +24,7 @@ The Cybereason integration collects six types of logs: Logon Session, Malop Conn
 
 - **[Poll Malop](https://api-doc.cybereason.com/en/latest/APIReference/MalopAPI/getMalopsMalware.html#getmalopsmalware)** - This data stream provides comprehensive information about Malops detected by Cybereason's EDR system, enabling security teams to analyze and respond to potential threats effectively.
 
-- **[Suspicions Process]()** - This data stream provides detailed information about processes that are suspected or deemed malicious within the endpoint detection and response (EDR) system.
+- **Suspicions Process** - This data stream provides detailed information about processes that are suspected or deemed malicious within the endpoint detection and response (EDR) system.
 
 **NOTE**: Suspicions Process has the same endpoint as the first three data streams, we have added a filter - `hasSuspicions : true` and some custom fields to get the logs related to suspicions.
 

--- a/packages/cybereason/changelog.yml
+++ b/packages/cybereason/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "1.5.0"
   changes:
     - description: Add edr_xdr category.

--- a/packages/cybereason/changelog.yml
+++ b/packages/cybereason/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "1.5.0"
   changes:
     - description: Add edr_xdr category.

--- a/packages/cybereason/docs/README.md
+++ b/packages/cybereason/docs/README.md
@@ -24,7 +24,7 @@ The Cybereason integration collects six types of logs: Logon Session, Malop Conn
 
 - **[Poll Malop](https://api-doc.cybereason.com/en/latest/APIReference/MalopAPI/getMalopsMalware.html#getmalopsmalware)** - This data stream provides comprehensive information about Malops detected by Cybereason's EDR system, enabling security teams to analyze and respond to potential threats effectively.
 
-- **[Suspicions Process]()** - This data stream provides detailed information about processes that are suspected or deemed malicious within the endpoint detection and response (EDR) system.
+- **Suspicions Process** - This data stream provides detailed information about processes that are suspected or deemed malicious within the endpoint detection and response (EDR) system.
 
 **NOTE**: Suspicions Process has the same endpoint as the first three data streams, we have added a filter - `hasSuspicions : true` and some custom fields to get the logs related to suspicions.
 

--- a/packages/cybereason/manifest.yml
+++ b/packages/cybereason/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: cybereason
 title: Cybereason
-version: "1.5.0"
+version: "1.5.1"
 description: Collect logs from Cybereason with Elastic Agent.
 type: integration
 categories:

--- a/packages/google_cloud_storage/changelog.yml
+++ b/packages/google_cloud_storage/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "2.2.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/google_cloud_storage/changelog.yml
+++ b/packages/google_cloud_storage/changelog.yml
@@ -1,3 +1,8 @@
+- version: "2.2.1"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "2.2.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/google_cloud_storage/docs/README.md
+++ b/packages/google_cloud_storage/docs/README.md
@@ -54,4 +54,4 @@ Assuming you have GCS buckets already set up and the service account key availab
 This integration includes the ECS Dynamic Template, all fields that follow the ECS Schema will get assigned the correct index field mapping and do not need to be added manually.
 
 ## Ingest Pipelines
-Custom ingest pipelines may be added by adding the name to the pipeline configuration option, creating custom ingest pipelines can be done either through the API or the [Ingest Node Pipeline UI](/app/management/ingest/ingest_pipelines/).
+Custom ingest pipelines may be added by adding the name to the pipeline configuration option, creating custom ingest pipelines can be done either through the API or the [Ingest Node Pipeline UI](docs-content://reference/ingestion-tools/enrich-processor/ingest-pipelines.md).

--- a/packages/google_cloud_storage/manifest.yml
+++ b/packages/google_cloud_storage/manifest.yml
@@ -3,7 +3,7 @@ name: google_cloud_storage
 title: Custom GCS (Google Cloud Storage) Input
 description: Collect JSON data from configured GCS Bucket with Elastic Agent.
 type: input
-version: "2.2.0"
+version: "2.2.1"
 conditions:
   kibana:
     version: "^8.13.0 || ^9.0.0"
@@ -105,6 +105,7 @@ policy_templates:
         title: Buckets
         description: >
           This attribute contains the details about a specific bucket like, name, number_of_workers, poll, poll_interval and bucket_timeout. The attribute 'name' is specific to a bucket as it describes the bucket name, while the fields number_of_workers, poll, poll_interval and bucket_timeout can exist both at the bucket level and at the global level. If you have already defined the attributes globally, then you can only specify the name in this yaml config. If you want to override any specific attribute for a specific bucket, then, you can define it here. Any attribute defined in the yaml will override the global definitions. Please see the relevant [Documentation](https://www.elastic.co/guide/en/beats/filebeat/8.5/filebeat-input-gcs.html#attrib-buckets) for further information.
+
         required: true
         show_user: true
         default: |
@@ -130,6 +131,7 @@ policy_templates:
           # - regex: "event/"
         description: >
           If the GCS bucket will have events that correspond to files that this integration shouldn’t process, file_selectors can be used to limit the files that are downloaded. This is a list of selectors which is made up of regex patters. The regex should match the GCS bucket filepath. Regexes use [RE2 syntax](https://pkg.go.dev/regexp/syntax). Files that don’t match one of the regexes will not be processed.
+
       - name: timestamp_epoch
         type: integer
         title: Timestamp Epoch

--- a/packages/http_endpoint/changelog.yml
+++ b/packages/http_endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "2.5.1"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "2.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/http_endpoint/changelog.yml
+++ b/packages/http_endpoint/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "2.5.0"
   changes:
     - description: Update Kibana constraint to support 9.0.0.

--- a/packages/http_endpoint/docs/README.md
+++ b/packages/http_endpoint/docs/README.md
@@ -15,4 +15,4 @@ These are the possible response codes from the server.
 | 500                	| Internal Server Error  	| Returned if an I/O error occurs reading the request.               	|
 
 
-Custom ingest pipelines may be added by adding the name to the pipeline configuration option, creating custom ingest pipelines can be done either through the API or the [Ingest Node Pipeline UI](/app/management/ingest/ingest_pipelines/).
+Custom ingest pipelines may be added by adding the name to the pipeline configuration option, creating custom ingest pipelines can be done either through the API or the [Ingest Node Pipeline UI](docs-content://reference/ingestion-tools/enrich-processor/ingest-pipelines.md).

--- a/packages/http_endpoint/manifest.yml
+++ b/packages/http_endpoint/manifest.yml
@@ -3,7 +3,7 @@ name: http_endpoint
 title: Custom HTTP Endpoint Logs
 description: Collect JSON data from listening HTTP port with Elastic Agent.
 type: input
-version: "2.5.0"
+version: "2.5.1"
 conditions:
   kibana:
     version: "^8.15.0 || ^9.0.0"
@@ -89,10 +89,7 @@ policy_templates:
         type: text
         title: Prefix
         description: >-
-          This option specifies which prefix field the incoming request will be mapped to. Care should be taken when
-          setting this option in conjunction with the Preserve Original Event or the Include Headers options. These will
-          collide the `event` and `headers` fields respecetively, so avoid using a prefix that would result in data being
-          placed in those fields if those other options are used. If a collision occurs the behavior is unspecified.
+          This option specifies which prefix field the incoming request will be mapped to. Care should be taken when setting this option in conjunction with the Preserve Original Event or the Include Headers options. These will collide the `event` and `headers` fields respecetively, so avoid using a prefix that would result in data being placed in those fields if those other options are used. If a collision occurs the behavior is unspecified.
         required: false
         show_user: false
       - name: basic_auth
@@ -214,6 +211,7 @@ policy_templates:
         show_user: false
         description: >
           The request tracer logs HTTP requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.
+
 icons:
   - src: "/img/icon.svg"
     type: "image/svg+xml"

--- a/packages/keeper_security_siem_integration/_dev/build/docs/README.md
+++ b/packages/keeper_security_siem_integration/_dev/build/docs/README.md
@@ -265,4 +265,4 @@ Currently, no machine learning modules are included with this integration. Custo
 
 ### Change Log
 
-Refer to the [CHANGELOG.md](../../../changelog.yml) for version history and updates.
+Refer to the changelog for version history and updates.

--- a/packages/keeper_security_siem_integration/changelog.yml
+++ b/packages/keeper_security_siem_integration/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "0.1.0"
   changes:
     - description: Initial release of Keeper Security agentless integration

--- a/packages/keeper_security_siem_integration/changelog.yml
+++ b/packages/keeper_security_siem_integration/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.1.1"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "0.1.0"
   changes:
     - description: Initial release of Keeper Security agentless integration

--- a/packages/keeper_security_siem_integration/docs/README.md
+++ b/packages/keeper_security_siem_integration/docs/README.md
@@ -366,4 +366,4 @@ Currently, no machine learning modules are included with this integration. Custo
 
 ### Change Log
 
-Refer to the [CHANGELOG.md](../../../changelog.yml) for version history and updates.
+Refer to the changelog for version history and updates.

--- a/packages/keeper_security_siem_integration/manifest.yml
+++ b/packages/keeper_security_siem_integration/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: keeper
 title: "Keeper Security"
-version: 0.1.0
+version: 0.1.1
 description: >
   Keeper Security agentless integration for collecting audit events directly via Elasticsearch Bulk API. No agents required - Keeper pushes data directly to Elasticsearch.
 

--- a/packages/swimlane/_dev/build/docs/README.md
+++ b/packages/swimlane/_dev/build/docs/README.md
@@ -27,15 +27,15 @@ All fields ingested to this data stream are stored under `turbine.api` as an eve
 
 ### For Turbine Cloud Deployments
 Generate a personal access token for an administrator user.
-![Turbine Cloud Personal Access Token](/img/turbine-cloud-pat.png "Turbine Cloud Personal Access Token")
+![Turbine Cloud Personal Access Token](../img/turbine-cloud-pat.png "Turbine Cloud Personal Access Token")
 
 Configure the settings page with your Turbine Cloud URL, Account Id, and Private Token
-![Turbine Cloud Settings](/img/turbine-cloud-settings.png "Turbine Cloud Settings")
+![Turbine Cloud Settings](../img/turbine-cloud-settings.png "Turbine Cloud Settings")
 
 ### For Turbie Platform Installs (TPI)
 TPI settings can be configured in the administrator dashboard as seen below:
 
-![TPI Audit Log Settings](/img/tpi-audit-log-settings.png "TPI Audit Log Settings")
+![TPI Audit Log Settings](../img/tpi-audit-log-settings.png "TPI Audit Log Settings")
 
 ### For Helm or Kustomize Installs
 The following environment variables will need to be set for Audit logs to be outputted into the container pod logs.

--- a/packages/swimlane/changelog.yml
+++ b/packages/swimlane/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.2"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "0.4.1"
   changes:
     - description: Fix type conflict with other integration using `log.source` and use ECS definitions where possible.

--- a/packages/swimlane/changelog.yml
+++ b/packages/swimlane/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "0.4.1"
   changes:
     - description: Fix type conflict with other integration using `log.source` and use ECS definitions where possible.

--- a/packages/swimlane/docs/README.md
+++ b/packages/swimlane/docs/README.md
@@ -27,15 +27,15 @@ All fields ingested to this data stream are stored under `turbine.api` as an eve
 
 ### For Turbine Cloud Deployments
 Generate a personal access token for an administrator user.
-![Turbine Cloud Personal Access Token](/img/turbine-cloud-pat.png "Turbine Cloud Personal Access Token")
+![Turbine Cloud Personal Access Token](../img/turbine-cloud-pat.png "Turbine Cloud Personal Access Token")
 
 Configure the settings page with your Turbine Cloud URL, Account Id, and Private Token
-![Turbine Cloud Settings](/img/turbine-cloud-settings.png "Turbine Cloud Settings")
+![Turbine Cloud Settings](../img/turbine-cloud-settings.png "Turbine Cloud Settings")
 
 ### For Turbie Platform Installs (TPI)
 TPI settings can be configured in the administrator dashboard as seen below:
 
-![TPI Audit Log Settings](/img/tpi-audit-log-settings.png "TPI Audit Log Settings")
+![TPI Audit Log Settings](../img/tpi-audit-log-settings.png "TPI Audit Log Settings")
 
 ### For Helm or Kustomize Installs
 The following environment variables will need to be set for Audit logs to be outputted into the container pod logs.

--- a/packages/swimlane/manifest.yml
+++ b/packages/swimlane/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.5.1
 name: swimlane
 title: "Swimlane Turbine"
-version: 0.4.1
+version: 0.4.2
 description: "Collect Swimlane Turbine Audit logs with Elastic Agent"
 type: integration
 categories:

--- a/packages/threat_map/_dev/build/docs/README.md
+++ b/packages/threat_map/_dev/build/docs/README.md
@@ -77,7 +77,7 @@ The Threat Map visualization can be added to other dashboards in two ways:
   - **Existing Dashboard:** Select an existing dashboard from the dropdown, then click **Copy and Go to Dashboard**.
   - **New Dashboard:** Create a new dashboard with the visualization.
 
-![Copy to dashboard](../img/copy-to-dashboard.png?raw=true)
+![Copy to dashboard](../img/copy-to-dashboard.png)
 ---
 
 ## Visualizations
@@ -112,7 +112,7 @@ Data in panels can be sorted by clicking on the **Count** column header.
 - Apply a filter using the query bar.
 - Click **Save and Return** to apply changes.
 
-![Visualization-Specific Filters](../img/query-bar.png?raw=true)
+![Visualization-Specific Filters](../img/query-bar.png)
 ---
 
 ## Customization Options
@@ -131,5 +131,5 @@ To customize these options, click on **Edit visualization** from the dropdown in
 
 For additional customization options, see the [Vega Kibana Guide](https://www.elastic.co/guide/en/kibana/current/vega.html#vega-with-a-map).
 
-![Customization options](../img/customization-options.png?raw=true)
+![Customization options](../img/customization-options.png)
 ---

--- a/packages/threat_map/changelog.yml
+++ b/packages/threat_map/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "1.1.0"
   changes:
     - description: Improve documentation

--- a/packages/threat_map/changelog.yml
+++ b/packages/threat_map/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "1.1.0"
   changes:
     - description: Improve documentation

--- a/packages/threat_map/docs/README.md
+++ b/packages/threat_map/docs/README.md
@@ -77,7 +77,7 @@ The Threat Map visualization can be added to other dashboards in two ways:
   - **Existing Dashboard:** Select an existing dashboard from the dropdown, then click **Copy and Go to Dashboard**.
   - **New Dashboard:** Create a new dashboard with the visualization.
 
-![Copy to dashboard](../img/copy-to-dashboard.png?raw=true)
+![Copy to dashboard](../img/copy-to-dashboard.png)
 ---
 
 ## Visualizations
@@ -112,7 +112,7 @@ Data in panels can be sorted by clicking on the **Count** column header.
 - Apply a filter using the query bar.
 - Click **Save and Return** to apply changes.
 
-![Visualization-Specific Filters](../img/query-bar.png?raw=true)
+![Visualization-Specific Filters](../img/query-bar.png)
 ---
 
 ## Customization Options
@@ -131,5 +131,5 @@ To customize these options, click on **Edit visualization** from the dropdown in
 
 For additional customization options, see the [Vega Kibana Guide](https://www.elastic.co/guide/en/kibana/current/vega.html#vega-with-a-map).
 
-![Customization options](../img/customization-options.png?raw=true)
+![Customization options](../img/customization-options.png)
 ---

--- a/packages/threat_map/manifest.yml
+++ b/packages/threat_map/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.0
 name: threat_map
 title: Threat Map
-version: "1.1.0"
+version: "1.1.1"
 description: "The Threat Map integration includes a dashboard for analyzing network traffic data."
 type: integration
 categories:

--- a/packages/zscaler_zia/_dev/build/docs/README.md
+++ b/packages/zscaler_zia/_dev/build/docs/README.md
@@ -37,7 +37,7 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
         - Verify that the state of the NSS Server is healthy.
             - In the ZIA Admin Portal, go to Administration > Nanolog Streaming Service > NSS Servers.
             - In the State column, confirm that the state of the NSS server is healthy.
-            ![NSS server setup image](../img/nss_server.png?raw=true)
+            ![NSS server setup image](../img/nss_server.png)
     - In the ZIA Admin Portal, add an NSS Feed.
         - Refer to [Add NSS Feeds](https://help.zscaler.com/zia/adding-nss-feeds) and select the type of feed you want to configure. The following fields require specific inputs:
             - **SIEM IP Address**: Enter the IP address of the {{ url "fleet-overview" "Elastic agent" }} you’ll be assigning the Zscaler integration to.
@@ -50,7 +50,7 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
                 - **Tunnel**: 9013
                 - **Web**: 9014
             - **Feed Output Type**: Select Custom in Feed output type and paste the appropriate response format in Feed output format as follows:
-            ![NSS Feeds setup image](../img/nss_feeds.png?raw=true)
+            ![NSS Feeds setup image](../img/nss_feeds.png)
 
 ## Set up Cloud NSS Feeds
 
@@ -73,7 +73,7 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
               - **Web**: 9559
           - Select JSON as feed output type.
           - Add same custom header along with its value on both the side for additional security.
-          ![Cloud NSS Feeds setup image](../img/cloud_nss_feeds.png?raw=true)
+          ![Cloud NSS Feeds setup image](../img/cloud_nss_feeds.png)
 3. Repeat step 2 for each log type.
 
 **Note**: Make sure to use the latest version of given response formats for NSS and Cloud NSS Feeds.
@@ -199,7 +199,7 @@ Sample Response:
 - Default port (Cloud NSS Feed): _9559_
 - Add characters **"** and **\\** in **feed escape character** while configuring Web Log.
 
-![Escape feed setup image](../img/escape_feed.png?raw=true)
+![Escape feed setup image](../img/escape_feed.png)
 See: [Zscaler Vendor documentation](https://help.zscaler.com/zia/nss-feed-output-format-web-logs)
 
 Zscaler Web Log response format (v11):

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.17.2"
+  changes:
+    - description: Fix broken links and image paths in docs for docs-builder compatibility
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "3.17.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix broken links and image paths in docs for docs-builder compatibility
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18033
 - version: "3.17.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/zscaler_zia/docs/README.md
+++ b/packages/zscaler_zia/docs/README.md
@@ -37,7 +37,7 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
         - Verify that the state of the NSS Server is healthy.
             - In the ZIA Admin Portal, go to Administration > Nanolog Streaming Service > NSS Servers.
             - In the State column, confirm that the state of the NSS server is healthy.
-            ![NSS server setup image](../img/nss_server.png?raw=true)
+            ![NSS server setup image](../img/nss_server.png)
     - In the ZIA Admin Portal, add an NSS Feed.
         - Refer to [Add NSS Feeds](https://help.zscaler.com/zia/adding-nss-feeds) and select the type of feed you want to configure. The following fields require specific inputs:
             - **SIEM IP Address**: Enter the IP address of the [Elastic agent](https://www.elastic.co/guide/en/fleet/current/fleet-overview.html) you’ll be assigning the Zscaler integration to.
@@ -50,7 +50,7 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
                 - **Tunnel**: 9013
                 - **Web**: 9014
             - **Feed Output Type**: Select Custom in Feed output type and paste the appropriate response format in Feed output format as follows:
-            ![NSS Feeds setup image](../img/nss_feeds.png?raw=true)
+            ![NSS Feeds setup image](../img/nss_feeds.png)
 
 ## Set up Cloud NSS Feeds
 
@@ -73,7 +73,7 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
               - **Web**: 9559
           - Select JSON as feed output type.
           - Add same custom header along with its value on both the side for additional security.
-          ![Cloud NSS Feeds setup image](../img/cloud_nss_feeds.png?raw=true)
+          ![Cloud NSS Feeds setup image](../img/cloud_nss_feeds.png)
 3. Repeat step 2 for each log type.
 
 **Note**: Make sure to use the latest version of given response formats for NSS and Cloud NSS Feeds.
@@ -199,7 +199,7 @@ Sample Response:
 - Default port (Cloud NSS Feed): _9559_
 - Add characters **"** and **\\** in **feed escape character** while configuring Web Log.
 
-![Escape feed setup image](../img/escape_feed.png?raw=true)
+![Escape feed setup image](../img/escape_feed.png)
 See: [Zscaler Vendor documentation](https://help.zscaler.com/zia/nss-feed-output-format-web-logs)
 
 Zscaler Web Log response format (v11):

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -4,7 +4,7 @@ title: Zscaler Internet Access
 # When updating version, make sure the pkg_version parameter in
 # the check_template_version script in ingest pipelines is
 # updated to match.
-version: "3.17.1"
+version: "3.17.2"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Summary

Fixes docs-builder validation errors across 9 packages owned by `@elastic/security-service-integrations`:

| Package | Fix |
|---|---|
| bitdefender | Image paths `./img/` → `../img/` |
| cybereason | Remove empty URL from link |
| azure_blob_storage | Kibana app link → docs-content cross-link |
| http_endpoint | Kibana app link → docs-content cross-link |
| google_cloud_storage | Kibana app link → docs-content cross-link |
| swimlane | Image paths `/img/` → `../img/` |
| threat_map | Remove `?raw=true` from image paths |
| zscaler_zia | Remove `?raw=true` from image paths |
| keeper_security_siem_integration | Remove broken changelog link |

🤖 Generated with [Claude Code](https://claude.com/claude-code)