### PR TITLE
Add SpoofSentry integration

### DIFF
--- a/packages/spoofsentry/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/spoofsentry/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,95 @@
+---
+description: Pipeline for processing SpoofSentry domain security events
+processors:
+  - set:
+      field: ecs.version
+      value: "8.11.0"
+
+  - set:
+      field: event.kind
+      value: alert
+
+  - set:
+      field: event.dataset
+      value: spoofsentry.alert
+
+  - set:
+      field: event.provider
+      value: spoofsentry
+
+  - rename:
+      field: eventType
+      target_field: event.action
+      ignore_missing: true
+
+  - rename:
+      field: domain
+      target_field: host.domain
+      ignore_missing: true
+
+  - rename:
+      field: tenantId
+      target_field: labels.tenant_id
+      ignore_missing: true
+
+  # Map severity to ECS event.severity (numeric)
+  - script:
+      lang: painless
+      description: Map severity string to ECS numeric severity
+      source: >
+        Map severityMap = new HashMap();
+        severityMap.put('info', 1);
+        severityMap.put('low', 3);
+        severityMap.put('medium', 5);
+        severityMap.put('high', 7);
+        severityMap.put('critical', 10);
+        String sev = ctx.severity;
+        if (sev != null && severityMap.containsKey(sev.toLowerCase())) {
+          ctx.event.severity = severityMap.get(sev.toLowerCase());
+        } else {
+          ctx.event.severity = 1;
+        }
+      ignore_failure: true
+
+  # Categorize events
+  - script:
+      lang: painless
+      description: Set event.category and event.type based on event.action
+      source: >
+        String action = ctx.event?.action;
+        if (action == null) return;
+        action = action.toLowerCase();
+        if (action.contains('threat') || action.contains('spoofing') || action.contains('lookalike')) {
+          ctx.event.category = ['threat'];
+          ctx.event.type = ['indicator'];
+        } else if (action.contains('takedown')) {
+          ctx.event.category = ['threat'];
+          ctx.event.type = ['info'];
+        } else if (action.contains('dns') || action.contains('enforcement')) {
+          ctx.event.category = ['configuration'];
+          ctx.event.type = ['change'];
+        } else if (action.contains('alert')) {
+          ctx.event.category = ['threat'];
+          ctx.event.type = ['indicator'];
+        } else {
+          ctx.event.category = ['host'];
+          ctx.event.type = ['info'];
+        }
+      ignore_failure: true
+
+  # Preserve original severity as label
+  - set:
+      field: labels.severity
+      copy_from: severity
+      ignore_empty_value: true
+
+  - set:
+      field: labels.event_type
+      copy_from: event.action
+      ignore_empty_value: true
+
+  # Remove redundant top-level fields after remapping
+  - remove:
+      field:
+        - severity
+      ignore_missing: true

--- a/packages/spoofsentry/kibana/dashboard/spoofsentry-overview.json
+++ b/packages/spoofsentry/kibana/dashboard/spoofsentry-overview.json
@@ -1,0 +1,77 @@
+{
+  "id": "spoofsentry-overview",
+  "type": "dashboard",
+  "attributes": {
+    "title": "SpoofSentry — Domain Security Overview",
+    "description": "DMARC monitoring, spoofing detection, lookalike domains, and takedown events from SpoofSentry",
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "title": "Total Events (24h)",
+          "description": "Total SpoofSentry events in the last 24 hours"
+        },
+        "gridData": { "x": 0, "y": 0, "w": 12, "h": 8, "i": "1" },
+        "panelIndex": "1",
+        "type": "lens",
+        "panelRefName": "panel_1"
+      },
+      {
+        "embeddableConfig": {
+          "title": "Critical & High Threats",
+          "description": "Critical and high severity events"
+        },
+        "gridData": { "x": 12, "y": 0, "w": 12, "h": 8, "i": "2" },
+        "panelIndex": "2",
+        "type": "lens",
+        "panelRefName": "panel_2"
+      },
+      {
+        "embeddableConfig": {
+          "title": "Events by Severity Over Time",
+          "description": "Event volume broken down by severity"
+        },
+        "gridData": { "x": 24, "y": 0, "w": 24, "h": 8, "i": "3" },
+        "panelIndex": "3",
+        "type": "lens",
+        "panelRefName": "panel_3"
+      },
+      {
+        "embeddableConfig": {
+          "title": "Top Event Types",
+          "description": "Most frequent event types"
+        },
+        "gridData": { "x": 0, "y": 8, "w": 24, "h": 12, "i": "4" },
+        "panelIndex": "4",
+        "type": "lens",
+        "panelRefName": "panel_4"
+      },
+      {
+        "embeddableConfig": {
+          "title": "Top Domains",
+          "description": "Domains with the most security events"
+        },
+        "gridData": { "x": 24, "y": 8, "w": 24, "h": 12, "i": "5" },
+        "panelIndex": "5",
+        "type": "lens",
+        "panelRefName": "panel_5"
+      },
+      {
+        "embeddableConfig": {
+          "title": "Takedown Activity",
+          "description": "Takedown lifecycle events over time"
+        },
+        "gridData": { "x": 0, "y": 20, "w": 48, "h": 12, "i": "6" },
+        "panelIndex": "6",
+        "type": "lens",
+        "panelRefName": "panel_6"
+      }
+    ],
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "query": { "query": "event.dataset: spoofsentry.alert", "language": "kuery" },
+        "filter": []
+      }
+    }
+  },
+  "references": []
+}

