### PR TITLE
Use agentless deployment 'release' field to agentless deployment modes

### DIFF
--- a/packages/1password/changelog.yml
+++ b/packages/1password/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.34.0"
   changes:
     - description: Prevent updating fleet health status to degraded.

--- a/packages/1password/changelog.yml
+++ b/packages/1password/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.34.1"
+- version: "1.35.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/1password/manifest.yml
+++ b/packages/1password/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: 1password
 title: "1Password"
-version: "1.34.1"
+version: "1.35.0"
 description: Collect logs from 1Password with Elastic Agent.
 type: integration
 categories:

--- a/packages/1password/manifest.yml
+++ b/packages/1password/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: 1password
 title: "1Password"
-version: "1.34.0"
+version: "1.34.1"
 description: Collect logs from 1Password with Elastic Agent.
 type: integration
 categories:
@@ -33,6 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/abnormal_security/changelog.yml
+++ b/packages/abnormal_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.14.2"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/abnormal_security/manifest.yml
+++ b/packages/abnormal_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: abnormal_security
 title: Abnormal AI
-version: "1.14.2"
+version: "1.15.0"
 description: Collect logs from Abnormal AI with Elastic Agent.
 type: integration
 categories:
@@ -59,6 +59,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/admin_by_request_epm/changelog.yml
+++ b/packages/admin_by_request_epm/changelog.yml
@@ -1,4 +1,4 @@
-- version: "1.2.1"
+- version: "1.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/admin_by_request_epm/changelog.yml
+++ b/packages/admin_by_request_epm/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.2.0"
   changes:
     - description: Add Agentless deployment support.

--- a/packages/admin_by_request_epm/manifest.yml
+++ b/packages/admin_by_request_epm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: admin_by_request_epm
 title: Admin By Request EPM
-version: "1.2.0"
+version: "1.2.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Admin By Request EPM with Elastic Agent."
@@ -40,6 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/admin_by_request_epm/manifest.yml
+++ b/packages/admin_by_request_epm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: admin_by_request_epm
 title: Admin By Request EPM
-version: "1.2.1"
+version: "1.3.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Admin By Request EPM with Elastic Agent."

--- a/packages/agentless_hello_world/changelog.yml
+++ b/packages/agentless_hello_world/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.4.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.4.0"
   changes:
     - description: Add HTTPJSON input variant for the generic data stream with timestamp-based cursor tracking.

--- a/packages/agentless_hello_world/changelog.yml
+++ b/packages/agentless_hello_world/changelog.yml
@@ -1,4 +1,4 @@
-- version: "0.4.1"
+- version: "0.5.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/agentless_hello_world/manifest.yml
+++ b/packages/agentless_hello_world/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: agentless_hello_world
 title: Agentless Hello World
-version: "0.4.0"
+version: "0.4.1"
 description: A sample integration to exercise the Agentless infrastructure by fetching https://epr.elastic.co every minute. Optionally includes a counter data stream for high-rate mock metric ingestion testing.
 type: integration
 categories:
@@ -26,6 +26,7 @@ policy_templates:
       agentless:
         enabled: true
         is_default: true
+        release: beta
         organization: observability
         division: engineering
         team: ingest-managed-jobs

--- a/packages/agentless_hello_world/manifest.yml
+++ b/packages/agentless_hello_world/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: agentless_hello_world
 title: Agentless Hello World
-version: "0.4.1"
+version: "0.5.0"
 description: A sample integration to exercise the Agentless infrastructure by fetching https://epr.elastic.co every minute. Optionally includes a counter data stream for high-rate mock metric ingestion testing.
 type: integration
 categories:

--- a/packages/airlock_digital/changelog.yml
+++ b/packages/airlock_digital/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: '0.3.0'
   changes:
     - description: Add server activities data stream.

--- a/packages/airlock_digital/changelog.yml
+++ b/packages/airlock_digital/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.3.1"
+- version: "0.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/airlock_digital/manifest.yml
+++ b/packages/airlock_digital/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: airlock_digital
 title: Airlock Digital
-version: 0.3.1
+version: 0.4.0
 description: Collect logs from Airlock Digital with Elastic Agent.
 type: integration
 categories:

--- a/packages/airlock_digital/manifest.yml
+++ b/packages/airlock_digital/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: airlock_digital
 title: Airlock Digital
-version: 0.3.0
+version: 0.3.1
 description: Collect logs from Airlock Digital with Elastic Agent.
 type: integration
 categories:
@@ -38,6 +38,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/anthropic/changelog.yml
+++ b/packages/anthropic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.1.0"
   changes:
     - description: Initial release with the `audit` data stream for Anthropic Compliance Activities.

--- a/packages/anthropic/manifest.yml
+++ b/packages/anthropic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.2"
 name: anthropic
 title: Anthropic
-version: "0.1.0"
+version: "0.2.0"
 source:
   license: "Elastic-2.0"
 description: Collect compliance activity audit logs from Anthropic with Elastic Agent.
@@ -37,6 +37,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: integration-experience

--- a/packages/armis/changelog.yml
+++ b/packages/armis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.4.2"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/armis/manifest.yml
+++ b/packages/armis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: armis
 title: Armis
-version: "0.4.2"
+version: "0.5.0"
 description: Collect logs from Armis with Elastic Agent.
 type: integration
 categories:
@@ -42,6 +42,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/atlassian_bitbucket/changelog.yml
+++ b/packages/atlassian_bitbucket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.7.0"
   changes:
     - description: Add Agentless deployment support.

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: atlassian_bitbucket
 title: Atlassian Bitbucket
-version: "2.7.0"
+version: "2.8.0"
 description: Collect logs from Atlassian Bitbucket with Elastic Agent.
 type: integration
 categories:
@@ -24,6 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/authentik/changelog.yml
+++ b/packages/authentik/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.9.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/authentik/manifest.yml
+++ b/packages/authentik/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: authentik
 title: authentik
-version: "1.9.1"
+version: "1.10.0"
 description: Collect logs from authentik with Elastic Agent.
 type: integration
 categories:
@@ -36,6 +36,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.19.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "6.18.1"
   changes:
     - description: Add documentation for authenticating the CloudTrail integration using AWS IAM Roles Anywhere for agents running outside AWS.

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.18.1
+version: 6.19.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -113,6 +113,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -143,6 +144,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -213,6 +215,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations
@@ -254,6 +257,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -366,6 +370,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -421,6 +426,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -518,6 +524,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -604,6 +611,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -634,6 +642,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -664,6 +673,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -851,6 +861,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations
@@ -888,6 +899,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations
@@ -931,6 +943,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.1.0
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.0.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/aws_securityhub/changelog.yml
+++ b/packages/aws_securityhub/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: 1.1.0
+- version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/aws_securityhub/manifest.yml
+++ b/packages/aws_securityhub/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_securityhub
 title: "AWS Security Hub"
-version: 1.0.1
+version: 1.1.0
 source:
   license: "Elastic-2.0"
 description: Collect logs from AWS Security Hub with Elastic Agent.
@@ -35,6 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/azure_ai_foundry/changelog.yml
+++ b/packages/azure_ai_foundry/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.10.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.10.0"
   changes:
     - description: Add support for agentless deployment.

--- a/packages/azure_ai_foundry/changelog.yml
+++ b/packages/azure_ai_foundry/changelog.yml
@@ -1,4 +1,4 @@
-- version: "0.10.1"
+- version: "0.11.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/azure_ai_foundry/manifest.yml
+++ b/packages/azure_ai_foundry/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: azure_ai_foundry
 title: "Microsoft Foundry"
-version: "0.10.0"
+version: "0.10.1"
 source:
   license: "Elastic-2.0"
 description: "Collects Microsoft Foundry logs and metrics"
@@ -64,6 +64,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations

--- a/packages/azure_ai_foundry/manifest.yml
+++ b/packages/azure_ai_foundry/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: azure_ai_foundry
 title: "Microsoft Foundry"
-version: "0.10.1"
+version: "0.11.0"
 source:
   license: "Elastic-2.0"
 description: "Collects Microsoft Foundry logs and metrics"

