### PR TITLE
ti_*: Use num_failure_retries instead of unattended mode

### DIFF
--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.7.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "3.6.0"
   changes:
     - description: Add tags to ingest pipelines.

--- a/packages/ti_abusech/elasticsearch/transform/latest_ja3_fingerprints/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_ja3_fingerprints/transform.yml
@@ -37,6 +37,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_abusech/elasticsearch/transform/latest_malware/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malware/transform.yml
@@ -38,6 +38,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/transform.yml
@@ -38,6 +38,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_abusech/elasticsearch/transform/latest_sslblacklist/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_sslblacklist/transform.yml
@@ -37,6 +37,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_abusech/elasticsearch/transform/latest_threatfox/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_threatfox/transform.yml
@@ -37,6 +37,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_abusech/elasticsearch/transform/latest_url/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_url/transform.yml
@@ -37,6 +37,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: abuse.ch
-version: "3.6.0"
+version: "3.7.0"
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration
 format_version: "3.3.2"

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "2.6.1"
   changes:
     - description: Add missing request trace enabled default option.

--- a/packages/ti_anomali/elasticsearch/transform/latest_intelligence/transform.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_intelligence/transform.yml
@@ -32,6 +32,6 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
@@ -32,6 +32,6 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.6.0
+  fleet_transform_version: 0.7.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali ThreatStream
-version: "2.6.1"
+version: "2.7.0"
 description: Ingest threat intelligence indicators from Anomali ThreatStream with Elastic Agent.
 type: integration
 format_version: 3.3.2

--- a/packages/ti_anyrun/changelog.yml
+++ b/packages/ti_anyrun/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.0.1"
   changes:
     - description: Update UTM tags in documentation links

--- a/packages/ti_anyrun/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_anyrun/elasticsearch/transform/latest_ioc/transform.yml
@@ -24,4 +24,6 @@ retention_policy:
     max_age: 1m
 _meta:
   managed: true
-  fleet_transform_version: 1.0.0
+  fleet_transform_version: 1.1.0
+settings:
+  num_failure_retries: -1

--- a/packages/ti_anyrun/manifest.yml
+++ b/packages/ti_anyrun/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: ti_anyrun
 title: ANY.RUN Threat Intelligence Feeds
-version: 1.0.1
+version: 1.1.0
 source:
   license: Elastic-2.0
 description: Ingest Threat Intelligence indicators from ANY.RUN TI Feeds with Elastic Agent
@@ -22,7 +22,7 @@ screenshots:
   - src: /img/Intelligence_Dashboard.png
     title: Intelligence Dashboard
     size: 600x600
-    type: image/png 
+    type: image/png
 icons:
   - src: /img/anyrun-logo.svg
     title: ANY.RUN
@@ -55,7 +55,7 @@ policy_templates:
             required: true
             show_user: false
             default: https://api.any.run
-            description: Base URL of the ANY.RUN Threat Intelligence API. Defaults to https://api.any.run  
+            description: Base URL of the ANY.RUN Threat Intelligence API. Defaults to https://api.any.run
           - name: proxy_url
             type: text
             title: Proxy URL

--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.18.2"
   changes:
     - description: Use triple-brace Mustache templating when referencing variables in ingest pipelines.

--- a/packages/ti_cif3/elasticsearch/transform/latest_threat/transform.yml
+++ b/packages/ti_cif3/elasticsearch/transform/latest_threat/transform.yml
@@ -40,6 +40,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: "1.18.2"
+version: "1.19.0"
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."
 type: integration
 categories:

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "2.7.1"
   changes:
     - description: Change `data_stream.namespace` field type from constant_keyword to keyword in transform destination indices to support multiple namespaces.

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/transform.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_intel/transform.yml
@@ -22,7 +22,7 @@ latest:
 description: Latest Intel Indicator data retrieved from CrowdStrike Intel API.
 frequency: 30s
 settings:
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: event.ingested
@@ -35,4 +35,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0

