### PR TITLE
[ci] Add --strict to package docs validation

### DIFF
--- a/.github/workflows/validate-package-docs.yml
+++ b/.github/workflows/validate-package-docs.yml
@@ -80,7 +80,7 @@ jobs:
           cat .validate/docset.yml
           docker run --rm -v "$PWD/.validate:/workspace" -w /workspace \
             ghcr.io/elastic/docs-builder:edge \
-            --metadata-only
+            --metadata-only --strict
 
       - name: Signal failure for notification workflow
         if: steps.validate.outcome == 'failure'


### PR DESCRIPTION
## Summary

Adds `--strict` to the docs-builder invocation in the package docs validation workflow.

## Why

integration-docs runs docs-builder with `--strict` (the default in `preview-build.yml`), which treats warnings as errors. Without `--strict` here, issues like unknown code block languages pass validation but then break the integration-docs build downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)