### PR TITLE
atlassian_jira: fix missing timezone in Cloud audit API dates

### DIFF
--- a/packages/atlassian_jira/_dev/deploy/docker/files/config.yml
+++ b/packages/atlassian_jira/_dev/deploy/docker/files/config.yml
@@ -18,24 +18,27 @@ rules:
       authorization: Basic dGVzdC51c2VyOmFiYzEyMw==
     query_params:
       from: >-
-        {from:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?(?:(?:[+-][0-9]{4})|Z)?}
+        {from:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z}
       to: >-
-        {to:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?(?:(?:[+-][0-9]{4})|Z)?}
+        {to:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z}
       limit: "2"
     responses:
       - status_code: 200
         body: |-
           {"entities":[{"timestamp":"2021-11-22T00:34:47.536Z","author":{"name":"test.user","type":"ApplicationUser","id":"10000","uri":"http://jira.internal:8088/secure/ViewProfile.jspa?name=test.user","avatarUri":""},"type":{"categoryI18nKey":"atlassian.audit.event.category.audit","category":"Auditing","actionI18nKey":"atlassian.audit.event.action.audit.search","action":"Audit Log search performed"},"affectedObjects":[],"changedValues":[],"source":"175.16.199.1","system":"http://jira.internal:8088","method":"Browser","extraAttributes":[{"nameI18nKey":"atlassian.audit.event.attribute.id","name":"ID Range","value":"45 - 94"},{"nameI18nKey":"atlassian.audit.event.attribute.query","name":"Query","value":""},{"nameI18nKey":"atlassian.audit.event.attribute.results","name":"Results returned","value":"50"},{"nameI18nKey":"atlassian.audit.event.attribute.timestamp","name":"Timestamp Range","value":"2021-11-22T00:08:34.163Z - 2021-11-22T00:34:40.008Z"}]},{"timestamp":"2021-11-22T00:34:40.008Z","author":{"name":"test.user","type":"ApplicationUser","id":"10000","uri":"http://jira.internal:8088/secure/ViewProfile.jspa?name=test.user","avatarUri":""},"type":{"categoryI18nKey":"atlassian.audit.event.category.audit","category":"Auditing","actionI18nKey":"atlassian.audit.event.action.audit.search","action":"Audit Log search performed"},"affectedObjects":[],"changedValues":[],"source":"175.16.199.1","system":"http://jira.internal:8088","method":"Browser","extraAttributes":[{"nameI18nKey":"atlassian.audit.event.attribute.id","name":"ID Range","value":"44 - 93"},{"nameI18nKey":"atlassian.audit.event.attribute.query","name":"Query","value":""},{"nameI18nKey":"atlassian.audit.event.attribute.results","name":"Results returned","value":"50"},{"nameI18nKey":"atlassian.audit.event.attribute.timestamp","name":"Timestamp Range","value":"2021-11-22T00:08:34.151Z - 2021-11-22T00:34:23.154Z"}]}],"pagingInfo":{"nextPageOffset":0,"nextPageCursor":"1637539714166,47","nextPageLink":"http://{{ hostname }}:{{ env "PORT" }}/rest/auditing/1.0/events?offset=0&limit=2&pageCursor=1637539714166,47","lastPage":false,"size":2}}
   # JIRA Cloud
+  # References:
+  #   https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-audit-records/#api-rest-api-3-auditing-record-get
+  #   https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
   - path: /rest/api/3/auditing/record
     methods: ["GET"]
     request_headers:
       authorization: Basic dGVzdC51c2VyOmFiYzEyMw==
     query_params:
       from: >-
-        {from:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?(?:(?:[+-][0-9]{4})|Z)?}
+        {from:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z}
       to: >-
-        {to:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?(?:(?:[+-][0-9]{4})|Z)?}
+        {to:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z}
       offset: "2"
       limit: "2"
     responses:
@@ -48,9 +51,9 @@ rules:
       authorization: Basic dGVzdC51c2VyOmFiYzEyMw==
     query_params:
       from: >-
-        {from:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?(?:(?:[+-][0-9]{4})|Z)?}
+        {from:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z}
       to: >-
-        {to:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?(?:(?:[+-][0-9]{4})|Z)?}
+        {to:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z}
       limit: "2"
       offset: "0"
     responses:
@@ -68,9 +71,9 @@ rules:
       authorization: Basic dGVzdC51c2VyOmFiYzEyMw==
     query_params:
       from: >-
-        {from:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?(?:(?:[+-][0-9]{4})|Z)?}
+        {from:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z}
       to: >-
-        {to:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?(?:(?:[+-][0-9]{4})|Z)?}
+        {to:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z}
       limit: "2"
       offset: "4"
     responses:

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.1"
+  changes:
+    - description: Fix missing timezone suffix in Jira Cloud audit API date parameters that caused empty responses.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18106
 - version: "1.31.0"
   changes:
     - description: Prevent updating fleet health status to degraded when pagination completes.

--- a/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -36,10 +36,10 @@ request.transforms:
   - set:
       target: url.params.from
       value: "[[.cursor.last_timestamp]]"
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15:04:05.999"]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15:04:05.999Z"]]'
   - set:
       target: url.params.to
-      value: '[[formatDate (now) "2006-01-02T15:04:05.999"]]'
+      value: '[[formatDate (now) "2006-01-02T15:04:05.999Z"]]'
   - set:
       target: url.params.offset
       value: '0'

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.31.0"
+version: "1.31.1"
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
atlassian_jira: fix missing timezone in Cloud audit API dates

The Cloud httpjson config formatted the from/to date query
parameters without a timezone suffix. The Jira Cloud audit
API returned HTTP 200 with an empty records array for these
requests, causing zero documents to be ingested.

Append Z to the Go time format strings for the from and to
query parameters. The cursor format already included Z and
is unchanged.

Update the system test mock to require a timezone suffix in
the from/to regex patterns.

Fixes #18138
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related

- Fixes #18138

## Author's Notes

This is for a bug reported on the Elastic community Slack.

> After enabling request tracing, I found the issue. The API returns HTTP 200 but with an empty records array every time:
> {"offset": 0, "limit": 1000, "total": 112, "records": []}
> 
> (The total field is misleading, it shows the instance-wide count, not the filtered result.)
> 
>  After a lot of testing, I narrowed it down to the date format the integration sends in the from/to parameters. Through the Cloud ID URL:
> 
>  - from=2026-03-25T08:37:30.699 (no timezone, what the integration sends) → 0 records
>  - from=2026-01-01T00:00:00.000+0000 (with timezone offset) → 112 records
>  - No from/to params at all → 112 records
> 
> So the integration's date format works fine with the site URL, but not with the Cloud ID URL that scoped tokens require.