--- a/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_crowdstrike/elasticsearch/transform/latest_ioc/transform.yml
@@ -22,7 +22,7 @@ latest:
 description: Latest IOC Indicator data retrieved from CrowdStrike IOC API.
 frequency: 30s
 settings:
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: event.ingested
@@ -35,4 +35,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.6.0
+  fleet_transform_version: 0.7.0

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "2.7.1"
+version: "2.8.0"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.6.0"
   changes:
     - description: Document `max_executions` setting and add troubleshooting guidance for the "exceeding maximum number of CEL executions" error.

--- a/packages/ti_custom/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_custom/elasticsearch/transform/latest_ioc/transform.yml
@@ -31,6 +31,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.6.0
+  fleet_transform_version: 0.7.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_custom/manifest.yml
+++ b/packages/ti_custom/manifest.yml
@@ -3,7 +3,7 @@ name: ti_custom
 title: Custom Threat Intelligence
 description: Ingest threat intelligence data in STIX 2.1 format with Elastic Agent
 type: integration
-version: "1.6.0"
+version: "1.7.0"
 categories:
   - custom
   - security

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.35.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.34.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/ti_cybersixgill/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_cybersixgill/elasticsearch/transform/latest_ioc/transform.yml
@@ -34,6 +34,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.34.1"
+version: "1.35.0"
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_cyware_intel_exchange/changelog.yml
+++ b/packages/ti_cyware_intel_exchange/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "0.2.0"
   changes:
     - description: Update documentation and add "IOC Expiration Duration" configuration parameter.

--- a/packages/ti_cyware_intel_exchange/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_cyware_intel_exchange/elasticsearch/transform/latest_ioc/transform.yml
@@ -23,7 +23,7 @@ description: Latest IOC Indicator data retrieved from Cyware Intel Exchange API.
 frequency: 2m
 settings:
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -38,5 +38,5 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0
   run_as_kibana_system: false

--- a/packages/ti_cyware_intel_exchange/manifest.yml
+++ b/packages/ti_cyware_intel_exchange/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_cyware_intel_exchange
 title: Cyware Intel Exchange
-version: 0.2.0
+version: 0.3.0
 description: Collect logs from Cyware Intel Exchange with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]
@@ -17,7 +17,7 @@ icons:
     type: image/svg+xml
 screenshots:
   - src: /img/cyware-indicator-dashboard.png
-    title: Indicator Dashboard 
+    title: Indicator Dashboard
     size: 600x600
     type: image/png
 policy_templates:

--- a/packages/ti_domaintools/changelog.yml
+++ b/packages/ti_domaintools/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.3.0"
   changes:
     - description: Allow transforms to run in unattended mode.

--- a/packages/ti_domaintools/elasticsearch/transform/latest_domaindiscovery/transform.yml
+++ b/packages/ti_domaintools/elasticsearch/transform/latest_domaindiscovery/transform.yml
@@ -32,6 +32,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 1.1.0
+  fleet_transform_version: 1.2.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_domaintools/elasticsearch/transform/latest_domainhotlist/transform.yml
+++ b/packages/ti_domaintools/elasticsearch/transform/latest_domainhotlist/transform.yml
@@ -32,6 +32,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 1.1.0
+  fleet_transform_version: 1.2.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_domaintools/elasticsearch/transform/latest_domainrdap/transform.yml
+++ b/packages/ti_domaintools/elasticsearch/transform/latest_domainrdap/transform.yml
@@ -32,6 +32,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 1.1.0
+  fleet_transform_version: 1.2.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_domaintools/elasticsearch/transform/latest_domainrisk/transform.yml
+++ b/packages/ti_domaintools/elasticsearch/transform/latest_domainrisk/transform.yml
@@ -32,6 +32,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 1.1.0
+  fleet_transform_version: 1.2.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_domaintools/elasticsearch/transform/latest_nad/transform.yml
+++ b/packages/ti_domaintools/elasticsearch/transform/latest_nad/transform.yml
@@ -32,6 +32,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 1.1.0
+  fleet_transform_version: 1.2.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_domaintools/elasticsearch/transform/latest_nod/transform.yml
+++ b/packages/ti_domaintools/elasticsearch/transform/latest_nod/transform.yml
@@ -32,6 +32,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 1.1.0
+  fleet_transform_version: 1.2.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_domaintools/manifest.yml
+++ b/packages/ti_domaintools/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_domaintools
 title: "DomainTools Feeds"
