### PR TITLE
[Kubernetes Otel] Represent pod phases, node readiness, and container ready states as strings

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Represent pod phases, node readiness, and container ready states as human-readable strings instead of numeric values in Cluster Details, Deployment Details, and Pod Details dashboards
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18382
 - version: 2.0.0-preview5
   changes:
     - description: Improvements to Cluster, Cluster details, Deployment, Deployment details, Pod, Pod details, Workload details dashboards.

--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.0.0-preview6
+  changes:
+    - description: Represent pod phases, node readiness, and container ready states as human-readable strings instead of numeric values in Cluster Details, Deployment Details, and Pod Details dashboards
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 2.0.0-preview5
   changes:
     - description: Improvements to Cluster, Cluster details, Deployment, Deployment details, Pod, Pod details, Workload details dashboards.

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
@@ -58,8 +58,8 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_96ea6ed8-bdfc-44d6-8f78-d71e270e1be1_dashboard",
-                            "label": "< Overview",
+                            "destinationRefName": "link_3c2823c1-c3b5-4ee1-b156-6c1b7c286faf_dashboard",
+                            "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
                                 "use_filters": false,
@@ -84,10 +84,30 @@
                     "attributes": {
                         "references": [],
                         "state": {
-                            "adHocDataViews": {},
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
                                 "textBased": {
-                                    "indexPatternRefs": [],
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
                                         "75c10a74-0909-4bcd-a3d7-b4462341ce07": {
                                             "allColumns": [
@@ -116,8 +136,9 @@
                                                     }
                                                 }
                                             ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.pod.name), name = MAX(k8s.pod.name)\n| EVAL name = CASE(count == 1, name, CONCAT(TO_STRING(count), \" pods\"))\n| KEEP name"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.pod.name), names = VALUES(k8s.pod.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" pods\"))\n| KEEP name"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -125,9 +146,9 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS name = MAX(k8s.pod.name)\n"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.pod.name), names = VALUES(k8s.pod.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" pods\"))\n| KEEP name"
                             },
                             "visualization": {
                                 "colorMode": "none",
@@ -144,10 +165,10 @@
                             }
                         },
                         "title": "",
-                        "type": "lens",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 3,
@@ -164,10 +185,30 @@
                     "attributes": {
                         "references": [],
                         "state": {
-                            "adHocDataViews": {},
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
                                 "textBased": {
-                                    "indexPatternRefs": [],
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
                                         "ac4df9dc-46c7-4813-beb3-bd1d6db3e3fb": {
                                             "allColumns": [
@@ -196,8 +237,9 @@
                                                     }
                                                 }
                                             ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.phase IS NOT NULL AND k8s.pod.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.pod.name), phase = MAX(k8s.pod.phase)\n| EVAL phase = CASE(\n    count > 1, \"N/A\",\n    phase == 1, \"Pending\",\n    phase == 2, \"Running\",\n    phase == 3, \"Succeeded\",\n    phase == 4, \"Failed\",\n    \"Unknown\"\n  )\n| KEEP phase"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.phase IS NOT NULL AND k8s.pod.name IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.pod.name\n| WHERE @timestamp == latest_ts\n| STATS count = COUNT_DISTINCT(k8s.pod.name), phase = MAX(k8s.pod.phase)\n| EVAL phase = CASE(\n    count \u003e 1, \"N/A\",\n    phase == 1, \"Pending\",\n    phase == 2, \"Running\",\n    phase == 3, \"Succeeded\",\n    phase == 4, \"Failed\",\n    \"Unknown\"\n  )\n| KEEP phase"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -205,9 +247,9 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.pod.phase IS NOT NULL AND k8s.pod.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.pod.name), phase = MAX(k8s.pod.phase)\n| EVAL phase = CASE(\n    count > 1, \"N/A\",\n    phase == 1, \"Pending\",\n    phase == 2, \"Running\",\n    phase == 3, \"Succeeded\",\n    phase == 4, \"Failed\",\n    \"Unknown\"\n  )\n| KEEP phase"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.phase IS NOT NULL AND k8s.pod.name IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.pod.name\n| WHERE @timestamp == latest_ts\n| STATS count = COUNT_DISTINCT(k8s.pod.name), phase = MAX(k8s.pod.phase)\n| EVAL phase = CASE(\n    count \u003e 1, \"N/A\",\n    phase == 1, \"Pending\",\n    phase == 2, \"Running\",\n    phase == 3, \"Succeeded\",\n    phase == 4, \"Failed\",\n    \"Unknown\"\n  )\n| KEEP phase"
                             },
                             "visualization": {
                                 "colorMode": "none",
@@ -223,11 +265,11 @@
                             }
                         },
                         "title": "",
-                        "type": "lens",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Pod phase: Pending/Running/Succeeded/Failed/Unknown."
+                    "description": "Pod phase: Pending/Running/Succeeded/Failed/Unknown.",
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 3,
@@ -459,7 +501,7 @@
                             "open_in_new_tab": true,
                             "trigger": "on_click_value",
                             "type": "url_drilldown",
-                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))&_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.pod.name:\"{{event.value}}\"'))"
+                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.pod.name:\"{{event.value}}\"'))"
                         }
                     ]
                 },
