### PR TITLE
[microsoft_exchange_online_message_trace] Adapt README.md concerning permissions of type 'Application'

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/_dev/build/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/_dev/build/docs/README.md
@@ -18,7 +18,7 @@ The new Message Trace experience includes an updated PowerShell cmdlet, `Get-Mes
 
 To collect message trace logs from Microsoft's Graph API, you need to:
 - Create an Entra app and record the Directory ID (tenant ID) and Application ID (client ID).
-- Add the `ExchangeMessageTrace.Read.All` permission and grant admin consent for it.
+- Add the `ExchangeMessageTrace.Read.All` permission of type `Application` and grant admin consent for it.
 - Create a client secret and record it.
 - Create a service principal for Microsoft's internal Message Trace app in the tenant.
 

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.2"
+  changes:
+    - description: Adapt README.md concerning permissions of type 'Application'.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18162
 - version: "2.0.1"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/microsoft_exchange_online_message_trace/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/docs/README.md
@@ -18,7 +18,7 @@ The new Message Trace experience includes an updated PowerShell cmdlet, `Get-Mes
 
 To collect message trace logs from Microsoft's Graph API, you need to:
 - Create an Entra app and record the Directory ID (tenant ID) and Application ID (client ID).
-- Add the `ExchangeMessageTrace.Read.All` permission and grant admin consent for it.
+- Add the `ExchangeMessageTrace.Read.All` permission of type `Application` and grant admin consent for it.
 - Create a client secret and record it.
 - Create a service principal for Microsoft's internal Message Trace app in the tenant.
 

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "2.0.1"
+version: "2.0.2"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Added information about which type of Permission is necessary to make the Integration work. This was missing in the official description, but is mentioned in the provided link ([Graph-based message trace API onboarding guide](https://learn.microsoft.com/en-us/exchange/monitoring/trace-an-email-message/graph-api-message-trace)).

In the screenshot you see both types. The type Delegated is not working, type Application works perfectly fine.

## Checklist

- [X] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Screenshots

<img width="470" height="79" alt="image" src="https://github.com/user-attachments/assets/63101970-5ab1-43e5-b378-2f5cf76d5c91" />