--- a/packages/azure_application_insights/changelog.yml
+++ b/packages/azure_application_insights/changelog.yml
@@ -1,4 +1,4 @@
-- version: "1.11.1"
+- version: "1.12.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/azure_application_insights/changelog.yml
+++ b/packages/azure_application_insights/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.11.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.11.0"
   changes:
     - description: Add support for agentless deployment.

--- a/packages/azure_application_insights/manifest.yml
+++ b/packages/azure_application_insights/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_application_insights
 title: Azure Application Insights Metrics Overview
-version: "1.11.1"
+version: "1.12.0"
 description: Collect application insights metrics from Azure Monitor with Elastic Agent.
 type: integration
 icons:

--- a/packages/azure_application_insights/manifest.yml
+++ b/packages/azure_application_insights/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_application_insights
 title: Azure Application Insights Metrics Overview
-version: "1.11.0"
+version: "1.11.1"
 description: Collect application insights metrics from Azure Monitor with Elastic Agent.
 type: integration
 icons:
@@ -82,6 +82,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations
@@ -111,6 +112,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.10.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.10.0"
   changes:
     - description: Add support for agentless deployment.

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,4 +1,4 @@
-- version: "1.10.1"
+- version: "1.11.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/azure_billing/manifest.yml
+++ b/packages/azure_billing/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_billing
 title: Azure Billing Metrics
-version: "1.10.0"
+version: "1.10.1"
 description: Collect billing metrics with Elastic Agent.
 type: integration
 icons:
@@ -84,6 +84,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations

--- a/packages/azure_billing/manifest.yml
+++ b/packages/azure_billing/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_billing
 title: Azure Billing Metrics
-version: "1.10.1"
+version: "1.11.0"
 description: Collect billing metrics with Elastic Agent.
 type: integration
 icons:

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.13.1"
+- version: "0.14.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.13.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.13.0"
   changes:
     - description: Add support for agentless deployment.

--- a/packages/azure_functions/manifest.yml
+++ b/packages/azure_functions/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: azure_functions
 title: "Azure Functions"
-version: "0.13.0"
+version: "0.13.1"
 source:
   license: "Elastic-2.0"
 description: "Get metrics and logs from Azure Functions"
@@ -50,6 +50,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations

--- a/packages/azure_functions/manifest.yml
+++ b/packages/azure_functions/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: azure_functions
 title: "Azure Functions"
-version: "0.13.1"
+version: "0.14.0"
 source:
   license: "Elastic-2.0"
 description: "Get metrics and logs from Azure Functions"

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.12.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: 1.12.0
   changes:
     - description: Enable agentless deployment mode for the integration.

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,4 +1,4 @@
-- version: "1.12.1"
+- version: "1.13.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: "1.12.0"
+version: "1.12.1"
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:
@@ -106,6 +106,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -135,6 +136,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -164,6 +166,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -195,6 +198,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -226,6 +230,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -257,6 +262,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -288,6 +294,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -317,6 +324,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: "1.12.1"
+version: "1.13.0"
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.12.0"
   changes:
     - description: Add support for agentless deployment.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.12.1"
+- version: "1.13.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/azure_openai/manifest.yml
+++ b/packages/azure_openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: azure_openai
 title: "Azure OpenAI"
-version: "1.12.0"
+version: "1.12.1"
 source:
   license: "Elastic-2.0"
 description: "Collects Azure OpenAI Logs and Metrics"
@@ -60,6 +60,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations

--- a/packages/azure_openai/manifest.yml
+++ b/packages/azure_openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: azure_openai
 title: "Azure OpenAI"
-version: "1.12.1"
+version: "1.13.0"
 source:
   license: "Elastic-2.0"
 description: "Collects Azure OpenAI Logs and Metrics"

--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -1,4 +1,4 @@
-- version: "1.1.1"
+- version: "1.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.1.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.1.0"
   changes:
     - description: Add Agentless deployment support.

--- a/packages/beyondinsight_password_safe/manifest.yml
+++ b/packages/beyondinsight_password_safe/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: beyondinsight_password_safe
 title: BeyondInsight and Password Safe
-version: "1.1.0"
+version: "1.1.1"
 source:
   license: "Elastic-2.0"
 description: Ingest privileged access management (PAM) data from BeyondTrust's BeyondInsight PAM Reporting Platform and Password Safe, using Elastic Agent.
@@ -40,6 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/beyondinsight_password_safe/manifest.yml
+++ b/packages/beyondinsight_password_safe/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: beyondinsight_password_safe
 title: BeyondInsight and Password Safe
-version: "1.1.1"
+version: "1.2.0"
 source:
   license: "Elastic-2.0"
 description: Ingest privileged access management (PAM) data from BeyondTrust's BeyondInsight PAM Reporting Platform and Password Safe, using Elastic Agent.

--- a/packages/beyondtrust_pra/changelog.yml
+++ b/packages/beyondtrust_pra/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.1"
+- version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/beyondtrust_pra/changelog.yml
+++ b/packages/beyondtrust_pra/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.0.0"
   changes:
     - description: Release BeyondTrust PRA as GA.

--- a/packages/beyondtrust_pra/manifest.yml
+++ b/packages/beyondtrust_pra/manifest.yml
@@ -1,6 +1,6 @@
 name: beyondtrust_pra
 title: "BeyondTrust PRA"
-version: 1.0.0
+version: 1.0.1
 description: "Collect logs from BeyondTrust PRA with Elastic Agent."
 type: integration
 format_version: 3.3.2
@@ -34,6 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/beyondtrust_pra/manifest.yml
+++ b/packages/beyondtrust_pra/manifest.yml
@@ -1,6 +1,6 @@
 name: beyondtrust_pra
 title: "BeyondTrust PRA"
-version: 1.0.1
+version: 1.1.0
 description: "Collect logs from BeyondTrust PRA with Elastic Agent."
 type: integration
 format_version: 3.3.2

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.9.0"
   changes:
     - description: Enable agentless deployment mode.

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.9.1"
+- version: "2.10.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: bitdefender
 title: "BitDefender"
-version: "2.9.0"
+version: "2.9.1"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"
@@ -38,6 +38,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: bitdefender
 title: "BitDefender"
-version: "2.9.1"
+version: "2.10.0"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"

--- a/packages/bitsight/changelog.yml
+++ b/packages/bitsight/changelog.yml
@@ -1,4 +1,4 @@
-- version: "0.2.1"
+- version: "0.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/bitsight/changelog.yml
+++ b/packages/bitsight/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.2.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.2.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/bitsight/manifest.yml
+++ b/packages/bitsight/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: bitsight
 title: "Bitsight"
-version: 0.2.0
+version: 0.2.1
 source:
   license: "Elastic-2.0"
 description: "Ingest data from the Bitsight API."
@@ -28,6 +28,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/bitsight/manifest.yml
+++ b/packages/bitsight/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: bitsight
 title: "Bitsight"
-version: 0.2.1
+version: 0.3.0
 source:
   license: "Elastic-2.0"
 description: "Ingest data from the Bitsight API."

--- a/packages/bitwarden/changelog.yml
+++ b/packages/bitwarden/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.19.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/bitwarden/changelog.yml
+++ b/packages/bitwarden/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.19.1"
+- version: "1.20.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/bitwarden/manifest.yml
+++ b/packages/bitwarden/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: bitwarden
 title: Bitwarden
-version: "1.19.1"
+version: "1.20.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Bitwarden with Elastic Agent.

--- a/packages/bitwarden/manifest.yml
+++ b/packages/bitwarden/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: bitwarden
 title: Bitwarden
-version: "1.19.0"
+version: "1.19.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Bitwarden with Elastic Agent.
@@ -45,6 +45,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/blacklens/changelog.yml
+++ b/packages/blacklens/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.1.1"
+- version: "1.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/blacklens/changelog.yml
+++ b/packages/blacklens/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.1.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/blacklens/manifest.yml
+++ b/packages/blacklens/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: blacklens
 title: "blacklens.io"
-version: "1.1.1"
+version: "1.2.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from blacklens.io with Elastic Agent"

--- a/packages/blacklens/manifest.yml
+++ b/packages/blacklens/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: blacklens
 title: "blacklens.io"
