### PR TITLE
[Elasticsearch] Fix authentication failure when password contains YAML special characters

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.2"
+  changes:
+    - description: Fix authentication failure when password contains YAML special characters (e.g. double quotes) by using the escape_string Handlebars helper.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/18434
 - version: "1.20.1"
   changes:
     - description: Make Elasticsearch server log pipeline tolerate missing elasticsearch fields

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.20.2"
   changes:
-    - description: Fix authentication failure when password contains YAML special characters (e.g. double quotes) by using the escape_string Handlebars helper.
+    - description: Fix authentication failure when username or password contains YAML special characters (e.g. double quotes) by using the escape_string Handlebars helper.
       type: bugfix
       link: https://github.com/elastic/integrations/issues/18434
 - version: "1.20.1"

--- a/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -9,7 +9,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -6,7 +6,7 @@ hosts:
 index_recovery.active_only: {{active.only}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/ingest_pipeline/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ingest_pipeline/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/ingest_pipeline/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ingest_pipeline/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
@@ -8,7 +8,7 @@ scope: {{scope}}
 username: {{username}}
 {{/if}}
 {{#if password}}
-password: {{password}}
+password: {{escape_string password}}
 {{/if}}
 {{#if api_key}}
 api_key: {{api_key}}

--- a/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
@@ -5,7 +5,7 @@ hosts:
 {{/each}}
 scope: {{scope}}
 {{#if username}}
-username: {{username}}
+username: {{escape_string username}}
 {{/if}}
 {{#if password}}
 password: {{escape_string password}}

--- a/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
+++ b/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
@@ -119,7 +119,7 @@ pivot:
         script: "Math.max(0, params.end-params.start)"
 dest:
   index: "monitoring-indices"
-  pipeline: "1.20.1-monitoring_indices"
+  pipeline: "1.20.2-monitoring_indices"
 description: This transform runs every 10 minutes to compute extra metrics for the Elasticsearch indices.
 frequency: 10m
 settings:

--- a/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
+++ b/packages/elasticsearch/elasticsearch/transform/index_pivot/transform.yml
@@ -119,7 +119,7 @@ pivot:
         script: "Math.max(0, params.end-params.start)"
 dest:
   index: "monitoring-indices"
-  pipeline: "1.20.2-monitoring_indices"
+  pipeline: '{{ ingestPipelineName "monitoring_indices" }}'
 description: This transform runs every 10 minutes to compute extra metrics for the Elasticsearch indices.
 frequency: 10m
 settings:

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.20.1
+version: 1.20.2
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
## Summary

Fixes #18434

Passwords containing YAML special characters (e.g. double quotes `"`) cause `401 Unauthorized` errors in all Elasticsearch metrics datasets because the compiled agent configuration strips those characters during YAML parsing.

### Root cause

All 12 Elasticsearch metrics dataset stream templates used the bare Handlebars expression:

```yaml
{{#if password}}
password: {{password}}
{{/if}}
```

When a password such as `"mysecret"` is rendered, the template produces:

```yaml
password: "mysecret"
```

YAML treats the double quotes as **string delimiters**, so the parsed value is `mysecret` — the characters are silently dropped. The Beat then authenticates with a truncated password and receives a `401 Unauthorized` response.

### Fix

Replace `{{password}}` with `{{escape_string password}}` in all 12 metrics dataset stream templates:

- `data_stream/cluster_stats/agent/stream/stream.yml.hbs`
- `data_stream/node_stats/agent/stream/stream.yml.hbs`
- `data_stream/node/agent/stream/stream.yml.hbs`
- `data_stream/index/agent/stream/stream.yml.hbs`
- `data_stream/index_recovery/agent/stream/stream.yml.hbs`
- `data_stream/index_summary/agent/stream/stream.yml.hbs`
- `data_stream/ccr/agent/stream/stream.yml.hbs`
- `data_stream/enrich/agent/stream/stream.yml.hbs`
- `data_stream/ingest_pipeline/agent/stream/stream.yml.hbs`
- `data_stream/ml_job/agent/stream/stream.yml.hbs`
- `data_stream/pending_tasks/agent/stream/stream.yml.hbs`
- `data_stream/shard/agent/stream/stream.yml.hbs`

The `escape_string` helper (registered in Fleet's Handlebars engine) wraps the value in YAML single quotes and escapes any interior single quotes by doubling them — safely preserving all special characters including `"`, `\`, `:`, `#`, etc.

**Before** (password `"mysecret"` → stored as `mysecret`):
```yaml
password: "mysecret"
```

**After** (password `"mysecret"` → stored correctly as `"mysecret"`):
```yaml
password: '"mysecret"'
```

This pattern is already used correctly by other integrations for similar fields (e.g. `ibmmq`, `apache_tomcat`, `websphere_application_server`, `cloudflare`).

### Testing

Configure an Elasticsearch integration policy with a password containing `"` characters and confirm the `components-actual.yaml` preserves the full password value, and that metrics collection succeeds without `401` errors.

## Checklist

- [x] I have reviewed the [guidelines for contributing](https://github.com/elastic/integrations/blob/main/CONTRIBUTING.md) to this repository.
- [x] I have verified that my code works as expected.
- [x] I have incremented the package's version per the [versioning guidelines](https://github.com/elastic/integrations/blob/main/docs/developer_workflow_design_build_test_integration.md#package-versioning) and updated the [changelog](packages/elasticsearch/changelog.yml).
- [x] I have updated the package's [changelog](packages/elasticsearch/changelog.yml).
