### PR TITLE
[o365_metrics,checkpoint_harmony_endpoint] Fix upto/Extention typos in user-facing text

### DIFF
--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Fix "Extention" -> "Extension" typo in zerophishing field description and README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/NNN
 - version: "1.2.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix "Extention" -> "Extension" typo in zerophishing field description and README.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/NNN
+      link: https://github.com/elastic/integrations/pull/18520
 - version: "1.2.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/fields/fields.yml
+++ b/packages/checkpoint_harmony_endpoint/data_stream/zerophishing/fields/fields.yml
@@ -48,7 +48,7 @@
       description: Name of the event
     - name: extension_version
       type: keyword
-      description: Browser Extention version
+      description: Browser Extension version
     - name: malware
       type: group
       fields:

--- a/packages/checkpoint_harmony_endpoint/docs/README.md
+++ b/packages/checkpoint_harmony_endpoint/docs/README.md
@@ -1241,7 +1241,7 @@ An example event for `zerophishing` looks as following:
 | checkpoint_harmony_endpoint.zerophishing.confidence_level | Can be Low/Medim/High/N-A | keyword |
 | checkpoint_harmony_endpoint.zerophishing.description | Details of the event | text |
 | checkpoint_harmony_endpoint.zerophishing.event_type | Name of the event | keyword |
-| checkpoint_harmony_endpoint.zerophishing.extension_version | Browser Extention version | keyword |
+| checkpoint_harmony_endpoint.zerophishing.extension_version | Browser Extension version | keyword |
 | checkpoint_harmony_endpoint.zerophishing.installed_products | List of installed Endpoint Software Blades | keyword |
 | checkpoint_harmony_endpoint.zerophishing.malware.action | Additional information about detection, for example "User reused corporate credentials" | keyword |
 | checkpoint_harmony_endpoint.zerophishing.orig |  | ip |

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "1.2.0"
+version: "1.2.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"

--- a/packages/o365_metrics/changelog.yml
+++ b/packages/o365_metrics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix "upto" -> "up to" typo in o365_metrics sync description help text.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/NNN
+      link: https://github.com/elastic/integrations/pull/18520
 - version: "1.1.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/o365_metrics/changelog.yml
+++ b/packages/o365_metrics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.2"
+  changes:
+    - description: Fix "upto" -> "up to" typo in o365_metrics sync description help text.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/NNN
 - version: "1.1.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/o365_metrics/data_stream/groups_activity_group_detail/manifest.yml
+++ b/packages/o365_metrics/data_stream/groups_activity_group_detail/manifest.yml
@@ -38,7 +38,7 @@ streams:
         type: integer
         title: Sync Days in the past
         description: >
-          Specifies the number of days in the past to sync per request. As Microsoft reports are not real-time, and can take upto 48h or more to be available, this value allows to fetch the data from *N* days in the past. This re-fetching of data helps in filling any gaps between Elastic and Microsoft reports. Only values between 1-27 are allowed.
+          Specifies the number of days in the past to sync per request. As Microsoft reports are not real-time, and can take up to 48h or more to be available, this value allows to fetch the data from *N* days in the past. This re-fetching of data helps in filling any gaps between Elastic and Microsoft reports. Only values between 1-27 are allowed.
 
         show_user: true
         required: true

--- a/packages/o365_metrics/data_stream/onedrive_usage_account_detail/manifest.yml
+++ b/packages/o365_metrics/data_stream/onedrive_usage_account_detail/manifest.yml
@@ -38,7 +38,7 @@ streams:
         type: integer
         title: Sync Days in the past
         description: >
-          Specifies the number of days in the past to sync per request. As Microsoft reports are not real-time, and can take upto 48h or more to be available, this value allows to fetch the data from *N* days in the past. This re-fetching of data helps in filling any gaps between Elastic and Microsoft reports. Only values between 1-27 are allowed.
+          Specifies the number of days in the past to sync per request. As Microsoft reports are not real-time, and can take up to 48h or more to be available, this value allows to fetch the data from *N* days in the past. This re-fetching of data helps in filling any gaps between Elastic and Microsoft reports. Only values between 1-27 are allowed.
 
         show_user: true
         required: true

--- a/packages/o365_metrics/data_stream/teams_user_activity_user_detail/manifest.yml
+++ b/packages/o365_metrics/data_stream/teams_user_activity_user_detail/manifest.yml
@@ -38,7 +38,7 @@ streams:
         type: integer
         title: Sync Days in the past
         description: >
-          Specifies the number of days in the past to sync per request. As Microsoft reports are not real-time, and can take upto 48h or more to be available, this value allows to fetch the data from *N* days in the past. This re-fetching of data helps in filling any gaps between Elastic and Microsoft reports. Only values between 1-27 are allowed.
+          Specifies the number of days in the past to sync per request. As Microsoft reports are not real-time, and can take up to 48h or more to be available, this value allows to fetch the data from *N* days in the past. This re-fetching of data helps in filling any gaps between Elastic and Microsoft reports. Only values between 1-27 are allowed.
 
         show_user: true
         required: true

--- a/packages/o365_metrics/data_stream/viva_engage_groups_activity_group_detail/manifest.yml
+++ b/packages/o365_metrics/data_stream/viva_engage_groups_activity_group_detail/manifest.yml
@@ -38,7 +38,7 @@ streams:
         type: integer
         title: Sync Days in the past
         description: >
-          Specifies the number of days in the past to sync per request. As Microsoft reports are not real-time, and can take upto 48h or more to be available, this value allows to fetch the data from *N* days in the past. This re-fetching of data helps in filling any gaps between Elastic and Microsoft reports. Only values between 1-27 are allowed.
+          Specifies the number of days in the past to sync per request. As Microsoft reports are not real-time, and can take up to 48h or more to be available, this value allows to fetch the data from *N* days in the past. This re-fetching of data helps in filling any gaps between Elastic and Microsoft reports. Only values between 1-27 are allowed.
 
         show_user: true
         required: true

--- a/packages/o365_metrics/manifest.yml
+++ b/packages/o365_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: o365_metrics
 title: Microsoft Office 365 Metrics
-version: "1.1.1"
+version: "1.1.2"
 description: Collect metrics from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION
Refs #18497.

Picks up the two typo families the Text Auditor workflow flagged. Both are user-visible strings (Kibana help text and field descriptions), no behaviour change required.

## Changes

### `upto` → `up to` (o365_metrics, 4 occurrences)

`...can take upto 48h or more to be available...`  →  `...can take up to 48h or more to be available...`

- `packages/o365_metrics/data_stream/groups_activity_group_detail/manifest.yml`
- `packages/o365_metrics/data_stream/viva_engage_groups_activity_group_detail/manifest.yml`
- `packages/o365_metrics/data_stream/onedrive_usage_account_detail/manifest.yml`
- `packages/o365_metrics/data_stream/teams_user_activity_user_detail/manifest.yml`

### `Extention` → `Extension` (checkpoint_harmony_endpoint, 2 occurrences)

`Browser Extention version`  →  `Browser Extension version`

- `packages/checkpoint_harmony_endpoint/data_stream/zerophishing/fields/fields.yml`
- `packages/checkpoint_harmony_endpoint/docs/README.md`

## Version bumps

Per the repo's release policy, each touched package gets a patch bump with a changelog entry:

- `o365_metrics`: `1.1.1` → `1.1.2` (bugfix)
- `checkpoint_harmony_endpoint`: `1.2.0` → `1.2.1` (bugfix)

The `link:` fields in the new changelog entries currently point at `PR NNN` — I'll swap them to this PR's number once GitHub assigns it (or a reviewer is welcome to push that tweak before merging).