### PR TITLE
trend_micro_vision_one: reword telemetry CEL comment to avoid flaky policy tests

### DIFF
--- a/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/policy/test-all.expected
+++ b/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/policy/test-all.expected
@@ -35,8 +35,8 @@ inputs:
             //   a package having `createdDateTime == endDateTime` will be rare.**
             //
             //   The documentation calls it "the end of the data retrieval time range".
-            //   It also says that "The data pipeline ingests data at least every 2
-            //   minutes." If a package is created every minute on average, there's a
+            //   It also says that - the data pipeline ingests data at least every 2
+            //   minutes. If a package is created every minute on average, there's a
             //   1.7% chance it's creation time will fall on the last second of a given
             //   15 minute window.
             //   If the condition is inclusive and a package falls on the `endDateTime`,

--- a/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/policy/test-all.expected
+++ b/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/policy/test-all.expected
@@ -35,8 +35,8 @@ inputs:
             //   a package having `createdDateTime == endDateTime` will be rare.**
             //
             //   The documentation calls it "the end of the data retrieval time range".
-            //   It also says that - the data pipeline ingests data at least every 2
-            //   minutes. If a package is created every minute on average, there's a
+            //   It also says that "The data pipeline ingests data at least every 2 minutes."
+            //   If a package is created every minute on average, there's a
             //   1.7% chance it's creation time will fall on the last second of a given
             //   15 minute window.
             //   If the condition is inclusive and a package falls on the `endDateTime`,

--- a/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/policy/test-default.expected
+++ b/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/policy/test-default.expected
@@ -30,8 +30,8 @@ inputs:
             //   a package having `createdDateTime == endDateTime` will be rare.**
             //
             //   The documentation calls it "the end of the data retrieval time range".
-            //   It also says that - the data pipeline ingests data at least every 2
-            //   minutes. If a package is created every minute on average, there's a
+            //   It also says that "The data pipeline ingests data at least every 2 minutes."
+            //   If a package is created every minute on average, there's a
             //   1.7% chance it's creation time will fall on the last second of a given
             //   15 minute window.
             //   If the condition is inclusive and a package falls on the `endDateTime`,

--- a/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/policy/test-default.expected
+++ b/packages/trend_micro_vision_one/data_stream/telemetry/_dev/test/policy/test-default.expected
@@ -30,8 +30,8 @@ inputs:
             //   a package having `createdDateTime == endDateTime` will be rare.**
             //
             //   The documentation calls it "the end of the data retrieval time range".
-            //   It also says that "The data pipeline ingests data at least every 2
-            //   minutes." If a package is created every minute on average, there's a
+            //   It also says that - the data pipeline ingests data at least every 2
+            //   minutes. If a package is created every minute on average, there's a
             //   1.7% chance it's creation time will fall on the last second of a given
             //   15 minute window.
             //   If the condition is inclusive and a package falls on the `endDateTime`,

--- a/packages/trend_micro_vision_one/data_stream/telemetry/agent/stream/cel.yml.hbs
+++ b/packages/trend_micro_vision_one/data_stream/telemetry/agent/stream/cel.yml.hbs
@@ -65,8 +65,8 @@ program: |
   //   a package having `createdDateTime == endDateTime` will be rare.**
   //
   //   The documentation calls it "the end of the data retrieval time range".
-  //   It also says that - the data pipeline ingests data at least every 2
-  //   minutes. If a package is created every minute on average, there's a
+  //   It also says that "The data pipeline ingests data at least every 2 minutes."
+  //   If a package is created every minute on average, there's a
   //   1.7% chance it's creation time will fall on the last second of a given
   //   15 minute window.
   //   If the condition is inclusive and a package falls on the `endDateTime`,

--- a/packages/trend_micro_vision_one/data_stream/telemetry/agent/stream/cel.yml.hbs
+++ b/packages/trend_micro_vision_one/data_stream/telemetry/agent/stream/cel.yml.hbs
@@ -65,8 +65,8 @@ program: |
   //   a package having `createdDateTime == endDateTime` will be rare.**
   //
   //   The documentation calls it "the end of the data retrieval time range".
-  //   It also says that "The data pipeline ingests data at least every 2
-  //   minutes." If a package is created every minute on average, there's a
+  //   It also says that - the data pipeline ingests data at least every 2
+  //   minutes. If a package is created every minute on average, there's a
   //   1.7% chance it's creation time will fall on the last second of a given
   //   15 minute window.
   //   If the condition is inclusive and a package falls on the `endDateTime`,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
trend_micro_vision_one: reword telemetry CEL comment to avoid policy flake

The daily Serverless policy test for the telemetry data stream
intermittently failed because Fleet on Serverless re-emits the
`program: |` literal block scalar differently from the local 9.4.0
stack. When a comment contained a quoted phrase that spanned two
adjacent lines, the re-emitted YAML folded those lines into one and
the resulting policy no longer matched the expected output.

Drop the cross-line double-quoted phrase in the CEL comment block and
update both policy test expectations so the template and expected
output stay consistent. This is a content-level workaround; the
underlying emitter behaviour in Serverless is not addressed here.

Fixes #18519, #18518
```

> [!NOTE]
> No changelog: this only adjusts a comment in the telemetry CEL program and the corresponding policy-test expectations. Not a user-facing change. 

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/18519
- Closes https://github.com/elastic/integrations/issues/18518