-version: "1.1.0"
+version: "1.1.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from blacklens.io with Elastic Agent"
@@ -34,6 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.2.1"
+- version: "3.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.2.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.2.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: box_events
 title: Box Events
-version: "3.2.1"
+version: "3.3.0"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: box_events
 title: Box Events
-version: "3.2.0"
+version: "3.2.1"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:
@@ -101,6 +101,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.2.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "4.2.0"
   changes:
     - description: Make rows_per_page configurable in alerts_7 data stream and cap it at a maximum value of 10000.

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "4.2.1"
+- version: "4.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "4.2.1"
+version: "4.3.0"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "4.2.0"
+version: "4.2.1"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:
@@ -29,6 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/checkpoint_email/changelog.yml
+++ b/packages/checkpoint_email/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.4.0"
   changes:
     - description: Shorten token expiry period to help avoid expiration races.

--- a/packages/checkpoint_email/changelog.yml
+++ b/packages/checkpoint_email/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.4.1"
+- version: "1.5.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/checkpoint_email/manifest.yml
+++ b/packages/checkpoint_email/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: checkpoint_email
 title: Check Point Harmony Email & Collaboration
-version: "1.4.1"
+version: "1.5.0"
 description: Collect logs from Check Point Harmony Email & Collaboration with Elastic Agent.
 type: integration
 categories:

--- a/packages/checkpoint_email/manifest.yml
+++ b/packages/checkpoint_email/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: checkpoint_email
 title: Check Point Harmony Email & Collaboration
-version: "1.4.0"
+version: "1.4.1"
 description: Collect logs from Check Point Harmony Email & Collaboration with Elastic Agent.
 type: integration
 categories:
@@ -32,6 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.2.1"
+- version: "1.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/checkpoint_harmony_endpoint/changelog.yml
+++ b/packages/checkpoint_harmony_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.2.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "1.2.0"
+version: "1.2.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"
@@ -38,6 +38,7 @@ policy_templates:
         enabled: true 
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/checkpoint_harmony_endpoint/manifest.yml
+++ b/packages/checkpoint_harmony_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: checkpoint_harmony_endpoint
 title: "Check Point Harmony Endpoint"
-version: "1.2.1"
+version: "1.3.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Check Point Harmony Endpoint"

--- a/packages/cisa_kevs/changelog.yml
+++ b/packages/cisa_kevs/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.8.1"
+- version: "1.9.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/cisa_kevs/changelog.yml
+++ b/packages/cisa_kevs/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.8.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/cisa_kevs/manifest.yml
+++ b/packages/cisa_kevs/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cisa_kevs
 title: "CISA Known Exploited Vulnerabilities"
-version: "1.8.1"
+version: "1.9.0"
 description: "This package allows the ingest of known exploited vulnerabilities according to the Cybersecurity and Infrastructure Security Agency of the United States of America. This information could be used to enrich or track exisiting vulnerabilities that are known to be exploited in the wild."
 type: integration
 categories:

--- a/packages/cisa_kevs/manifest.yml
+++ b/packages/cisa_kevs/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cisa_kevs
 title: "CISA Known Exploited Vulnerabilities"
-version: "1.8.0"
+version: "1.8.1"
 description: "This package allows the ingest of known exploited vulnerabilities according to the Cybersecurity and Infrastructure Security Agency of the United States of America. This information could be used to enrich or track exisiting vulnerabilities that are known to be exploited in the wild."
 type: integration
 categories:
@@ -30,6 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.9.1"
+- version: "2.10.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/cisco_duo/changelog.yml
+++ b/packages/cisco_duo/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.9.0"
   changes:
     - description: Enable request trace log removal.

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: cisco_duo
 title: Cisco Duo
-version: "2.9.1"
+version: "2.10.0"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:

--- a/packages/cisco_duo/manifest.yml
+++ b/packages/cisco_duo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: cisco_duo
 title: Cisco Duo
-version: "2.9.0"
+version: "2.9.1"
 description: Collect logs from Cisco Duo with Elastic Agent.
 type: integration
 categories:
@@ -53,6 +53,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cisco_secure_endpoint/changelog.yml
+++ b/packages/cisco_secure_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.35.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.34.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/cisco_secure_endpoint/manifest.yml
+++ b/packages/cisco_secure_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cisco_secure_endpoint
 title: Cisco Secure Endpoint
-version: "2.34.0"
+version: "2.35.0"
 description: Collect logs from Cisco Secure Endpoint (AMP) with Elastic Agent.
 type: integration
 categories:
@@ -29,6 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/claroty_ctd/changelog.yml
+++ b/packages/claroty_ctd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.3.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/claroty_ctd/manifest.yml
+++ b/packages/claroty_ctd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: claroty_ctd
 title: Claroty CTD
-version: "1.3.0"
+version: "1.4.0"
 description: Collect logs from Claroty CTD using Elastic Agent.
 type: integration
 categories:
@@ -58,6 +58,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/claroty_xdome/changelog.yml
+++ b/packages/claroty_xdome/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.0.4"
   changes:
     - description: Fix CEL response `events` field for evaluations with no work to do.

--- a/packages/claroty_xdome/manifest.yml
+++ b/packages/claroty_xdome/manifest.yml
@@ -1,6 +1,6 @@
 name: claroty_xdome
 title: "Claroty xDome"
-version: 1.0.4
+version: 1.1.0
 description: "Collect logs from Claroty xDome with Elastic Agent."
 type: integration
 format_version: 3.3.2
@@ -39,6 +39,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -8,6 +8,11 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.5.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.5.0"
   changes:
     - description: Release version 1.5.0

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -8,7 +8,7 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
-- version: "1.5.1"
+- version: "1.6.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.5.0"
+version: "1.5.1"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"
@@ -36,6 +36,7 @@ policy_templates:
       agentless:
         enabled: true
         is_default: true
+        release: beta
         organization: security
         division: engineering
         team: cloud-services

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.5.1"
+version: "1.6.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -19,6 +19,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "3.3.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/TBD
 - version: "3.3.0"
   changes:
     - description: Release version 3.3.0

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -23,7 +23,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/TBD
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.3.0"
   changes:
     - description: Release version 3.3.0

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -19,7 +19,7 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "3.3.1"
+- version: "3.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as GA.
       type: enhancement

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.3.1"
+version: "3.4.0"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "3.3.0"
+version: "3.3.1"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -122,6 +122,7 @@ policy_templates:
       agentless:
         enabled: true
         is_default: true
+        release: ga
         organization: security
         division: engineering
         team: cloud-services

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.33.1"
+- version: "2.34.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.33.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.33.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: "2.33.0"
+version: "2.33.1"
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -35,6 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: "2.33.1"
+version: "2.34.0"
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
 format_version: "3.3.2"

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1057,7 +1057,7 @@
     - description: Fix logic that checks for the 'forwarded' tag
       type: bugfix
       link: https://github.com/elastic/integrations/pull/1812
-- version: '1.0.0'
+- version: "1.0.0"
   changes:
     - description: make GA
       type: enhancement
@@ -1083,7 +1083,7 @@
     - description: Add cleanup processor to Falcon
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1522
-- version: '0.7.1'
+- version: "0.7.1"
   changes:
     - description: update to ECS 1.11.0
       type: enhancement

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.21.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.20.0"
   changes:
     - description: Improve dashboards for coverage, control, and consistency.

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -67,6 +67,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "3.20.0"
+version: "3.21.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.4.0"

--- a/packages/cursor/changelog.yml
+++ b/packages/cursor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/cursor/changelog.yml
+++ b/packages/cursor/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.1.1"
+- version: "0.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/cursor/manifest.yml
+++ b/packages/cursor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.2
 name: cursor
 title: "Cursor"
-version: "0.1.1"
+version: "0.2.0"
 description: "Collect audit logs from Cursor with Elastic Agent"
 type: integration
 categories:

--- a/packages/cursor/manifest.yml
+++ b/packages/cursor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.2
 name: cursor
 title: "Cursor"
-version: "0.1.0"
+version: "0.1.1"
 description: "Collect audit logs from Cursor with Elastic Agent"
 type: integration
 categories:
@@ -35,6 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: integration-experience

