### PR TITLE
network_traffic: fix DHCPv4 ECS-compliant dashboard table columns

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix DHCPv4 ECS-compliant dashboard table columns to use network_traffic.dhcpv4 field names.
       type: bugfix
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/18167
 - version: "1.34.1"
   changes:
     - description: Fix flows dashboards to work with ECS-mapped flow fields and Kibana 9.x filter handling.

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.2"
+  changes:
+    - description: Fix DHCPv4 ECS-compliant dashboard table columns to use network_traffic.dhcpv4 field names.
+      type: bugfix
+      link: TODO
 - version: "1.34.1"
   changes:
     - description: Fix flows dashboards to work with ECS-mapped flow fields and Kibana 9.x filter handling.

--- a/packages/network_traffic/kibana/dashboard/network_traffic-472af5e0-8f1f-11ee-a185-3df81c6deea3.json
+++ b/packages/network_traffic/kibana/dashboard/network_traffic-472af5e0-8f1f-11ee-a185-3df81c6deea3.json
@@ -1240,7 +1240,7 @@
     },
     "references": [
         {
-            "id": "network_traffic-b8992150-8ba8-11e8-9676-ef67484126fb",
+            "id": "network_traffic-dhcpv4-ecs",
             "name": "5:panel_5",
             "type": "search"
         },

--- a/packages/network_traffic/kibana/dashboard/network_traffic-472af5e0-8f1f-11ee-a185-3df81c6deea3.json
+++ b/packages/network_traffic/kibana/dashboard/network_traffic-472af5e0-8f1f-11ee-a185-3df81c6deea3.json
@@ -1240,7 +1240,7 @@
     },
     "references": [
         {
-            "id": "network_traffic-dhcpv4-ecs",
+            "id": "network_traffic-dhcpv4-ecs-search",
             "name": "5:panel_5",
             "type": "search"
         },

--- a/packages/network_traffic/kibana/search/network_traffic-dhcpv4-ecs-search.json
+++ b/packages/network_traffic/kibana/search/network_traffic-dhcpv4-ecs-search.json
@@ -62,7 +62,7 @@
     },
     "coreMigrationVersion": "8.6.2",
     "created_at": "2023-05-15T08:46:13.876Z",
-    "id": "network_traffic-dhcpv4-ecs",
+    "id": "network_traffic-dhcpv4-ecs-search",
     "migrationVersion": {
         "search": "8.0.0"
     },

--- a/packages/network_traffic/kibana/search/network_traffic-dhcpv4-ecs.json
+++ b/packages/network_traffic/kibana/search/network_traffic-dhcpv4-ecs.json
@@ -1,0 +1,82 @@
+{
+    "attributes": {
+        "columns": [
+            "network_traffic.dhcpv4.transaction_id",
+            "network_traffic.dhcpv4.op_code",
+            "network_traffic.dhcpv4.option.message_type",
+            "source.ip",
+            "destination.ip",
+            "network_traffic.dhcpv4.client_mac",
+            "network_traffic.dhcpv4.option.hostname",
+            "network_traffic.dhcpv4.option.class_identifier"
+        ],
+        "description": "",
+        "grid": {},
+        "hideChart": false,
+        "hits": 0,
+        "isTextBasedQuery": false,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "network_traffic.dhcpv4"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "network_traffic.dhcpv4"
+                            }
+                        }
+                    }
+                ],
+                "highlightAll": true,
+                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                },
+                "version": true
+            }
+        },
+        "sort": [
+            [
+                "@timestamp",
+                "desc"
+            ]
+        ],
+        "timeRestore": false,
+        "title": "[Network Packet Capture] DHCPv4 (ECS compliant)",
+        "usesAdHocDataView": false,
+        "version": 1
+    },
+    "coreMigrationVersion": "8.6.2",
+    "created_at": "2023-05-15T08:46:13.876Z",
+    "id": "network_traffic-dhcpv4-ecs",
+    "migrationVersion": {
+        "search": "8.0.0"
+    },
+    "references": [
+        {
+            "id": "f92a3031-6c42-4b41-851e-22792543101a",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "f92a3031-6c42-4b41-851e-22792543101a",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "search"
+}

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: network_traffic
 title: Network Packet Capture
-version: "1.34.1"
+version: "1.34.2"
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
The ECS-compliant DHCPv4 dashboard was sharing the same search object as the non-ECS dashboard, causing table columns to reference bare dhcpv4.* fields instead of network_traffic.dhcpv4.* ECS fields.

Create a dedicated ECS search object with properly prefixed field names and update the ECS dashboard to reference it.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

elastic-package test system -d dhcpv4

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
