### PR TITLE
Update Logstash single pipeline dashboard with batch byte_size metrics for p50 p90 max

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Update existing batch graphs with 50th and 90th percentiles during last minute. Note that these metrics will only show results for Logstash versions 9.4.0 or later.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/17785
 - version: "2.10.1"
   changes:
     - description: Fixes navigation of batch metrics when the integration is used to monitor an older version of Logstash that doesn't expose.

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.11.0"
   changes:
-    - description: Update existing batch graphs with 50th and 90th percentiles during last minute. Note that these metrics will only show results for Logstash versions 9.4.0 or later.
+    - description: Update existing batch graphs with 50th and 90th percentiles during last minute. Replace average lifetime metric with last one minute, for both batch's byte size and value, to be coherent with the other graphed percentiles.. Note that these metrics will only show results for Logstash versions 9.4.0 or later.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/17785
 - version: "2.10.1"

--- a/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
@@ -65,7 +65,7 @@ program: |
             "current": body.pipelines[pipeline_name].?batch.event_count.current.orValue([]),
             "average.lifetime": body.pipelines[pipeline_name].?batch.event_count.average.lifetime.orValue([]),
             "p50.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p50.last_1_minute.orValue([]),
-            "p90.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p90.last_1_minute.orValue([])
+            "p90.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p90.last_1_minute.orValue([]),
           },
           "byte_size":{
             "current": body.pipelines[pipeline_name].?batch.byte_size.current.orValue([]),

--- a/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
@@ -64,12 +64,14 @@ program: |
           "event_count":{
             "current": body.pipelines[pipeline_name].?batch.event_count.current.orValue([]),
             "average.lifetime": body.pipelines[pipeline_name].?batch.event_count.average.lifetime.orValue([]),
+            "average.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.average.last_1_minute.orValue([]),
             "p50.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p50.last_1_minute.orValue([]),
             "p90.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p90.last_1_minute.orValue([]),
           },
           "byte_size":{
             "current": body.pipelines[pipeline_name].?batch.byte_size.current.orValue([]),
             "average.lifetime": body.pipelines[pipeline_name].?batch.byte_size.average.lifetime.orValue([]),
+            "average.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.average.last_1_minute.orValue([]),
             "p50.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.p50.last_1_minute.orValue([]),
             "p90.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.p90.last_1_minute.orValue([]),
             "max.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.max.last_1_minute.orValue([]),

--- a/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
@@ -63,14 +63,12 @@ program: |
         "batch":{
           "event_count":{
             "current": body.pipelines[pipeline_name].?batch.event_count.current.orValue([]),
-            "average.lifetime": body.pipelines[pipeline_name].?batch.event_count.average.lifetime.orValue([]),
             "average.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.average.last_1_minute.orValue([]),
             "p50.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p50.last_1_minute.orValue([]),
             "p90.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p90.last_1_minute.orValue([]),
           },
           "byte_size":{
             "current": body.pipelines[pipeline_name].?batch.byte_size.current.orValue([]),
-            "average.lifetime": body.pipelines[pipeline_name].?batch.byte_size.average.lifetime.orValue([]),
             "average.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.average.last_1_minute.orValue([]),
             "p50.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.p50.last_1_minute.orValue([]),
             "p90.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.p90.last_1_minute.orValue([]),

--- a/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
@@ -63,11 +63,16 @@ program: |
         "batch":{
           "event_count":{
             "current": body.pipelines[pipeline_name].?batch.event_count.current.orValue([]),
-            "average.lifetime": body.pipelines[pipeline_name].?batch.event_count.average.lifetime.orValue([])
+            "average.lifetime": body.pipelines[pipeline_name].?batch.event_count.average.lifetime.orValue([]),
+            "p50.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p50.last_1_minute.orValue([]),
+            "p90.last_1_minute": body.pipelines[pipeline_name].?batch.event_count.p90.last_1_minute.orValue([])
           },
           "byte_size":{
             "current": body.pipelines[pipeline_name].?batch.byte_size.current.orValue([]),
             "average.lifetime": body.pipelines[pipeline_name].?batch.byte_size.average.lifetime.orValue([]),
+            "p50.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.p50.last_1_minute.orValue([]),
+            "p90.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.p90.last_1_minute.orValue([]),
+            "max.last_1_minute": body.pipelines[pipeline_name].?batch.byte_size.max.last_1_minute.orValue([]),
           },
         },
         "events":{

--- a/packages/logstash/data_stream/pipeline/fields/fields.yml
+++ b/packages/logstash/data_stream/pipeline/fields/fields.yml
@@ -49,10 +49,6 @@
           type: long
           description: Number of events contained in batch by the pipeline
           metric_type: gauge
-        - name: batch.event_count.average.lifetime
-          type: long
-          description: Number of average events contained in batch by the pipeline (Lifetime)
-          metric_type: gauge
         - name: batch.event_count.average.last_1_minute
           type: long
           description: Number of average events contained in batch by the pipeline (last 1 minute)
@@ -69,11 +65,6 @@
           type: long
           unit: byte
           description: Size in bytes of batch by the pipeline
-          metric_type: gauge
-        - name: batch.byte_size.average.lifetime
-          type: long
-          unit: byte
-          description: Average size in bytes of batch by the pipeline (Lifetime)
           metric_type: gauge
         - name: batch.byte_size.average.last_1_minute
           type: long

--- a/packages/logstash/data_stream/pipeline/fields/fields.yml
+++ b/packages/logstash/data_stream/pipeline/fields/fields.yml
@@ -53,6 +53,10 @@
           type: long
           description: Number of average events contained in batch by the pipeline (Lifetime)
           metric_type: gauge
+        - name: batch.event_count.average.last_1_minute
+          type: long
+          description: Number of average events contained in batch by the pipeline (last 1 minute)
+          metric_type: gauge  
         - name: batch.event_count.p50.last_1_minute
           type: long
           description: 50th percentile of events per batch for the pipeline (last 1 minute)
@@ -70,6 +74,11 @@
           type: long
           unit: byte
           description: Average size in bytes of batch by the pipeline (Lifetime)
+          metric_type: gauge
+        - name: batch.byte_size.average.last_1_minute
+          type: long
+          unit: byte
+          description: Average size in bytes of batch by the pipeline (last 1 minute)
           metric_type: gauge
         - name: batch.byte_size.p50.last_1_minute
           type: long

--- a/packages/logstash/data_stream/pipeline/fields/fields.yml
+++ b/packages/logstash/data_stream/pipeline/fields/fields.yml
@@ -53,6 +53,14 @@
           type: long
           description: Number of average events contained in batch by the pipeline (Lifetime)
           metric_type: gauge
+        - name: batch.event_count.p50.last_1_minute
+          type: long
+          description: 50th percentile of events per batch for the pipeline (last 1 minute)
+          metric_type: gauge
+        - name: batch.event_count.p90.last_1_minute
+          type: long
+          description: 90th percentile of events per batch for the pipeline (last 1 minute)
+          metric_type: gauge
         - name: batch.byte_size.current
           type: long
           unit: byte
@@ -62,6 +70,21 @@
           type: long
           unit: byte
           description: Average size in bytes of batch by the pipeline (Lifetime)
+          metric_type: gauge
+        - name: batch.byte_size.p50.last_1_minute
+          type: long
+          unit: byte
+          description: 50th percentile of batch size in bytes for the pipeline (last 1 minute)
+          metric_type: gauge
+        - name: batch.byte_size.p90.last_1_minute
+          type: long
+          unit: byte
+          description: 90th percentile of batch size in bytes for the pipeline (last 1 minute)
+          metric_type: gauge
+        - name: batch.byte_size.max.last_1_minute
+          type: long
+          unit: byte
+          description: Maximum batch size in bytes for the pipeline (last 1 minute)
           metric_type: gauge
         - name: events.filtered
           type: long

--- a/packages/logstash/docs/README.md
+++ b/packages/logstash/docs/README.md
@@ -461,11 +461,13 @@ This is the `pipeline` dataset, which drives the Pipeline dashboard pages.
 | logstash.pipeline.info.ephemeral_id | Ephemeral Id for the running pipeline | keyword |  |  |
 | logstash.pipeline.info.workers | Number of workers for the running pipeline | long |  | gauge |
 | logstash.pipeline.name | Logstash Pipeline id/name | keyword |  |  |
+| logstash.pipeline.total.batch.byte_size.average.last_1_minute | Average size in bytes of batch by the pipeline (last 1 minute) | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.average.lifetime | Average size in bytes of batch by the pipeline (Lifetime) | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.current | Size in bytes of batch by the pipeline | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.max.last_1_minute | Maximum batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.p50.last_1_minute | 50th percentile of batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.p90.last_1_minute | 90th percentile of batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
+| logstash.pipeline.total.batch.event_count.average.last_1_minute | Number of average events contained in batch by the pipeline (last 1 minute) | long |  | gauge |
 | logstash.pipeline.total.batch.event_count.average.lifetime | Number of average events contained in batch by the pipeline (Lifetime) | long |  | gauge |
 | logstash.pipeline.total.batch.event_count.current | Number of events contained in batch by the pipeline | long |  | gauge |
 | logstash.pipeline.total.batch.event_count.p50.last_1_minute | 50th percentile of events per batch for the pipeline (last 1 minute) | long |  | gauge |

--- a/packages/logstash/docs/README.md
+++ b/packages/logstash/docs/README.md
@@ -462,13 +462,11 @@ This is the `pipeline` dataset, which drives the Pipeline dashboard pages.
 | logstash.pipeline.info.workers | Number of workers for the running pipeline | long |  | gauge |
 | logstash.pipeline.name | Logstash Pipeline id/name | keyword |  |  |
 | logstash.pipeline.total.batch.byte_size.average.last_1_minute | Average size in bytes of batch by the pipeline (last 1 minute) | long | byte | gauge |
-| logstash.pipeline.total.batch.byte_size.average.lifetime | Average size in bytes of batch by the pipeline (Lifetime) | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.current | Size in bytes of batch by the pipeline | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.max.last_1_minute | Maximum batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.p50.last_1_minute | 50th percentile of batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.p90.last_1_minute | 90th percentile of batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
 | logstash.pipeline.total.batch.event_count.average.last_1_minute | Number of average events contained in batch by the pipeline (last 1 minute) | long |  | gauge |
-| logstash.pipeline.total.batch.event_count.average.lifetime | Number of average events contained in batch by the pipeline (Lifetime) | long |  | gauge |
 | logstash.pipeline.total.batch.event_count.current | Number of events contained in batch by the pipeline | long |  | gauge |
 | logstash.pipeline.total.batch.event_count.p50.last_1_minute | 50th percentile of events per batch for the pipeline (last 1 minute) | long |  | gauge |
 | logstash.pipeline.total.batch.event_count.p90.last_1_minute | 90th percentile of events per batch for the pipeline (last 1 minute) | long |  | gauge |

--- a/packages/logstash/docs/README.md
+++ b/packages/logstash/docs/README.md
@@ -463,8 +463,13 @@ This is the `pipeline` dataset, which drives the Pipeline dashboard pages.
 | logstash.pipeline.name | Logstash Pipeline id/name | keyword |  |  |
 | logstash.pipeline.total.batch.byte_size.average.lifetime | Average size in bytes of batch by the pipeline (Lifetime) | long | byte | gauge |
 | logstash.pipeline.total.batch.byte_size.current | Size in bytes of batch by the pipeline | long | byte | gauge |
+| logstash.pipeline.total.batch.byte_size.max.last_1_minute | Maximum batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
+| logstash.pipeline.total.batch.byte_size.p50.last_1_minute | 50th percentile of batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
+| logstash.pipeline.total.batch.byte_size.p90.last_1_minute | 90th percentile of batch size in bytes for the pipeline (last 1 minute) | long | byte | gauge |
 | logstash.pipeline.total.batch.event_count.average.lifetime | Number of average events contained in batch by the pipeline (Lifetime) | long |  | gauge |
 | logstash.pipeline.total.batch.event_count.current | Number of events contained in batch by the pipeline | long |  | gauge |
+| logstash.pipeline.total.batch.event_count.p50.last_1_minute | 50th percentile of events per batch for the pipeline (last 1 minute) | long |  | gauge |
+| logstash.pipeline.total.batch.event_count.p90.last_1_minute | 90th percentile of events per batch for the pipeline (last 1 minute) | long |  | gauge |
 | logstash.pipeline.total.events.filtered | Number of events filtered by the pipeline | long |  | counter |
 | logstash.pipeline.total.events.in | Number of events received by the pipeline | long |  | counter |
 | logstash.pipeline.total.events.out | Number of events emitted by the pipeline | long |  | counter |

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -6789,12 +6789,12 @@
                         "references": [
                             {
                                 "id": "logstash-sm-metrics",
-                                "name": "indexpattern-datasource-layer-a8c2c277-1b48-416e-84fa-31ef12f6b5ed",
+                                "name": "indexpattern-datasource-layer-a7473309-8ac9-4157-b1fc-88c459a5d220",
                                 "type": "index-pattern"
                             },
                             {
                                 "id": "logstash-sm-metrics",
-                                "name": "indexpattern-datasource-layer-a7473309-8ac9-4157-b1fc-88c459a5d220",
+                                "name": "indexpattern-datasource-layer-a8c2c277-1b48-416e-84fa-31ef12f6b5ed",
                                 "type": "index-pattern"
                             }
                         ],
@@ -6807,7 +6807,10 @@
                                             "columnOrder": [
                                                 "35953d49-dc19-4f0e-884d-094811a16375",
                                                 "6090c0d4-2421-4b1d-8b2d-d9186c16dbd7",
-                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6"
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6",
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6X0",
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6X1",
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6X2"
                                             ],
                                             "columns": {
                                                 "35953d49-dc19-4f0e-884d-094811a16375": {
@@ -6827,7 +6830,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "p50 last minute",
-                                                    "operationType": "average",
+                                                    "operationType": "median",
                                                     "params": {
                                                         "emptyAsNull": true
                                                     },
@@ -6837,12 +6840,63 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "p90 last minute",
+                                                    "label": "p90 last minute (delta)",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "formula": "average(logstash.pipeline.total.batch.byte_size.p90.last_1_minute) - average(logstash.pipeline.total.batch.byte_size.p50.last_1_minute) ",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "e29cbd4d-2d96-4b76-a135-b3162e3563d6X2"
+                                                    ]
+                                                },
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of p90 last minute (delta)",
                                                     "operationType": "average",
                                                     "params": {
-                                                        "emptyAsNull": true
+                                                        "emptyAsNull": false
                                                     },
                                                     "sourceField": "logstash.pipeline.total.batch.byte_size.p90.last_1_minute"
+                                                },
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of p90 last minute (delta)",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "sourceField": "logstash.pipeline.total.batch.byte_size.p50.last_1_minute"
+                                                },
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6X2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of p90 last minute (delta)",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6X0",
+                                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6X1"
+                                                            ],
+                                                            "location": {
+                                                                "max": 136,
+                                                                "min": 0
+                                                            },
+                                                            "name": "subtract",
+                                                            "text": "average(logstash.pipeline.total.batch.byte_size.p90.last_1_minute) - average(logstash.pipeline.total.batch.byte_size.p50.last_1_minute) ",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "e29cbd4d-2d96-4b76-a135-b3162e3563d6X0",
+                                                        "e29cbd4d-2d96-4b76-a135-b3162e3563d6X1"
+                                                    ]
                                                 }
                                             },
                                             "ignoreGlobalFilters": false,