@@ -788,8 +830,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "CPU usage over time with request (dashed yellow) and limit (dashed red) reference lines.",
-                    "drilldowns": [],
-                    "title": "CPU usage vs requests & limits"
+                    "title": "CPU usage vs requests \u0026 limits"
                 },
                 "gridData": {
                     "h": 10,
@@ -1142,8 +1183,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Memory working set over time. Yellow dashed = requests, solid red = limits (OOMKill threshold).",
-                    "drilldowns": [],
-                    "title": "Memory working set vs requests & limits"
+                    "title": "Memory working set vs requests \u0026 limits"
                 },
                 "gridData": {
                     "h": 10,
@@ -1394,7 +1434,6 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "drilldowns": [],
                     "title": "Volume usage over time"
                 },
                 "gridData": {
@@ -1541,7 +1580,6 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "drilldowns": [],
                     "title": "Container count over time"
                 },
                 "gridData": {
@@ -2060,7 +2098,6 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Memory composition over time. RSS, working set, and available memory as separate series. SUM per 1m bucket.",
-                    "drilldowns": [],
                     "title": "Memory composition"
                 },
                 "gridData": {
@@ -2281,7 +2318,6 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Network I/O over time. SUM(RATE(k8s.pod.network.io)) per 1m bucket.",
-                    "drilldowns": [],
                     "title": "Network I/O over time"
                 },
                 "gridData": {
@@ -2598,7 +2634,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS\n    ready        = MAX(k8s.container.ready),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name\n| EVAL\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit > 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| SORT restarts DESC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| INLINE STATS latest_ts = MAX(CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name, k8s.container.name\n| EVAL ready_val = CASE(@timestamp == latest_ts, k8s.container.ready, NULL)\n| STATS\n    ready_num    = MAX(ready_val),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2608,11 +2644,75 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS\n    ready        = MAX(k8s.container.ready),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name\n| EVAL\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit > 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| SORT restarts DESC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| INLINE STATS latest_ts = MAX(CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name, k8s.container.name\n| EVAL ready_val = CASE(@timestamp == latest_ts, k8s.container.ready, NULL)\n| STATS\n    ready_num    = MAX(ready_val),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
                                     {
+                                        "colorMapping": {
+                                            "assignments": [
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 0,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Ready"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 6,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Not Ready"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 1,
+                                                        "paletteId": "neutral",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Unknown"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                }
+                                            ],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "default",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorMode": "cell",
                                         "columnId": "ready"
                                     },
                                     {
@@ -2694,7 +2794,7 @@
                             "open_in_new_tab": true,
                             "trigger": "on_click_value",
                             "type": "url_drilldown",
-                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))&_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.pod.name:\"{{event.value}}\"'))"
+                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.pod.name:\"{{event.value}}\"'))"
                         }
                     ],
                     "title": "Containers"
@@ -2857,7 +2957,6 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "CPU usage per container. avg(container.cpu.usage) broken down by k8s.container.name.",
-                    "drilldowns": [],
                     "title": "CPU usage by container"
                 },
                 "gridData": {
@@ -2907,12 +3006,12 @@
         "title": "[OTEL][Kubernetes] Pod Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-02T07:45:24.241Z",
+    "created_at": "2026-04-14T04:50:07.562Z",
     "id": "kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-pod-back-link:link_96ea6ed8-bdfc-44d6-8f78-d71e270e1be1_dashboard",
+            "name": "v3-pod-back-link:link_3c2823c1-c3b5-4ee1-b156-6c1b7c286faf_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13.json
@@ -1,6 +1,6 @@
 {
     "attributes": {
-        "description": "Single cluster deep dive with health summary, resource usage & capacity, node health, and top consumers.",
+        "description": "Single cluster deep dive with health summary, resource usage \u0026 capacity, node health, and top consumers.",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "query": {
@@ -26,8 +26,8 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_113796d8-ddae-403e-83c1-1b70af16a09f_dashboard",
-                            "label": "< Overview",
+                            "destinationRefName": "link_9bb5439e-e11b-4c90-a8bb-6a9adff51246_dashboard",
+                            "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
                                 "use_filters": false,
@@ -53,16 +53,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "d3b7e528216ce7ef65e68e07a803b7ab53e440cafdb52d9d7ee1ef4bbf5d8afa": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "metrics-*",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
-                                    "title": "metrics-*",
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -70,8 +71,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "metrics-*",
-                                            "title": "metrics-*"
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -89,9 +91,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.cluster.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.cluster.name), name = MAX(k8s.cluster.name)\n| EVAL name = CASE(count == 1, name, CONCAT(TO_STRING(count), \" clusters\"))\n| KEEP name"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.cluster.name), names = VALUES(k8s.cluster.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" clusters\"))\n| KEEP name"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -101,7 +103,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.cluster.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.cluster.name), name = MAX(k8s.cluster.name)\n| EVAL name = CASE(count == 1, name, CONCAT(TO_STRING(count), \" clusters\"))\n| KEEP name"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.cluster.name), names = VALUES(k8s.cluster.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" clusters\"))\n| KEEP name"
                             },
                             "visualization": {
                                 "colorMode": "none",
@@ -120,97 +122,17 @@
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 3,
                     "i": "v3-cd-header-name",
-                    "w": 21,
+                    "w": 38,
                     "x": 4,
                     "y": 0
                 },
                 "panelIndex": "v3-cd-header-name",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                    "managed": false,
-                                    "name": "metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [],
-                                    "layers": {
-                                        "f32ba2d8-2bd9-4da6-a7bf-a17d71a217af": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "23e382d8-4149-479d-8904-8cb30199e747",
-                                                    "customLabel": true,
-                                                    "fieldName": "created_str",
-                                                    "inMetricDimension": true,
-                                                    "label": "Created on",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "keyword"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                            "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.cluster.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.cluster.name), created = MIN(@timestamp)\n| EVAL created_str = CASE(count == 1, DATE_FORMAT(\"MMM dd, yyyy\", created), \"N/A\")\n| KEEP created_str"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.cluster.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.cluster.name), created = MIN(@timestamp)\n| EVAL created_str = CASE(count == 1, DATE_FORMAT(\"MMM dd, yyyy\", created), \"N/A\")\n| KEEP created_str"
-                            },
-                            "visualization": {
-                                "colorMode": "none",
-                                "layerId": "f32ba2d8-2bd9-4da6-a7bf-a17d71a217af",
-                                "layerType": "data",
-                                "metricAccessor": "23e382d8-4149-479d-8904-8cb30199e747",
-                                "primaryAlign": "left",
-                                "showBar": false,
-                                "titleWeight": "normal",
-                                "titlesTextSize": "xxs",
-                                "valueFontMode": "fit",
-                                "valuesTextSize": "xs"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    }
-                },
-                "gridData": {
-                    "h": 3,
-                    "i": "v3-cd-header-created",
-                    "w": 17,
-                    "x": 25,
-                    "y": 0
-                },
-                "panelIndex": "v3-cd-header-created",
                 "type": "lens"
             },
             {
@@ -308,7 +230,7 @@
                             "open_in_new_tab": true,
                             "trigger": "on_click_value",
                             "type": "url_drilldown",
-                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))&_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.cluster.name:\"{{event.value}}\"'))"
+                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.cluster.name:\"{{event.value}}\"'))"
                         }
                     ]
                 },