--- a/packages/cyberark_epm/changelog.yml
+++ b/packages/cyberark_epm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.4.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/cyberark_epm/manifest.yml
+++ b/packages/cyberark_epm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cyberark_epm
 title: CyberArk EPM
-version: "1.4.1"
+version: "1.5.0"
 description: Collect logs from CyberArk EPM with Elastic Agent.
 type: integration
 categories:

--- a/packages/cyberark_epm/manifest.yml
+++ b/packages/cyberark_epm/manifest.yml
@@ -38,6 +38,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/cybereason/changelog.yml
+++ b/packages/cybereason/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.6.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/cybereason/manifest.yml
+++ b/packages/cybereason/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cybereason
 title: Cybereason
-version: "1.6.0"
+version: "1.7.0"
 description: Collect logs from Cybereason with Elastic Agent.
 type: integration
 categories:
@@ -51,6 +51,7 @@ policy_templates:
        enabled: true
      agentless:
        enabled: true
+       release: beta
        organization: security
        division: engineering
        team: security-service-integrations

--- a/packages/cyera/changelog.yml
+++ b/packages/cyera/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.6.1"
+- version: "0.7.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/cyera/changelog.yml
+++ b/packages/cyera/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: 0.6.0
   changes:
     - description: Update the client secret field name to client_secret.

--- a/packages/cyera/manifest.yml
+++ b/packages/cyera/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cyera
 title: Cyera
-version: 0.6.1
+version: 0.7.0
 description: Collect logs from Cyera with Elastic Agent.
 type: integration
 categories:

--- a/packages/cyera/manifest.yml
+++ b/packages/cyera/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cyera
 title: Cyera
-version: 0.6.0
+version: 0.6.1
 description: Collect logs from Cyera with Elastic Agent.
 type: integration
 categories:
@@ -42,6 +42,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.1.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.1.1"
+- version: "2.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/darktrace/manifest.yml
+++ b/packages/darktrace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: darktrace
 title: Darktrace
-version: "2.1.0"
+version: "2.1.1"
 description: Collect logs from Darktrace with Elastic Agent.
 type: integration
 categories:
@@ -29,6 +29,7 @@ policy_templates:
        enabled: true
      agentless:
        enabled: true
+       release: beta
        organization: security
        division: engineering
        team: security-service-integrations

--- a/packages/darktrace/manifest.yml
+++ b/packages/darktrace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: darktrace
 title: Darktrace
-version: "2.1.1"
+version: "2.2.0"
 description: Collect logs from Darktrace with Elastic Agent.
 type: integration
 categories:

--- a/packages/digital_guardian/changelog.yml
+++ b/packages/digital_guardian/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.9.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/digital_guardian/manifest.yml
+++ b/packages/digital_guardian/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: digital_guardian
 title: Digital Guardian
-version: "1.9.0"
+version: "1.10.0"
 description: Collect logs from Digital Guardian with Elastic Agent.
 type: integration
 categories:
@@ -33,6 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/doppel/changelog.yml
+++ b/packages/doppel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.2.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.1.1"
   changes:
     - description: Fix kibana.version constraints to allow v9 stack.

--- a/packages/doppel/manifest.yml
+++ b/packages/doppel/manifest.yml
@@ -32,12 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-<<<<<<< HEAD
-=======
         release: beta
-        # is_default: true          # default agentless mode for directly test as agentless
-
->>>>>>> 7e38ae2bf5 (Add release field to newly agentless-enabled integrations (bitdefender, bitsight, bitwarden, o365_metrics, blacklens, box_events, cisa_kevs, azure_ai_foundry, azure_billing, azure_functions, azure_openai, azure_metrics, cursor, cyberark_epm, darktrace, openai, claroty_ctd, cybereason, doppel, first_epss, microsoft_exchange_online_message_trace))
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/doppel/manifest.yml
+++ b/packages/doppel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: doppel
 title: "Doppel"
-version: 0.1.1
+version: 0.2.0
 description: "Collects Doppel alerts and sends them to Elastic"
 type: integration
 source:
@@ -32,6 +32,12 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+<<<<<<< HEAD
+=======
+        release: beta
+        # is_default: true          # default agentless mode for directly test as agentless
+
+>>>>>>> 7e38ae2bf5 (Add release field to newly agentless-enabled integrations (bitdefender, bitsight, bitwarden, o365_metrics, blacklens, box_events, cisa_kevs, azure_ai_foundry, azure_billing, azure_functions, azure_openai, azure_metrics, cursor, cyberark_epm, darktrace, openai, claroty_ctd, cybereason, doppel, first_epss, microsoft_exchange_online_message_trace))
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.4"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: 1.0.3
   changes:
     - description: Add Sandfly Security Connector policy template

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.4"
+- version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.1.0"
   changes:
-    - description: Use new `release` field for agentless deployment mode to establish as beta.
+    - description: Use new `release` field for agentless deployment mode to establish as GA.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/18552
 - version: 1.0.3

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -40,7 +40,7 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
-        release: beta
+        release: ga
         organization: elastic
         division: engineering
         team: search-extract-and-transform

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.1
 name: elastic_connectors
 title: "Elastic Connectors"
-version: 1.0.4
+version: 1.1.0
 source:
   license: "Elastic-2.0"
 description: "Sync data from source to the Elasticsearch index."

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.1
 name: elastic_connectors
 title: "Elastic Connectors"
-version: 1.0.3
+version: 1.0.4
 source:
   license: "Elastic-2.0"
 description: "Sync data from source to the Elasticsearch index."
@@ -40,6 +40,7 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
+        release: beta
         organization: elastic
         division: engineering
         team: search-extract-and-transform

--- a/packages/elastic_security/changelog.yml
+++ b/packages/elastic_security/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: 0.5.0
+- version: "0.5.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/elastic_security/changelog.yml
+++ b/packages/elastic_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.5.0
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.4.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/elastic_security/manifest.yml
+++ b/packages/elastic_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: elastic_security
 title: Elastic Security
-version: 0.4.1
+version: 0.5.0
 source:
   license: "Elastic-2.0"
 description: Collect logs from Elastic Instance with Elastic Agent.
@@ -33,6 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ess_billing/changelog.yml
+++ b/packages/ess_billing/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.7.3"
+- version: "1.8.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ess_billing/changelog.yml
+++ b/packages/ess_billing/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.3"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.7.2"
   changes:
     - description: Handle null instances in billing data.

--- a/packages/ess_billing/manifest.yml
+++ b/packages/ess_billing/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ess_billing
 title: "Elasticsearch Service Billing"
-version: "1.7.2"
+version: "1.7.3"
 source:
   license: "Elastic-2.0"
 description: "Collects billing metrics from Elasticsearch Service billing API"
@@ -37,6 +37,7 @@ policy_templates:
       agentless:
         enabled: true
         is_default: true
+        release: beta
         organization: elastic
         division: field
         team: csg

--- a/packages/ess_billing/manifest.yml
+++ b/packages/ess_billing/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ess_billing
 title: "Elasticsearch Service Billing"
-version: "1.7.3"
+version: "1.8.0"
 source:
   license: "Elastic-2.0"
 description: "Collects billing metrics from Elasticsearch Service billing API"

--- a/packages/extrahop/changelog.yml
+++ b/packages/extrahop/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.2.1"
   changes:
     - description: Downgrade the `format_version` to the minimum version that supports all the necessary features for the package.

--- a/packages/extrahop/changelog.yml
+++ b/packages/extrahop/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.2.2"
+- version: "0.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/extrahop/manifest.yml
+++ b/packages/extrahop/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: extrahop
 title: ExtraHop
-version: 0.2.1
+version: 0.2.2
 description: Collect logs from ExtraHop RevealX 360 with Elastic Agent.
 type: integration
 categories:
@@ -34,6 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/extrahop/manifest.yml
+++ b/packages/extrahop/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: extrahop
 title: ExtraHop
-version: 0.2.2
+version: 0.3.0
 description: Collect logs from ExtraHop RevealX 360 with Elastic Agent.
 type: integration
 categories:

--- a/packages/first_epss/changelog.yml
+++ b/packages/first_epss/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.3.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/first_epss/manifest.yml
+++ b/packages/first_epss/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: first_epss
 title: First EPSS