-version: "1.3.0"
+version: "1.4.0"
 source:
   license: "Elastic-2.0"
 description: "DomainTools Feeds provide data on the different stages of the domain lifecycle: from first-observed in the wild, to newly re-activated after a period of quiet."

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.6.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.5.0"
   changes:
     - description: Allow transforms to run in unattended mode.

--- a/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_eclecticiq/elasticsearch/transform/latest_ioc/transform.yml
@@ -28,6 +28,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_eclecticiq/manifest.yml
+++ b/packages/ti_eclecticiq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eclecticiq
 title: EclecticIQ
-version: "1.5.0"
+version: "1.6.0"
 description: Ingest threat intelligence from EclecticIQ with Elastic Agent
 type: integration
 categories:

--- a/packages/ti_eset/changelog.yml
+++ b/packages/ti_eset/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.9.0"
   changes:
     - description: Allow transforms to run in unattended mode.

--- a/packages/ti_eset/elasticsearch/transform/apt_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/apt_latest_ioc/transform.yml
@@ -1,5 +1,5 @@
 _meta:
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
   managed: true
 description: Latest ESET APT IoC data
 dest:
@@ -25,4 +25,4 @@ sync:
     delay: 120s
     field: event.ingested
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_eset/elasticsearch/transform/botnet_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/botnet_latest_ioc/transform.yml
@@ -1,5 +1,5 @@
 _meta:
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
   managed: true
 description: Latest ESET Botnet IoC data
 dest:
@@ -25,4 +25,4 @@ sync:
     delay: 120s
     field: event.ingested
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_eset/elasticsearch/transform/cc_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/cc_latest_ioc/transform.yml
@@ -1,5 +1,5 @@
 _meta:
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
   managed: true
 description: Latest ESET C&C IoC data
 dest:
@@ -25,4 +25,4 @@ sync:
     delay: 120s
     field: event.ingested
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_eset/elasticsearch/transform/domains_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/domains_latest_ioc/transform.yml
@@ -1,5 +1,5 @@
 _meta:
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
   managed: true
 description: Latest ESET Domains IoC data
 dest:
@@ -25,4 +25,4 @@ sync:
     delay: 120s
     field: event.ingested
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_eset/elasticsearch/transform/files_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/files_latest_ioc/transform.yml
@@ -1,5 +1,5 @@
 _meta:
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
   managed: true
 description: Latest ESET Files IoC data
 dest:
@@ -25,4 +25,4 @@ sync:
     delay: 120s
     field: event.ingested
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_eset/elasticsearch/transform/ip_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/ip_latest_ioc/transform.yml
@@ -1,5 +1,5 @@
 _meta:
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
   managed: true
 description: Latest ESET IP IoC data
 dest:
@@ -25,4 +25,4 @@ sync:
     delay: 120s
     field: event.ingested
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_eset/elasticsearch/transform/url_latest_ioc/transform.yml
+++ b/packages/ti_eset/elasticsearch/transform/url_latest_ioc/transform.yml
@@ -1,5 +1,5 @@
 _meta:
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
   managed: true
 description: Latest ESET URL IoC data
 dest:
@@ -25,4 +25,4 @@ sync:
     delay: 120s
     field: event.ingested
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_eset/manifest.yml
+++ b/packages/ti_eset/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eset
 title: "ESET Threat Intelligence"
-version: "1.9.0"
+version: "1.10.0"
 description: "Ingest threat intelligence indicators from ESET Threat Intelligence with Elastic Agent."
 type: integration
 categories:

--- a/packages/ti_flashpoint/changelog.yml
+++ b/packages/ti_flashpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: 0.1.0
   changes:
     - description: Initial release.

--- a/packages/ti_flashpoint/elasticsearch/transform/latest_indicator/transform.yml
+++ b/packages/ti_flashpoint/elasticsearch/transform/latest_indicator/transform.yml
@@ -34,4 +34,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0
+settings:
+  num_failure_retries: -1

--- a/packages/ti_flashpoint/manifest.yml
+++ b/packages/ti_flashpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_flashpoint
 title: Flashpoint
-version: 0.1.0
+version: 0.2.0
 description: Collect logs from Flashpoint with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "0.8.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/domain_ioc/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/domain_ioc/transform.yml
@@ -40,7 +40,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -55,7 +55,7 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   # We are currently using multiple source indices in this transform because system tests do not support
   # executing queries defined within the transform. This causes test failures, so we've raised the issue here:
   # https://github.com/elastic/elastic-package/issues/2676

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/domain_ioc_st/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/domain_ioc_st/transform.yml
@@ -27,7 +27,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -42,5 +42,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   run_as_kibana_system: false

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/file_ioc/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/file_ioc/transform.yml
@@ -40,7 +40,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -55,7 +55,7 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   # We are currently using multiple source indices in this transform because system tests do not support
   # executing queries defined within the transform. This causes test failures, so we've raised the issue here:
   # https://github.com/elastic/elastic-package/issues/2676

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/file_ioc_st/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/file_ioc_st/transform.yml
@@ -27,7 +27,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -42,5 +42,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   run_as_kibana_system: false

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/ip_ioc/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/ip_ioc/transform.yml
@@ -40,7 +40,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -55,7 +55,7 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   # We are currently using multiple source indices in this transform because system tests do not support
   # executing queries defined within the transform. This causes test failures, so we've raised the issue here:
   # https://github.com/elastic/elastic-package/issues/2676

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/ip_ioc_st/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/ip_ioc_st/transform.yml
@@ -27,7 +27,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -42,5 +42,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   run_as_kibana_system: false

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/rule/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/rule/transform.yml
@@ -28,7 +28,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "@timestamp"
@@ -43,5 +43,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   run_as_kibana_system: false

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/rule_ioc_st/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/rule_ioc_st/transform.yml
@@ -27,7 +27,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "@timestamp"
@@ -42,5 +42,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   run_as_kibana_system: false

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/url_ioc/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/url_ioc/transform.yml
@@ -40,7 +40,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -55,7 +55,7 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   # We are currently using multiple source indices in this transform because system tests do not support
   # executing queries defined within the transform. This causes test failures, so we've raised the issue here:
   # https://github.com/elastic/elastic-package/issues/2676

--- a/packages/ti_google_threat_intelligence/elasticsearch/transform/url_ioc_st/transform.yml
+++ b/packages/ti_google_threat_intelligence/elasticsearch/transform/url_ioc_st/transform.yml
@@ -27,7 +27,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -42,5 +42,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   run_as_kibana_system: false

--- a/packages/ti_google_threat_intelligence/manifest.yml
+++ b/packages/ti_google_threat_intelligence/manifest.yml
@@ -3,7 +3,7 @@ name: ti_google_threat_intelligence
 title: Google Threat Intelligence
 # This version must match the User-Agent version used in CEL code.
 # Remember to update the User-Agent in CEL code when changing this version.
-version: "0.8.1"
+version: "0.9.0"
 description: Collect Threat Intelligence Events from Google Threat Intelligence using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:

--- a/packages/ti_greynoise/changelog.yml
+++ b/packages/ti_greynoise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "0.7.3"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/ti_greynoise/elasticsearch/transform/ip/transform.yml
+++ b/packages/ti_greynoise/elasticsearch/transform/ip/transform.yml
@@ -22,7 +22,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "event.ingested"
@@ -37,5 +37,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.1
+  fleet_transform_version: 0.8.0
   run_as_kibana_system: false

