### PR TITLE
[Enhancement] Adding processor, preserve_original_event and tag to logstash log manifest

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,14 @@
 # newer versions go on top
+- version: "2.10.3"
+  changes:
+    - description: Adding processor, preserve_original_event and tag as option to logstash stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxxx
+- version: "2.10.2"
+  changes:
+    - description: Added logstash-json to default, if log.format is changed https://www.elastic.co/docs/reference/logstash/logstash-settings-file.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxxx
 - version: "2.10.1"
   changes:
     - description: Fixes navigation of batch metrics when the integration is used to monitor an older version of Logstash that doesn't expose.

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -3,12 +3,12 @@
   changes:
     - description: Adding processor, preserve_original_event and tag as option to logstash stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxxx
+      link: https://github.com/elastic/integrations/pull/18316
 - version: "2.10.2"
   changes:
     - description: Added logstash-json to default, if log.format is changed https://www.elastic.co/docs/reference/logstash/logstash-settings-file.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxxx
+      link: https://github.com/elastic/integrations/pull/18316
 - version: "2.10.1"
   changes:
     - description: Fixes navigation of batch metrics when the integration is used to monitor an older version of Logstash that doesn't expose.

--- a/packages/logstash/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/logstash/data_stream/log/agent/stream/log.yml.hbs
@@ -15,6 +15,16 @@ processors:
     target: ''
     fields:
       ecs.version: 1.10.0
+{{#if processors}}
+{{processors}}
+{{/if}}
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}  
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/logstash/data_stream/log/manifest.yml
+++ b/packages/logstash/data_stream/log/manifest.yml
@@ -11,6 +11,30 @@ streams:
         show_user: true
         default:
           - /var/log/logstash/logstash-plain*.log
+          - /var/log/logstash/logstash-json*.log
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        required: false
+        show_user: false
+        default:        
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false          
     template_path: log.yml.hbs
     title: Logstash logs
     description: Collect Logstash logs from standard files

--- a/packages/logstash/data_stream/slowlog/agent/stream/log.yml.hbs
+++ b/packages/logstash/data_stream/slowlog/agent/stream/log.yml.hbs
@@ -11,6 +11,16 @@ processors:
     target: ''
     fields:
       ecs.version: 1.10.0
+{{#if processors}}
+{{processors}}
+{{/if}}
+tags:
+{{#if preserve_original_event}}
+  - preserve_original_event
+{{/if}}
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}      
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/logstash/data_stream/slowlog/manifest.yml
+++ b/packages/logstash/data_stream/slowlog/manifest.yml
@@ -11,6 +11,30 @@ streams:
         show_user: true
         default:
           - /var/log/logstash/logstash-slowlog-plain*.log
+          - /var/log/logstash/logstash-slowlog-json*.log
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        required: false
+        show_user: false
+        default:        
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`
+        type: bool
+        multi: false
+        default: false          
     template_path: log.yml.hbs
     title: Logstash slowlog logs
     description: Collect logstash slowlog logs using log input

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.10.1
+version: 2.10.3
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

The integration Logstash has multiple datastream, this change is only for log present in /var/log/logstash/*. The same change as in https://github.com/elastic/integrations/pull/18215, is to add processors, preserve_original_event and tags as advanced option visual option in Kibana.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist
None

## How to test this PR locally
No testing, copied code from other existing integrations

## Related issues
None that where found

## Screenshots
None