-version: "1.3.0"
+version: "1.4.0"
 description: Collect exploit prediction score data from the First EPSS API with Elastic Agent.
 type: integration
 categories:
@@ -31,6 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/forgerock/changelog.yml
+++ b/packages/forgerock/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.23.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/forgerock/manifest.yml
+++ b/packages/forgerock/manifest.yml
@@ -1,6 +1,6 @@
 name: forgerock
 title: "ForgeRock"
-version: "1.23.0"
+version: "1.24.0"
 description: Collect audit logs from ForgeRock with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -22,6 +22,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.25.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.24.0"
   changes:
     - description: Declare `github.ruleset_*` fields in the audit data stream so ES|QL detections referencing lifecycle variants (`_added`, `_deleted`, `_updated`) or old-state pairs (`ruleset_old_name`, `ruleset_old_enforcement`) resolve consistently across backing-index rollovers.

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: "2.24.0"
+version: "2.25.0"
 description: Collect logs from GitHub with Elastic Agent.
 type: integration
 format_version: "3.4.0"
@@ -55,6 +55,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/google_scc/changelog.yml
+++ b/packages/google_scc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.4.0"
   changes:
     - description: Add timestamp range filter and storage tier exclusion to latest transform source queries to reduce scan scope and improve performance.

--- a/packages/google_scc/changelog.yml
+++ b/packages/google_scc/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.4.1"
+- version: "2.5.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/google_scc/manifest.yml
+++ b/packages/google_scc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.2.3"
 name: google_scc
 title: Google Security Command Center
-version: "2.4.1"
+version: "2.5.0"
 description: Collect logs from Google Security Command Center with Elastic Agent.
 type: integration
 categories:

--- a/packages/google_scc/manifest.yml
+++ b/packages/google_scc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.2.3"
 name: google_scc
 title: Google Security Command Center
-version: "2.4.0"
+version: "2.4.1"
 description: Collect logs from Google Security Command Center with Elastic Agent.
 type: integration
 categories:
@@ -50,6 +50,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/google_secops/changelog.yml
+++ b/packages/google_secops/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.2.2"
   changes:
     - description: Downgrade the `format_version` to the minimum version that supports all the necessary features for the package.

--- a/packages/google_secops/changelog.yml
+++ b/packages/google_secops/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.2.3"
+- version: "1.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/google_secops/manifest.yml
+++ b/packages/google_secops/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: google_secops
 title: Google SecOps
-version: 1.2.3
+version: 1.3.0
 description: Collect alerts from Google SecOps with Elastic Agent.
 type: integration
 categories:

--- a/packages/google_secops/manifest.yml
+++ b/packages/google_secops/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: google_secops
 title: Google SecOps
-version: 1.2.2
+version: 1.2.3
 description: Collect alerts from Google SecOps with Elastic Agent.
 type: integration
 categories:
@@ -32,6 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.3.3"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "3.3.3"
+version: "3.4.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.
@@ -89,6 +89,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ibm_qradar/changelog.yml
+++ b/packages/ibm_qradar/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.1"
+- version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ibm_qradar/changelog.yml
+++ b/packages/ibm_qradar/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.0.0"
   changes:
     - description: Promote integration to GA.

--- a/packages/ibm_qradar/manifest.yml
+++ b/packages/ibm_qradar/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ibm_qradar
 title: IBM QRadar
-version: 1.0.1
+version: 1.1.0
 description: Collect logs from IBM QRadar with Elastic Agent.
 type: integration
 categories:

--- a/packages/ibm_qradar/manifest.yml
+++ b/packages/ibm_qradar/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ibm_qradar
 title: IBM QRadar
-version: 1.0.0
+version: 1.0.1
 description: Collect logs from IBM QRadar with Elastic Agent.
 type: integration
 categories:
@@ -31,6 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ironscales/changelog.yml
+++ b/packages/ironscales/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: 0.1.0
   changes:
     - description: Initial release.

--- a/packages/ironscales/changelog.yml
+++ b/packages/ironscales/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.1.1"
+- version: "0.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ironscales/manifest.yml
+++ b/packages/ironscales/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ironscales
 title: IRONSCALES
-version: 0.1.1
+version: 0.2.0
 description: Collect logs from IRONSCALES with Elastic Agent.
 type: integration
 categories:

--- a/packages/ironscales/manifest.yml
+++ b/packages/ironscales/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ironscales
 title: IRONSCALES
-version: 0.1.0
+version: 0.1.1
 description: Collect logs from IRONSCALES with Elastic Agent.
 type: integration
 categories:
@@ -30,6 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/island_browser/changelog.yml
+++ b/packages/island_browser/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.1"
+- version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/island_browser/changelog.yml
+++ b/packages/island_browser/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.0.0"
   changes:
     - description: Release package as GA.

--- a/packages/island_browser/manifest.yml
+++ b/packages/island_browser/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: island_browser
 title: Island Browser
-version: 1.0.0
+version: 1.0.1
 description: Collect logs from Island Browser with Elastic Agent.
 type: integration
 categories:
@@ -46,6 +46,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/island_browser/manifest.yml
+++ b/packages/island_browser/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: island_browser
 title: Island Browser
-version: 1.0.1
+version: 1.1.0
 description: Collect logs from Island Browser with Elastic Agent.
 type: integration
 categories:

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.20.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/jumpcloud/manifest.yml
+++ b/packages/jumpcloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: jumpcloud
 title: "JumpCloud"
-version: "1.20.0"
+version: "1.21.0"
 description: "Collect logs from JumpCloud Directory as a Service"
 type: integration
 categories:
@@ -31,6 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/jupiter_one/changelog.yml
+++ b/packages/jupiter_one/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.1"
+- version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/jupiter_one/changelog.yml
+++ b/packages/jupiter_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: 1.0.0
   changes:
     - description: Promote integration to GA.

--- a/packages/jupiter_one/manifest.yml
+++ b/packages/jupiter_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: jupiter_one
 title: JupiterOne
-version: 1.0.1
+version: 1.1.0
 description: Collect logs from JupiterOne with Elastic Agent.
 type: integration
 categories:

--- a/packages/jupiter_one/manifest.yml
+++ b/packages/jupiter_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: jupiter_one
 title: JupiterOne
-version: 1.0.0
+version: 1.0.1
 description: Collect logs from JupiterOne with Elastic Agent.
 type: integration
 categories:
@@ -34,6 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/lastpass/changelog.yml
+++ b/packages/lastpass/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.22.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/lastpass/manifest.yml
+++ b/packages/lastpass/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: lastpass
 title: LastPass
-version: "1.22.0"
+version: "1.23.0"
 description: Collect logs from LastPass with Elastic Agent.
 type: integration
 categories:
@@ -31,6 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "5.15.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "5.14.0"
   changes:
     - description: Switch vulnerability data stream from gzip export API (SoftwareVulnerabilitiesExport) to paginated delta API (SoftwareVulnerabilityChangesByMachine) to eliminate in-memory gzip decompression and reduce RSS usage. Add initial_interval variable, new EventTimestamp and Status fields. Remove SAS Valid Hours and Max Retries variables. Widen transform retention from 4h to 90d for incremental semantics. Bump transform version to trigger reinstall.

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: m365_defender
 title: Microsoft Defender XDR
-version: "5.14.0"
+version: "5.15.0"
 description: Collect logs from Microsoft Defender XDR with Elastic Agent.
 categories:
   - "security"
@@ -23,6 +23,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/microsoft_defender_cloud/changelog.yml
+++ b/packages/microsoft_defender_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.4.0"
   changes:
     - description: Add timestamp range filter and storage tier exclusion to latest transform source queries to reduce scan scope and improve performance.

--- a/packages/microsoft_defender_cloud/changelog.yml
+++ b/packages/microsoft_defender_cloud/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.4.1"
+- version: "3.5.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/microsoft_defender_cloud/manifest.yml
+++ b/packages/microsoft_defender_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: '3.3.2'
 name: microsoft_defender_cloud
 title: Microsoft Defender for Cloud
