### PR TITLE
[k8s otel] Convert Pod details dashboard panels from formBased to ES|QL

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,9 +1,4 @@
 # newer versions go on top
-- version: 1.6.0
-  changes:
-    - description: "Convert formBased Lens panels to ES|QL and fix single-metric aggregation accuracy in the Pod details dashboard"
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/18116
 - version: 1.5.0
   changes:
     - description: Lens to ESQL conversion for the Cluster dashboard. Fix issues with the dashboard.

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 1.6.0
+version: 1.5.0
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:


### PR DESCRIPTION
## Summary
- Convert remaining `formBased` Lens visualizations in the Pod details dashboard to ES|QL (`textBased`), including: Container count over time, Containers table, CPU usage by container, Volume usage over time, Volume capacity, Volume utilization gauge, and Memory limit.
- Fix single-metric aggregation accuracy for CPU limits, Memory limit, and Volume capacity panels by using a two-step deduplication pattern (`MAX BY entity` then `SUM`) instead of a direct `SUM` across all documents.
- Remove dangling tag reference and restore proper structured `data_stream.dataset` filter in `searchSourceJSON`.
- Remove the "Created on" panel (`k8s.pod.start_time` is not available from the OTel collector).


## Test plan
- [ ] Verify all panels render correctly in Kibana with OTel Kubernetes data
- [ ] Confirm single-metric panels (CPU limits, Memory limit, Volume capacity) show accurate values when filtered to a single pod
- [ ] Verify time-series panels (CPU usage by container, Volume usage, Container count) display correct trends
- [ ] Confirm Containers table shows per-container stats with correct restart counts and memory utilization
- [ ] Validate drilldown actions still work on applicable panels
- [ ] Run `elastic-package build` successfully