--- a/packages/spoofsentry/manifest.yml
+++ b/packages/spoofsentry/manifest.yml
@@ -44,3 +44,4 @@ policy_templates:
             type: password
             title: Secret Value
             description: Expected token value for authentication
+            secret: true

--- a/packages/spoofsentry/manifest.yml
+++ b/packages/spoofsentry/manifest.yml
@@ -1,0 +1,46 @@
+format_version: 2.0.0
+name: spoofsentry
+title: SpoofSentry
+version: 1.0.0
+description: Ingest DMARC monitoring, spoofing detection, and takedown events from SpoofSentry
+type: integration
+categories:
+  - security
+  - email_security
+conditions:
+  kibana.version: "^8.0.0"
+  elastic.subscription: basic
+owner:
+  github: netallion
+  type: community
+icons:
+  - src: /img/spoofsentry-logo.svg
+    title: SpoofSentry
+    size: 32x32
+    type: image/svg+xml
+policy_templates:
+  - name: spoofsentry
+    title: SpoofSentry Events
+    description: Collect domain security events from SpoofSentry
+    inputs:
+      - type: http_endpoint
+        title: SpoofSentry HTTP Endpoint
+        description: Receive SpoofSentry events via HTTP
+        vars:
+          - name: listen_address
+            type: text
+            title: Listen Address
+            default: "0.0.0.0"
+          - name: listen_port
+            type: integer
+            title: Listen Port
+            default: 8089
+          - name: secret_header
+            type: text
+            title: Secret Header
+            description: Header name containing the authentication token
+            default: "Authorization"
+          - name: secret_value
+            type: password
+            title: Secret Value
+            description: Expected token value for authentication


### PR DESCRIPTION
## Summary

Adds a new community integration for **SpoofSentry** by DomainSeal — a DMARC monitoring, domain spoofing detection, and automated takedown platform.

## What's Included

- **Fleet integration manifest** — `http_endpoint` input for receiving SpoofSentry events
- **Ingest pipeline** — ECS field mapping with painless scripts for severity and event categorization
- **Kibana dashboard** — 6-panel domain security overview (events, threats, severity, domains, takedowns)

## ECS Mapping

| Source | ECS Field |
|--------|-----------|
| `eventType` | `event.action` |
| `severity` | `event.severity` (numeric: info=1, low=3, medium=5, high=7, critical=10) |
| `domain` | `host.domain` |
| `tenantId` | `labels.tenant_id` |
| — | `event.kind` = `alert` |
| — | `event.dataset` = `spoofsentry.alert` |
| — | `event.provider` = `spoofsentry` |
| — | `event.category` = `threat` / `configuration` / `host` |

## Event Types

DMARC failures, spoofing campaigns, lookalike domains, DNS enforcement changes, takedown orchestration lifecycle.

## Author

- **Company:** DomainSeal
- **Website:** https://spoofsentry.com
- **Support:** hello@spoofsentry.com