-version: '3.4.0'
+version: '3.4.1'
 description: Collect logs from Microsoft Defender for Cloud with Elastic Agent.
 type: integration
 categories:
@@ -33,6 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/microsoft_defender_cloud/manifest.yml
+++ b/packages/microsoft_defender_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: '3.3.2'
 name: microsoft_defender_cloud
 title: Microsoft Defender for Cloud
-version: '3.4.1'
+version: '3.5.0'
 description: Collect logs from Microsoft Defender for Cloud with Elastic Agent.
 type: integration
 categories:

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.8.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "4.7.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "4.7.1"
+version: "4.8.0"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - security
@@ -23,6 +23,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.1.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "2.1.1"
+version: "2.2.0"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:
@@ -30,6 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/microsoft_sentinel/changelog.yml
+++ b/packages/microsoft_sentinel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.3.2"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/microsoft_sentinel/manifest.yml
+++ b/packages/microsoft_sentinel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: microsoft_sentinel
 title: Microsoft Sentinel
-version: "1.3.2"
+version: "1.4.0"
 description: Collect logs from Microsoft Sentinel with Elastic Agent.
 type: integration
 categories:
@@ -40,6 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.3.3"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.3.2"
   changes:
     - description: Fix parsing of "logon-authentication-failed" & "user-logged-on" audit events.

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.3.3"
+- version: "3.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: mimecast
 title: "Mimecast"
-version: "3.3.2"
+version: "3.3.3"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]
@@ -27,6 +27,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: mimecast
 title: "Mimecast"
-version: "3.3.3"
+version: "3.4.0"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]

--- a/packages/mongodb_atlas/changelog.yml
+++ b/packages/mongodb_atlas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.2.2"
   changes:
     - description: Guard against null value for hostlist in disk, hardware, mongod_audit, mongod_database and process data streams.

--- a/packages/mongodb_atlas/manifest.yml
+++ b/packages/mongodb_atlas/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: mongodb_atlas
 title: "MongoDB Atlas"
-version: 1.2.2
+version: 1.3.0
 source:
   license: "Elastic-2.0"
 description: This Elastic integration collects logs and metrics from MongoDB Atlas instance.
@@ -66,6 +66,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations

--- a/packages/neon_cyber/changelog.yml
+++ b/packages/neon_cyber/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.1.1"
+- version: "0.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/neon_cyber/changelog.yml
+++ b/packages/neon_cyber/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.1.0"
   changes:
     - description: Initial version of the package.

--- a/packages/neon_cyber/manifest.yml
+++ b/packages/neon_cyber/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: neon_cyber
 title: 'Neon Cyber'
-version: 0.1.1
+version: 0.2.0
 source:
     license: 'Elastic-2.0'
 description: 'The Neon Cyber integration for the Elastic Stack'

--- a/packages/neon_cyber/manifest.yml
+++ b/packages/neon_cyber/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: neon_cyber
 title: 'Neon Cyber'
-version: 0.1.0
+version: 0.1.1
 source:
     license: 'Elastic-2.0'
 description: 'The Neon Cyber integration for the Elastic Stack'
@@ -33,6 +33,7 @@ policy_templates:
               enabled: true
           agentless:
               enabled: true
+              release: beta
               organization: security
               division: engineering
               team: security-service-integrations

--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.2.1"
   changes:
     - description: Downgrade the `format_version` to the minimum version that supports all the necessary features for the package.

--- a/packages/nozomi_networks/changelog.yml
+++ b/packages/nozomi_networks/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.2.2"
+- version: "0.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/nozomi_networks/manifest.yml
+++ b/packages/nozomi_networks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: nozomi_networks
 title: Nozomi Networks
-version: 0.2.1
+version: 0.2.2
 description: Collect logs from Nozomi Networks with Elastic Agent.
 type: integration
 categories:
@@ -59,6 +59,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/nozomi_networks/manifest.yml
+++ b/packages/nozomi_networks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: nozomi_networks
 title: Nozomi Networks
-version: 0.2.2
+version: 0.3.0
 description: Collect logs from Nozomi Networks with Elastic Agent.
 type: integration
 categories:

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.9.0"
   changes:
     - description: Remove unnecessary `event.original` duplication from CEL program and gate pipeline serialization on `preserve_original_event` tag to reduce agent memory usage and avoid wasteful serialization that Fleet's final pipeline discards.

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "3.9.0"
+version: "3.10.0"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"
@@ -41,6 +41,7 @@ policy_templates:
         enabled: true 
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/o365_metrics/changelog.yml
+++ b/packages/o365_metrics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.2.1"
   changes:
     - description: Guard against null value for call records in teams_call_quality response.

--- a/packages/o365_metrics/manifest.yml
+++ b/packages/o365_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: o365_metrics
 title: Microsoft Office 365 Metrics
-version: "1.2.1"
+version: "1.3.0"
 description: Collect metrics from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -61,6 +61,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.15.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.14.2"
   changes:
     - description: Reorganize variables, and make agentless the default deployment mode.

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -27,11 +27,8 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-<<<<<<< HEAD
-        is_default: true
-=======
         release: beta
->>>>>>> 6ccc603391 (Add new release field for integrations with agentless deployment modes in beta)
+        is_default: true
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "3.14.2"
+version: "3.15.0"
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
 format_version: "3.6.1"
@@ -27,7 +27,11 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+<<<<<<< HEAD
         is_default: true
+=======
+        release: beta
+>>>>>>> 6ccc603391 (Add new release field for integrations with agentless deployment modes in beta)
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/openai/changelog.yml
+++ b/packages/openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.0.0"
   changes:
     - description: Add audit data stream to fetch audit logs.

--- a/packages/openai/changelog.yml
+++ b/packages/openai/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.0.1"
+- version: "2.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/openai/manifest.yml
+++ b/packages/openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: openai
 title: OpenAI
-version: 2.0.1
+version: 2.1.0
 description: Collect OpenAI usage metrics and audit logs with Elastic Agent.
 type: integration
 categories:

--- a/packages/openai/manifest.yml
+++ b/packages/openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: openai
 title: OpenAI
-version: 2.0.0
+version: 2.0.1
 description: Collect OpenAI usage metrics and audit logs with Elastic Agent.
 type: integration
 categories:
@@ -52,6 +52,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.5.3"
+- version: "2.6.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.3"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.5.2"
   changes:
     - description: Fix alerts CEL pagination getting stuck when offset exceeds total_count, and align cursor and sort fields with filter field.

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,6 +1,6 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "2.5.3"
+version: "2.6.0"
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration
 format_version: "3.4.0"

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,6 +1,6 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "2.5.2"
+version: "2.5.3"
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration
 format_version: "3.4.0"
@@ -37,6 +37,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ping_one/changelog.yml
+++ b/packages/ping_one/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.23.1"
+- version: "1.24.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ping_one/changelog.yml
+++ b/packages/ping_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.23.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/ping_one/manifest.yml
+++ b/packages/ping_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: ping_one
 title: PingOne
-version: "1.23.1"
+version: "1.24.0"
 description: Collect logs from PingOne with Elastic-Agent.
 type: integration
 categories:

--- a/packages/ping_one/manifest.yml
+++ b/packages/ping_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: ping_one
 title: PingOne
-version: "1.23.0"
+version: "1.23.1"
 description: Collect logs from PingOne with Elastic-Agent.
 type: integration
 categories:
@@ -29,6 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.1.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "4.1.0"
   changes:
     - description: Add timestamp range filter and storage tier exclusion to latest transform source queries to reduce scan scope and improve performance.

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "4.1.1"
+- version: "4.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "4.1.0"
+version: "4.1.1"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:
@@ -57,6 +57,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "4.1.1"
+version: "4.2.0"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:

--- a/packages/proofpoint_essentials/changelog.yml
+++ b/packages/proofpoint_essentials/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.1"
+- version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/proofpoint_essentials/changelog.yml
+++ b/packages/proofpoint_essentials/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.0.0"
   changes:
     - description: Promote integration to GA.

--- a/packages/proofpoint_essentials/manifest.yml
+++ b/packages/proofpoint_essentials/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: proofpoint_essentials
 title: Proofpoint Essentials
