### PR TITLE
[test] Intentional doc errors to test validation + notification

### DIFF
--- a/packages/1password/docs/README.md
+++ b/packages/1password/docs/README.md
@@ -4,6 +4,8 @@ With [1Password Business](https://support.1password.com/explore/business/), you 
 
 Get reports about 1Password activity, such as sign-in attempts and item usage, while you manage all your company’s applications and services from a central location.
 
+Check [Setup instructions](#setup-instructions) for details.
+
 With 1Password Events Reporting and Elastic SIEM, you can:
 
 -	Control your 1Password data retention
@@ -11,8 +13,26 @@ With 1Password Events Reporting and Elastic SIEM, you can:
 -	Set up custom alerts that trigger specific actions
 -	Cross-reference 1Password events with the data from other services
 
-You can set up Events Reporting if you’re an owner or administrator.  
+You can set up Events Reporting if you’re an owner or administrator.
 Ready to get started? [Learn how to set up the Elastic Events Reporting integration](https://support.1password.com/events-reporting).
+
+Here is an example configuration:
+
+```hcl
+resource "elastic_integration" "onepassword" {
+  name = "1password"
+}
+```
+
+See also the [pipeline UI](/app/management/ingest/ingest_pipelines/).
+
+Link to [missing file](./missing-file.md).
+
+![Missing image](../img/nonexistent-screenshot.png)
+
+See the {ecloud} documentation for more details.
+
+Link with [empty url]().
 
 ## Agentless Enabled Integration
 


### PR DESCRIPTION
## DO NOT MERGE

Test PR to verify the docs-builder validation workflow catches errors and the notification workflow posts a comment.

### Intentional errors in 1password docs:

| Type | Error |
|---|---|
| Broken anchor | `#setup-instructions` (heading doesn't exist) |
| Unknown code block language | `hcl` |
| Kibana app link | `/app/management/ingest/ingest_pipelines/` |
| Broken file link | `./missing-file.md` |
| Missing image | `../img/nonexistent-screenshot.png` |
| Undefined substitution key | `{ecloud}` |
| Empty URL | `[empty url]()` |

### Expected behavior

1. `Validate Package Docs` check runs and shows errors (but passes due to `continue-on-error`)
2. `Notify on Package Docs Validation Failure` posts a comment mentioning `@elastic/integration-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)