### PR TITLE
[cloud_asset_inventory] Fix duplicated 'Discovery' in data stream descriptions

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -8,6 +8,11 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.5.1"
+  changes:
+    - description: Fix duplicated `Discovery` word in asset_inventory data stream descriptions for AWS, Azure, and GCP.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18242
 - version: "1.5.0"
   changes:
     - description: Release version 1.5.0

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
@@ -11,7 +11,7 @@ elasticsearch:
 streams:
   - input: cloudbeat/asset_inventory_aws
     title: AWS Asset Discovery
-    description: Asset Discovery Discovery for AWS
+    description: Asset Discovery for AWS
     template_path: aws.yml.hbs
     enabled: false
     required_vars:
@@ -148,7 +148,7 @@ streams:
         secret: true
   - input: cloudbeat/asset_inventory_azure
     title: Azure Asset Discovery
-    description: Asset Discovery Discovery for Azure
+    description: Asset Discovery for Azure
     template_path: azure.yml.hbs
     enabled: false
     required_vars:
@@ -307,7 +307,7 @@ streams:
         secret: false
   - input: cloudbeat/asset_inventory_gcp
     title: GCP Asset Discovery
-    description: Asset Discovery Discovery for GCP
+    description: Asset Discovery for GCP
     template_path: gcp.yml.hbs
     enabled: false
     required_vars:

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.5.0"
+version: "1.5.1"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"


### PR DESCRIPTION
Addresses one item from #18242 (text-auditor batch).

`packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml` contained `Asset Discovery Discovery` for all three cloud providers:

- AWS — line 14
- Azure — line 151
- GCP — line 310

The duplicated word renders in the Kibana data stream picker and the integrations catalog. Drop the duplicate so each entry reads `Asset Discovery for <provider>`.

- Bumped `cloud_asset_inventory` patch version to `1.5.1` and added a bugfix `changelog.yml` entry as required by the integrations release process.
- Verified the upstream still contains the duplication on `main` before opening this PR.
- Scoped to a single package (per #18242 the auditor flagged many packages — happy to follow up with separate one-package-per-PR fixes if this is the preferred style).