### PR TITLE
Rename app crash to device crash

### DIFF
--- a/packages/otel_android_dashboards/changelog.yml
+++ b/packages/otel_android_dashboards/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update crash event name from app.crash to device.crash
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/18183
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/otel_android_dashboards/changelog.yml
+++ b/packages/otel_android_dashboards/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Update crash event name from app.crash to device.crash
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/otel_android_dashboards/kibana/dashboard/otel_android_dashboards-4cff90ff-0bd6-48eb-9ea6-57f91391ebce.json
+++ b/packages/otel_android_dashboards/kibana/dashboard/otel_android_dashboards-4cff90ff-0bd6-48eb-9ea6-57f91391ebce.json
@@ -1767,7 +1767,7 @@
                             ],
                             "query": {
                                 "language": "kuery",
-                                "query": "os.name: \"Android\" and event_name: \"app.crash\" "
+                                "query": "os.name: \"Android\" and event_name: \"device.crash\" "
                             },
                             "visualization": {
                                 "columns": [
@@ -1821,7 +1821,7 @@
                     "hidePanelTitles": true,
                     "query": {
                         "language": "kuery",
-                        "query": "os.name: \"Android\" and event_name: \"app.crash\" "
+                        "query": "os.name: \"Android\" and event_name: \"device.crash\" "
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -1883,7 +1883,7 @@
                                             ],
                                             "index": "2bf6c579d4c4cba3a8bafdcba1f34a0b84db423ec8133082a178141fd612ccc2",
                                             "query": {
-                                                "esql": "FROM logs-generic.otel*\n | WHERE os.name == \"Android\" AND session.id IS NOT NULL and event_name == \"app.crash\"\n | STATS count=COUNT()"
+                                                "esql": "FROM logs-generic.otel*\n | WHERE os.name == \"Android\" AND session.id IS NOT NULL and event_name == \"device.crash\"\n | STATS count=COUNT()"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1893,7 +1893,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM logs-generic.otel*\n | WHERE os.name == \"Android\" AND session.id IS NOT NULL and event_name == \"app.crash\"\n | STATS count=COUNT()"
+                                "esql": "FROM logs-generic.otel*\n | WHERE os.name == \"Android\" AND session.id IS NOT NULL and event_name == \"device.crash\"\n | STATS count=COUNT()"
                             },
                             "visualization": {
                                 "color": "#F6726A",
@@ -1914,7 +1914,7 @@
                     "filters": [],
                     "hidePanelTitles": true,
                     "query": {
-                        "esql": "FROM logs-generic.otel*\n | WHERE os.name == \"Android\" AND session.id IS NOT NULL and event_name == \"app.crash\"\n | STATS count=COUNT()"
+                        "esql": "FROM logs-generic.otel*\n | WHERE os.name == \"Android\" AND session.id IS NOT NULL and event_name == \"device.crash\"\n | STATS count=COUNT()"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -1984,7 +1984,7 @@
                                             ],
                                             "index": "2bf6c579d4c4cba3a8bafdcba1f34a0b84db423ec8133082a178141fd612ccc2",
                                             "query": {
-                                                "esql": "FROM logs-generic.otel*\n| WHERE os.name == \"Android\" AND session.id IS NOT NULL AND event_name == \"app.crash\"\n| STATS crashes = COUNT() BY session.id\n| STATS sessionAvg = COALESCE(AVG(crashes), 0)"
+                                                "esql": "FROM logs-generic.otel*\n| WHERE os.name == \"Android\" AND session.id IS NOT NULL AND event_name == \"device.crash\"\n| STATS crashes = COUNT() BY session.id\n| STATS sessionAvg = COALESCE(AVG(crashes), 0)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1994,7 +1994,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM logs-generic.otel*\n| WHERE os.name == \"Android\" AND session.id IS NOT NULL AND event_name == \"app.crash\"\n| STATS crashes = COUNT() BY session.id\n| STATS sessionAvg = COALESCE(AVG(crashes), 0)"
+                                "esql": "FROM logs-generic.otel*\n| WHERE os.name == \"Android\" AND session.id IS NOT NULL AND event_name == \"device.crash\"\n| STATS crashes = COUNT() BY session.id\n| STATS sessionAvg = COALESCE(AVG(crashes), 0)"
                             },
                             "visualization": {
                                 "layerId": "97e0e256-026d-4ec8-a28c-7626290e208e",
@@ -2058,7 +2058,7 @@
                     "filters": [],
                     "hidePanelTitles": true,
                     "query": {
-                        "esql": "FROM logs-generic.otel*\n| WHERE os.name == \"Android\" AND session.id IS NOT NULL AND event_name == \"app.crash\"\n| STATS crashes = COUNT() BY session.id\n| STATS sessionAvg = COALESCE(AVG(crashes), 0)"
+                        "esql": "FROM logs-generic.otel*\n| WHERE os.name == \"Android\" AND session.id IS NOT NULL AND event_name == \"device.crash\"\n| STATS crashes = COUNT() BY session.id\n| STATS sessionAvg = COALESCE(AVG(crashes), 0)"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -2347,7 +2347,7 @@
         "version": 3
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-02-23T11:10:26.707Z",
+    "created_at": "2026-04-01T12:02:27.713Z",
     "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
     "id": "otel_android_dashboards-4cff90ff-0bd6-48eb-9ea6-57f91391ebce",
     "references": [

--- a/packages/otel_android_dashboards/kibana/dashboard/otel_android_dashboards-66c53e5e-9a86-43f3-a85d-a1d90d974bff.json
+++ b/packages/otel_android_dashboards/kibana/dashboard/otel_android_dashboards-66c53e5e-9a86-43f3-a85d-a1d90d974bff.json
@@ -1296,7 +1296,7 @@
         "version": 3
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-02-23T11:10:26.707Z",
+    "created_at": "2026-04-01T12:02:27.713Z",
     "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
     "id": "otel_android_dashboards-66c53e5e-9a86-43f3-a85d-a1d90d974bff",
     "references": [

--- a/packages/otel_android_dashboards/manifest.yml
+++ b/packages/otel_android_dashboards/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: otel_android_dashboards
 title: "Android OpenTelemetry Assets"
-version: 0.1.0
+version: 0.1.1
 description: "Dashboards for visualizing Android application's telemetry"
 type: content
 categories:


### PR DESCRIPTION
## Proposed commit message

Update crash event name from `app.crash` to `device.crash` in the Android OpenTelemetry dashboards.

**WHAT**: Updated ES|QL and KQL queries in the Application Overview dashboard to use `device.crash` instead of `app.crash` as the event name for crash events.

**WHY**: The EDOT Android SDK's crash events will be sent using the event name `device.crash` (aligning with OpenTelemetry Android). This change updates the dashboard queries to match the new event name so crash data is correctly displayed.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Verified crash events appear correctly in the dashboard with the updated queries

## How to test this PR locally

1. Install the package in Kibana
2. Send crash telemetry from an Android app using EDOT Android SDK v1.6.0+
3. Open the "Application Overview" dashboard and verify crash data appears in the crash-related panels