### PR TITLE
[ci] Fix docs validation notification: use Jobs API instead of artifacts

### DIFF
--- a/.github/workflows/notify-package-docs-failure.yml
+++ b/.github/workflows/notify-package-docs-failure.yml
@@ -5,51 +5,46 @@ on:
     workflows: ["Validate Package Docs"]
     types: [completed]
 
-permissions:
-  pull-requests: write
-  actions: read
-
 jobs:
   notify:
     name: Comment on PR
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
     steps:
-      - name: Check for validation failure
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          # Check if the docs-builder step failed (even though the job succeeded via continue-on-error)
-          FAILED=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
-            --jq '[.jobs[].steps[] | select(.name == "Validate with docs-builder" and .conclusion == "failure")] | length')
-          if [ "$FAILED" = "0" ]; then
-            echo "No validation failure detected"
-            echo "notify=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          # Find the PR number from the head SHA
-          PR_NUMBER=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
-            --jq '.[0].number' 2>/dev/null || true)
-          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
-            echo "Could not find PR for SHA ${HEAD_SHA}"
-            echo "notify=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "notify=true" >> $GITHUB_OUTPUT
+      - name: Download failure signal
+        id: artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-validation-failed
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: validate-result
+        continue-on-error: true
 
       - name: Comment on PR
-        if: steps.check.outputs.notify == 'true'
+        if: steps.artifact.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.check.outputs.pr_number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
+          PR_NUMBER=$(cat validate-result/pr_number 2>/dev/null || true)
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "Could not read PR number from artifact"
+            exit 0
+          fi
+          # Verify the PR number matches the head SHA to prevent
+          # a forked PR from targeting a different PR's comments
+          ACTUAL_PR=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq '.[0].number' 2>/dev/null || true)
+          if [ "$PR_NUMBER" != "$ACTUAL_PR" ]; then
+            echo "PR number mismatch: artifact=$PR_NUMBER actual=$ACTUAL_PR"
+            exit 0
+          fi
           # Avoid duplicate comments
           EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --jq '[.[] | select(.body | contains("Package docs validation failed"))] | length')

--- a/.github/workflows/validate-package-docs.yml
+++ b/.github/workflows/validate-package-docs.yml
@@ -43,6 +43,7 @@ jobs:
         continue-on-error: true
         env:
           CHANGED_FILES: ${{ steps.changed-docs.outputs.files }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Build an isolated directory so docs-builder only sees our
           # generated docset and not docs/docset.yml or other repo files.
@@ -78,6 +79,18 @@ jobs:
             done
           } > .validate/docset.yml
           cat .validate/docset.yml
-          docker run --rm -v "$PWD/.validate:/workspace" -w /workspace \
+          mkdir -p "$PWD/validate-result"
+          if ! docker run --rm -v "$PWD/.validate:/workspace" -w /workspace \
             ghcr.io/elastic/docs-builder:edge \
-            --metadata-only --strict
+            --metadata-only --strict; then
+            echo "${PR_NUMBER}" > "$PWD/validate-result/pr_number"
+          fi
+
+      - name: Upload failure signal
+        if: steps.changed-docs.outputs.skip != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-validation-failed
+          path: validate-result/pr_number
+          if-no-files-found: ignore
+          retention-days: 1


### PR DESCRIPTION
## Summary

Reworks the notification mechanism for the package docs validation workflow. When docs-builder finds errors, a comment is posted on the PR mentioning `@elastic/integration-docs`.

## How it works

1. **Validation workflow** (`validate-package-docs.yml`): When docs-builder exits non-zero, uploads a `docs-validation-failed` artifact containing the PR number. Uses `upload-artifact@v7`. Stays non-blocking (`continue-on-error: true`) with `contents: read` only.

2. **Notification workflow** (`notify-package-docs-failure.yml`): Triggered by `workflow_run`. Downloads the artifact via `download-artifact@v8` with `run-id` and `github-token` for cross-workflow access. If artifact exists, posts a comment. Permissions at job level (`pull-requests: write`, `actions: read`).

## Security

- Validation workflow: `pull_request` trigger, `contents: read` only — safe for forks
- Notification workflow: `workflow_run` trigger, runs in base branch context — safe for forks
- Permissions at job level per least-permissive approach
- All GitHub context values passed via env vars, not inline interpolation

## Testing

Artifact upload confirmed in test PR #18049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)