### PR TITLE
feat(azure): flatten auditlogs additional_details and add modified_properties_by_name

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.37.0"
+  changes:
+    - description: Flatten `additional_details` key-value array into a queryable map and add name-keyed `modified_properties_by_name` field for auditlogs target resources.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.36.1"
   changes:
     - description: Add missing event.kind pipeline_error handling to ingest pipeline on_failure handlers.

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Flatten `additional_details` key-value array into a queryable map and add name-keyed `modified_properties_by_name` field for auditlogs target resources.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/18127
 - version: "1.36.1"
   changes:
     - description: Add missing event.kind pipeline_error handling to ingest pipeline on_failure handlers.

--- a/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-audit-logs-duration-as-string.log-expected.json
+++ b/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-audit-logs-duration-as-string.log-expected.json
@@ -12,16 +12,10 @@
                     "properties": {
                         "activity_datetime": "2022-01-22T18:15:02.3875429+00:00",
                         "activity_display_name": "Update service principal",
-                        "additional_details": [
-                            {
-                                "key": "User-Agent",
-                                "value": "Microsoft Azure Graph Client Library 2.1.17-internal"
-                            },
-                            {
-                                "key": "AppId",
-                                "value": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
-                            }
-                        ],
+                        "additional_details": {
+                            "User-Agent": "Microsoft Azure Graph Client Library 2.1.17-internal",
+                            "AppId": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
+                        },
                         "category": "ApplicationManagement",
                         "correlation_id": "87979703-118b-498f-99c2-ccd1a56f1a5a",
                         "id": "Directory_87979703-118b-498f-99c2-ccd1a56f1a5a_ULAYA_144938566",
@@ -41,6 +35,11 @@
                                 "modified_properties": {
                                     "0": {
                                         "display_name": "TargetId.ServicePrincipalNames",
+                                        "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
+                                    }
+                                },
+                                "modified_properties_by_name": {
+                                    "TargetId.ServicePrincipalNames": {
                                         "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
                                     }
                                 },

--- a/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-audit-logs-edgecases.log-expected.json
+++ b/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-audit-logs-edgecases.log-expected.json
@@ -12,16 +12,10 @@
                     "properties": {
                         "activity_datetime": "2022-01-22T18:15:02.3875429+00:00",
                         "activity_display_name": "Update service principal",
-                        "additional_details": [
-                            {
-                                "key": "User-Agent",
-                                "value": "Microsoft Azure Graph Client Library 2.1.17-internal"
-                            },
-                            {
-                                "key": "AppId",
-                                "value": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
-                            }
-                        ],
+                        "additional_details": {
+                            "User-Agent": "Microsoft Azure Graph Client Library 2.1.17-internal",
+                            "AppId": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
+                        },
                         "category": "ApplicationManagement",
                         "correlation_id": "87979703-118b-498f-99c2-ccd1a56f1a5a",
                         "id": "Directory_87979703-118b-498f-99c2-ccd1a56f1a5a_ULAYA_144938566",
@@ -41,6 +35,11 @@
                                 "modified_properties": {
                                     "0": {
                                         "display_name": "TargetId.ServicePrincipalNames",
+                                        "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
+                                    }
+                                },
+                                "modified_properties_by_name": {
+                                    "TargetId.ServicePrincipalNames": {
                                         "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
                                     }
                                 },
@@ -110,16 +109,10 @@
                     "properties": {
                         "activity_datetime": "2022-01-22T18:15:02.3875429+00:00",
                         "activity_display_name": "Update service principal",
-                        "additional_details": [
-                            {
-                                "key": "User-Agent",
-                                "value": "Microsoft Azure Graph Client Library 2.1.17-internal"
-                            },
-                            {
-                                "key": "AppId",
-                                "value": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
-                            }
-                        ],
+                        "additional_details": {
+                            "User-Agent": "Microsoft Azure Graph Client Library 2.1.17-internal",
+                            "AppId": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
+                        },
                         "category": "ApplicationManagement",
                         "correlation_id": "87979703-118b-498f-99c2-ccd1a56f1a5a",
                         "id": "Directory_87979703-118b-498f-99c2-ccd1a56f1a5a_ULAYA_144938566",
@@ -139,6 +132,11 @@
                                 "modified_properties": {
                                     "0": {
                                         "display_name": "TargetId.ServicePrincipalNames",
+                                        "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
+                                    }
+                                },
+                                "modified_properties_by_name": {
+                                    "TargetId.ServicePrincipalNames": {
                                         "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
                                     }
                                 },

--- a/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-audit-logs-sample.log-expected.json
+++ b/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-audit-logs-sample.log-expected.json
@@ -12,16 +12,10 @@
                     "properties": {
                         "activity_datetime": "2022-01-22T18:15:02.5168093+00:00",
                         "activity_display_name": "Add service principal credentials",
-                        "additional_details": [
-                            {
-                                "key": "User-Agent",
-                                "value": "Microsoft Azure Graph Client Library 2.1.17-internal"
-                            },
-                            {
-                                "key": "AppId",
-                                "value": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
-                            }
-                        ],
+                        "additional_details": {
+                            "User-Agent": "Microsoft Azure Graph Client Library 2.1.17-internal",
+                            "AppId": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
+                        },
                         "category": "ApplicationManagement",
                         "correlation_id": "53161141-e3f4-4944-85b6-7b953f17265e",
                         "id": "Directory_53161141-e3f4-4944-85b6-7b953f17265e_6X649_134684731",
@@ -50,6 +44,18 @@
                                     },
                                     "2": {
                                         "display_name": "TargetId.ServicePrincipalNames",
+                                        "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
+                                    }
+                                },
+                                "modified_properties_by_name": {
+                                    "KeyDescription": {
+                                        "new_value": "[\"[KeyIdentifier=c9c0b961-a80a-4a71-9c3a-b67b33edf874,KeyType=AsymmetricX509Cert,KeyUsage=Verify,DisplayName=CN=a70a7931-c387-4dce-9f35-fbf95bdcc91e]\",\"[KeyIdentifier=7dffcdc5-f2d5-43ae-86f1-682561befd4b,KeyType=AsymmetricX509Cert,KeyUsage=Verify,DisplayName=CN=a70a7931-c387-4dce-9f35-fbf95bdcc91e]\",\"[KeyIdentifier=d747da7e-e11b-4af2-aede-0487c44067af,KeyType=AsymmetricX509Cert,KeyUsage=Verify,DisplayName=CN=a70a7931-c387-4dce-9f35-fbf95bdcc91e]\"]",
+                                        "old_value": "[\"[KeyIdentifier=7dffcdc5-f2d5-43ae-86f1-682561befd4b,KeyType=AsymmetricX509Cert,KeyUsage=Verify,DisplayName=CN=a70a7931-c387-4dce-9f35-fbf95bdcc91e]\",\"[KeyIdentifier=c9c0b961-a80a-4a71-9c3a-b67b33edf874,KeyType=AsymmetricX509Cert,KeyUsage=Verify,DisplayName=CN=a70a7931-c387-4dce-9f35-fbf95bdcc91e]\"]"
+                                    },
+                                    "Included Updated Properties": {
+                                        "new_value": "\"KeyDescription\""
+                                    },
+                                    "TargetId.ServicePrincipalNames": {
                                         "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
                                     }
                                 },
@@ -116,16 +122,10 @@
                     "properties": {
                         "activity_datetime": "2022-01-22T18:15:02.5168093+00:00",
                         "activity_display_name": "Update service principal",
-                        "additional_details": [
-                            {
-                                "key": "User-Agent",
-                                "value": "Microsoft Azure Graph Client Library 2.1.17-internal"
-                            },
-                            {
-                                "key": "AppId",
-                                "value": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
-                            }
-                        ],
+                        "additional_details": {
+                            "User-Agent": "Microsoft Azure Graph Client Library 2.1.17-internal",
+                            "AppId": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
+                        },
                         "category": "ApplicationManagement",
                         "correlation_id": "53161141-e3f4-4944-85b6-7b953f17265e",
                         "id": "Directory_53161141-e3f4-4944-85b6-7b953f17265e_6X649_134684743",
@@ -149,6 +149,14 @@
                                     },
                                     "1": {
                                         "display_name": "Included Updated Properties",
+                                        "new_value": "\"KeyDescription\""
+                                    }
+                                },
+                                "modified_properties_by_name": {
+                                    "TargetId.ServicePrincipalNames": {
+                                        "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
+                                    },
+                                    "Included Updated Properties": {
                                         "new_value": "\"KeyDescription\""
                                     }
                                 },
@@ -215,16 +223,10 @@
                     "properties": {
                         "activity_datetime": "2022-01-22T18:15:02.3875429+00:00",
                         "activity_display_name": "Update service principal",
-                        "additional_details": [
-                            {
-                                "key": "User-Agent",
-                                "value": "Microsoft Azure Graph Client Library 2.1.17-internal"
-                            },
-                            {
-                                "key": "AppId",
-                                "value": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
-                            }
-                        ],
+                        "additional_details": {
+                            "User-Agent": "Microsoft Azure Graph Client Library 2.1.17-internal",
+                            "AppId": "a70a7931-c387-4dce-9f35-fbf95bdcc91e"
+                        },
                         "category": "ApplicationManagement",
                         "correlation_id": "87979703-118b-498f-99c2-ccd1a56f1a5a",
                         "id": "Directory_87979703-118b-498f-99c2-ccd1a56f1a5a_ULAYA_144938566",
@@ -244,6 +246,11 @@
                                 "modified_properties": {
                                     "0": {
                                         "display_name": "TargetId.ServicePrincipalNames",
+                                        "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
+                                    }
+                                },
+                                "modified_properties_by_name": {
+                                    "TargetId.ServicePrincipalNames": {
                                         "new_value": "\"a70a7931-c387-4dce-9f35-fbf95bdcc91e;https://identity.azure.net/N8CUySpCeRFU3iB/PEuFlON4zd8+n8d3qgzrF1MviSY=\""
                                     }
                                 },

--- a/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-auditlogs-raw.log-expected.json
+++ b/packages/azure/data_stream/auditlogs/_dev/test/pipeline/test-auditlogs-raw.log-expected.json
@@ -36,6 +36,12 @@
                                         "old_value": ""
                                     }
                                 },
