### PR TITLE
[elastic_agent] Add TSDB dimensions and fix metric_type declarations

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.0"
+  changes:
+    - description: Add TSDB dimensions and complete/fix metric_type declarations across elastic_agent metrics data streams.
+      type: enhancement
+      link: "https://github.com/elastic/integrations/pull/18508"
 - version: "2.8.0"
   changes:
     - description: Replace markdown navigation links with Links panels for space-aware dashboard navigation

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -243,7 +284,7 @@
                     Number of events acknowledged
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -299,12 +340,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/ecs.yml
@@ -9,8 +9,10 @@
   dimension: true
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -195,6 +197,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -230,6 +233,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -195,6 +197,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -230,6 +233,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -445,13 +449,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
@@ -5,10 +5,12 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
+      dimension: true
     - name: snapshot
       type: boolean
       description: Is the agent running from a snapshot build
@@ -190,6 +192,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -225,6 +228,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -440,13 +444,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
@@ -5,11 +5,13 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -194,6 +196,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -229,6 +232,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -444,13 +448,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/ecs.yml
@@ -9,8 +9,10 @@
   dimension: true
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -196,6 +198,7 @@
             - name: percpu
               type: object
               object_type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -231,6 +234,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -446,13 +450,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
@@ -13,7 +13,7 @@
     # Common dynamic fields for all inputs
     - name: '*.histogram.count'
       type: long
-      metric_type: gauge
+      metric_type: counter
       description: Map all fields with `path_match:``*.histogram.count` to `long`
     - name: '*.histogram.*'
       type: double
@@ -37,6 +37,7 @@
       description: URL-ish of CEL input resource
     - name: cel_executions
       type: long
+      metric_type: counter
       description: URL-ish of input resource
     # Lumberjack specific fields
     - name: bind_address
@@ -48,6 +49,7 @@
       description: Name of the UDP device being monitored
     - name: system_packet_drops
       type: long
+      metric_type: counter
       description: Number of udp drops noted in /proc/net/udp
 - name: component
   type: group
@@ -59,13 +61,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -195,6 +197,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -230,6 +233,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -445,13 +449,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/ecs.yml
@@ -9,8 +9,10 @@
   dimension: true
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -195,6 +197,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -230,6 +233,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -195,6 +197,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -230,6 +233,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -445,13 +449,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -195,6 +197,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -230,6 +233,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -445,13 +449,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -195,6 +197,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -230,6 +233,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -445,13 +449,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/agent.yml
@@ -38,8 +38,10 @@
       external: ecs
     - name: domain
       external: ecs
+      dimension: true
     - name: hostname
       external: ecs
+      dimension: true
     - name: id
       external: ecs
     - name: ip
@@ -48,6 +50,7 @@
       external: ecs
     - name: name
       external: ecs
+      dimension: true
     - name: os.family
       external: ecs
     - name: os.kernel

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/beat-fields.yml
@@ -1,3 +1,4 @@
 - name: beat.type
   description: Beat type.
   type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/beat-stats-fields.yml
@@ -6,12 +6,16 @@
       fields:
         - name: name
           type: keyword
+          dimension: true
         - name: host
           type: keyword
+          dimension: true
         - name: type
           type: keyword
+          dimension: true
         - name: uuid
           type: keyword
+          dimension: true
         - name: version
           type: keyword
     - name: system
@@ -19,41 +23,55 @@
       fields:
         - name: cpu.cores
           type: long
+          metric_type: gauge
         - name: load
           type: group
           fields:
             - name: "1"
               type: double
+              metric_type: gauge
             - name: "15"
               type: double
+              metric_type: gauge
             - name: "5"
               type: double
+              metric_type: gauge
             - name: norm
               type: group
               fields:
                 - name: "1"
                   type: double
+                  metric_type: gauge
                 - name: "15"
                   type: double
+                  metric_type: gauge
                 - name: "5"
                   type: double
+                  metric_type: gauge
     - name: cpu
       type: group
       fields:
         - name: system.ticks
           type: long
+          metric_type: counter
         - name: system.time.ms
           type: long
+          metric_type: counter
         - name: total.value
           type: long
+          metric_type: counter
         - name: total.ticks
           type: long
+          metric_type: counter
         - name: total.time.ms
           type: long
+          metric_type: counter
         - name: user.ticks
           type: long
+          metric_type: counter
         - name: user.time.ms
           type: long
+          metric_type: counter
     - name: info
       type: group
       fields:
@@ -61,6 +79,7 @@
           type: keyword
         - name: uptime.ms
           type: long
+          metric_type: counter
     - name: cgroup
       type: group
       fields:
@@ -69,8 +88,10 @@
           fields:
             - name: cfs.period.us
               type: long
+              metric_type: gauge
             - name: cfs.quota.us
               type: long
+              metric_type: gauge
             - name: id
               type: keyword
             - name: stats
@@ -78,14 +99,18 @@
               fields:
                 - name: periods
                   type: long
+                  metric_type: counter
                 - name: throttled.periods
                   type: long
