### PR TITLE
[system_otel] Remove host.ip and host.mac

### DIFF
--- a/packages/system_otel/changelog.yml
+++ b/packages/system_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.7"
+  changes:
+    - description: Remove `host.ip` and `host.mac` from dashboard
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "0.2.6"
   changes:
     - description: Use `host.id` so cloud metadata works with default attributes

--- a/packages/system_otel/changelog.yml
+++ b/packages/system_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove `host.ip` and `host.mac` from dashboard
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/18390
 - version: "0.2.6"
   changes:
     - description: Use `host.id` so cloud metadata works with default attributes

--- a/packages/system_otel/docs/README.md
+++ b/packages/system_otel/docs/README.md
@@ -107,10 +107,6 @@ processors:
           enabled: false
         host.arch:
           enabled: true
-        host.ip:
-          enabled: true
-        host.mac:
-          enabled: true
         host.cpu.vendor.id:
           enabled: true
         host.cpu.family:
@@ -193,8 +189,6 @@ Also, it's recommended to enable the [`resourcedetection` processor](https://git
 - `host.name`
 - `host.id`
 - `host.arch`
-- `host.ip`
-- `host.mac`
 - `host.cpu.vendor.id`
 - `host.cpu.family`
 - `host.cpu.model.id`

--- a/packages/system_otel/kibana/dashboard/system_otel-329ee135-f301-4dab-91f4-af52cd58cb88.json
+++ b/packages/system_otel/kibana/dashboard/system_otel-329ee135-f301-4dab-91f4-af52cd58cb88.json
@@ -547,7 +547,7 @@
                                             ],
                                             "index": "metrics-hostmetricsreceiver.otel-*",
                                             "query": {
-                                                "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| STATS BY \nos = resource.attributes.os.description ,\nip = resource.attributes.host.ip,\nname = resource.attributes.host.name\n| EVAL ip_str = TO_STRING(ip)\n| EVAL str = CONCAT(\"os.description$\",os, \"|\",\n\"host.ip$\", ip_str, \"|\",\n\"host.name$\", name\n)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
+                                                "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| STATS BY \nos = resource.attributes.os.description ,\nname = resource.attributes.host.name\n| EVAL str = CONCAT(\"os.description$\",os, \"|\",\n\"host.name$\", name\n)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -557,7 +557,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| STATS BY \nos = resource.attributes.os.description ,\nip = resource.attributes.host.ip,\nname = resource.attributes.host.name\n| EVAL ip_str = TO_STRING(ip)\n| EVAL str = CONCAT(\"os.description$\",os, \"|\",\n\"host.ip$\", ip_str, \"|\",\n\"host.name$\", name\n)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
+                                "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| STATS BY \nos = resource.attributes.os.description ,\nname = resource.attributes.host.name\n| EVAL str = CONCAT(\"os.description$\",os, \"|\",\n\"host.name$\", name\n)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
                             },
                             "visualization": {
                                 "columns": [
@@ -585,7 +585,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| STATS BY \nos = resource.attributes.os.description ,\nip = resource.attributes.host.ip,\nname = resource.attributes.host.name\n| EVAL ip_str = TO_STRING(ip)\n| EVAL str = CONCAT(\"os.description$\",os, \"|\",\n\"host.ip$\", ip_str, \"|\",\n\"host.name$\", name\n)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
+                        "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| STATS BY \nos = resource.attributes.os.description ,\nname = resource.attributes.host.name\n| EVAL str = CONCAT(\"os.description$\",os, \"|\",\n\"host.name$\", name\n)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
                     },
                     "searchSessionId": "d7cfaf51-c948-4acb-9f00-c5af03f94c72",
                     "syncColors": false,

--- a/packages/system_otel/kibana/dashboard/system_otel-c2749107-6de5-49b5-b007-582a88de8d7c.json
+++ b/packages/system_otel/kibana/dashboard/system_otel-c2749107-6de5-49b5-b007-582a88de8d7c.json
@@ -201,7 +201,7 @@
                                             ],
                                             "index": "metrics-hostmetricsreceiver.otel-*",
                                             "query": {
-                                                "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| LIMIT 1\n| STATS BY \narch = resource.attributes.host.arch,\nip = resource.attributes.host.ip,\nmac = resource.attributes.host.mac,\nname = resource.attributes.host.name\n| EVAL ip_str = TO_STRING(ip)\n| EVAL str = CONCAT(\"host.arch$\",arch, \"|\",\n\"host.ip$\", ip_str, \"|\",\n\"host.mac$\",mac, \"|\",\n\"host.name$\", name)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
+                                                "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| LIMIT 1\n| STATS BY \narch = resource.attributes.host.arch,\nname = resource.attributes.host.name\n| EVAL str = CONCAT(\"host.arch$\",arch, \"|\",\n\"host.name$\", name)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -211,7 +211,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| LIMIT 1\n| STATS BY \narch = resource.attributes.host.arch,\nip = resource.attributes.host.ip,\nmac = resource.attributes.host.mac,\nname = resource.attributes.host.name\n| EVAL ip_str = TO_STRING(ip)\n| EVAL str = CONCAT(\"host.arch$\",arch, \"|\",\n\"host.ip$\", ip_str, \"|\",\n\"host.mac$\",mac, \"|\",\n\"host.name$\", name)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
+                                "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| LIMIT 1\n| STATS BY \narch = resource.attributes.host.arch,\nname = resource.attributes.host.name\n| EVAL str = CONCAT(\"host.arch$\",arch, \"|\",\n\"host.name$\", name)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
                             },
                             "visualization": {
                                 "columns": [
@@ -239,7 +239,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| LIMIT 1\n| STATS BY \narch = resource.attributes.host.arch,\nip = resource.attributes.host.ip,\nmac = resource.attributes.host.mac,\nname = resource.attributes.host.name\n| EVAL ip_str = TO_STRING(ip)\n| EVAL str = CONCAT(\"host.arch$\",arch, \"|\",\n\"host.ip$\", ip_str, \"|\",\n\"host.mac$\",mac, \"|\",\n\"host.name$\", name)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
+                        "esql": "FROM metrics-hostmetricsreceiver.otel-*\n| LIMIT 1\n| STATS BY \narch = resource.attributes.host.arch,\nname = resource.attributes.host.name\n| EVAL str = CONCAT(\"host.arch$\",arch, \"|\",\n\"host.name$\", name)\n| EVAL arr = SPLIT(str, \"|\")\n| MV_EXPAND arr\n| EVAL pairs = SPLIT(arr, \"$\")\n| EVAL `Resource Attribute` = MV_FIRST(pairs), value = MV_LAST(pairs)\n| keep `Resource Attribute`, value\n| STATS `Value` = MV_DEDUPE(TOP(value, 400, \"asc\")) BY `Resource Attribute`"
                     },
                     "searchSessionId": "d3777fa7-1c8f-4127-ad65-b28bdc06a24e",
                     "syncColors": false,

--- a/packages/system_otel/manifest.yml
+++ b/packages/system_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: system_otel
 title: "System OpenTelemetry Assets"
-version: 0.2.6
+version: 0.2.7
 description: "Dashboards for the OpenTelemetry data collected with the `hostmetrics` receiver."
 type: content
 categories:


### PR DESCRIPTION
## Proposed commit message

Removed `host.ip` and `host.mac` from system_otel content pack as those values are set to no longer be collected by default due to the high volume of data they might generated in k8s environments.

Check related issues:
- https://github.com/elastic/elastic-agent/issues/13575
- https://github.com/elastic/opentelemetry-dev/issues/1311


Please explain:

Removed `host.ip` and `host.mac` from ESQL queries. 

These values were not made optional due to the fact that if they were never ingested into ES, the mappings won't be know, causing the whole query to fail. 


## How to test this PR locally

Point `elastic-package` to the right ES instance (local or ECS) 

`elastic-package build`
`elastic-package install`


helm-install otel-operator with one of the value files from PR: https://github.com/elastic/elastic-agent/pull/13566

Wait for content pack to get enabled.

Point 

## Related issues

- Closes #18334 

## Screenshots

<img width="1081" height="342" alt="Screenshot 2026-04-14 at 15 25 40" src="https://github.com/user-attachments/assets/e49eabf3-b12f-4e2e-9bb5-71e95aec5fcd" />


<img width="815" height="345" alt="Screenshot 2026-04-14 at 15 25 46" src="https://github.com/user-attachments/assets/b042f877-ac85-476f-a151-895966b9b70e" />