@@ -6930,6 +6984,7 @@
                                     "yLeft": true,
                                     "yRight": true
                                 },
+                                "fillOpacity": 0.3,
                                 "labelsOrientation": {
                                     "x": 0,
                                     "yLeft": 0,
@@ -6970,14 +7025,17 @@
                                         "xAccessor": "e830e95e-ada9-476f-9392-8514bb6dfaf3",
                                         "yConfig": [
                                             {
+                                                "axisMode": "left",
                                                 "color": "#61a2ff",
                                                 "forAccessor": "38a796b9-1ccf-4a53-a940-8da67a133b5d"
                                             },
                                             {
+                                                "axisMode": "left",
                                                 "color": "#bfdbff",
                                                 "forAccessor": "a20aba59-2eb3-408c-ae36-6d7fd5546caa"
                                             },
                                             {
+                                                "axisMode": "left",
                                                 "color": "#f6726a",
                                                 "forAccessor": "02dedb74-d833-479b-aa0d-740cd01d0d9e"
                                             }
@@ -6985,8 +7043,8 @@
                                     },
                                     {
                                         "accessors": [
-                                            "6090c0d4-2421-4b1d-8b2d-d9186c16dbd7",
-                                            "e29cbd4d-2d96-4b76-a135-b3162e3563d6"
+                                            "e29cbd4d-2d96-4b76-a135-b3162e3563d6",
+                                            "6090c0d4-2421-4b1d-8b2d-d9186c16dbd7"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
@@ -7011,16 +7069,18 @@
                                         "layerId": "a7473309-8ac9-4157-b1fc-88c459a5d220",
                                         "layerType": "data",
                                         "position": "top",
-                                        "seriesType": "area",
+                                        "seriesType": "area_stacked",
                                         "showGridlines": false,
                                         "xAccessor": "35953d49-dc19-4f0e-884d-094811a16375",
                                         "yConfig": [
                                             {
-                                                "color": "#0ef270",
+                                                "axisMode": "left",
+                                                "color": "#fdffff",
                                                 "forAccessor": "6090c0d4-2421-4b1d-8b2d-d9186c16dbd7"
                                             },
                                             {
-                                                "color": "#eaae01",
+                                                "axisMode": "left",
+                                                "color": "#d57558",
                                                 "forAccessor": "e29cbd4d-2d96-4b76-a135-b3162e3563d6"
                                             }
                                         ]
@@ -7072,7 +7132,7 @@
         "title": "[Metrics Logstash] Logstash Single Pipeline View"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-09T10:07:20.769Z",
+    "created_at": "2026-04-17T12:30:41.002Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "references": [
         {
@@ -7267,12 +7327,12 @@
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "94713cee-aa91-4b06-afff-ac6b8082b6e0:indexpattern-datasource-layer-a8c2c277-1b48-416e-84fa-31ef12f6b5ed",
+            "name": "94713cee-aa91-4b06-afff-ac6b8082b6e0:indexpattern-datasource-layer-a7473309-8ac9-4157-b1fc-88c459a5d220",
             "type": "index-pattern"
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "94713cee-aa91-4b06-afff-ac6b8082b6e0:indexpattern-datasource-layer-a7473309-8ac9-4157-b1fc-88c459a5d220",
+            "name": "94713cee-aa91-4b06-afff-ac6b8082b6e0:indexpattern-datasource-layer-a8c2c277-1b48-416e-84fa-31ef12f6b5ed",
             "type": "index-pattern"
         }
     ],

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -6802,7 +6802,6 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "logstash-sm-metrics",
                                     "layers": {
                                         "a7473309-8ac9-4157-b1fc-88c459a5d220": {
                                             "columnOrder": [
@@ -6902,7 +6901,6 @@
                                             },
                                             "ignoreGlobalFilters": false,
                                             "incompleteColumns": {},
-                                            "indexPatternId": "logstash-sm-metrics",
                                             "sampling": 1
                                         },
                                         "a8c2c277-1b48-416e-84fa-31ef12f6b5ed": {
@@ -6969,7 +6967,6 @@
                                             },
                                             "ignoreGlobalFilters": false,
                                             "incompleteColumns": {},
-                                            "indexPatternId": "logstash-sm-metrics",
                                             "sampling": 1
                                         }
                                     }
@@ -7034,7 +7031,7 @@
                                             },
                                             {
                                                 "axisMode": "left",
-                                                "color": "#bfdbff",
+                                                "color": "#39d5d1",
                                                 "forAccessor": "a20aba59-2eb3-408c-ae36-6d7fd5546caa"
                                             },
                                             {
@@ -7135,7 +7132,7 @@
         "title": "[Metrics Logstash] Logstash Single Pipeline View"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-05-11T12:35:06.008Z",
+    "created_at": "2026-05-20T08:27:47.656Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "references": [
         {

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -36,6 +36,7 @@
                         "existsSelected": false,
                         "fieldName": "logstash.pipeline.name",
                         "searchTechnique": "prefix",
+                        "selectedOptions": [],
                         "sort": {
                             "by": "_count",
                             "direction": "desc"
@@ -53,7 +54,6 @@
         "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -238,6 +238,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsMetric"
                     },
                     "enhancements": {},
@@ -347,6 +348,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsMetric"
                     },
                     "enhancements": {},
@@ -456,6 +458,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsMetric"
                     },
                     "enhancements": {},
