### PR TITLE
[docker_otel] Use Elastic line-optimized palette for Lens charts

### DIFF
--- a/packages/docker_otel/kibana/dashboard/docker_otel-56a63a68-2c29-48f3-ba77-5020e5f88bba.json
+++ b/packages/docker_otel/kibana/dashboard/docker_otel-56a63a68-2c29-48f3-ba77-5020e5f88bba.json
@@ -839,7 +839,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1075,7 +1075,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1370,7 +1370,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1649,7 +1649,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1905,7 +1905,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2253,7 +2253,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2445,7 +2445,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2642,7 +2642,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2873,7 +2873,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -3078,7 +3078,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {

--- a/packages/docker_otel/kibana/dashboard/docker_otel-89b3721a-c290-4b7f-a89a-b2efc58a5b0c.json
+++ b/packages/docker_otel/kibana/dashboard/docker_otel-89b3721a-c290-4b7f-a89a-b2efc58a5b0c.json
@@ -524,7 +524,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1221,7 +1221,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1467,7 +1467,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1681,7 +1681,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1948,7 +1948,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2189,7 +2189,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2430,7 +2430,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2692,7 +2692,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_brand_2023",
                                             "specialAssignments": [
                                                 {
                                                     "color": {


### PR DESCRIPTION
## Summary
- Switch Lens `colorMapping.paletteId` in the Docker OTel dashboard saved objects from `eui_amsterdam_color_blind` to `elastic_brand_2023`.
- This improves visual separation for multi-series line charts where the default Elastic palette can make series hard to distinguish.

## Test plan
- [ ] Install/update the `docker_otel` integration in a test stack.
- [ ] Open `[Metrics Docker] Overview` and `[Metrics Docker] Container Stats` dashboards.
- [ ] Confirm line charts render with Elastic line-optimized colors and series are visually distinct.

Made with [Cursor](https://cursor.com)