-version: 1.0.0
+version: 1.0.1
 description: Collect logs from Proofpoint Essentials with Elastic Agent.
 type: integration
 categories:
@@ -34,6 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/proofpoint_essentials/manifest.yml
+++ b/packages/proofpoint_essentials/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: proofpoint_essentials
 title: Proofpoint Essentials
-version: 1.0.1
+version: 1.1.0
 description: Collect logs from Proofpoint Essentials with Elastic Agent.
 type: integration
 categories:

--- a/packages/proofpoint_itm/changelog.yml
+++ b/packages/proofpoint_itm/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.2"
+- version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/proofpoint_itm/changelog.yml
+++ b/packages/proofpoint_itm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.0.1"
   changes:
     - description: Downgrade the `format_version` to the minimum version that supports all the necessary features for the package.

--- a/packages/proofpoint_itm/manifest.yml
+++ b/packages/proofpoint_itm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: proofpoint_itm
 title: Proofpoint ITM
-version: "1.0.2"
+version: "1.1.0"
 description: Collect logs from Proofpoint ITM using Elastic Agent.
 type: integration
 categories:

--- a/packages/proofpoint_itm/manifest.yml
+++ b/packages/proofpoint_itm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: proofpoint_itm
 title: Proofpoint ITM
-version: "1.0.1"
+version: "1.0.2"
 description: Collect logs from Proofpoint ITM using Elastic Agent.
 type: integration
 categories:
@@ -30,6 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.30.0"
   changes:
     - description: Add note on excluding trailing slash from URL.

--- a/packages/proofpoint_tap/manifest.yml
+++ b/packages/proofpoint_tap/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: proofpoint_tap
 title: Proofpoint TAP
-version: "1.30.0"
+version: "1.31.0"
 description: Collect logs from Proofpoint TAP with Elastic Agent.
 type: integration
 categories:
@@ -29,6 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/qualys_gav/changelog.yml
+++ b/packages/qualys_gav/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.7.3"
+- version: "0.8.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/qualys_gav/changelog.yml
+++ b/packages/qualys_gav/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.3"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.7.2"
   changes:
     - description: Fix pagination failure when Qualys API returns an empty asset list with hasMore set.

--- a/packages/qualys_gav/manifest.yml
+++ b/packages/qualys_gav/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: qualys_gav
 title: Qualys Global AssetView
-version: 0.7.2
+version: 0.7.3
 description: Collect logs from Qualys Global AssetView with Elastic Agent.
 type: integration
 categories:
@@ -30,6 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/qualys_gav/manifest.yml
+++ b/packages/qualys_gav/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: qualys_gav
 title: Qualys Global AssetView
-version: 0.7.3
+version: 0.8.0
 description: Collect logs from Qualys Global AssetView with Elastic Agent.
 type: integration
 categories:

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.18.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "6.18.0"
   changes:
     - description: Add timestamp range filter and storage tier exclusion to latest transform source queries to reduce scan scope and improve performance.

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "6.18.1"
+- version: "6.19.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "6.18.1"
+version: "6.19.0"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "6.18.0"
+version: "6.18.1"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:
@@ -41,6 +41,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/qualys_was/changelog.yml
+++ b/packages/qualys_was/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.3.2"
+- version: "0.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/qualys_was/changelog.yml
+++ b/packages/qualys_was/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.2"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.3.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/qualys_was/manifest.yml
+++ b/packages/qualys_was/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_was
 title: Qualys Web Application Scanning (WAS)
-version: "0.3.1"
+version: "0.3.2"
 description: Collect data from Qualys Web Application Scanning platform with Elastic Agent or Agentless
 type: integration
 categories:
@@ -26,6 +26,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/qualys_was/manifest.yml
+++ b/packages/qualys_was/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: qualys_was
 title: Qualys Web Application Scanning (WAS)
-version: "0.3.2"
+version: "0.4.0"
 description: Collect data from Qualys Web Application Scanning platform with Elastic Agent or Agentless
 type: integration
 categories:

--- a/packages/rapid7_insightvm/changelog.yml
+++ b/packages/rapid7_insightvm/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.8.1"
+- version: "2.9.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/rapid7_insightvm/changelog.yml
+++ b/packages/rapid7_insightvm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.8.0"
   changes:
     - description: Add timestamp range filter and storage tier exclusion to latest transform source queries to reduce scan scope and improve performance.

--- a/packages/rapid7_insightvm/manifest.yml
+++ b/packages/rapid7_insightvm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: rapid7_insightvm
 title: Rapid7 InsightVM
-version: "2.8.0"
+version: "2.8.1"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Rapid7 InsightVM with Elastic Agent.
@@ -39,6 +39,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/rapid7_insightvm/manifest.yml
+++ b/packages/rapid7_insightvm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: rapid7_insightvm
 title: Rapid7 InsightVM
-version: "2.8.1"
+version: "2.9.0"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Rapid7 InsightVM with Elastic Agent.

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.7.1"
+- version: "2.8.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.7.0"
   changes:
     - description: Expose max_executions for the application data stream and persist worklist in cursor across restarts.

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: sentinel_one
 title: SentinelOne
-version: "2.7.1"
+version: "2.8.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: sentinel_one
 title: SentinelOne
-version: "2.7.0"
+version: "2.7.1"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:
@@ -61,6 +61,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.27.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.27.1"
+- version: "1.28.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: slack
 title: "Slack Logs"
-version: "1.27.0"
+version: "1.27.1"
 description: "Slack Logs Integration"
 type: integration
 categories:
@@ -24,6 +24,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: slack
 title: "Slack Logs"
-version: "1.27.1"
+version: "1.28.0"
 description: "Slack Logs Integration"
 type: integration
 categories:

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.4"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.4.3"
   changes:
     - description: Fix audit_logs event type filter being ignored due to state key mismatch.

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.4.4"
+- version: "3.5.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/snyk/manifest.yml
+++ b/packages/snyk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: snyk
 title: "Snyk"
-version: "3.4.3"
+version: "3.4.4"
 description: Collect logs from Snyk with Elastic Agent.
 type: integration
 categories:
@@ -26,6 +26,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/snyk/manifest.yml
+++ b/packages/snyk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: snyk
 title: "Snyk"
-version: "3.4.4"
+version: "3.5.0"
 description: Collect logs from Snyk with Elastic Agent.
 type: integration
 categories:

--- a/packages/splunk/changelog.yml
+++ b/packages/splunk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.0.2"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/splunk/manifest.yml
+++ b/packages/splunk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: splunk
 title: Splunk
-version: "1.0.2"
+version: "1.1.0"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Splunk with Elastic Agent.
@@ -33,6 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/sublime_security/changelog.yml
+++ b/packages/sublime_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.11.3"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/sublime_security/manifest.yml
+++ b/packages/sublime_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: sublime_security
 title: Sublime Security
-version: "1.11.3"
+version: "1.12.0"
 description: Collect logs from Sublime Security with Elastic Agent.
 type: integration
 categories:
@@ -44,6 +44,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "4.10.1"
+- version: "4.11.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.10.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "4.10.0"
   changes:
     - description: Add timestamp range filter and storage tier exclusion to latest transform source queries to reduce scan scope and improve performance.

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "4.10.0"
+version: "4.10.1"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:
@@ -31,6 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "4.10.1"
+version: "4.11.0"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:

--- a/packages/tenable_sc/changelog.yml
+++ b/packages/tenable_sc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.2.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/tenable_sc/manifest.yml
+++ b/packages/tenable_sc/manifest.yml
@@ -2,7 +2,7 @@ format_version: "3.3.2"
 name: tenable_sc
 title: Tenable Security Center
 # The version must be updated in the input configuration templates as well, in order to set the correct User-Agent header. Until elastic/kibana#121310 is implemented we will have to manually sync these.
-version: "2.2.1"
+version: "2.3.0"
 description: |
   Collect data from Tenable Security Center with Elastic Agent.
 type: integration
@@ -31,6 +31,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.0.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "4.0.0"
   changes:
     - description: Switch URL data stream from full export ZIP to incremental `/v1/urls/recent/` API and add user-configurable `ioc_expiration_duration` setting (default 90d).