@@ -661,6 +664,7 @@
                         },
                         "title": "Average Time processed per event (ms)",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -947,6 +951,7 @@
                         },
                         "title": "Average Time processed per event (ms)",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -1108,6 +1113,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -1350,6 +1356,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -1512,6 +1519,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -2092,6 +2100,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {
@@ -2100,6 +2109,7 @@
                                 {
                                     "action": {
                                         "config": {
+                                            "dashboardId": "logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975",
                                             "openInNewTab": true,
                                             "useCurrentDateRange": true,
                                             "useCurrentFilters": true
@@ -2323,6 +2333,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -2531,6 +2542,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -3244,6 +3256,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {
@@ -3252,6 +3265,7 @@
                                 {
                                     "action": {
                                         "config": {
+                                            "dashboardId": "logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975",
                                             "openInNewTab": true,
                                             "useCurrentDateRange": true,
                                             "useCurrentFilters": true
@@ -3267,6 +3281,7 @@
                                 {
                                     "action": {
                                         "config": {
+                                            "dashboardId": "logstash-b5234e70-6f54-11ee-910d-eb0006359086",
                                             "openInNewTab": true,
                                             "useCurrentDateRange": true,
                                             "useCurrentFilters": true
@@ -3282,6 +3297,7 @@
                                 {
                                     "action": {
                                         "config": {
+                                            "dashboardId": "logstash-b516a470-71ea-11ee-aadf-e577130ac888",
                                             "openInNewTab": true,
                                             "useCurrentDateRange": true,
                                             "useCurrentFilters": true
@@ -3587,6 +3603,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -3795,6 +3812,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -4000,6 +4018,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -4208,6 +4227,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -4895,6 +4915,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {
@@ -4903,6 +4924,7 @@
                                 {
                                     "action": {
                                         "config": {
+                                            "dashboardId": "logstash-fe17b800-6eb4-11ee-86f6-d7074508d975",
                                             "openInNewTab": true,
                                             "useCurrentDateRange": true,
                                             "useCurrentFilters": true
@@ -4918,6 +4940,7 @@
                                 {
                                     "action": {
                                         "config": {
+                                            "dashboardId": "logstash-4bbf4a50-6ece-11ee-910d-eb0006359086",
                                             "openInNewTab": true,
                                             "useCurrentDateRange": true,
                                             "useCurrentFilters": true
@@ -5222,6 +5245,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -5430,6 +5454,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -5635,6 +5660,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -5843,6 +5869,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -6521,6 +6548,7 @@
                         },
                         "title": "",
                         "type": "lens",
+                        "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
                     "enhancements": {
@@ -6763,21 +6791,83 @@
                                 "id": "logstash-sm-metrics",
                                 "name": "indexpattern-datasource-layer-a8c2c277-1b48-416e-84fa-31ef12f6b5ed",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-a7473309-8ac9-4157-b1fc-88c459a5d220",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "logstash-sm-metrics",
                                     "layers": {
+                                        "a7473309-8ac9-4157-b1fc-88c459a5d220": {
+                                            "columnOrder": [
+                                                "35953d49-dc19-4f0e-884d-094811a16375",
+                                                "6090c0d4-2421-4b1d-8b2d-d9186c16dbd7",
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6"
+                                            ],
+                                            "columns": {
+                                                "35953d49-dc19-4f0e-884d-094811a16375": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "6090c0d4-2421-4b1d-8b2d-d9186c16dbd7": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "p50 last minute",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "sourceField": "logstash.pipeline.total.batch.byte_size.p50.last_1_minute"
+                                                },
+                                                "e29cbd4d-2d96-4b76-a135-b3162e3563d6": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "p90 last minute",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "sourceField": "logstash.pipeline.total.batch.byte_size.p90.last_1_minute"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        },
                                         "a8c2c277-1b48-416e-84fa-31ef12f6b5ed": {
                                             "columnOrder": [
                                                 "e830e95e-ada9-476f-9392-8514bb6dfaf3",
                                                 "a20aba59-2eb3-408c-ae36-6d7fd5546caa",
-                                                "38a796b9-1ccf-4a53-a940-8da67a133b5d"
+                                                "38a796b9-1ccf-4a53-a940-8da67a133b5d",
+                                                "02dedb74-d833-479b-aa0d-740cd01d0d9e"
                                             ],
                                             "columns": {
+                                                "02dedb74-d833-479b-aa0d-740cd01d0d9e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "max last minute",
+                                                    "operationType": "median",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "sourceField": "logstash.pipeline.total.batch.byte_size.max.last_1_minute"
+                                                },
                                                 "38a796b9-1ccf-4a53-a940-8da67a133b5d": {
                                                     "customLabel": true,
                                                     "dataType": "number",
@@ -6823,24 +6913,9 @@
                                             },
                                             "ignoreGlobalFilters": false,
                                             "incompleteColumns": {},
-                                            "indexPatternId": "logstash-sm-metrics",
                                             "sampling": 1
                                         }
                                     }
-                                },
-                                "indexpattern": {
-                                    "currentIndexPatternId": "logstash-sm-metrics",
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "logstash-sm-metrics",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-*,metricbeat-*,.monitoring-*"
-                                        }
-                                    ],
-                                    "layers": {}
                                 }
                             },
                             "filters": [],
@@ -6864,7 +6939,8 @@
                                     {
                                         "accessors": [
                                             "a20aba59-2eb3-408c-ae36-6d7fd5546caa",
-                                            "38a796b9-1ccf-4a53-a940-8da67a133b5d"
+                                            "38a796b9-1ccf-4a53-a940-8da67a133b5d",
+                                            "02dedb74-d833-479b-aa0d-740cd01d0d9e"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
@@ -6900,6 +6976,52 @@
                                             {
                                                 "color": "#bfdbff",
                                                 "forAccessor": "a20aba59-2eb3-408c-ae36-6d7fd5546caa"
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "forAccessor": "02dedb74-d833-479b-aa0d-740cd01d0d9e"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "accessors": [
+                                            "6090c0d4-2421-4b1d-8b2d-d9186c16dbd7",
+                                            "e29cbd4d-2d96-4b76-a135-b3162e3563d6"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "default",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "a7473309-8ac9-4157-b1fc-88c459a5d220",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area",
+                                        "showGridlines": false,
+                                        "xAccessor": "35953d49-dc19-4f0e-884d-094811a16375",
+                                        "yConfig": [
+                                            {
+                                                "color": "#0ef270",
+                                                "forAccessor": "6090c0d4-2421-4b1d-8b2d-d9186c16dbd7"
+                                            },
+                                            {
+                                                "color": "#eaae01",
+                                                "forAccessor": "e29cbd4d-2d96-4b76-a135-b3162e3563d6"
                                             }
                                         ]
                                     }
@@ -6908,7 +7030,7 @@
                                     "isVisible": true,
                                     "position": "right"
                                 },
-                                "preferredSeriesType": "line",
+                                "preferredSeriesType": "area",
                                 "title": "Empty XY chart",
                                 "valueLabels": "hide",
                                 "yTitle": "Total bytes size"
@@ -6947,13 +7069,52 @@
             }
         ],
         "timeRestore": false,
-        "title": "[Metrics Logstash] Logstash Single Pipeline View",
-        "version": 1
+        "title": "[Metrics Logstash] Logstash Single Pipeline View"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-02-27T14:44:27.024Z",
+    "created_at": "2026-04-09T10:07:20.769Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "references": [
+        {
+            "id": "logstash-sm-metrics",
+            "name": "controlGroup_73fdfb3a-3e86-499a-93f1-993479254e4e:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "controlGroup_94cc8a2a-a81e-451b-891b-407075069331:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-79270240-48ee-11ee-8cb5-99927777c522",
+            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-79270240-48ee-11ee-8cb5-99927777c522_dashboard",
+            "type": "dashboard"
+        },
+        {
+            "id": "logstash-ee860840-41ed-11ee-874b-fdb94cc3273a",
+            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-ee860840-41ed-11ee-874b-fdb94cc3273a_dashboard",
+            "type": "dashboard"
+        },
+        {
+            "id": "logstash-9d450b10-4680-11ee-9ddc-919f87fe352d",
+            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-9d450b10-4680-11ee-9ddc-919f87fe352d_dashboard",
+            "type": "dashboard"
+        },
+        {
+            "id": "logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5",
+            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5_dashboard",
+            "type": "dashboard"
+        },
+        {
+            "id": "logstash-c0594170-526a-11ee-9ecc-31444cb79548",
+            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-c0594170-526a-11ee-9ecc-31444cb79548_dashboard",
+            "type": "dashboard"
+        },
+        {
+            "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
+            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc_dashboard",
+            "type": "dashboard"
+        },
         {
             "id": "logstash-sm-metrics",
             "name": "915b448c-f617-44a5-a07c-61d720e45fc9:indexpattern-datasource-layer-6cc6ec80-cf6c-4421-a323-256f08b59426",
@@ -7111,47 +7272,12 @@
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "controlGroup_73fdfb3a-3e86-499a-93f1-993479254e4e:optionsListDataView",
+            "name": "94713cee-aa91-4b06-afff-ac6b8082b6e0:indexpattern-datasource-layer-a7473309-8ac9-4157-b1fc-88c459a5d220",
             "type": "index-pattern"
-        },
-        {
-            "id": "logstash-sm-metrics",
-            "name": "controlGroup_94cc8a2a-a81e-451b-891b-407075069331:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logstash-79270240-48ee-11ee-8cb5-99927777c522",
-            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-79270240-48ee-11ee-8cb5-99927777c522_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "logstash-ee860840-41ed-11ee-874b-fdb94cc3273a",
-            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-ee860840-41ed-11ee-874b-fdb94cc3273a_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "logstash-9d450b10-4680-11ee-9ddc-919f87fe352d",
-            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-9d450b10-4680-11ee-9ddc-919f87fe352d_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5",
-            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "logstash-c0594170-526a-11ee-9ecc-31444cb79548",
-            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-c0594170-526a-11ee-9ecc-31444cb79548_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
-            "name": "f5dd97b2-38f8-429c-a1e2-cf305bee75f8:link_logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc_dashboard",
-            "type": "dashboard"
         }
     ],
     "type": "dashboard",
     "managed": true,
-    "typeMigrationVersion": "10.2.0",
+    "typeMigrationVersion": "8.9.0",
     "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -6802,6 +6802,7 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logstash-sm-metrics",
                                     "layers": {
                                         "a7473309-8ac9-4157-b1fc-88c459a5d220": {
                                             "columnOrder": [
@@ -6901,6 +6902,7 @@
                                             },
                                             "ignoreGlobalFilters": false,
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logstash-sm-metrics",
                                             "sampling": 1
                                         },
                                         "a8c2c277-1b48-416e-84fa-31ef12f6b5ed": {
@@ -6942,15 +6944,15 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "\"logstash.pipeline.total.batch.byte_size.average.lifetime\": *"
+                                                        "query": "\"logstash.pipeline.total.batch.byte_size.average.last_1_minute\": *"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Average Lifetime",
+                                                    "label": "Average last minute",
                                                     "operationType": "last_value",
                                                     "params": {
                                                         "sortField": "@timestamp"
                                                     },
-                                                    "sourceField": "logstash.pipeline.total.batch.byte_size.average.lifetime"
+                                                    "sourceField": "logstash.pipeline.total.batch.byte_size.average.last_1_minute"
                                                 },
                                                 "e830e95e-ada9-476f-9392-8514bb6dfaf3": {
                                                     "dataType": "date",
@@ -6967,6 +6969,7 @@
                                             },
                                             "ignoreGlobalFilters": false,
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logstash-sm-metrics",
                                             "sampling": 1
                                         }
                                     }
@@ -7338,5 +7341,6 @@
     ],
     "type": "dashboard",
     "managed": true,
-    "typeMigrationVersion": "8.9.0"
+    "typeMigrationVersion": "8.9.0",
+    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
 }

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -6643,15 +6643,15 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "\"logstash.pipeline.total.batch.event_count.average.lifetime\": *"
+                                                        "query": "\"logstash.pipeline.total.batch.event_count.average.last_1_minute\": *"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Average Lifetime",
+                                                    "label": "Average last minute",
                                                     "operationType": "last_value",
                                                     "params": {
                                                         "sortField": "@timestamp"
                                                     },
-                                                    "sourceField": "logstash.pipeline.total.batch.event_count.average.lifetime"
+                                                    "sourceField": "logstash.pipeline.total.batch.event_count.average.last_1_minute"
                                                 }
                                             },
                                             "ignoreGlobalFilters": false,
@@ -7135,7 +7135,7 @@
         "title": "[Metrics Logstash] Logstash Single Pipeline View"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-05-05T13:46:50.578Z",
+    "created_at": "2026-05-11T12:35:06.008Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "references": [
         {

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -7132,7 +7132,7 @@
         "title": "[Metrics Logstash] Logstash Single Pipeline View"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-17T12:30:41.002Z",
+    "created_at": "2026-05-05T13:46:50.578Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "references": [
         {
@@ -7338,6 +7338,5 @@
     ],
     "type": "dashboard",
     "managed": true,
-    "typeMigrationVersion": "8.9.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.10.1
+version: 2.11.0
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

Update the cel script to store p50 p90 and max byte size metrics of the batch for the last minute.
Switch to use the average last one minute metric instead of the lifetime for both batch's byte size and value to be coherent with the other graphed percentiles.
Update the Single Pipeline View to include these new values.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

The test is based on a running Logstash instance monitored by an  ElasticAgent which push metric data to be processed by the integration.

Requirements: Docker must be running on test host.

1. Install `elastic-package`
   1. Download from https://github.com/elastic/elastic-package/releases/tag/v0.117.1
   2. Add permission to the file with 
   
         ```sh
         xattr -r -d com.apple.quarantine elastic-package
         ```
     
   3. Run it 
   
         ```sh
         ./elastic-package
         ```

2. Bring up stack and build/install the integration (from `integration/packages/logstash` of the Elastic Integration local clone)
   1. Launch the stack

         ```sh
         /path/to/elastic-package stack up -v
         ```   

   2. Build the package locally

         ```sh
         /path/to/elastic-package build
         ```  

   3. Install into the package registry running in the Docker, so it can be served to Fleet

         ```sh
         /path/to/elastic-package install
         ```  

   4. Verify the integration is installed, check the listing: https://localhost:5601/app/integrations/installed?currentPage=1

3. Now install and configure a local Logstash that generates some metrics, this is monitored by a local agent that will be installed in next step
   1. Download Logstash `>= 8.2.0` from https://www.elastic.co/downloads/logstash
   2. Once unpacked edit the `config/logstash.yml` to have the following settings:

         ```yaml
         pipeline.batch.metrics.sampling_mode: "full"
         monitoring.enabled: false # this is already the default
         ```
   3. Run Logstash with a pipeline, **rememeber to check which HTTP API port is bound**, usually 9600 but since the Docker compose already setup a Logstash instance in the container, it could be `9601` or so:
   
         ```
         bin/logstash -e "input{ tcp {port => 3333} } output{ sink{} }"
         ```      

   4. Generate some flow with a simple script (requires `JDK` and `JBang` installed locally, use `sdkman` to do that). Use the traffic generator script at https://github.com/andsel/traffic_simulator and run with:

         ```sh
         ./TrafficSimulator.java -p 3333 -e continuous -w exponential
         ```  
       If JBang is not able to resolve dependencies, check your `~/.m2/settings.xml` and eventually remove it.   

4. Add Logstash integration and create new policy and enroll a local agent that monitor the launched Logstash:
   1. In Fleet go to the Logstash integration and press `Add Logstash`
   2. Create a new policy and enroll a new agent
   3. Follow the instructions to download the agent and run it, but to the proposed command line remember to add: `--develop --insecure`. Add `--develop` to be able run side by side the existing Agent, and `--insecure` to avoid x509 certificate verification. As example should be something like:

         ```sh
         ./elastic-agent install --url=https://localhost:8220 --enrollment-token=<PROVIDED TOKEN> --develop --insecure
         ```

   4. In the configuration of the policy set the port where local Logstash bound (step `3.iii`)
   5. It may require to update your ´/etc/hosts´ file to avoid some error in Fleet UI like "Error get fleet-server" or something related to reaching `elasticsearch`, in case add the following to your hosts:

         ```
         127.0.0.1       fleet-server
         127.0.0.1       elasticsearch #I'm not sure of this!
         ```

6. Verify the dashboard `[Metrics Logstash] Logstash Single Pipeline View`   
   1. Scroll down the dashboard there are 2 new graphs that display the batch size and event count.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #17009 
- Closes https://github.com/elastic/logstash/issues/18972

## Screenshots

<img width="724" height="420" alt="Screenshot 2026-04-09 at 14 15 39" src="https://github.com/user-attachments/assets/547ae6f9-0f37-4674-8d1d-23bde2ba5afd" />
