### PR TITLE
fix(dga): infer dns.question.registered_domain from dns.question.name…

### DIFF
--- a/packages/dga/changelog.yml
+++ b/packages/dga/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.7"
+  changes:
+    - description: Infer dns.question.registered_domain from dns.question.name when missing, preventing false positive DGA detections on events without registered_domain.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18341
 - version: "2.3.6"
   changes:
     - description: Update documentation for blogs

--- a/packages/dga/elasticsearch/ingest_pipeline/ml_dga_ingest_pipeline.yml
+++ b/packages/dga/elasticsearch/ingest_pipeline/ml_dga_ingest_pipeline.yml
@@ -1,6 +1,12 @@
 ---
 description: Pipelines for enriching DNS data. Ignores non-DNS data.
 processors:
+  - registered_domain:
+      if: "ctx.network?.protocol == 'dns' && ctx.dns?.question?.name != null && ctx.dns?.question?.registered_domain == null"
+      field: dns.question.name
+      target_field: dns.question
+      ignore_missing: true
+      ignore_failure: true
   - pipeline:
       if: ctx.network?.protocol == 'dns' && ctx.dns?.question?.type != 'PTR'
       name: '{{ IngestPipeline "ml_dga_inference_pipeline" }}'

--- a/packages/dga/manifest.yml
+++ b/packages/dga/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.4
 name: dga
 title: "Domain Generation Algorithm Detection"
-version: 2.3.6
+version: 2.3.7
 source:
   license: "Elastic-2.0"
 description: "ML solution package to detect domain generation algorithm (DGA) activity in your network data."


### PR DESCRIPTION
… when missing

  When dns.question.registered_domain field is null the DGA inference
  pipeline falls back to using the full domain name as the SLD feature,
  causing false positive malicious predictions for benign domains.

  Add a registered_domain processor as the first step in the ingest pipeline
  to infer registered_domain, top_level_domain, and subdomain from
  dns.question.name using the Mozilla Public Suffix List bundled in
  Elasticsearch. The processor only runs when registered_domain is null,
  leaving events from Packetbeat and other enriched sources unaffected.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

The PR was tested in local kibana stack.
New pipeline was installed from local integrations repo and pipeline was tested as follows.

Before the pipeline update:
<img width="3804" height="1148" alt="image" src="https://github.com/user-attachments/assets/0ceaa43f-5171-4879-a65a-6a68c3fa623a" />

Features are extracted on subdomain as well. Resulting in sample classified as malicious.

After the pipeline change:
<img width="3830" height="1010" alt="image" src="https://github.com/user-attachments/assets/aaadd1c8-0ab5-4a3c-b3bc-10981e3b3fc3" />

<img width="3824" height="1046" alt="image" src="https://github.com/user-attachments/assets/6bf92abd-50fa-4aea-a1b1-a5e57cc54693" />

Subdomain no longer considered for feature extraction.
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
https://github.com/elastic/detection-rules/issues/5787
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->