--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "4.0.1"
+- version: "4.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: abuse.ch
-version: "4.0.0"
+version: "4.0.1"
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration
 format_version: "3.3.2"
@@ -45,6 +45,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: abuse.ch
-version: "4.0.1"
+version: "4.1.0"
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration
 format_version: "3.3.2"

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.7.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.7.1"
+- version: "2.8.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali ThreatStream
-version: "2.7.0"
+version: "2.7.1"
 description: Ingest threat intelligence indicators from Anomali ThreatStream with Elastic Agent.
 type: integration
 format_version: 3.3.2
@@ -45,6 +45,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali ThreatStream
-version: "2.7.1"
+version: "2.8.0"
 description: Ingest threat intelligence indicators from Anomali ThreatStream with Elastic Agent.
 type: integration
 format_version: 3.3.2

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.8.1"
+- version: "2.9.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.8.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "2.8.0"
+version: "2.8.1"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:
@@ -35,6 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "2.8.1"
+version: "2.9.0"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_cyware_intel_exchange/changelog.yml
+++ b/packages/ti_cyware_intel_exchange/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.3.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_cyware_intel_exchange/changelog.yml
+++ b/packages/ti_cyware_intel_exchange/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.3.1"
+- version: "0.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ti_cyware_intel_exchange/manifest.yml
+++ b/packages/ti_cyware_intel_exchange/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_cyware_intel_exchange
 title: Cyware Intel Exchange
-version: 0.3.1
+version: 0.4.0
 description: Collect logs from Cyware Intel Exchange with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]

--- a/packages/ti_cyware_intel_exchange/manifest.yml
+++ b/packages/ti_cyware_intel_exchange/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_cyware_intel_exchange
 title: Cyware Intel Exchange
-version: 0.3.0
+version: 0.3.1
 description: Collect logs from Cyware Intel Exchange with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]
@@ -29,6 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_flashpoint/changelog.yml
+++ b/packages/ti_flashpoint/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.2.1"
+- version: "0.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ti_flashpoint/changelog.yml
+++ b/packages/ti_flashpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.2.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_flashpoint/manifest.yml
+++ b/packages/ti_flashpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_flashpoint
 title: Flashpoint
-version: 0.2.0
+version: 0.2.1
 description: Collect logs from Flashpoint with Elastic Agent.
 type: integration
 categories:
@@ -39,6 +39,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_flashpoint/manifest.yml
+++ b/packages/ti_flashpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_flashpoint
 title: Flashpoint
-version: 0.2.1
+version: 0.3.0
 description: Collect logs from Flashpoint with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,4 +1,9 @@
-# later versions go on top
+# newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.10.1"
   changes:
     - description: Make security rules discoverable in the Add Elastic rules UI.

--- a/packages/ti_google_threat_intelligence/manifest.yml
+++ b/packages/ti_google_threat_intelligence/manifest.yml
@@ -3,7 +3,7 @@ name: ti_google_threat_intelligence
 title: Google Threat Intelligence
 # This version must match the User-Agent version used in CEL code.
 # Remember to update the User-Agent in CEL code when changing this version.
-version: "0.10.1"
+version: "0.11.0"
 description: Collect Threat Intelligence Events from Google Threat Intelligence using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:
@@ -49,6 +49,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_greynoise/changelog.yml
+++ b/packages/ti_greynoise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.8.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/ti_greynoise/manifest.yml
+++ b/packages/ti_greynoise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_greynoise
 title: GreyNoise
-version: "0.8.1"
+version: "0.9.0"
 description: Collect Threat Intelligence Indicators from GreyNoise using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:
@@ -37,6 +37,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.9.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.9.1"
+- version: "2.10.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
-version: "2.9.0"
+version: "2.9.1"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories:
@@ -50,6 +50,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
-version: "2.9.1"
+version: "2.10.0"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_recordedfuture/changelog.yml
+++ b/packages/ti_recordedfuture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.5.2"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "2.5.2"
+version: "2.6.0"
 description: Ingest threat intelligence and alert data from Recorded Future with Elastic Agent.
 type: integration
 format_version: 3.3.2
@@ -45,6 +45,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_socradar_taxii/changelog.yml
+++ b/packages/ti_socradar_taxii/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.2.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/ti_socradar_taxii/manifest.yml
+++ b/packages/ti_socradar_taxii/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ti_socradar_taxii
 title: SOCRadar Threat Intelligence (TAXII)
-version: "0.1.0"
+version: "0.2.0"
 description: Ingest threat intelligence indicators from SOCRadar's TAXII 2.1 server in STIX 2.1 format with Elastic Agent.
 type: integration
 categories:
@@ -26,6 +26,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.38.1"
+- version: "1.39.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.38.1"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "1.38.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.38.1"
+version: "1.39.0"
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
 format_version: "3.3.1"

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.38.0"
+version: "1.38.1"
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
 format_version: "3.3.1"
@@ -37,6 +37,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/trend_micro_vision_one/changelog.yml
+++ b/packages/trend_micro_vision_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.13.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "2.12.1"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/trend_micro_vision_one/manifest.yml
+++ b/packages/trend_micro_vision_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: trend_micro_vision_one
 title: TrendAI Vision One
-version: "2.12.1"
+version: "2.13.0"
 description: Collect logs from TrendAI Vision One with Elastic Agent.
 type: integration
 categories:
@@ -53,6 +53,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/vectra_rux/changelog.yml
+++ b/packages/vectra_rux/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.3.4"
+- version: "0.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/vectra_rux/changelog.yml
+++ b/packages/vectra_rux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.4"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.3.3"
   changes:
     - description: Downgrade the `format_version` to the minimum version that supports all the necessary features for the package.

--- a/packages/vectra_rux/manifest.yml
+++ b/packages/vectra_rux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: vectra_rux
 title: "Vectra RUX"
-version: 0.3.3
+version: 0.3.4
 description: "Collect logs from Vectra RUX with Elastic Agent."
 type: integration
 categories:
@@ -49,6 +49,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/vectra_rux/manifest.yml
+++ b/packages/vectra_rux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: vectra_rux
 title: "Vectra RUX"
-version: 0.3.4
+version: 0.4.0
 description: "Collect logs from Vectra RUX with Elastic Agent."
 type: integration
 categories:

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.2"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "0.0.1"
   changes:
     - description: >-

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.0.2"
+- version: "0.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: verifier_otel
 title: "Permission Verifier"
-version: 0.0.1
+version: 0.0.2
 source:
   license: "Elastic-2.0"
 description: "Verify identity federation based integration permissions and report results to Elasticsearch using the Verifier receiver of the OTel Collector."
@@ -33,6 +33,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: cloud-services

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: verifier_otel
 title: "Permission Verifier"
-version: 0.0.2
+version: 0.1.0
 source:
   license: "Elastic-2.0"
 description: "Verify identity federation based integration permissions and report results to Elasticsearch using the Verifier receiver of the OTel Collector."

--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.4.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "4.3.0"
   changes:
     - description: |

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: wiz
 title: Wiz
-version: "4.3.0"
+version: "4.4.0"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:
@@ -65,6 +65,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.20.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18552
 - version: "3.19.0"
   changes:
     - description: Add support for SaaS Security data stream.

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -4,7 +4,7 @@ title: Zscaler Internet Access
 # When updating version, make sure the pkg_version parameter in
 # the check_template_version script in ingest pipelines is
 # updated to match.
-version: "3.19.0"
+version: "3.20.0"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:
@@ -74,6 +74,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations


### PR DESCRIPTION
## Summary 

- Adds the new `release` field for agentless deployments to explicitly declare maturity (beta | ga)
    - All current agentless deployments are updated with a `release` of `beta`, unless agentless is the only deployment mode and policy template in a package. In that case, maturity defers to package semver.
    - exception is for CSPM and elastic connectors which are already GA.
- package-spec support in: https://github.com/elastic/package-spec/issues/1098

These changes will have a 2-week TTL for package owners to review and confirm `release` value.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Adds the new `release` field for agentless deployments to explicitly declare maturity (beta | ga)

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes: https://github.com/elastic/integrations/issues/18294
- Requires: https://github.com/elastic/package-spec/issues/1098

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