--- a/packages/ti_greynoise/elasticsearch/transform/rule/transform.yml
+++ b/packages/ti_greynoise/elasticsearch/transform/rule/transform.yml
@@ -24,7 +24,7 @@ frequency: 30s
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
-  unattended: true
+  num_failure_retries: -1
 sync:
   time:
     field: "@timestamp"
@@ -39,5 +39,5 @@ _meta:
   managed: false
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.7.0
+  fleet_transform_version: 0.8.0
   run_as_kibana_system: false

--- a/packages/ti_greynoise/manifest.yml
+++ b/packages/ti_greynoise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_greynoise
 title: GreyNoise
-version: "0.7.3"
+version: "0.8.0"
 description: Collect Threat Intelligence Indicators from GreyNoise using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:

--- a/packages/ti_maltiverse/changelog.yml
+++ b/packages/ti_maltiverse/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.7.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.6.0"
   changes:
     - description: Allow transforms to run in unattended mode.

--- a/packages/ti_maltiverse/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_maltiverse/elasticsearch/transform/latest/transform.yml
@@ -29,6 +29,6 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_maltiverse/manifest.yml
+++ b/packages/ti_maltiverse/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_maltiverse
 title: Maltiverse
-version: "1.6.0"
+version: "1.7.0"
 description: Ingest threat intelligence indicators from Maltiverse feeds with Elastic Agent
 type: integration
 format_version: 3.0.2

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.43.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.42.0"
   changes:
     - description: Add MISP API rate-limit response headers (`X-Rate-Limit-*`) to httpjson.

--- a/packages/ti_misp/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_misp/elasticsearch/transform/latest_ioc/transform.yml
@@ -33,6 +33,6 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.42.0"
+version: "1.43.0"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.14.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "2.13.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/ti_opencti/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_opencti/elasticsearch/transform/latest_ioc/transform.yml
@@ -39,6 +39,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during
   # package installation.
-  fleet_transform_version: 0.6.0
+  fleet_transform_version: 0.7.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: ti_opencti
 title: OpenCTI
-version: "2.13.0"
+version: "2.14.0"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.30.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/ti_otx/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_otx/elasticsearch/transform/latest_ioc/transform.yml
@@ -33,6 +33,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.30.1"
+version: "1.31.0"
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "2.8.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_alert/transform.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_alert/transform.yml
@@ -37,6 +37,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_ioc/transform.yml
@@ -40,6 +40,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_vulnerability/transform.yml
+++ b/packages/ti_rapid7_threat_command/elasticsearch/transform/latest_vulnerability/transform.yml
@@ -37,6 +37,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.0
+  fleet_transform_version: 0.4.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
-version: "2.8.0"
+version: "2.9.0"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_recordedfuture/changelog.yml
+++ b/packages/ti_recordedfuture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "2.4.2"
   changes:
     - description: Fix `primary_entity` and `rule.use_case_deprecation` mapping for the triggered alerts data stream by adding `primary_entity.id`, `primary_entity.name`, `primary_entity.type` and `rule.use_case_deprecation.description` fields.

--- a/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_recordedfuture/elasticsearch/transform/latest_ioc/transform.yml
@@ -35,6 +35,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.5.0
+  fleet_transform_version: 0.6.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "2.4.2"
+version: "2.5.0"
 description: Ingest threat intelligence and alert data from Recorded Future with Elastic Agent.
 type: integration
 format_version: 3.3.2

--- a/packages/ti_strider/changelog.yml
+++ b/packages/ti_strider/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "0.0.1"
   changes:
     - description: First Strider Shield integration

--- a/packages/ti_strider/elasticsearch/transform/latest_item/transform.yml
+++ b/packages/ti_strider/elasticsearch/transform/latest_item/transform.yml
@@ -31,4 +31,6 @@ retention_policy:
     max_age: 1m # how long items are retained in DEST index
 _meta:
   managed: true
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0
+settings:
+  num_failure_retries: -1