@@ -1852,7 +1774,6 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Number of pods running over time.",
-                    "drilldowns": [],
                     "title": "Pod count over time"
                 },
                 "gridData": {
@@ -1986,7 +1907,7 @@
                                             ],
                                             "index": "9ff905cea813eb1905e3c025058dbb6a5bfd43238dcadce16f72ea80f42a0216",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.condition_ready IS NOT NULL\n| STATS ready_nodes = COUNT_DISTINCT(k8s.node.name) WHERE k8s.node.condition_ready > 0\n"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.condition_ready IS NOT NULL\n| STATS ready_nodes = COUNT_DISTINCT(k8s.node.name) WHERE k8s.node.condition_ready \u003e 0\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1996,7 +1917,7 @@
                             "filters": [],
                             "internalReferences": [],
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.condition_ready IS NOT NULL\n| STATS ready_nodes = COUNT_DISTINCT(k8s.node.name) WHERE k8s.node.condition_ready > 0\n"
+                                "esql": "FROM metrics-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.condition_ready IS NOT NULL\n| STATS ready_nodes = COUNT_DISTINCT(k8s.node.name) WHERE k8s.node.condition_ready \u003e 0\n"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -2047,7 +1968,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Nodes in Ready state. COUNT_DISTINCT(k8s.node.name) WHERE condition_ready > 0."
+                    "description": "Nodes in Ready state. COUNT_DISTINCT(k8s.node.name) WHERE condition_ready \u003e 0."
                 },
                 "gridData": {
                     "h": 4,
@@ -2100,7 +2021,7 @@
                                             ],
                                             "index": "9ff905cea813eb1905e3c025058dbb6a5bfd43238dcadce16f72ea80f42a0216",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.condition_ready IS NOT NULL\n| STATS not_ready = COUNT_DISTINCT(k8s.node.name) WHERE k8s.node.condition_ready <= 0\n"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.condition_ready IS NOT NULL\n| STATS not_ready = COUNT_DISTINCT(k8s.node.name) WHERE k8s.node.condition_ready \u003c= 0\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2110,7 +2031,7 @@
                             "filters": [],
                             "internalReferences": [],
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.condition_ready IS NOT NULL\n| STATS not_ready = COUNT_DISTINCT(k8s.node.name) WHERE k8s.node.condition_ready <= 0\n"
+                                "esql": "FROM metrics-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.condition_ready IS NOT NULL\n| STATS not_ready = COUNT_DISTINCT(k8s.node.name) WHERE k8s.node.condition_ready \u003c= 0\n"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -2161,7 +2082,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Nodes not in Ready state. COUNT_DISTINCT(k8s.node.name) WHERE condition_ready <= 0.",
+                    "description": "Nodes not in Ready state. COUNT_DISTINCT(k8s.node.name) WHERE condition_ready \u003c= 0.",
                     "hide_title": true
                 },
                 "gridData": {
@@ -3018,7 +2939,7 @@
                                             ],
                                             "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.cpu.usage IS NOT NULL OR k8s.node.allocatable_cpu IS NOT NULL)\n| STATS sum_usage = SUM(k8s.node.cpu.usage),\n        sum_alloc = SUM(k8s.node.allocatable_cpu)\n    BY k8s.node.name\n| EVAL utilization = ROUND(sum_usage / sum_alloc, 4)\n| SORT utilization DESC\n| LIMIT 10\n| KEEP k8s.node.name, utilization"
+                                                "esql": "TS metrics-*\n| WHERE k8s.node.name IS NOT NULL\n| STATS avg_usage = AVG(k8s.node.cpu.usage),\n        avg_alloc = AVG(k8s.node.allocatable_cpu)\n  BY k8s.node.name, timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| STATS utilization = ROUND(AVG(avg_usage) / AVG(avg_alloc), 4)\n  BY k8s.node.name\n| SORT utilization DESC\n| LIMIT 10\n| KEEP k8s.node.name, utilization"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3028,7 +2949,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.cpu.usage IS NOT NULL OR k8s.node.allocatable_cpu IS NOT NULL)\n| STATS sum_usage = SUM(k8s.node.cpu.usage),\n        sum_alloc = SUM(k8s.node.allocatable_cpu)\n    BY k8s.node.name\n| EVAL utilization = ROUND(sum_usage / sum_alloc, 4)\n| SORT utilization DESC\n| LIMIT 10\n| KEEP k8s.node.name, utilization"
+                                "esql": "TS metrics-*\n| WHERE k8s.node.name IS NOT NULL\n| STATS avg_usage = AVG(k8s.node.cpu.usage),\n        avg_alloc = AVG(k8s.node.allocatable_cpu)\n  BY k8s.node.name, timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| STATS utilization = ROUND(AVG(avg_usage) / AVG(avg_alloc), 4)\n  BY k8s.node.name\n| SORT utilization DESC\n| LIMIT 10\n| KEEP k8s.node.name, utilization"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3097,6 +3018,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "CPU utilization per node as bar chart. sum(k8s.node.cpu.usage) / sum(k8s.node.allocatable_cpu) by node.",
+                    "drilldowns": [],
                     "title": "Top 10 nodes by CPU utilization"
                 },
                 "gridData": {
@@ -3174,7 +3096,7 @@
                                             ],
                                             "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.memory.working_set IS NOT NULL OR k8s.node.allocatable_memory IS NOT NULL)\n| STATS sum_ws = SUM(k8s.node.memory.working_set),\n        sum_alloc = SUM(k8s.node.allocatable_memory)\n    BY k8s.node.name\n| EVAL utilization = ROUND(TO_DOUBLE(sum_ws) / TO_DOUBLE(sum_alloc), 4)\n| SORT utilization DESC\n| LIMIT 10\n| KEEP k8s.node.name, utilization"