+                                "modified_properties_by_name": {
+                                    "Included Updated Properties": {
+                                        "new_value": "\"\"",
+                                        "old_value": ""
+                                    }
+                                },
                                 "type": "Device"
                             }
                         }
@@ -107,6 +113,12 @@
                                 "modified_properties": {
                                     "0": {
                                         "display_name": "Included Updated Properties",
+                                        "new_value": "\"\"",
+                                        "old_value": ""
+                                    }
+                                },
+                                "modified_properties_by_name": {
+                                    "Included Updated Properties": {
                                         "new_value": "\"\"",
                                         "old_value": ""
                                     }
@@ -185,6 +197,7 @@
                                         "old_value": ""
                                     }
                                 },
+                                "modified_properties_by_name": {},
                                 "type": "Device"
                             }
                         }

--- a/packages/azure/data_stream/auditlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/auditlogs/elasticsearch/ingest_pipeline/default.yml
@@ -121,6 +121,17 @@ processors:
       field: azure.auditlogs.properties.additionalDetails
       target_field: azure.auditlogs.properties.additional_details
       ignore_missing: true
+  - script:
+      description: "Turns the additional_details array elements into key/value pairs. For example, the array element ``{key: 'AppId', value: 'some-id'}`` becomes ``{AppId: 'some-id'}``."
+      lang: painless
+      source: |
+        def tmp = [:];
+        for (item in ctx.azure.auditlogs.properties.additional_details) {
+            tmp[item.key] = item.value;
+        }
+        ctx.azure.auditlogs.properties.additional_details = tmp;
+      if: ctx.azure?.auditlogs?.properties?.additional_details != null && ctx.azure.auditlogs.properties.additional_details instanceof List
+      ignore_failure: true
   - convert:
       field: azure.auditlogs.callerIpAddress
       target_field: source.ip
