### PR TITLE
[Atlassian Confluence] Add agentless support

### DIFF
--- a/packages/atlassian_confluence/_dev/build/docs/README.md
+++ b/packages/atlassian_confluence/_dev/build/docs/README.md
@@ -2,6 +2,11 @@
 
 The Confluence integration collects [audit logs](https://confluence.atlassian.com/doc/auditing-in-confluence-829076528.html) from the audit log files or the [audit API](https://developer.atlassian.com/cloud/confluence/rest/api-group-audit/).
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Authentication Set-Up
 
 When setting up the Atlassian Confluence Integration for Atlassian Cloud you will need to use the "Confluence User Identifier" and "Confluence API Token" fields in the integration configuration. These will allow connection to the [Atlassian Cloud REST API](https://developer.atlassian.com/cloud/confluence/basic-auth-for-rest-apis/).

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.0"
+  changes:
+    - description: Add Agentless deployment support.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.30.0"
   changes:
     - description: Prevent updating fleet health status to degraded when pagination completes.

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add Agentless deployment support.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18516
 - version: "1.30.0"
   changes:
     - description: Prevent updating fleet health status to degraded when pagination completes.

--- a/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_confluence/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/atlassian_confluence/data_stream/audit/manifest.yml
+++ b/packages/atlassian_confluence/data_stream/audit/manifest.yml
@@ -49,7 +49,6 @@ streams:
   - input: httpjson
     title: Confluence audit logs via Confluence audit API
     description: Collect Confluence audit logs via Confluence audit API
-    enabled: false
     template_path: httpjson.yml.hbs
     vars:
       - name: api_url

--- a/packages/atlassian_confluence/data_stream/audit/manifest.yml
+++ b/packages/atlassian_confluence/data_stream/audit/manifest.yml
@@ -50,6 +50,7 @@ streams:
     title: Confluence audit logs via Confluence audit API
     description: Collect Confluence audit logs via Confluence audit API
     template_path: httpjson.yml.hbs
+    enabled: false
     vars:
       - name: api_url
         type: text

--- a/packages/atlassian_confluence/data_stream/audit/manifest.yml
+++ b/packages/atlassian_confluence/data_stream/audit/manifest.yml
@@ -49,8 +49,8 @@ streams:
   - input: httpjson
     title: Confluence audit logs via Confluence audit API
     description: Collect Confluence audit logs via Confluence audit API
-    template_path: httpjson.yml.hbs
     enabled: false
+    template_path: httpjson.yml.hbs
     vars:
       - name: api_url
         type: text

--- a/packages/atlassian_confluence/docs/README.md
+++ b/packages/atlassian_confluence/docs/README.md
@@ -2,6 +2,11 @@
 
 The Confluence integration collects [audit logs](https://confluence.atlassian.com/doc/auditing-in-confluence-829076528.html) from the audit log files or the [audit API](https://developer.atlassian.com/cloud/confluence/rest/api-group-audit/).
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Authentication Set-Up
 
 When setting up the Atlassian Confluence Integration for Atlassian Cloud you will need to use the "Confluence User Identifier" and "Confluence API Token" fields in the integration configuration. These will allow connection to the [Atlassian Cloud REST API](https://developer.atlassian.com/cloud/confluence/basic-auth-for-rest-apis/).

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.2"
+format_version: "3.3.2"
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.30.0"
+version: "1.31.0"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:
@@ -19,6 +19,14 @@ policy_templates:
   - name: audit
     title: Audit Logs
     description: Collect audit logs from Atlassian Confluence with Elastic Agent.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: logfile
         title: "Collect Confluence audit logs via log files"

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - productivity_security
 conditions:
   kibana:
-    version: "^8.19.4 || ~9.0.7 || ^9.1.4"
+    version: "^8.19.16 || ~9.3.5 || ^9.4.1"
 icons:
   - src: /img/confluence-logo.svg
     title: Confluence Logo


### PR DESCRIPTION
## Proposed commit message

```
atlassian_confluence: add agentless support and update kibana version constraint

Adds support for agentless and updates the Kibana version constraint to avoid a known issue 
where selecting agentless deployment mode hides configuration fields and blocks 
deployment if inputs default to `enabled: false`.

Ref: https://github.com/elastic/kibana/pull/265106
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/atlassian_confluence directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #18401