+                                                "esql": "TS metrics-*\n| WHERE k8s.node.name IS NOT NULL\n| STATS avg_ws = AVG(k8s.node.memory.working_set),\n        avg_alloc = AVG(k8s.node.allocatable_memory)\n  BY k8s.node.name, timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| STATS utilization = ROUND(AVG(avg_ws) / AVG(avg_alloc), 4)\n  BY k8s.node.name\n| SORT utilization DESC\n| LIMIT 10\n| KEEP k8s.node.name, utilization"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3184,7 +3106,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.memory.working_set IS NOT NULL OR k8s.node.allocatable_memory IS NOT NULL)\n| STATS sum_ws = SUM(k8s.node.memory.working_set),\n        sum_alloc = SUM(k8s.node.allocatable_memory)\n    BY k8s.node.name\n| EVAL utilization = ROUND(TO_DOUBLE(sum_ws) / TO_DOUBLE(sum_alloc), 4)\n| SORT utilization DESC\n| LIMIT 10\n| KEEP k8s.node.name, utilization"
+                                "esql": "TS metrics-*\n| WHERE k8s.node.name IS NOT NULL\n| STATS avg_ws = AVG(k8s.node.memory.working_set),\n        avg_alloc = AVG(k8s.node.allocatable_memory)\n  BY k8s.node.name, timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| STATS utilization = ROUND(AVG(avg_ws) / AVG(avg_alloc), 4)\n  BY k8s.node.name\n| SORT utilization DESC\n| LIMIT 10\n| KEEP k8s.node.name, utilization"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3253,6 +3175,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Memory utilization per node as bar chart. sum(k8s.node.memory.working_set) / sum(k8s.node.allocatable_memory) by node.",
+                    "drilldowns": [],
                     "title": "Top 10 nodes by memory utilization"
                 },
                 "gridData": {
@@ -3450,7 +3373,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.name != \"\"\n| STATS\n    ready         = MAX(k8s.node.condition_ready),\n    mem_pressure  = MAX(k8s.node.condition_memory_pressure),\n    mem_available = AVG(k8s.node.memory.available),\n    cpu_usage     = AVG(k8s.node.cpu.usage),\n    alloc_cpu     = MAX(k8s.node.allocatable_cpu),\n    mem_ws        = AVG(k8s.node.memory.working_set),\n    alloc_mem     = MAX(k8s.node.allocatable_memory),\n    fs_usage      = MAX(k8s.node.filesystem.usage),\n    fs_cap        = MAX(k8s.node.filesystem.capacity),\n    pods          = COUNT_DISTINCT(k8s.pod.uid)\n  BY k8s.cluster.name, k8s.node.name\n| EVAL\n    cpu_util  = ROUND(cpu_usage / alloc_cpu, 4),\n    mem_util  = ROUND(TO_DOUBLE(mem_ws) / TO_DOUBLE(alloc_mem), 4),\n    disk_util = ROUND(TO_DOUBLE(fs_usage) / TO_DOUBLE(fs_cap), 4)\n| KEEP k8s.node.name, ready, mem_pressure, pods, cpu_util, mem_util, disk_util, mem_available, k8s.cluster.name\n| SORT cpu_util DESC"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.name != \"\"\n| STATS\n    ready_val     = MAX(k8s.node.condition_ready),\n    mem_press_val = MAX(k8s.node.condition_memory_pressure),\n    mem_available = AVG(k8s.node.memory.available),\n    cpu_usage     = AVG(k8s.node.cpu.usage),\n    alloc_cpu     = MAX(k8s.node.allocatable_cpu),\n    mem_ws        = AVG(k8s.node.memory.working_set),\n    alloc_mem     = MAX(k8s.node.allocatable_memory),\n    fs_usage      = MAX(k8s.node.filesystem.usage),\n    fs_cap        = MAX(k8s.node.filesystem.capacity),\n    pods          = COUNT_DISTINCT(k8s.pod.uid)\n  BY k8s.cluster.name, k8s.node.name\n| EVAL\n    ready = CASE(\n      ready_val == 1, \"Ready\",\n      ready_val == 0, \"Not Ready\",\n      ready_val == -1, \"Unknown\",\n      \"Unknown\"),\n    mem_pressure = CASE(\n      mem_press_val == 0, \"No\",\n      mem_press_val == 1, \"Yes\",\n      \"Unknown\"),\n    cpu_util  = ROUND(cpu_usage / alloc_cpu, 4),\n    mem_util  = ROUND(TO_DOUBLE(mem_ws) / TO_DOUBLE(alloc_mem), 4),\n    disk_util = ROUND(TO_DOUBLE(fs_usage) / TO_DOUBLE(fs_cap), 4)\n| KEEP k8s.node.name, ready, mem_pressure, pods, cpu_util, mem_util, disk_util, mem_available, k8s.cluster.name\n| SORT cpu_util DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3460,7 +3383,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.name != \"\"\n| STATS\n    ready         = MAX(k8s.node.condition_ready),\n    mem_pressure  = MAX(k8s.node.condition_memory_pressure),\n    mem_available = AVG(k8s.node.memory.available),\n    cpu_usage     = AVG(k8s.node.cpu.usage),\n    alloc_cpu     = MAX(k8s.node.allocatable_cpu),\n    mem_ws        = AVG(k8s.node.memory.working_set),\n    alloc_mem     = MAX(k8s.node.allocatable_memory),\n    fs_usage      = MAX(k8s.node.filesystem.usage),\n    fs_cap        = MAX(k8s.node.filesystem.capacity),\n    pods          = COUNT_DISTINCT(k8s.pod.uid)\n  BY k8s.cluster.name, k8s.node.name\n| EVAL\n    cpu_util  = ROUND(cpu_usage / alloc_cpu, 4),\n    mem_util  = ROUND(TO_DOUBLE(mem_ws) / TO_DOUBLE(alloc_mem), 4),\n    disk_util = ROUND(TO_DOUBLE(fs_usage) / TO_DOUBLE(fs_cap), 4)\n| KEEP k8s.node.name, ready, mem_pressure, pods, cpu_util, mem_util, disk_util, mem_available, k8s.cluster.name\n| SORT cpu_util DESC"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.node.name IS NOT NULL\n  AND k8s.node.name != \"\"\n| STATS\n    ready_val     = MAX(k8s.node.condition_ready),\n    mem_press_val = MAX(k8s.node.condition_memory_pressure),\n    mem_available = AVG(k8s.node.memory.available),\n    cpu_usage     = AVG(k8s.node.cpu.usage),\n    alloc_cpu     = MAX(k8s.node.allocatable_cpu),\n    mem_ws        = AVG(k8s.node.memory.working_set),\n    alloc_mem     = MAX(k8s.node.allocatable_memory),\n    fs_usage      = MAX(k8s.node.filesystem.usage),\n    fs_cap        = MAX(k8s.node.filesystem.capacity),\n    pods          = COUNT_DISTINCT(k8s.pod.uid)\n  BY k8s.cluster.name, k8s.node.name\n| EVAL\n    ready = CASE(\n      ready_val == 1, \"Ready\",\n      ready_val == 0, \"Not Ready\",\n      ready_val == -1, \"Unknown\",\n      \"Unknown\"),\n    mem_pressure = CASE(\n      mem_press_val == 0, \"No\",\n      mem_press_val == 1, \"Yes\",\n      \"Unknown\"),\n    cpu_util  = ROUND(cpu_usage / alloc_cpu, 4),\n    mem_util  = ROUND(TO_DOUBLE(mem_ws) / TO_DOUBLE(alloc_mem), 4),\n    disk_util = ROUND(TO_DOUBLE(fs_usage) / TO_DOUBLE(fs_cap), 4)\n| KEEP k8s.node.name, ready, mem_pressure, pods, cpu_util, mem_util, disk_util, mem_available, k8s.cluster.name\n| SORT cpu_util DESC"
                             },
                             "visualization": {
                                 "columns": [
@@ -3469,42 +3392,75 @@
                                         "oneClickFilter": true
                                     },
                                     {
-                                        "colorMode": "cell",
-                                        "columnId": "ready",
-                                        "palette": {
-                                            "name": "custom",
-                                            "params": {
-                                                "colorStops": [
-                                                    {
-                                                        "color": "#f6726a",
-                                                        "stop": 0
+                                        "colorMapping": {
+                                            "assignments": [
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 0,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
                                                     },
-                                                    {
-                                                        "color": "#24c292",
-                                                        "stop": 1
-                                                    }
-                                                ],
-                                                "continuity": "above",
-                                                "name": "custom",
-                                                "progression": "fixed",
-                                                "rangeMax": null,
-                                                "rangeMin": 0,
-                                                "rangeType": "number",
-                                                "reverse": false,
-                                                "steps": 5,
-                                                "stops": [
-                                                    {
-                                                        "color": "#f6726a",
-                                                        "stop": 1
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Ready"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 6,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
                                                     },
-                                                    {
-                                                        "color": "#24c292",
-                                                        "stop": 2
-                                                    }
-                                                ]
+                                                    "rules": [
+                                                        {
+                                                            "matchCase": true,
+                                                            "matchEntireWord": true,
+                                                            "pattern": "Not Ready",
+                                                            "type": "match"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 8,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "matchCase": true,
+                                                            "matchEntireWord": true,
+                                                            "pattern": "Unknown",
+                                                            "type": "match"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                }
+                                            ],
+                                            "colorMode": {
+                                                "type": "categorical"
                                             },
-                                            "type": "palette"
-                                        }
+                                            "paletteId": "default",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorMode": "cell",
+                                        "columnId": "ready"
                                     },
                                     {
                                         "columnId": "mem_pressure"
@@ -4575,12 +4531,12 @@
         "title": "[OTEL][Kubernetes] Cluster Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-08T14:00:36.685Z",
+    "created_at": "2026-04-13T07:15:53.477Z",
     "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-cluster-back-link:link_113796d8-ddae-403e-83c1-1b70af16a09f_dashboard",
+            "name": "v3-cluster-back-link:link_9bb5439e-e11b-4c90-a8bb-6a9adff51246_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
@@ -88,8 +88,8 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_9cc0e2c6-cbd9-4c02-88e8-12faad0b39cf_dashboard",
-                            "label": "< Overview",
+                            "destinationRefName": "link_d7c1ba62-e32f-4de2-9020-16788bf86ece_dashboard",
+                            "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
                                 "use_filters": false,
@@ -108,169 +108,6 @@
                 },
                 "panelIndex": "v3-deployment-back-link",
                 "type": "links"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                    "managed": false,
-                                    "name": "metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [],
-                                    "layers": {
-                                        "f8a1797c-dc52-4a8b-8524-1db4bb4253ba": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "379ca9d0-0628-4a1f-9164-48a89141c51a",
-                                                    "customLabel": true,
-                                                    "fieldName": "name",
-                                                    "inMetricDimension": true,
-                                                    "label": "Deployment",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "keyword"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                            "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name), name = MAX(k8s.deployment.name)\n| EVAL name = CASE(count == 1, name, CONCAT(TO_STRING(count), \" deployments\"))\n| KEEP name"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS name = MAX(k8s.deployment.name)\n"
-                            },
-                            "visualization": {
-                                "colorMode": "none",
-                                "layerId": "f8a1797c-dc52-4a8b-8524-1db4bb4253ba",
-                                "layerType": "data",
-                                "metricAccessor": "379ca9d0-0628-4a1f-9164-48a89141c51a",
-                                "primaryAlign": "left",
-                                "showBar": false,
-                                "titleWeight": "normal",
-                                "titlesTextAlign": "left",
-                                "titlesTextSize": "xxs",
-                                "valueFontMode": "fit",
-                                "valuesTextSize": "xs"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    }
-                },
-                "gridData": {
-                    "h": 3,
-                    "i": "v3-wd-header-name",
-                    "w": 20,
-                    "x": 4,
-                    "y": 0
-                },
-                "panelIndex": "v3-wd-header-name",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                    "managed": false,
-                                    "name": "metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [],
-                                    "layers": {
-                                        "85a8526a-d0f3-42e9-97a8-caa72c6c6e89": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "432e5bfb-4f7c-40d5-9a0c-8a90ab0aa43e",
-                                                    "customLabel": true,
-                                                    "fieldName": "created_str",
-                                                    "inMetricDimension": true,
-                                                    "label": "Created on",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "keyword"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                            "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name), created = MIN(@timestamp)\n| EVAL created_str = CASE(count == 1, DATE_FORMAT(\"MMM dd, yyyy\", created), \"N/A\")\n| KEEP created_str"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name), created = MIN(@timestamp)\n| EVAL created_str = CASE(count == 1, DATE_FORMAT(\"MMM dd, yyyy\", created), \"N/A\")\n| KEEP created_str"
-                            },
-                            "visualization": {
-                                "colorMode": "none",
-                                "layerId": "85a8526a-d0f3-42e9-97a8-caa72c6c6e89",
-                                "layerType": "data",
-                                "metricAccessor": "432e5bfb-4f7c-40d5-9a0c-8a90ab0aa43e",
-                                "primaryAlign": "left",
-                                "showBar": false,
-                                "titleWeight": "normal",
-                                "titlesTextSize": "xxs",
-                                "valueFontMode": "fit",
-                                "valuesTextSize": "xs"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    }
-                },
-                "gridData": {
-                    "h": 3,
-                    "i": "v3-wd-header-created",
-                    "w": 17,
-                    "x": 24,
-                    "y": 0
-                },
-                "panelIndex": "v3-wd-header-created",
-                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -368,7 +205,7 @@
                             "open_in_new_tab": true,
                             "trigger": "on_click_value",
                             "type": "url_drilldown",
-                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))&_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.deployment.name:\"{{event.value}}\"'))"
+                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.deployment.name:\"{{event.value}}\"'))"
                         }
                     ],
                     "hide_title": true
