### PR TITLE
[github] change API key variable to optional for security advisories data stream

### DIFF
--- a/packages/github/_dev/build/docs/README.md
+++ b/packages/github/_dev/build/docs/README.md
@@ -113,7 +113,7 @@ If misconfigured, the integration could run successfully without any data being 
 
 The GitHub Security Advisories datastream lets you retrieve reviewed and unreviewed global security advisories from the GitHub advisory database. Check [Working with security advisories](https://docs.github.com/en/code-security/security-advisories) for more details.
 
-To use this integration, you must [create a fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) (GitHub App user access tokens, GitHub App installation access tokens, Fine-grained personal access tokens). This fine-grained token does not require any permissions. 
+To use this integration, you may [create a fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) (GitHub App user access tokens, GitHub App installation access tokens, Fine-grained personal access tokens). This fine-grained token does not require any permissions. Authentication is not required when accessing data from public repositories, so you can leave the API key field blank in that case.
 
 {{fields "security_advisories"}}
 

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.23.1"
+  changes:
+    - description: Change API key variable to optional for security advisories data stream, as authentication is not required for public repositories.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.23.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Change API key variable to optional for security advisories data stream, as authentication is not required for public repositories.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18545
 - version: "2.23.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/github/data_stream/security_advisories/_dev/deploy/docker/files/config.yml
+++ b/packages/github/data_stream/security_advisories/_dev/deploy/docker/files/config.yml
@@ -421,3 +421,276 @@ rules:
             }
           ]
           `}}
+  - path: /advisories
+    methods: ["GET"]
+    query_params:
+      per_page: "1"
+      type: reviewed
+      sort: published
+      order: desc
+      after: null
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - application/json
+          Link:
+            - '<http://{{ hostname }}:{{ env "PORT" }}/advisories?after=next_page>; rel="next"'
+        body: |-
+          {{ minify_json `
+          [
+            {
+              "ghsa_id": "GHSA-95rc-wc32-gm53",
+              "cve_id": "CVE-2025-48494",
+              "url": "https://api.github.com/advisories/GHSA-95rc-wc32-gm53",
+              "html_url": "https://github.com/advisories/GHSA-95rc-wc32-gm53",
+              "summary": "Gokapi vulnerable to stored XSS via uploading file with malicious file name",
+              "description": "### Impact\n\nWhen using end-to-end encryption, a stored XSS vulnerability can be exploited by uploading a file with JavaScript code embedded in the filename. After upload and every time someone opens the upload list, the script is then parsed.\n\nWith the affected versions <v2.0, there was no user permission system implemented, therefore all authenticated users were already able to see and modify all resources, even if end-to-end encrypted, as the encryption key had to be the same for all users with <v2.0. Nethertheless with XSS, other attack vectors like redirection or crypto mining would be possble.\n\n### Patches\n\nThis CVE has been fixed in v2.0.0\n\n### Workarounds\n\nIf you are the only authenticated user using Gokapi, you are not affected. A workaround would be to disable end-to-end encryption.",
+              "type": "reviewed",
+              "severity": "medium",
+              "repository_advisory_url": "https://api.github.com/repos/Forceu/Gokapi/security-advisories/GHSA-95rc-wc32-gm53",
+              "source_code_location": "https://github.com/Forceu/Gokapi",
+              "identifiers": [
+                {
+                  "value": "GHSA-95rc-wc32-gm53",
+                  "type": "GHSA"
+                },
+                {
+                  "value": "CVE-2025-48494",
+                  "type": "CVE"
+                }
+              ],
+              "references": [
+                "https://github.com/Forceu/Gokapi/security/advisories/GHSA-95rc-wc32-gm53",
+                "https://nvd.nist.gov/vuln/detail/CVE-2025-48494",
+                "https://github.com/Forceu/Gokapi/commit/343cc566cfd7f4efcd522c92371561d494aed6b0",
+                "https://github.com/Forceu/Gokapi/releases/tag/v2.0.0",
+                "https://github.com/advisories/GHSA-95rc-wc32-gm53"
+              ],
+              "published_at": "2025-06-03T06:28:08Z",
+              "updated_at": "2025-06-03T06:28:10Z",
+              "github_reviewed_at": "2025-06-03T06:28:08Z",
+              "nvd_published_at": "2025-06-02T11:15:22Z",
+              "withdrawn_at": null,
+              "vulnerabilities": [
+                {
+                  "package": {
+                    "ecosystem": "go",
+                    "name": "github.com/forceu/gokapi"
+                  },
+                  "vulnerable_version_range": ">= 1.0.1, <= 1.9.6",
+                  "first_patched_version": null,
+                  "vulnerable_functions": []
+                },
+                {
+                  "package": {
+                    "ecosystem": "go",
+                    "name": "github.com/forceu/gokapi"
+                  },
+                  "vulnerable_version_range": "< 0.0.0-20250530191232-343cc566cfd7",
+                  "first_patched_version": "0.0.0-20250530191232-343cc566cfd7",
+                  "vulnerable_functions": []
+                }
+              ],
+              "cvss_severities": {
+                "cvss_v3": {
+                  "vector_string": null,
+                  "score": 0
+                },
+                "cvss_v4": {
+                  "vector_string": "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:L",
+                  "score": 4.8
+                }
+              },
+              "cwes": [
+                {
+                  "cwe_id": "CWE-79",
+                  "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                },
+                {
+                  "cwe_id": "CWE-87",
+                  "name": "Improper Neutralization of Alternate XSS Syntax"
+                }
+              ],
+              "credits": [
+                {
+                  "user": {
+                    "login": "4rdr",
+                    "id": 170187038,
+                    "node_id": "U_kgDOCiTZHg",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/170187038?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/4rdr",
+                    "html_url": "https://github.com/4rdr",
+                    "followers_url": "https://api.github.com/users/4rdr/followers",
+                    "following_url": "https://api.github.com/users/4rdr/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/4rdr/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/4rdr/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/4rdr/subscriptions",
+                    "organizations_url": "https://api.github.com/users/4rdr/orgs",
+                    "repos_url": "https://api.github.com/users/4rdr/repos",
+                    "events_url": "https://api.github.com/users/4rdr/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/4rdr/received_events",
+                    "type": "User",
+                    "user_view_type": "public",
+                    "site_admin": false
+                  },
+                  "type": "reporter"
+                },
+                {
+                  "user": {
+                    "login": "Forceu",
+                    "id": 1593467,
+                    "node_id": "MDQ6VXNlcjE1OTM0Njc=",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/1593467?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/Forceu",
+                    "html_url": "https://github.com/Forceu",
+                    "followers_url": "https://api.github.com/users/Forceu/followers",
+                    "following_url": "https://api.github.com/users/Forceu/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/Forceu/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/Forceu/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/Forceu/subscriptions",
+                    "organizations_url": "https://api.github.com/users/Forceu/orgs",
+                    "repos_url": "https://api.github.com/users/Forceu/repos",
+                    "events_url": "https://api.github.com/users/Forceu/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/Forceu/received_events",
+                    "type": "User",
+                    "user_view_type": "public",
+                    "site_admin": false
+                  },
+                  "type": "remediation_developer"
+                }
+              ],
+              "cvss": {
+                "vector_string": null,
+                "score": null
+              },
+              "epss": {
+                "percentage": 0.00023,
+                "percentile": 0.0471
+              }
+            }
+          ]
+          `}}
+  - path: /advisories
+    methods: ["GET"]
+    query_params:
+      after: next_page
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - application/json
+        body: |-
+          {{ minify_json `
+          [
+            {
+              "ghsa_id": "GHSA-4xg4-54hm-9j77",
+              "cve_id": "CVE-2025-48495",
+              "url": "https://api.github.com/advisories/GHSA-4xg4-54hm-9j77",
+              "html_url": "https://github.com/advisories/GHSA-4xg4-54hm-9j77",
+              "summary": "Gokapi has stored XSS vulnerability in friendly name for API keys",
+              "description": "### Impact\n\nBy renaming the friendly name of an API key, an authenticated user could inject JS into the API key overview, which would also be executed when another user clicks on his API tab.\nWith the affected versions <v2.0, there was no user permission system implemented, therefore all authenticated users were already able to see and modify all resources, even if end-to-end encrypted, as the encryption key had to be the same for all users with <v2.0. Nethertheless with XSS, other attack vectors like redirection or crypto mining would be possble.\n\n### Patches\n\nThis CVE has been fixed in v2.0.0\n\n### Workarounds\n\nIf you are the only authenticated user using Gokapi, you are not affected. A workaround would be to not open the API page if you suspect that another user might have injected code.",
+              "type": "reviewed",
+              "severity": "medium",
+              "repository_advisory_url": "https://api.github.com/repos/Forceu/Gokapi/security-advisories/GHSA-4xg4-54hm-9j77",
+              "source_code_location": "https://github.com/Forceu/Gokapi",
+              "identifiers": [
+                {
+                  "value": "GHSA-4xg4-54hm-9j77",
+                  "type": "GHSA"
+                },
+                {
+                  "value": "CVE-2025-48495",
+                  "type": "CVE"
+                }
+              ],
+              "references": [
+                "https://github.com/Forceu/Gokapi/security/advisories/GHSA-4xg4-54hm-9j77",
+                "https://nvd.nist.gov/vuln/detail/CVE-2025-48495",
+                "https://github.com/Forceu/Gokapi/commit/65ddbc68fbfdf1c80cadb477f4bcbb7f2c4fdbf8",
+                "https://github.com/advisories/GHSA-4xg4-54hm-9j77"
+              ],
+              "published_at": "2025-06-03T06:27:28Z",
+              "updated_at": "2025-06-03T06:27:29Z",
+              "github_reviewed_at": "2025-06-03T06:27:28Z",
+              "nvd_published_at": "2025-06-02T12:15:25Z",
+              "withdrawn_at": null,
+              "vulnerabilities": [
+                {
+                  "package": {
+                    "ecosystem": "go",
+                    "name": "github.com/forceu/gokapi"
+                  },
+                  "vulnerable_version_range": ">= 1.0.1, <= 1.9.6",
+                  "first_patched_version": null,
+                  "vulnerable_functions": []
+                },
+                {
+                  "package": {
+                    "ecosystem": "go",
+                    "name": "github.com/forceu/gokapi"
+                  },
+                  "vulnerable_version_range": "< 0.0.0-20250530185940-65ddbc68fbfd",
+                  "first_patched_version": "0.0.0-20250530185940-65ddbc68fbfd",
+                  "vulnerable_functions": []
+                }
+              ],
+              "cvss_severities": {
+                "cvss_v3": {
+                  "vector_string": null,
+                  "score": 0
+                },
+                "cvss_v4": {
+                  "vector_string": "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:L",
+                  "score": 4.8
+                }
+              },
+              "cwes": [
+                {
+                  "cwe_id": "CWE-79",
+                  "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                },
+                {
+                  "cwe_id": "CWE-87",
+                  "name": "Improper Neutralization of Alternate XSS Syntax"
+                }
+              ],
+              "credits": [
+                {
+                  "user": {
+                    "login": "Forceu",
+                    "id": 1593467,
+                    "node_id": "MDQ6VXNlcjE1OTM0Njc=",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/1593467?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/Forceu",
+                    "html_url": "https://github.com/Forceu",
+                    "followers_url": "https://api.github.com/users/Forceu/followers",
+                    "following_url": "https://api.github.com/users/Forceu/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/Forceu/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/Forceu/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/Forceu/subscriptions",
+                    "organizations_url": "https://api.github.com/users/Forceu/orgs",
+                    "repos_url": "https://api.github.com/users/Forceu/repos",
+                    "events_url": "https://api.github.com/users/Forceu/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/Forceu/received_events",
+                    "type": "User",
+                    "user_view_type": "public",
+                    "site_admin": false
+                  },
+                  "type": "finder"
+                }
+              ],
+              "cvss": {
+                "vector_string": null,
+                "score": null
+              },
+              "epss": {
+                "percentage": 0.00025,
+                "percentile": 0.0513
+              }
+            }
+          ]
+          `}}

--- a/packages/github/data_stream/security_advisories/_dev/test/system/test-non-authentication-config.yml
+++ b/packages/github/data_stream/security_advisories/_dev/test/system/test-non-authentication-config.yml
@@ -1,0 +1,11 @@
+input: cel
+deployer: docker
+service: github
+vars: ~
+data_stream:
+  vars:
+    api_url: http://{{Hostname}}:{{Port}}/advisories
+    advisory_type: reviewed
+    batch_size: 1
+assert:
+  hit_count: 2

--- a/packages/github/data_stream/security_advisories/agent/stream/cel.yml.hbs
+++ b/packages/github/data_stream/security_advisories/agent/stream/cel.yml.hbs
@@ -11,9 +11,14 @@ state:
 {{/if}}
   advisory_type: {{advisory_type}}
   batch_size: {{batch_size}}
+{{#if api_key}}
 redact:
   fields:
     - api_key
+{{else}}
+redact:
+  fields: ~
+{{/if}}
 regexp:
   github_link_next: '<([^>]+)>; rel="next"'
 max_executions: 5000

--- a/packages/github/data_stream/security_advisories/agent/stream/cel.yml.hbs
+++ b/packages/github/data_stream/security_advisories/agent/stream/cel.yml.hbs
@@ -6,7 +6,9 @@ resource.tracer:
   maxbackups: 5
 resource.url: {{api_url}}
 state:
+{{#if api_key}}
   api_key: {{api_key}}
+{{/if}}
   advisory_type: {{advisory_type}}
   batch_size: {{batch_size}}
 redact:
@@ -29,7 +31,7 @@ program: |-
     "Header": {
         "Accept": ["application/vnd.github+json"],
         "X-GitHub-Api-Version": ["2022-11-28"],
-        "Authorization": ["Bearer " + state.api_key],
+        ?"Authorization": has(state.api_key) && state.api_key != "" ? optional.ofNonZeroValue(["Bearer " + state.api_key]) : optional.ofNonZeroValue([]),
     },
   }).do_request().as(resp, (resp.StatusCode != 200) ?
     {
@@ -50,7 +52,7 @@ program: |-
   :
     bytes(resp.Body).decode_json().as(body,
       {
-        "api_key": state.api_key,
+        ?"api_key": state.?api_key,
         "advisory_type": state.advisory_type,
         "batch_size": state.batch_size,
         "cursor": {

--- a/packages/github/data_stream/security_advisories/manifest.yml
+++ b/packages/github/data_stream/security_advisories/manifest.yml
@@ -17,9 +17,9 @@ streams:
       - name: api_key
         type: password
         title: API key
-        description: API key for GitHub REST API. This Personal Access Token is used to authenticate with the GitHub REST API and should be kept secret.
+        description: The GitHub Personal Access Token (PAT) is used to authenticate with the GitHub REST API. You may leave this field blank for public repositories, as authentication is not required for them.
         multi: false
-        required: true
+        required: false
         show_user: true
         secret: true
       - name: advisory_type

--- a/packages/github/data_stream/security_advisories/sample_event.json
+++ b/packages/github/data_stream/security_advisories/sample_event.json
@@ -1,24 +1,24 @@
 {
-    "@timestamp": "2025-07-09T07:00:19.578Z",
+    "@timestamp": "2026-04-24T05:57:27.225Z",
     "agent": {
-        "ephemeral_id": "783ac826-d0e3-421b-9e05-3f8df55ef1f4",
-        "id": "827d1836-740e-4d2c-840e-e42baa4160d9",
-        "name": "elastic-agent-76840",
+        "ephemeral_id": "31ed0e78-957c-462b-b201-4068ee3c76a8",
+        "id": "015adde9-572c-425b-b861-e378d104de20",
+        "name": "elastic-agent-17838",
         "type": "filebeat",
-        "version": "8.16.0"
+        "version": "8.19.10"
     },
     "data_stream": {
         "dataset": "github.security_advisories",
-        "namespace": "89850",
+        "namespace": "70395",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "827d1836-740e-4d2c-840e-e42baa4160d9",
+        "id": "015adde9-572c-425b-b861-e378d104de20",
         "snapshot": false,
-        "version": "8.16.0"
+        "version": "8.19.10"
     },
     "event": {
         "agent_id_status": "verified",
@@ -26,7 +26,7 @@
             "vulnerability"
         ],
         "dataset": "github.security_advisories",
-        "ingested": "2025-07-09T07:00:22Z",
+        "ingested": "2026-04-24T05:57:30Z",
         "kind": "enrichment",
         "type": [
             "info"
@@ -34,125 +34,41 @@
     },
     "github": {
         "security_advisory": {
-            "credits": [
-                {
-                    "type": "reporter",
-                    "user": {
-                        "avatar_url": "https://avatars.githubusercontent.com/u/170187038?v=4",
-                        "events_url": "https://api.github.com/users/4rdr/events{/privacy}",
-                        "followers_url": "https://api.github.com/users/4rdr/followers",
-                        "following_url": "https://api.github.com/users/4rdr/following{/other_user}",
-                        "gists_url": "https://api.github.com/users/4rdr/gists{/gist_id}",
-                        "html_url": "https://github.com/4rdr",
-                        "id": 170187038,
-                        "login": "4rdr",
-                        "node_id": "U_kgDOCiTZHg",
-                        "organizations_url": "https://api.github.com/users/4rdr/orgs",
-                        "received_events_url": "https://api.github.com/users/4rdr/received_events",
-                        "repos_url": "https://api.github.com/users/4rdr/repos",
-                        "site_admin": false,
-                        "starred_url": "https://api.github.com/users/4rdr/starred{/owner}{/repo}",
-                        "subscriptions_url": "https://api.github.com/users/4rdr/subscriptions",
-                        "type": "User",
-                        "url": "https://api.github.com/users/4rdr",
-                        "user_view_type": "public"
-                    }
-                },
-                {
-                    "type": "remediation_developer",
-                    "user": {
-                        "avatar_url": "https://avatars.githubusercontent.com/u/1593467?v=4",
-                        "events_url": "https://api.github.com/users/Forceu/events{/privacy}",
-                        "followers_url": "https://api.github.com/users/Forceu/followers",
-                        "following_url": "https://api.github.com/users/Forceu/following{/other_user}",
-                        "gists_url": "https://api.github.com/users/Forceu/gists{/gist_id}",
-                        "html_url": "https://github.com/Forceu",
-                        "id": 1593467,
-                        "login": "Forceu",
-                        "node_id": "MDQ6VXNlcjE1OTM0Njc=",
-                        "organizations_url": "https://api.github.com/users/Forceu/orgs",
-                        "received_events_url": "https://api.github.com/users/Forceu/received_events",
-                        "repos_url": "https://api.github.com/users/Forceu/repos",
-                        "site_admin": false,
-                        "starred_url": "https://api.github.com/users/Forceu/starred{/owner}{/repo}",
-                        "subscriptions_url": "https://api.github.com/users/Forceu/subscriptions",
-                        "type": "User",
-                        "url": "https://api.github.com/users/Forceu",
-                        "user_view_type": "public"
-                    }
-                }
-            ],
-            "cve_id": "CVE-2025-48494",
+            "cve_id": "CVE-2025-23096",
             "cvss_severities": {
                 "cvss_v3": {
                     "score": 0
                 },
                 "cvss_v4": {
-                    "score": 4.8,
-                    "vector_string": "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:L"
+                    "score": 0
                 }
             },
-            "cwes": [
-                {
-                    "cwe_id": "CWE-79",
-                    "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-                },
-                {
-                    "cwe_id": "CWE-87",
-                    "name": "Improper Neutralization of Alternate XSS Syntax"
-                }
-            ],
-            "description": "### Impact\n\nWhen using end-to-end encryption, a stored XSS vulnerability can be exploited by uploading a file with JavaScript code embedded in the filename. After upload and every time someone opens the upload list, the script is then parsed.\n\nWith the affected versions <v2.0, there was no user permission system implemented, therefore all authenticated users were already able to see and modify all resources, even if end-to-end encrypted, as the encryption key had to be the same for all users with <v2.0. Nethertheless with XSS, other attack vectors like redirection or crypto mining would be possble.\n\n### Patches\n\nThis CVE has been fixed in v2.0.0\n\n### Workarounds\n\nIf you are the only authenticated user using Gokapi, you are not affected. A workaround would be to disable end-to-end encryption.",
-            "epss": {
-                "percentage": 0.00023,
-                "percentile": 0.0471
-            },
-            "ghsa_id": "GHSA-95rc-wc32-gm53",
-            "github_reviewed_at": "2025-06-03T06:28:08.000Z",
-            "html_url": "https://github.com/advisories/GHSA-95rc-wc32-gm53",
+            "description": "An issue was discovered in Samsung Mobile Processor Exynos 1280, 2200, 1380, 1480, 2400. A Double Free in the mobile processor leads to privilege escalation.",
+            "ghsa_id": "GHSA-vpq6-j9hp-2h3w",
+            "html_url": "https://github.com/advisories/GHSA-vpq6-j9hp-2h3w",
             "identifiers": [
                 {
                     "type": "GHSA",
-                    "value": "GHSA-95rc-wc32-gm53"
+                    "value": "GHSA-vpq6-j9hp-2h3w"
                 },
                 {
                     "type": "CVE",
-                    "value": "CVE-2025-48494"
+                    "value": "CVE-2025-23096"
                 }
             ],
-            "nvd_published_at": "2025-06-02T11:15:22.000Z",
-            "published_at": "2025-06-03T06:28:08.000Z",
+            "nvd_published_at": "2025-06-04T15:15:23.000Z",
+            "published_at": "2025-06-04T15:30:41.000Z",
             "references": [
-                "https://github.com/Forceu/Gokapi/security/advisories/GHSA-95rc-wc32-gm53",
-                "https://nvd.nist.gov/vuln/detail/CVE-2025-48494",
-                "https://github.com/Forceu/Gokapi/commit/343cc566cfd7f4efcd522c92371561d494aed6b0",
-                "https://github.com/Forceu/Gokapi/releases/tag/v2.0.0",
-                "https://github.com/advisories/GHSA-95rc-wc32-gm53"
+                "https://nvd.nist.gov/vuln/detail/CVE-2025-23096",
+                "https://semiconductor.samsung.com/support/quality-support/product-security-updates",
+                "https://semiconductor.samsung.com/support/quality-support/product-security-updates/cve-2025-23096",
+                "https://github.com/advisories/GHSA-vpq6-j9hp-2h3w"
             ],
-            "repository_advisory_url": "https://api.github.com/repos/Forceu/Gokapi/security-advisories/GHSA-95rc-wc32-gm53",
-            "severity": "medium",
-            "source_code_location": "https://github.com/Forceu/Gokapi",
-            "summary": "Gokapi vulnerable to stored XSS via uploading file with malicious file name",
-            "type": "reviewed",
-            "updated_at": "2025-06-03T06:28:10.000Z",
-            "url": "https://api.github.com/advisories/GHSA-95rc-wc32-gm53",
-            "vulnerabilities": [
-                {
-                    "package": {
-                        "ecosystem": "go",
-                        "name": "github.com/forceu/gokapi"
-                    },
-                    "vulnerable_version_range": ">= 1.0.1, <= 1.9.6"
-                },
-                {
-                    "first_patched_version": "0.0.0-20250530191232-343cc566cfd7",
-                    "package": {
-                        "ecosystem": "go",
-                        "name": "github.com/forceu/gokapi"
-                    },
-                    "vulnerable_version_range": "< 0.0.0-20250530191232-343cc566cfd7"
-                }
-            ]
+            "severity": "unknown",
+            "summary": "An issue was discovered in Samsung Mobile Processor Exynos 1280, 2200, 1380, 1480, 2400. A Double...",
+            "type": "unreviewed",
+            "updated_at": "2025-06-04T15:30:46.000Z",
+            "url": "https://api.github.com/advisories/GHSA-vpq6-j9hp-2h3w"
         }
     },
     "input": {
@@ -164,16 +80,16 @@
     ],
     "url": {
         "domain": "github.com",
-        "full": "https://github.com/advisories/GHSA-95rc-wc32-gm53",
-        "original": "https://github.com/advisories/GHSA-95rc-wc32-gm53",
-        "path": "/advisories/GHSA-95rc-wc32-gm53",
+        "full": "https://github.com/advisories/GHSA-vpq6-j9hp-2h3w",
+        "original": "https://github.com/advisories/GHSA-vpq6-j9hp-2h3w",
+        "path": "/advisories/GHSA-vpq6-j9hp-2h3w",
         "scheme": "https"
     },
     "vulnerability": {
         "classification": "CVSS",
-        "description": "### Impact\n\nWhen using end-to-end encryption, a stored XSS vulnerability can be exploited by uploading a file with JavaScript code embedded in the filename. After upload and every time someone opens the upload list, the script is then parsed.\n\nWith the affected versions <v2.0, there was no user permission system implemented, therefore all authenticated users were already able to see and modify all resources, even if end-to-end encrypted, as the encryption key had to be the same for all users with <v2.0. Nethertheless with XSS, other attack vectors like redirection or crypto mining would be possble.\n\n### Patches\n\nThis CVE has been fixed in v2.0.0\n\n### Workarounds\n\nIf you are the only authenticated user using Gokapi, you are not affected. A workaround would be to disable end-to-end encryption.",
+        "description": "An issue was discovered in Samsung Mobile Processor Exynos 1280, 2200, 1380, 1480, 2400. A Double Free in the mobile processor leads to privilege escalation.",
         "enumeration": "CVE",
-        "id": "CVE-2025-48494",
-        "severity": "medium"
+        "id": "CVE-2025-23096",
+        "severity": "unknown"
     }
 }

--- a/packages/github/docs/README.md
+++ b/packages/github/docs/README.md
@@ -1113,26 +1113,26 @@ An example event for `security_advisories` looks as following:
 
 ```json
 {
-    "@timestamp": "2025-07-09T07:00:19.578Z",
+    "@timestamp": "2026-04-24T05:57:27.225Z",
     "agent": {
-        "ephemeral_id": "783ac826-d0e3-421b-9e05-3f8df55ef1f4",
-        "id": "827d1836-740e-4d2c-840e-e42baa4160d9",
-        "name": "elastic-agent-76840",
+        "ephemeral_id": "31ed0e78-957c-462b-b201-4068ee3c76a8",
+        "id": "015adde9-572c-425b-b861-e378d104de20",
+        "name": "elastic-agent-17838",
         "type": "filebeat",
-        "version": "8.16.0"
+        "version": "8.19.10"
     },
     "data_stream": {
         "dataset": "github.security_advisories",
-        "namespace": "89850",
+        "namespace": "70395",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "827d1836-740e-4d2c-840e-e42baa4160d9",
+        "id": "015adde9-572c-425b-b861-e378d104de20",
         "snapshot": false,
-        "version": "8.16.0"
+        "version": "8.19.10"
     },
     "event": {
         "agent_id_status": "verified",
@@ -1140,7 +1140,7 @@ An example event for `security_advisories` looks as following:
             "vulnerability"
         ],
         "dataset": "github.security_advisories",
-        "ingested": "2025-07-09T07:00:22Z",
+        "ingested": "2026-04-24T05:57:30Z",
         "kind": "enrichment",
         "type": [
             "info"
@@ -1148,125 +1148,41 @@ An example event for `security_advisories` looks as following:
     },
     "github": {
         "security_advisory": {
-            "credits": [
-                {
-                    "type": "reporter",
-                    "user": {
-                        "avatar_url": "https://avatars.githubusercontent.com/u/170187038?v=4",
-                        "events_url": "https://api.github.com/users/4rdr/events{/privacy}",
-                        "followers_url": "https://api.github.com/users/4rdr/followers",
-                        "following_url": "https://api.github.com/users/4rdr/following{/other_user}",
-                        "gists_url": "https://api.github.com/users/4rdr/gists{/gist_id}",
-                        "html_url": "https://github.com/4rdr",
-                        "id": 170187038,
-                        "login": "4rdr",
-                        "node_id": "U_kgDOCiTZHg",
-                        "organizations_url": "https://api.github.com/users/4rdr/orgs",
-                        "received_events_url": "https://api.github.com/users/4rdr/received_events",
-                        "repos_url": "https://api.github.com/users/4rdr/repos",
-                        "site_admin": false,
-                        "starred_url": "https://api.github.com/users/4rdr/starred{/owner}{/repo}",
-                        "subscriptions_url": "https://api.github.com/users/4rdr/subscriptions",
-                        "type": "User",
-                        "url": "https://api.github.com/users/4rdr",
-                        "user_view_type": "public"
-                    }
-                },
-                {
-                    "type": "remediation_developer",
-                    "user": {
-                        "avatar_url": "https://avatars.githubusercontent.com/u/1593467?v=4",
-                        "events_url": "https://api.github.com/users/Forceu/events{/privacy}",
-                        "followers_url": "https://api.github.com/users/Forceu/followers",
-                        "following_url": "https://api.github.com/users/Forceu/following{/other_user}",
-                        "gists_url": "https://api.github.com/users/Forceu/gists{/gist_id}",
-                        "html_url": "https://github.com/Forceu",
-                        "id": 1593467,
-                        "login": "Forceu",
-                        "node_id": "MDQ6VXNlcjE1OTM0Njc=",
-                        "organizations_url": "https://api.github.com/users/Forceu/orgs",
-                        "received_events_url": "https://api.github.com/users/Forceu/received_events",
-                        "repos_url": "https://api.github.com/users/Forceu/repos",
-                        "site_admin": false,
-                        "starred_url": "https://api.github.com/users/Forceu/starred{/owner}{/repo}",
-                        "subscriptions_url": "https://api.github.com/users/Forceu/subscriptions",
-                        "type": "User",
-                        "url": "https://api.github.com/users/Forceu",
-                        "user_view_type": "public"
-                    }
-                }
-            ],
-            "cve_id": "CVE-2025-48494",
+            "cve_id": "CVE-2025-23096",
             "cvss_severities": {
                 "cvss_v3": {
                     "score": 0
                 },
                 "cvss_v4": {
-                    "score": 4.8,
-                    "vector_string": "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:L"
+                    "score": 0
                 }
             },
-            "cwes": [
-                {
-                    "cwe_id": "CWE-79",
-                    "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-                },
-                {
-                    "cwe_id": "CWE-87",
-                    "name": "Improper Neutralization of Alternate XSS Syntax"
-                }
-            ],
-            "description": "### Impact\n\nWhen using end-to-end encryption, a stored XSS vulnerability can be exploited by uploading a file with JavaScript code embedded in the filename. After upload and every time someone opens the upload list, the script is then parsed.\n\nWith the affected versions <v2.0, there was no user permission system implemented, therefore all authenticated users were already able to see and modify all resources, even if end-to-end encrypted, as the encryption key had to be the same for all users with <v2.0. Nethertheless with XSS, other attack vectors like redirection or crypto mining would be possble.\n\n### Patches\n\nThis CVE has been fixed in v2.0.0\n\n### Workarounds\n\nIf you are the only authenticated user using Gokapi, you are not affected. A workaround would be to disable end-to-end encryption.",
-            "epss": {
-                "percentage": 0.00023,
-                "percentile": 0.0471
-            },
-            "ghsa_id": "GHSA-95rc-wc32-gm53",
-            "github_reviewed_at": "2025-06-03T06:28:08.000Z",
-            "html_url": "https://github.com/advisories/GHSA-95rc-wc32-gm53",
+            "description": "An issue was discovered in Samsung Mobile Processor Exynos 1280, 2200, 1380, 1480, 2400. A Double Free in the mobile processor leads to privilege escalation.",
+            "ghsa_id": "GHSA-vpq6-j9hp-2h3w",
+            "html_url": "https://github.com/advisories/GHSA-vpq6-j9hp-2h3w",
             "identifiers": [
                 {
                     "type": "GHSA",
-                    "value": "GHSA-95rc-wc32-gm53"
+                    "value": "GHSA-vpq6-j9hp-2h3w"
                 },
                 {
                     "type": "CVE",
-                    "value": "CVE-2025-48494"
+                    "value": "CVE-2025-23096"
                 }
             ],
-            "nvd_published_at": "2025-06-02T11:15:22.000Z",
-            "published_at": "2025-06-03T06:28:08.000Z",
+            "nvd_published_at": "2025-06-04T15:15:23.000Z",
+            "published_at": "2025-06-04T15:30:41.000Z",
             "references": [
-                "https://github.com/Forceu/Gokapi/security/advisories/GHSA-95rc-wc32-gm53",
-                "https://nvd.nist.gov/vuln/detail/CVE-2025-48494",
-                "https://github.com/Forceu/Gokapi/commit/343cc566cfd7f4efcd522c92371561d494aed6b0",
-                "https://github.com/Forceu/Gokapi/releases/tag/v2.0.0",
-                "https://github.com/advisories/GHSA-95rc-wc32-gm53"
+                "https://nvd.nist.gov/vuln/detail/CVE-2025-23096",
+                "https://semiconductor.samsung.com/support/quality-support/product-security-updates",
+                "https://semiconductor.samsung.com/support/quality-support/product-security-updates/cve-2025-23096",
+                "https://github.com/advisories/GHSA-vpq6-j9hp-2h3w"
             ],
-            "repository_advisory_url": "https://api.github.com/repos/Forceu/Gokapi/security-advisories/GHSA-95rc-wc32-gm53",
-            "severity": "medium",
-            "source_code_location": "https://github.com/Forceu/Gokapi",
-            "summary": "Gokapi vulnerable to stored XSS via uploading file with malicious file name",
-            "type": "reviewed",
-            "updated_at": "2025-06-03T06:28:10.000Z",
-            "url": "https://api.github.com/advisories/GHSA-95rc-wc32-gm53",
-            "vulnerabilities": [
-                {
-                    "package": {
-                        "ecosystem": "go",
-                        "name": "github.com/forceu/gokapi"
-                    },
-                    "vulnerable_version_range": ">= 1.0.1, <= 1.9.6"
-                },
-                {
-                    "first_patched_version": "0.0.0-20250530191232-343cc566cfd7",
-                    "package": {
-                        "ecosystem": "go",
-                        "name": "github.com/forceu/gokapi"
-                    },
-                    "vulnerable_version_range": "< 0.0.0-20250530191232-343cc566cfd7"
-                }
-            ]
+            "severity": "unknown",
+            "summary": "An issue was discovered in Samsung Mobile Processor Exynos 1280, 2200, 1380, 1480, 2400. A Double...",
+            "type": "unreviewed",
+            "updated_at": "2025-06-04T15:30:46.000Z",
+            "url": "https://api.github.com/advisories/GHSA-vpq6-j9hp-2h3w"
         }
     },
     "input": {
@@ -1278,17 +1194,17 @@ An example event for `security_advisories` looks as following:
     ],
     "url": {
         "domain": "github.com",
-        "full": "https://github.com/advisories/GHSA-95rc-wc32-gm53",
-        "original": "https://github.com/advisories/GHSA-95rc-wc32-gm53",
-        "path": "/advisories/GHSA-95rc-wc32-gm53",
+        "full": "https://github.com/advisories/GHSA-vpq6-j9hp-2h3w",
+        "original": "https://github.com/advisories/GHSA-vpq6-j9hp-2h3w",
+        "path": "/advisories/GHSA-vpq6-j9hp-2h3w",
         "scheme": "https"
     },
     "vulnerability": {
         "classification": "CVSS",
-        "description": "### Impact\n\nWhen using end-to-end encryption, a stored XSS vulnerability can be exploited by uploading a file with JavaScript code embedded in the filename. After upload and every time someone opens the upload list, the script is then parsed.\n\nWith the affected versions <v2.0, there was no user permission system implemented, therefore all authenticated users were already able to see and modify all resources, even if end-to-end encrypted, as the encryption key had to be the same for all users with <v2.0. Nethertheless with XSS, other attack vectors like redirection or crypto mining would be possble.\n\n### Patches\n\nThis CVE has been fixed in v2.0.0\n\n### Workarounds\n\nIf you are the only authenticated user using Gokapi, you are not affected. A workaround would be to disable end-to-end encryption.",
+        "description": "An issue was discovered in Samsung Mobile Processor Exynos 1280, 2200, 1380, 1480, 2400. A Double Free in the mobile processor leads to privilege escalation.",
         "enumeration": "CVE",
-        "id": "CVE-2025-48494",
-        "severity": "medium"
+        "id": "CVE-2025-23096",
+        "severity": "unknown"
     }
 }
 ```

--- a/packages/github/docs/README.md
+++ b/packages/github/docs/README.md
@@ -1027,7 +1027,7 @@ An example event for `issues` looks as following:
 
 The GitHub Security Advisories datastream lets you retrieve reviewed and unreviewed global security advisories from the GitHub advisory database. Check [Working with security advisories](https://docs.github.com/en/code-security/security-advisories) for more details.
 
-To use this integration, you must [create a fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) (GitHub App user access tokens, GitHub App installation access tokens, Fine-grained personal access tokens). This fine-grained token does not require any permissions. 
+To use this integration, you may [create a fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) (GitHub App user access tokens, GitHub App installation access tokens, Fine-grained personal access tokens). This fine-grained token does not require any permissions. Authentication is not required when accessing data from public repositories, so you can leave the API key field blank in that case.
 
 **Exported fields**
 

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: "2.23.0"
+version: "2.23.1"
 description: Collect logs from GitHub with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
github: change API key variable to optional for security advisories data stream,
as authentication is not required for public repositories

[1] https://docs.github.com/en/rest/security-advisories/global-advisories?apiVersion=2026-03-10#list-global-security-advisories
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/github directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- #18318 

