### PR TITLE
Add username extraction for another message case

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.16.0"
+  changes:
+    - description: Extract user.name and source.address from PAM key-value log messages and password change events in the auth data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "2.15.0"
   changes:
     - description: Add process.args_count to security process events (event 4688).

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Extract user.name and source.address from PAM key-value log messages and password change events in the auth data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/18280
 - version: "2.15.0"
   changes:
     - description: Add process.args_count to security process events (event 4688).

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11-preserve-original.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11-preserve-original.json-expected.json
@@ -1317,6 +1317,9 @@
             "related": {
                 "hosts": [
                     "bullseye"
+                ],
+                "user": [
+                    "fred"
                 ]
             },
             "tags": [
@@ -1329,7 +1332,8 @@
                     },
                     "id": "0"
                 },
-                "id": "1000"
+                "id": "1000",
+                "name": "fred"
             }
         },
         {

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11.json-expected.json
@@ -1275,6 +1275,9 @@
             "related": {
                 "hosts": [
                     "bullseye"
+                ],
+                "user": [
+                    "fred"
                 ]
             },
             "user": {
@@ -1284,7 +1287,8 @@
                     },
                     "id": "0"
                 },
-                "id": "1000"
+                "id": "1000",
+                "name": "fred"
             }
         },
         {

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
@@ -2481,10 +2481,16 @@
             "related": {
                 "hosts": [
                     "precise32"
+                ],
+                "user": [
+                    "tsg"
                 ]
             },
             "system": {
                 "auth": {}
+            },
+            "user": {
+                "name": "tsg"
             }
         },
         {
@@ -2655,10 +2661,16 @@
             "related": {
                 "hosts": [
                     "precise32"
+                ],
+                "user": [
+                    "tsg"
                 ]
             },
             "system": {
                 "auth": {}
+            },
+            "user": {
+                "name": "tsg"
             }
         },
         {

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-extraction.log
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-extraction.log
@@ -1,0 +1,5 @@
+Mar 15 10:30:01 webserver sshd[12345]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=10.0.0.5  user=admin
+Mar 15 10:30:02 webserver sshd[12346]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=10.0.0.5  user=deploy
+Mar 15 10:30:03 webserver passwd[12347]: pam_unix(passwd:chauthtok): password changed for jsmith
+Mar 15 10:30:04 webserver sudo: pam_unix(sudo:auth): authentication failure; logname=jsmith uid=1001 euid=0 tty=/dev/pts/0 ruser=jsmith rhost=  user=jsmith
+Mar 15 10:30:05 webserver sshd[12348]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.1.100

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-extraction.log-config.yml
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-extraction.log-config.yml
@@ -1,0 +1,7 @@
+fields:
+  event:
+    timezone: "+0000"
+  input.type: log
+dynamic_fields:
+  "event.ingested": "^.*$"
+  "@timestamp": "^[0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}\\.[0-9]{3}Z$"

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-extraction.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-extraction.log-expected.json
@@ -1,0 +1,214 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-03-15T10:30:01.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "authentication"
+                ],
+                "kind": "event",
+                "original": "Mar 15 10:30:01 webserver sshd[12345]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=10.0.0.5  user=admin",
+                "outcome": "failure",
+                "timezone": "+0000"
+            },
+            "host": {
+                "hostname": "webserver"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=10.0.0.5  user=admin",
+            "process": {
+                "name": "sshd",
+                "pid": 12345
+            },
+            "related": {
+                "hosts": [
+                    "webserver"
+                ],
+                "ip": [
+                    "10.0.0.5"
+                ],
+                "user": [
+                    "admin"
+                ]
+            },
+            "source": {
+                "address": "10.0.0.5",
+                "ip": "10.0.0.5"
+            },
+            "system": {
+                "auth": {}
+            },
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2026-03-15T10:30:02.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "authentication"
+                ],
+                "kind": "event",
+                "original": "Mar 15 10:30:02 webserver sshd[12346]: PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=10.0.0.5  user=deploy",
+                "outcome": "failure",
+                "timezone": "+0000"
+            },
+            "host": {
+                "hostname": "webserver"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "PAM 2 more authentication failures; logname= uid=0 euid=0 tty=ssh ruser= rhost=10.0.0.5  user=deploy",
+            "process": {
+                "name": "sshd",
+                "pid": 12346
+            },
+            "related": {
+                "hosts": [
+                    "webserver"
+                ],
+                "ip": [
+                    "10.0.0.5"
+                ],
+                "user": [
+                    "deploy"
+                ]
+            },
+            "source": {
+                "address": "10.0.0.5",
+                "ip": "10.0.0.5"
+            },
+            "system": {
+                "auth": {}
+            },
+            "user": {
+                "name": "deploy"
+            }
+        },
+        {
+            "@timestamp": "2026-03-15T10:30:03.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "event",
+                "original": "Mar 15 10:30:03 webserver passwd[12347]: pam_unix(passwd:chauthtok): password changed for jsmith",
+                "timezone": "+0000"
+            },
+            "host": {
+                "hostname": "webserver"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "pam_unix(passwd:chauthtok): password changed for jsmith",
+            "process": {
+                "name": "passwd",
+                "pid": 12347
+            },
+            "related": {
+                "hosts": [
+                    "webserver"
+                ],
+                "user": [
+                    "jsmith"
+                ]
+            },
+            "system": {
+                "auth": {}
+            },
+            "user": {
+                "name": "jsmith"
+            }
+        },
+        {
+            "@timestamp": "2026-03-15T10:30:04.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "authentication"
+                ],
+                "kind": "event",
+                "original": "Mar 15 10:30:04 webserver sudo: pam_unix(sudo:auth): authentication failure; logname=jsmith uid=1001 euid=0 tty=/dev/pts/0 ruser=jsmith rhost=  user=jsmith",
+                "outcome": "failure",
+                "timezone": "+0000"
+            },
+            "host": {
+                "hostname": "webserver"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "pam_unix(sudo:auth): authentication failure; logname=jsmith uid=1001 euid=0 tty=/dev/pts/0 ruser=jsmith rhost=  user=jsmith",
+            "process": {
+                "name": "sudo"
+            },
+            "related": {
+                "hosts": [
+                    "webserver"
+                ],
+                "user": [
+                    "jsmith"
+                ]
+            },
+            "system": {
+                "auth": {}
+            },
+            "user": {
+                "name": "jsmith"
+            }
+        },
+        {
+            "@timestamp": "2026-03-15T10:30:05.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "authentication"
+                ],
+                "kind": "event",
+                "original": "Mar 15 10:30:05 webserver sshd[12348]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.1.100",
+                "outcome": "failure",
+                "timezone": "+0000"
+            },
+            "host": {
+                "hostname": "webserver"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=192.168.1.100",
+            "process": {
+                "name": "sshd",
+                "pid": 12348
+            },
+            "related": {
+                "hosts": [
+                    "webserver"
+                ],
+                "ip": [
+                    "192.168.1.100"
+                ]
+            },
+            "source": {
+                "address": "192.168.1.100",
+                "ip": "192.168.1.100"
+            },
+            "system": {
+                "auth": {}
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-secure-rhel7.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-secure-rhel7.log-expected.json
@@ -169,10 +169,41 @@
             "related": {
                 "hosts": [
                     "slave22"
+                ],
+                "ip": [
+                    "89.160.20.156"
+                ],
+                "user": [
+                    "root"
                 ]
+            },
+            "source": {
+                "address": "89.160.20.156",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.156"
             },
             "system": {
                 "auth": {}
+            },
+            "user": {
+                "name": "root"
             }
         },
         {
@@ -233,10 +264,41 @@
             "related": {
                 "hosts": [
                     "slave22"
+                ],
+                "ip": [
+                    "89.160.20.156"
+                ],
+                "user": [
+                    "root"
                 ]
+            },
+            "source": {
+                "address": "89.160.20.156",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.156"
             },
             "system": {
                 "auth": {}
+            },
+            "user": {
+                "name": "root"
             }
         },
         {

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
@@ -51,6 +51,25 @@ processors:
       patterns:
         - '^pam_unix(%{DATA}:%{WORD:_temp.category})'
       if: ctx.message != null && ctx.message.contains('pam_unix(')
+  - grok:
+      description: Extract rhost and user from PAM key-value messages.
+      tag: grok-pam-kv
+      field: message
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.message != null && ctx.message.contains('rhost=')
+      patterns:
+        - 'rhost=%{IPORHOST:_temp.pam_rhost}%{SPACE}(?:user=%{DATA:_temp.pam_user})?$'
+        - 'rhost=%{SPACE}user=%{DATA:_temp.pam_user}$'
+  - grok:
+      description: Extract username from PAM password change messages.
+      tag: grok-pam-password-changed
+      field: message
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.message != null && ctx.message.contains('password changed for')
+      patterns:
+        - 'password changed for %{USERNAME:_temp.pam_user}$'
   - kv:
       tag: "kv_syslog_structured_semicolon_colon"
       if: ctx.syslog5424_sd != null && ctx.syslog5424_sd != ''
@@ -168,6 +187,20 @@ processors:
       ignore_missing: true
       ignore_failure: true
       if: ctx.user?.name != null
+  - rename:
+      tag: rename_pam_rhost
+      field: _temp.pam_rhost
+      target_field: source.address
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx._temp?.pam_rhost != null && ctx.source?.address == null
+  - rename:
+      tag: rename_pam_user
+      field: _temp.pam_user
+      target_field: user.name
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx._temp?.pam_user != null && ctx._temp.pam_user != '' && (ctx.user?.name == null || ctx.user?.name == '')
   - remove:
       tag: remove_temp
       field: _temp

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.15.0"
+version: "2.16.0"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

This adds a missing case of extracting the username from the auth log ingest pipeline
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

The PR includes test coverage of the change in the regular stack tests for the audit integration