--- a/packages/ti_strider/manifest.yml
+++ b/packages/ti_strider/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_strider
 title: Strider Shield
-version: 0.0.1
+version: 0.1.0
 description: Ingest threat intelligence indicators from Strider Shield with Elastic Agent.
 type: integration
 format_version: 3.0.0

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "2.0.0"
   changes:
     - description: Normalize all hash fields to be lowercase.

--- a/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
+++ b/packages/ti_threatconnect/elasticsearch/transform/latest/transform.yml
@@ -33,6 +33,6 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.10.0
+  fleet_transform_version: 0.11.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: "2.0.0"
+version: "2.1.0"
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.38.0"
+  changes:
+    - description: Use num_failure_retries instead of unattended mode for transform failure recovery.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18404
 - version: "1.37.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/ti_threatq/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_threatq/elasticsearch/transform/latest_ioc/transform.yml
@@ -32,6 +32,6 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.4.0
+  fleet_transform_version: 0.5.0
 settings:
-  unattended: true
+  num_failure_retries: -1

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.37.1"
+version: "1.38.0"
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
 format_version: "3.3.1"


### PR DESCRIPTION
## Proposed commit message
```
ti_*: use num_failure_retries instead of unattended mode

Replace settings.unattended: true with settings.num_failure_retries: -1
in all ti_* managed transforms. Unlike unattended mode which retries
all failures indefinitely (masking irrecoverable errors),
num_failure_retries: -1 retries only recoverable failures while still
surfacing genuinely irrecoverable ones to users.

Three packages (ti_anyrun, ti_flashpoint, ti_strider) that were added
after the original unattended PR (#16535) had no failure resilience at
all and now get num_failure_retries: -1 added.

[git-generate]
for transform in $(find packages/ti_*/ -type f -name transform.yml \
  -path '*/elasticsearch/transform/*'); do
    yq -i 'del(.settings.unattended)' "$transform"
    yq -i '.settings.num_failure_retries = -1' "$transform"
done

for transform in $(git diff --name-only packages/ | \
  grep 'transform\.yml$'); do
    current=$(yq '._meta.fleet_transform_version' "$transform")
    next=$(echo "$current" | awk -F. '{printf "%d.%d.%d",$1,$2+1,0}')
    yq -i "._meta.fleet_transform_version = \"$next\"" "$transform"
done

for pkg in $(git diff --name-only packages/ | cut -d/ -f1,2 | \
  sort -u); do
    cd "$pkg"
    elastic-package changelog add \
      --description "Use num_failure_retries instead of unattended mode for transform failure recovery." \
      --type enhancement --next minor \
      --link "https://github.com/elastic/integrations/pull/18404"
    cd ../../
done
```

## Summary

Switches all `ti_*` managed transforms from `settings.unattended: true` to `settings.num_failure_retries: -1`.

- **`unattended: true`** retries _all_ failures indefinitely, including irrecoverable ones, which masks real problems from users.
- **`num_failure_retries: -1`** retries only _recoverable_ failures indefinitely (network blips, transient cluster instability) while still surfacing irrecoverable errors.

This covers 52 transforms across 23 packages. Three packages (`ti_anyrun`, `ti_flashpoint`, `ti_strider`) were added after the original `unattended` PR (#16535) and had no failure resilience at all -- they now get `num_failure_retries: -1` for the first time.

### Changes per package

For each affected transform:
1. Removed `settings.unattended: true`
2. Added `settings.num_failure_retries: -1`
3. Bumped `_meta.fleet_transform_version` (minor bump triggers reinstall)
4. Added a changelog entry

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Related issues

- Relates https://github.com/elastic/security-team/issues/14926
- Relates https://github.com/elastic/package-spec/issues/1124
- Relates https://github.com/elastic/integrations/pull/16535 (added `unattended: true`)
- Closes https://github.com/elastic/integrations/issues/18403