+                  metric_type: counter
                 - name: throttled.ns
                   type: long
+                  metric_type: counter
         - name: cpuacct.id
           type: keyword
         - name: cpuacct.total.ns
           type: long
+          metric_type: counter
         - name: memory
           type: group
           fields:
@@ -93,34 +118,45 @@
               type: keyword
             - name: mem.limit.bytes
               type: long
+              metric_type: gauge
             - name: mem.usage.bytes
               type: long
+              metric_type: gauge
     - name: memstats
       type: group
       fields:
         - name: gc_next
           type: long
+          metric_type: gauge
         - name: memory.alloc
           type: long
+          metric_type: gauge
         - name: memory.total
           type: long
+          metric_type: counter
         - name: rss
           type: long
+          metric_type: gauge
     - name: handles
       type: group
       fields:
         - name: open
           type: long
+          metric_type: gauge
         - name: limit.hard
           type: long
+          metric_type: gauge
         - name: limit.soft
           type: long
+          metric_type: gauge
     - name: uptime.ms
       type: long
+      metric_type: counter
       description: >
         Beat uptime
     - name: runtime.goroutines
       type: long
+      metric_type: gauge
       description: >
         Number of goroutines running in Beat
     - name: libbeat
@@ -133,6 +169,7 @@
           fields:
             - name: clients
               type: long
+              metric_type: gauge
             - name: queue
               type: group
               fields:
@@ -196,7 +233,7 @@
               fields:
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                 - name: dropped
                   type: long
                   metric_type: counter
@@ -220,12 +257,16 @@
           fields:
             - name: reloads
               type: long
+              metric_type: counter
             - name: running
               type: long
+              metric_type: gauge
             - name: starts
               type: long
+              metric_type: counter
             - name: stops
               type: long
+              metric_type: counter
         - name: output
           type: group
           fields:
@@ -244,7 +285,7 @@
 
                 - name: active
                   type: long
-                  metric_type: counter
+                  metric_type: gauge
                   description: >
                     Number of active events
                 - name: batches
@@ -300,12 +341,16 @@
                       fields:
                         - name: count
                           type: long
+                          metric_type: counter
                         - name: max
                           type: float
+                          metric_type: gauge
                         - name: median
                           type: long
+                          metric_type: gauge
                         - name: p99
                           type: float
+                          metric_type: gauge
             - name: read
               type: group
               description: >

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/ecs.yml
@@ -6,8 +6,10 @@
   external: ecs
 - name: agent.name
   external: ecs
+  dimension: true
 - name: agent.type
   external: ecs
+  dimension: true
 - name: agent.version
   external: ecs
 - name: log.level

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
@@ -5,12 +5,14 @@
       type: keyword
       ignore_above: 1024
       description: Elastic Agent id.
+      dimension: true
     - name: process
       level: extended
       type: keyword
       ignore_above: 1024
       description: Process run by the Elastic Agent.
       example: metricbeat
+      dimension: true
     - name: snapshot
       level: extended
       type: boolean
@@ -195,6 +197,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: long
+              metric_type: counter
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -230,6 +233,7 @@
                 The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
             - name: mem.failures
               type: long
+              metric_type: counter
               description: |
                 The number of times that the memory limit (mem.limit.bytes) was reached.
             - name: memsw.usage.bytes
@@ -445,13 +449,16 @@
       description: Component id
     - name: type
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The type of the component
     - name: binary
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
     - name: dataset
       type: keyword
+      dimension: true
       ignore_above: 1024

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.8.0
+version: 2.9.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.6.0


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
[elastic_agent] Add TSDB dimensions and fix metric_type declarations

Add `dimension: true` to fields across the 12 elastic_agent metrics data streams. The added dimensions are redundant with the existing dimensions (1-to-1 with `agent.id` or `component.id`) and therefore do not increase time-series cardinality.

Fix metric_type on:
- beat.stats.libbeat.pipeline.events.active: counter -> gauge
- beat.stats.libbeat.output.events.active: counter -> gauge
- filebeat_input.*.histogram.count: gauge -> counter

Add metric_type on numeric fields that were missing it: system stats, cpu ticks, memstats, handles, runtime.goroutines, uptime, cgroup stats, libbeat pipeline/config/output metrics, write-latency histogram, system.process.cgroup.{memory.mem.failures, cpuacct.percpu}, and filebeat_input.{cel_executions, system_packet_drops}.

Assisted by Claude Code
```
## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to review the PR

In order to better see what fields are being changes I suggest using git to see the diff with more context:
 - fetch/switch to the branch
 - run `git show -U10 HEAD`

the flag `-U` controls how much context (lines before and after the change) to show.

## How to test this PR locally

- spin up a stack. (I found an [issue with the agent hostname](https://github.com/elastic/integrations/issues/18523)) filter on 8.15.5, so, use the 8.19.x to have the dashboard working properly)
- install agents (I installed with fleet-server, defend and packetbeat)
- check the dashboard
- look for errors

## Related issues

- Closes #17349


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