@@ -753,6 +590,94 @@
                     "y": 3
                 },
                 "panelIndex": "v2-deploy-detail-restarts",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "f8a1797c-dc52-4a8b-8524-1db4bb4253ba": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "379ca9d0-0628-4a1f-9164-48a89141c51a",
+                                                    "customLabel": true,
+                                                    "fieldName": "name",
+                                                    "inMetricDimension": true,
+                                                    "label": "Deployment",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "keyword"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name), names = VALUES(k8s.deployment.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" deployments\"))\n| KEEP name"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name), names = VALUES(k8s.deployment.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" deployments\"))\n| KEEP name"
+                            },
+                            "visualization": {
+                                "colorMode": "none",
+                                "layerId": "f8a1797c-dc52-4a8b-8524-1db4bb4253ba",
+                                "layerType": "data",
+                                "metricAccessor": "379ca9d0-0628-4a1f-9164-48a89141c51a",
+                                "primaryAlign": "left",
+                                "showBar": false,
+                                "titleWeight": "normal",
+                                "titlesTextAlign": "left",
+                                "titlesTextSize": "xxs",
+                                "valueFontMode": "fit",
+                                "valuesTextSize": "xs"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "drilldowns": []
+                },
+                "gridData": {
+                    "h": 3,
+                    "i": "v3-wd-header-name",
+                    "w": 37,
+                    "x": 4,
+                    "y": 0
+                },
+                "panelIndex": "v3-wd-header-name",
                 "type": "lens"
             },
             {
@@ -1749,8 +1674,7 @@
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    },
-                    "drilldowns": []
+                    }
                 },
                 "gridData": {
                     "h": 5,
@@ -2748,7 +2672,7 @@
                                             ],
                                             "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` > 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