@@ -184,10 +195,6 @@ processors:
       field: azure.auditlogs.Level
       target_field: azure.auditlogs.level
       ignore_missing: true
-  - rename:
-      field: azure.auditlogs.properties.additional_details.userAgent
-      target_field: azure.auditlogs.properties.additional_details.user_agent
-      ignore_missing: true
   - remove:
       description: Drop displayName field if value is null.
       if: ctx?.azure?.auditlogs?.properties?.initiatedBy?.user?.displayName == null
@@ -213,17 +220,27 @@ processors:
               ctx.azure.auditlogs.properties.target_resources[index].user_principal_name = ctx.azure.auditlogs.properties.targetResources[i].userPrincipalName;
             }
             ctx.azure.auditlogs.properties.target_resources[index].modified_properties = new HashMap();
+            ctx.azure.auditlogs.properties.target_resources[index].modified_properties_by_name = new HashMap();
             for (def j = 0; j < ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties.length; j++) {
               String n = String.valueOf(j);
               ctx.azure.auditlogs.properties.target_resources[index].modified_properties[n] = new HashMap();
 
-              ctx.azure.auditlogs.properties.target_resources[index].modified_properties[n].display_name = ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties[j].displayName;
-              
-              if (ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties[j].newValue != null) {
-                ctx.azure.auditlogs.properties.target_resources[index].modified_properties[n].new_value = ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties[j].newValue;
+              def displayName = ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties[j].displayName;
+              ctx.azure.auditlogs.properties.target_resources[index].modified_properties[n].display_name = displayName;
+
+              def newVal = ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties[j].newValue;
+              def oldVal = ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties[j].oldValue;
+              if (newVal != null) {
+                ctx.azure.auditlogs.properties.target_resources[index].modified_properties[n].new_value = newVal;
               }
-              if (ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties[j].oldValue != null) {
-                ctx.azure.auditlogs.properties.target_resources[index].modified_properties[n].old_value = ctx.azure.auditlogs.properties.targetResources[i].modifiedProperties[j].oldValue;
+              if (oldVal != null) {
+                ctx.azure.auditlogs.properties.target_resources[index].modified_properties[n].old_value = oldVal;
+              }
+              if (displayName != null && displayName != '') {
+                def entry = new HashMap();
+                if (newVal != null) { entry.new_value = newVal; }
+                if (oldVal != null) { entry.old_value = oldVal; }
+                ctx.azure.auditlogs.properties.target_resources[index].modified_properties_by_name[displayName] = entry;
               }
             }
           }

--- a/packages/azure/data_stream/auditlogs/fields/fields.yml
+++ b/packages/azure/data_stream/auditlogs/fields/fields.yml
@@ -109,6 +109,10 @@
                   type: keyword
                   description: |
                     Old value
+            - name: modified_properties_by_name
+              type: flattened
+              description: |
+                Modified properties keyed by display name. Each key maps to an object with new_value and/or old_value fields.
         - name: initiated_by
           type: group
           fields:
@@ -155,17 +159,9 @@
                   description: |
                     User roles
         - name: additional_details
-          type: group
-          fields:
-            - name: user_agent
-              type: keyword
-              description: User agent name.
-            - name: key
-              type: keyword
-              description: Additional details key
-            - name: value
-              type: keyword
-              description: Additional details value
+          type: flattened
+          description: |
+            Additional details of the audit log event, stored as a key-value map. Common keys include AppId, AppOwnerOrganizationId, ServicePrincipalProvisioningType, User-Agent, and others.
         - name: authentication_protocol
           type: keyword
           description: Authentication protocol type.

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: "1.36.1"
+version: "1.37.0"
 description: This Elastic integration collects logs from Azure
 type: integration
 icons:


### PR DESCRIPTION
## Summary

- Convert `additional_details` key-value array (`[{key, value}]`) into a flat queryable map (`{key: value}`), matching the existing `signinlogs.authentication_processing_details` pattern.
- Add `modified_properties_by_name` flattened field alongside existing positional `modified_properties` for each target resource, enabling queries by property name instead of brittle positional indices.
- Both fields use the `flattened` mapping type to support KQL queries on arbitrary keys without mapping explosion.

## Context

The current `additional_details` structure stores keys and values as parallel array elements, making it impossible to correlate a specific key with its value in queries. Similarly, `modified_properties` uses positional indexing (`.0`, `.1`), which breaks when property order changes across events. These structural issues prevent effective detection rule authoring and threat hunting on auditlogs data.

Closes https://github.com/elastic/integrations/issues/13251

## Changes

- `packages/azure/data_stream/auditlogs/elasticsearch/ingest_pipeline/default.yml`: Added painless script to flatten `additional_details` array into key-value map; extended `targetResources` script to build `modified_properties_by_name` alongside positional indexing.
- `packages/azure/data_stream/auditlogs/fields/fields.yml`: Changed `additional_details` to `flattened` type; added `modified_properties_by_name` as `flattened` type.
- `packages/azure/changelog.yml`: Added 1.37.0 entry.
- `packages/azure/manifest.yml`: Version bump to 1.37.0.
- Updated all pipeline test expected outputs to reflect new field structures.

## Test plan

- [ ] Run `elastic-package test pipeline` for the auditlogs data stream
- [ ] Verify `additional_details` fields are queryable via KQL (e.g., `azure.auditlogs.properties.additional_details.AppId: "some-id"`)
- [ ] Verify `modified_properties_by_name` fields are queryable via KQL (e.g., `azure.auditlogs.properties.target_resources.0.modified_properties_by_name.TargetId\.ServicePrincipalNames: *`)
- [ ] Confirm backward compatibility: existing positional `modified_properties` fields are unchanged