+                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2758,7 +2682,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` > 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
+                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2997,7 +2921,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS\n    phase          = MAX(k8s.pod.phase),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    restarts = COALESCE(restarts, 0)\n| SORT restarts desc\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| INLINE STATS phase_latest = MAX(CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name\n| EVAL phase_val = CASE(@timestamp == phase_latest, k8s.pod.phase, NULL)\n| STATS\n    phase_num      = MAX(phase_val),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3007,11 +2931,107 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS\n    phase          = MAX(k8s.pod.phase),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    restarts = COALESCE(restarts, 0)\n| SORT restarts desc\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| INLINE STATS phase_latest = MAX(CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name\n| EVAL phase_val = CASE(@timestamp == phase_latest, k8s.pod.phase, NULL)\n| STATS\n    phase_num      = MAX(phase_val),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
                                     {
+                                        "colorMapping": {
+                                            "assignments": [
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 0,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Running"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 2,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Succeeded"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 9,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Pending"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 6,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "matchCase": true,
+                                                            "matchEntireWord": true,
+                                                            "pattern": "Failed",
+                                                            "type": "match"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 1,
+                                                        "paletteId": "neutral",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "matchCase": true,
+                                                            "matchEntireWord": true,
+                                                            "pattern": "Unknown",
+                                                            "type": "match"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                }
+                                            ],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "default",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                }
+                                            ]
+                                        },
+                                        "colorMode": "cell",
                                         "columnId": "phase"
                                     },
                                     {
@@ -3162,12 +3182,12 @@
         "title": "[OTEL][Kubernetes] Deployment Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-08T13:27:21.892Z",
+    "created_at": "2026-04-13T08:16:02.703Z",
     "id": "kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-deployment-back-link:link_9cc0e2c6-cbd9-4c02-88e8-12faad0b39cf_dashboard",
+            "name": "v3-deployment-back-link:link_d7c1ba62-e32f-4de2-9020-16788bf86ece_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
@@ -59,37 +59,37 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_d1d80d75-fb34-4f49-825e-ddab27c88795_dashboard",
+                            "destinationRefName": "link_a8411d40-0bc2-4026-ba66-c79f0f2d97e2_dashboard",
                             "label": "Overview",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_489e2f99-9cf2-4108-ae55-aa4ca13fd991_dashboard",
+                            "destinationRefName": "link_73ed7c58-f56e-4887-8f96-f752b2ad9a4c_dashboard",
                             "label": "Clusters",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_95dc7d38-8a72-4d0f-8776-540016d41cfc_dashboard",
+                            "destinationRefName": "link_722b24a3-628d-4b9b-8b72-bb611a4e7184_dashboard",
                             "label": "Nodes",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_51b815d9-cbb9-4f25-8373-131ddea6244e_dashboard",
+                            "destinationRefName": "link_cb5f2169-b798-4985-a4ab-3b46493817bf_dashboard",
                             "label": "Namespaces",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_65ce57e9-6221-455e-8da1-73021c861d30_dashboard",
+                            "destinationRefName": "link_156cd235-fa72-4942-a2aa-b3d5e93523b6_dashboard",
                             "label": "Workload resources",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_640b5bdb-01f3-4016-ae69-874eaf1fc9ee_dashboard",
+                            "destinationRefName": "link_ea77e832-1682-4ba8-ac68-4e82f231aafb_dashboard",
                             "label": "Pods",
                             "options": {},
                             "type": "dashboardLink"
@@ -136,25 +136,160 @@
                                         }
                                     ],
                                     "layers": {
-                                        "44b7253f-cb06-46f2-a7ca-7303d5255327": {
-                                            "columns": [
+                                        "e6f98a1a-9e38-4e5b-a32d-a1fc0d3984c9": {
+                                            "allColumns": [
+                                                {
+                                                    "columnId": "cpu_usage",
+                                                    "customLabel": false,
+                                                    "fieldName": "cpu_usage",
+                                                    "inMetricDimension": true,
+                                                    "label": "cpu_usage",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "33ee79af-253e-457f-9021-9705c18d3cdb",
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.pod.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "93ec0dc8-ba7c-4b8a-a182-07b09408bcf3",
+                                                    "fieldName": "k8s.node.name",
+                                                    "label": "k8s.node.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.node.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "440d2f21-bada-4923-b09e-94a9d4cd11cb",
+                                                    "fieldName": "phase",
+                                                    "inMetricDimension": true,
+                                                    "label": "phase",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "phase"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
                                                 {
                                                     "columnId": "phase",
+                                                    "fieldName": "phase",
+                                                    "label": "phase",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "memory_ws",
+                                                    "fieldName": "memory_ws",
+                                                    "label": "memory_ws",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "mem_limit_util",
+                                                    "fieldName": "mem_limit_util",
+                                                    "label": "mem_limit_util",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "restarts",
+                                                    "fieldName": "restarts",
+                                                    "label": "restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.node.name",
+                                                    "fieldName": "k8s.node.name",
+                                                    "label": "k8s.node.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "440d2f21-bada-4923-b09e-94a9d4cd11cb",
                                                     "customLabel": true,
                                                     "fieldName": "phase",
                                                     "inMetricDimension": true,
                                                     "label": "Phase",
                                                     "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "phase"
+                                                        },
+                                                        "type": "string"
                                                     }
                                                 },
                                                 {
@@ -177,13 +312,72 @@
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "memory_ws",
+                                                    "columnId": "33ee79af-253e-457f-9021-9705c18d3cdb",
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.pod.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "93ec0dc8-ba7c-4b8a-a182-07b09408bcf3",
+                                                    "fieldName": "k8s.node.name",
+                                                    "label": "k8s.node.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.node.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "e2647caf-aee8-421d-adc3-027cc1290c28",
                                                     "customLabel": true,
                                                     "fieldName": "memory_ws",
                                                     "inMetricDimension": true,
                                                     "label": "Memory working set",
                                                     "meta": {
                                                         "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "memory_ws"
+                                                        },
                                                         "type": "number"
                                                     },
                                                     "params": {
@@ -196,32 +390,20 @@
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "mem_limit",
-                                                    "customLabel": true,
-                                                    "fieldName": "mem_limit",
-                                                    "inMetricDimension": true,
-                                                    "label": "Memory limit",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "restarts",
+                                                    "columnId": "89fe5d77-19b2-4be3-bd78-65c7899fe627",
                                                     "customLabel": true,
                                                     "fieldName": "restarts",
                                                     "inMetricDimension": true,
                                                     "label": "Container restarts",
                                                     "meta": {
                                                         "esType": "long",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "restarts"
+                                                        },
                                                         "type": "number"
                                                     },
                                                     "params": {
@@ -234,13 +416,20 @@
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "mem_limit_util",
+                                                    "columnId": "dc0bd21c-2bb1-4d08-952e-1af545162b18",
                                                     "customLabel": true,
                                                     "fieldName": "mem_limit_util",
                                                     "inMetricDimension": true,
                                                     "label": "Memory utilization",
                                                     "meta": {
                                                         "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "mem_limit_util"
+                                                        },
                                                         "type": "number"
                                                     },
                                                     "params": {
@@ -251,43 +440,11 @@
                                                             }
                                                         }
                                                     }
-                                                },
-                                                {
-                                                    "columnId": "cf31709a-a867-4082-8996-277cef210af4",
-                                                    "fieldName": "k8s.pod.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "f19047d1-84a9-4e5e-bae1-20a6812ce47c",
-                                                    "fieldName": "k8s.namespace.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "3e678304-98a9-4b76-97d4-3640efc3ef1d",
-                                                    "fieldName": "k8s.node.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "b9ef2922-2bd1-404b-8443-97c3a5e02092",
-                                                    "fieldName": "k8s.cluster.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
                                                 }
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n|  WHERE k8s.pod.name IS NOT NULL\n| STATS\n    k8s.cluster.name     = MAX(k8s.cluster.name),    cpu_usage     = AVG(k8s.pod.cpu.usage),\n    memory_ws     = AVG(k8s.pod.memory.working_set),\n    phase         = MAX(k8s.pod.phase),\n    restarts      = MAX(k8s.container.restarts),\n    k8s.node.name = MAX(k8s.node.name),\n    mem_limit     = MAX(k8s.container.memory_limit)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit > 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| INLINE STATS phase_latest = MAX(CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name\n| EVAL phase_val = CASE(@timestamp == phase_latest, k8s.pod.phase, NULL)\n| STATS\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    cpu_usage        = AVG(k8s.pod.cpu.usage),\n    memory_ws        = AVG(k8s.pod.memory.working_set),\n    phase_num        = MAX(phase_val),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    mem_limit        = MAX(k8s.container.memory_limit)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -297,7 +454,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n|  WHERE k8s.pod.name IS NOT NULL\n| STATS\n    k8s.cluster.name     = MAX(k8s.cluster.name),    cpu_usage     = AVG(k8s.pod.cpu.usage),\n    memory_ws     = AVG(k8s.pod.memory.working_set),\n    phase         = MAX(k8s.pod.phase),\n    restarts      = MAX(k8s.container.restarts),\n    k8s.node.name = MAX(k8s.node.name),\n    mem_limit     = MAX(k8s.container.memory_limit)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit > 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| INLINE STATS phase_latest = MAX(CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name\n| EVAL phase_val = CASE(@timestamp == phase_latest, k8s.pod.phase, NULL)\n| STATS\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    cpu_usage        = AVG(k8s.pod.cpu.usage),\n    memory_ws        = AVG(k8s.pod.memory.working_set),\n    phase_num        = MAX(phase_val),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    mem_limit        = MAX(k8s.container.memory_limit)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
@@ -305,61 +462,136 @@
                                         "columnId": "cpu_usage"
                                     },
                                     {
-                                        "columnId": "memory_ws"
+                                        "columnId": "k8s.cluster.name",
+                                        "oneClickFilter": true
                                     },
                                     {
-                                        "colorMode": "cell",
-                                        "columnId": "phase",
-                                        "palette": {
-                                            "name": "custom",
-                                            "params": {
-                                                "colorStops": [
-                                                    {
-                                                        "color": "#EAAE01",
-                                                        "stop": 1
+                                        "columnId": "k8s.namespace.name",
+                                        "oneClickFilter": true
+                                    },
+                                    {
+                                        "columnId": "33ee79af-253e-457f-9021-9705c18d3cdb",
+                                        "isMetric": false,
+                                        "isTransposed": false,
+                                        "oneClickFilter": true
+                                    },
+                                    {
+                                        "columnId": "93ec0dc8-ba7c-4b8a-a182-07b09408bcf3",
+                                        "isMetric": false,
+                                        "isTransposed": false,
+                                        "oneClickFilter": true
+                                    },
+                                    {
+                                        "colorMapping": {
+                                            "assignments": [
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 0,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
                                                     },
-                                                    {
-                                                        "color": "#16C5C0",
-                                                        "stop": 2
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Running"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 2,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
                                                     },
-                                                    {
-                                                        "color": "#61A2FF",
-                                                        "stop": 3
-                                                    }
-                                                ],
-                                                "continuity": "above",
-                                                "name": "custom",
-                                                "progression": "fixed",
-                                                "rangeMax": null,
-                                                "rangeMin": 1,
-                                                "rangeType": "number",
-                                                "reverse": false,
-                                                "steps": 5,
-                                                "stops": [
-                                                    {
-                                                        "color": "#EAAE01",
-                                                        "stop": 2
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Succeeded"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 9,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
                                                     },
-                                                    {
-                                                        "color": "#16C5C0",
-                                                        "stop": 3
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Pending"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 6,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
                                                     },
-                                                    {
-                                                        "color": "#61A2FF",
-                                                        "stop": 4
-                                                    }
-                                                ]
+                                                    "rules": [
+                                                        {
+                                                            "matchCase": true,
+                                                            "matchEntireWord": true,
+                                                            "pattern": "Failed",
+                                                            "type": "match"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 1,
+                                                        "paletteId": "neutral",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "matchCase": true,
+                                                            "matchEntireWord": true,
+                                                            "pattern": "Unknown",
+                                                            "type": "match"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                }
+                                            ],
+                                            "colorMode": {
+                                                "type": "categorical"
                                             },
-                                            "type": "palette"
-                                        }
+                                            "paletteId": "default",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorMode": "cell",
+                                        "columnId": "440d2f21-bada-4923-b09e-94a9d4cd11cb",
+                                        "isMetric": true,
+                                        "isTransposed": false
                                     },
                                     {
-                                        "columnId": "mem_limit",
-                                        "hidden": true
+                                        "columnId": "e2647caf-aee8-421d-adc3-027cc1290c28",
+                                        "isMetric": true,
+                                        "isTransposed": false
                                     },
                                     {
                                         "colorMode": "cell",
-                                        "columnId": "restarts",
+                                        "columnId": "89fe5d77-19b2-4be3-bd78-65c7899fe627",
+                                        "isMetric": true,
+                                        "isTransposed": false,
                                         "palette": {
                                             "name": "custom",
                                             "params": {
@@ -369,7 +601,7 @@
                                                         "stop": 0
                                                     },
                                                     {
-                                                        "color": "#f6726a",
+                                                        "color": "#F6726A",
                                                         "stop": 1
                                                     }
                                                 ],
@@ -387,8 +619,8 @@
                                                         "stop": 1
                                                     },
                                                     {
-                                                        "color": "#f6726a",
-                                                        "stop": 1080
+                                                        "color": "#F6726A",
+                                                        "stop": 4131
                                                     }
                                                 ]
                                             },
@@ -396,34 +628,12 @@
                                         }
                                     },
                                     {
-                                        "columnId": "mem_limit_util"
-                                    },
-                                    {
-                                        "columnId": "cf31709a-a867-4082-8996-277cef210af4",
-                                        "isMetric": false,
-                                        "isTransposed": false,
-                                        "oneClickFilter": true
-                                    },
-                                    {
-                                        "columnId": "f19047d1-84a9-4e5e-bae1-20a6812ce47c",
-                                        "isMetric": false,
-                                        "isTransposed": false,
-                                        "oneClickFilter": true
-                                    },
-                                    {
-                                        "columnId": "3e678304-98a9-4b76-97d4-3640efc3ef1d",
-                                        "isMetric": false,
-                                        "isTransposed": false,
-                                        "oneClickFilter": true
-                                    },
-                                    {
-                                        "columnId": "b9ef2922-2bd1-404b-8443-97c3a5e02092",
-                                        "isMetric": false,
-                                        "isTransposed": false,
-                                        "oneClickFilter": true
+                                        "columnId": "dc0bd21c-2bb1-4d08-952e-1af545162b18",
+                                        "isMetric": true,
+                                        "isTransposed": false
                                     }
                                 ],
-                                "layerId": "44b7253f-cb06-46f2-a7ca-7303d5255327",
+                                "layerId": "e6f98a1a-9e38-4e5b-a32d-a1fc0d3984c9",
                                 "layerType": "data",
                                 "showRowNumbers": true
                             }
@@ -649,7 +859,6 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Memory composition over time. RSS, working set, and available memory as separate series. SUM per 1m bucket.",
-                    "drilldowns": [],
                     "title": "Memory composition"
                 },
                 "gridData": {
@@ -734,8 +943,7 @@
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    },
-                    "drilldowns": []
+                    }
                 },
                 "gridData": {
                     "h": 4,
@@ -854,8 +1062,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2.",
-                    "drilldowns": []
+                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2."
                 },
                 "gridData": {
                     "h": 4,
@@ -974,8 +1181,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1.",
-                    "drilldowns": []
+                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1."
                 },
                 "gridData": {
                     "h": 4,
@@ -1094,8 +1300,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4.",
-                    "drilldowns": []
+                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4."
                 },
                 "gridData": {
                     "h": 4,
@@ -1462,7 +1667,7 @@
                             "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "k8s.container.restarts > 0"
+                                "query": "k8s.container.restarts \u003e 0"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1530,37 +1735,37 @@
         "title": "[OTEL][Kubernetes] Pods"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-08T10:18:46.611Z",
+    "created_at": "2026-04-14T05:38:13.579Z",
     "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v2-pods-alt-nav:link_d1d80d75-fb34-4f49-825e-ddab27c88795_dashboard",
+            "name": "v2-pods-alt-nav:link_a8411d40-0bc2-4026-ba66-c79f0f2d97e2_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e",
-            "name": "v2-pods-alt-nav:link_489e2f99-9cf2-4108-ae55-aa4ca13fd991_dashboard",
+            "name": "v2-pods-alt-nav:link_73ed7c58-f56e-4887-8f96-f752b2ad9a4c_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0c88decf-de83-47a4-a5df-0a79dc8daff5",
-            "name": "v2-pods-alt-nav:link_95dc7d38-8a72-4d0f-8776-540016d41cfc_dashboard",
+            "name": "v2-pods-alt-nav:link_722b24a3-628d-4b9b-8b72-bb611a4e7184_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-c0765efe-f172-42c4-a2ea-f4552b6f42dc",
-            "name": "v2-pods-alt-nav:link_51b815d9-cbb9-4f25-8373-131ddea6244e_dashboard",
+            "name": "v2-pods-alt-nav:link_cb5f2169-b798-4985-a4ab-3b46493817bf_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
-            "name": "v2-pods-alt-nav:link_65ce57e9-6221-455e-8da1-73021c861d30_dashboard",
+            "name": "v2-pods-alt-nav:link_156cd235-fa72-4942-a2aa-b3d5e93523b6_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
-            "name": "v2-pods-alt-nav:link_640b5bdb-01f3-4016-ae69-874eaf1fc9ee_dashboard",
+            "name": "v2-pods-alt-nav:link_ea77e832-1682-4ba8-ac68-4e82f231aafb_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 2.0.0-preview5
+version: 2.0.0-preview6
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:


### PR DESCRIPTION

- Enhancement

## Proposed commit message

Convert numeric status fields to human-readable strings in kubernetes_otel dashboards

Represent pod phases, node readiness, and container ready states as human-readable strings instead of numeric values in Cluster Details, Deployment Details, and Pod Details dashboards.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- Manual verification

## How to test this PR locally

- `elastic-package build && elastic-package stack up -v -d --services package-registry`


## Screenshots

### Pods dashboard view

<img width="1716" height="238" alt="image" src="https://github.com/user-attachments/assets/a992588c-b1be-4701-9bbe-bfeabae1c20f" />


### Deployment details

<img width="1726" height="269" alt="image" src="https://github.com/user-attachments/assets/9004f2ea-12bf-43e9-bf15-61035f42b34c" />


### Pod details

<img width="1175" height="368" alt="image" src="https://github.com/user-attachments/assets/3d54b1bf-6f66-401e-aa35-44702afb512b" />


#### Cluster details

<img width="1720" height="141" alt="image" src="https://github.com/user-attachments/assets/c8bcf139-8869-4f96-ae51-6d688ff23391" />

