### PR TITLE
[Beyondtrust PRA] Change session_owner type from keyword to boolean and Update documentation

### DIFF
--- a/packages/beyondtrust_pra/_dev/build/docs/README.md
+++ b/packages/beyondtrust_pra/_dev/build/docs/README.md
@@ -24,7 +24,7 @@ Agentless deployments are only supported in Elastic Serverless and Elastic Cloud
 
 Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).
 You can install only one Elastic Agent per host.
-Elastic Agent is required to stream data from the GCP Pub/Sub or REST API and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
+Elastic Agent is required to stream data from the REST API and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
 
 ## Setup
 

--- a/packages/beyondtrust_pra/changelog.yml
+++ b/packages/beyondtrust_pra/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Change session_owner type from keyword to boolean.
       type: breaking-change
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18565
     - description: Remove gcp from documentation.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18565
 - version: "0.3.3"
   changes:
     - description: Improve custom_attribute handling and correctly parse IP addresses that include ports.

--- a/packages/beyondtrust_pra/changelog.yml
+++ b/packages/beyondtrust_pra/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Change session_owner type from keyword to boolean.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/1
+    - description: Remove gcp from documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.3"
   changes:
     - description: Improve custom_attribute handling and correctly parse IP addresses that include ports.

--- a/packages/beyondtrust_pra/data_stream/access_session/_dev/test/pipeline/test-event.log-expected.json
+++ b/packages/beyondtrust_pra/data_stream/access_session/_dev/test/pipeline/test-event.log-expected.json
@@ -27,7 +27,7 @@
                         "private_ip": "1.128.0.0",
                         "public_ip": "81.2.69.142",
                         "seconds_involved": 3600,
-                        "session_owner": "1",
+                        "session_owner": true,
                         "type": "representative",
                         "username": "admin_user"
                     },
@@ -57,7 +57,7 @@
                         "private_ip": "1.128.0.1",
                         "public_ip": "216.160.83.56",
                         "seconds_involved": 3600,
-                        "session_owner": "1",
+                        "session_owner": true,
                         "type": "representative",
                         "username": "admin_user"
                     },
@@ -303,7 +303,7 @@
                         "public_ip": "81.2.69.142",
                         "public_port": 100,
                         "seconds_involved": 3600,
-                        "session_owner": "1",
+                        "session_owner": true,
                         "type": "representative",
                         "username": "admin_user"
                     },
@@ -335,7 +335,7 @@
                         "public_ip": "216.160.83.56",
                         "public_port": 100,
                         "seconds_involved": 3600,
-                        "session_owner": "1",
+                        "session_owner": true,
                         "type": "representative",
                         "username": "admin_user"
                     },

--- a/packages/beyondtrust_pra/data_stream/access_session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/beyondtrust_pra/data_stream/access_session/elasticsearch/ingest_pipeline/default.yml
@@ -229,12 +229,16 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - convert:
-      field: json.destination.session_owner
-      tag: convert_destination_session_owner_to_string
-      target_field: beyondtrust_pra.access_session.destination.session_owner
-      type: string
-      ignore_missing: true
+  - set:
+      field: beyondtrust_pra.access_session.destination.session_owner
+      tag: set_destination_session_owner_true
+      value: true
+      if: ctx.json?.destination?.session_owner == 1
+  - set:
+      field: beyondtrust_pra.access_session.destination.session_owner
+      tag: set_destination_session_owner_false
+      value: false
+      if: ctx.json?.destination?.session_owner == 0
   - rename:
       field: json.destination.type
       tag: rename_destination_type
@@ -672,12 +676,16 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - convert:
-      field: json.performed_by.session_owner
-      tag: convert_performed_by_session_owner_to_string
-      target_field: beyondtrust_pra.access_session.performed_by.session_owner
-      type: string
-      ignore_missing: true
+  - set:
+      field: beyondtrust_pra.access_session.performed_by.session_owner
+      tag: set_performed_by_session_owner_true
+      value: true
+      if: ctx.json?.performed_by?.session_owner == 1
+  - set:
+      field: beyondtrust_pra.access_session.performed_by.session_owner
+      tag: set_performed_by_session_owner_false
+      value: false
+      if: ctx.json?.performed_by?.session_owner == 0
   - rename:
       field: json.performed_by.type
       tag: rename_performed_by_type

--- a/packages/beyondtrust_pra/data_stream/access_session/fields/fields.yml
+++ b/packages/beyondtrust_pra/data_stream/access_session/fields/fields.yml
@@ -56,8 +56,8 @@
               type: long
               description: Integer value indicating the number of seconds the user was involved in this session.
             - name: session_owner
-              type: keyword
-              description: Integer value (1 or 0) indicating whether the user was the owner of the session or was merely a conference member.
+              type: boolean
+              description: Boolean value indicating whether the user was the owner of the session or was merely a conference member.
             - name: type
               type: keyword
               description: Indicating whether this action was directed to the system, a customer, or a user.
@@ -125,8 +125,8 @@
               type: long
               description: Integer value indicating the number of seconds the user was involved in this session.
             - name: session_owner
-              type: keyword
-              description: Integer value (1 or 0) indicating whether the user was the owner of the session or was merely a conference member.
+              type: boolean
+              description: Boolean value indicating whether the user was the owner of the session or was merely a conference member.
             - name: type
               type: keyword
               description: Indicates whether this action was performed by the system, a endpoint, or a representative.

--- a/packages/beyondtrust_pra/data_stream/access_session/sample_event.json
+++ b/packages/beyondtrust_pra/data_stream/access_session/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2024-04-04T13:30:00.000Z",
     "agent": {
-        "ephemeral_id": "a11d10e2-15f6-4fe2-b096-28ed0b870085",
-        "id": "3728b9dc-4bc5-4b86-973b-9a2e303a863a",
-        "name": "elastic-agent-24720",
+        "ephemeral_id": "efa67a44-cb94-45ec-ae65-e5aa04cfaeed",
+        "id": "6d3a1abe-7f1c-4196-8c8f-57ba4f0b94e1",
+        "name": "elastic-agent-11622",
         "type": "filebeat",
-        "version": "8.17.0"
+        "version": "8.18.0"
     },
     "beyondtrust_pra": {
         "access_session": {
@@ -41,7 +41,7 @@
                 "private_ip": "1.128.0.2",
                 "public_ip": "175.16.199.0",
                 "seconds_involved": 3600,
-                "session_owner": "1",
+                "session_owner": true,
                 "type": "representative",
                 "username": "admin_user"
             },
@@ -157,7 +157,7 @@
     },
     "data_stream": {
         "dataset": "beyondtrust_pra.access_session",
-        "namespace": "12228",
+        "namespace": "99596",
         "type": "logs"
     },
     "destination": {
@@ -186,9 +186,9 @@
         "version": "8.17.0"
     },
     "elastic_agent": {
-        "id": "3728b9dc-4bc5-4b86-973b-9a2e303a863a",
+        "id": "6d3a1abe-7f1c-4196-8c8f-57ba4f0b94e1",
         "snapshot": false,
-        "version": "8.17.0"
+        "version": "8.18.0"
     },
     "event": {
         "action": "session-start",
@@ -197,7 +197,7 @@
             "session"
         ],
         "dataset": "beyondtrust_pra.access_session",
-        "ingested": "2025-04-15T07:58:33Z",
+        "ingested": "2026-04-21T11:59:30Z",
         "kind": "event",
         "original": "{\"body\":\"Session started by Admin\",\"destination\":{\"gsnumber\":\"C12345\",\"hostname\":\"remote-host\",\"os\":\"Windows 10\",\"private_ip\":\"1.128.0.1\",\"public_ip\":\"81.2.69.192\",\"type\":\"customer\",\"username\":\"remote_user\"},\"encoded_body\":\"U2Vzc2lvbiBzdGFydGVkIGJ5IEFkbWlu\",\"event_type\":\"Session Start\",\"filename\":\"logfile.txt\",\"files\":{\"file\":[{\"filename\":\"logfile.txt\",\"filesize\":\"1024\"}]},\"filesize\":1024,\"performed_by\":{\"display_name\":\"Admin\",\"gsnumber\":\"R56789\",\"hostname\":\"admin-host\",\"id\":\"112233\",\"invited\":1,\"os\":\"Windows 11\",\"private_ip\":\"1.128.0.2\",\"public_ip\":\"175.16.199.0\",\"seconds_involved\":3600,\"session_owner\":1,\"type\":\"representative\",\"username\":\"admin_user\"},\"session\":{\"command_shell_recordings\":{\"command_shell_recording\":[{\"download_url\":\"https://example.com/shell_download/12345\",\"instance\":\"0\",\"view_url\":\"https://example.com/shell_view/12345\"}]},\"custom_attributes\":{\"custom_attribute\":[{\"#text\":\"High\",\"code_name\":\"priority\",\"display_name\":\"priority\"},{\"#text\":\"High\",\"code_name\":\"priority\",\"display_name\":\"priority\"}]},\"duration\":\"01:00:00\",\"end_time\":{\"#text\":\"2024-04-04T14:00:00Z\",\"timestamp\":\"1712239200\"},\"file_delete_count\":0,\"file_move_count\":1,\"file_transfer_count\":3,\"jump_group\":{\"#text\":\"Support Team\",\"id\":\"56789\",\"type\":\"shared\"},\"jumpoint\":{\"#text\":\"Main Jumpoint\",\"id\":\"98765\"},\"lseq\":\"12345\",\"primary_customer\":{\"#text\":\"Remote PC\",\"gsnumber\":\"C12345\"},\"primary_rep\":{\"#text\":\"John Doe\",\"gsnumber\":\"R56789\",\"id\":\"112233\"},\"session_chat_download_url\":\"https://example.com/chat_download/12345\",\"session_chat_view_url\":\"https://example.com/chat_view/12345\",\"session_recording_download_url\":\"https://example.com/recording_download/12345\",\"session_recording_view_url\":\"https://example.com/recording_view/12345\",\"session_type\":\"support2\",\"start_time\":{\"#text\":\"2024-04-04T13:00:00Z\",\"timestamp\":\"1712235600\"}},\"system_information\":{\"category\":[{\"data\":{\"row\":[{\"field\":[{\"#text\":\"remote-host1\",\"name\":\"hostname\"},{\"#text\":\"h1234\",\"name\":\"hostname\"}]},{\"field\":[{\"#text\":\"remote-host2\",\"name\":\"hostname\"},{\"#text\":\"h5647\",\"name\":\"hostname\"}]}]},\"description\":{\"field\":[{\"#text\":\"Hostname\",\"name\":\"hostname\"},{\"#text\":\"Hostid\",\"name\":\"hostid\"}]},\"name\":\"OS Information\"}]},\"timestamp\":\"2024-04-04T13:30:00Z\"}",
         "type": [

--- a/packages/beyondtrust_pra/docs/README.md
+++ b/packages/beyondtrust_pra/docs/README.md
@@ -24,7 +24,7 @@ Agentless deployments are only supported in Elastic Serverless and Elastic Cloud
 
 Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](docs-content://reference/fleet/install-elastic-agents.md).
 You can install only one Elastic Agent per host.
-Elastic Agent is required to stream data from the GCP Pub/Sub or REST API and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
+Elastic Agent is required to stream data from the REST API and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
 
 ## Setup
 
@@ -77,7 +77,7 @@ This is the `Access Session` dataset.
 | beyondtrust_pra.access_session.destination.public_ip | The user's public IP address. | ip |
 | beyondtrust_pra.access_session.destination.public_port | The user's public port. | long |
 | beyondtrust_pra.access_session.destination.seconds_involved | Integer value indicating the number of seconds the user was involved in this session. | long |
-| beyondtrust_pra.access_session.destination.session_owner | Integer value (1 or 0) indicating whether the user was the owner of the session or was merely a conference member. | keyword |
+| beyondtrust_pra.access_session.destination.session_owner | Boolean value indicating whether the user was the owner of the session or was merely a conference member. | boolean |
 | beyondtrust_pra.access_session.destination.type | Indicating whether this action was directed to the system, a customer, or a user. | keyword |
 | beyondtrust_pra.access_session.destination.username | The username assigned to the user. | keyword |
 | beyondtrust_pra.access_session.encoded_body | Contains the base64 (RFC 2045 section 6.8) encoded value of what would have been shown in the \<body\> element, and is shown ONLY if the \<body\> text contains characters that are invalid according to XML specification. . | keyword |
@@ -97,7 +97,7 @@ This is the `Access Session` dataset.
 | beyondtrust_pra.access_session.performed_by.public_ip | The user's public IP address. | ip |
 | beyondtrust_pra.access_session.performed_by.public_port | The user's public port. | long |
 | beyondtrust_pra.access_session.performed_by.seconds_involved | Integer value indicating the number of seconds the user was involved in this session. | long |
-| beyondtrust_pra.access_session.performed_by.session_owner | Integer value (1 or 0) indicating whether the user was the owner of the session or was merely a conference member. | keyword |
+| beyondtrust_pra.access_session.performed_by.session_owner | Boolean value indicating whether the user was the owner of the session or was merely a conference member. | boolean |
 | beyondtrust_pra.access_session.performed_by.type | Indicates whether this action was performed by the system, a endpoint, or a representative. | keyword |
 | beyondtrust_pra.access_session.performed_by.username | The username assigned to the user. | keyword |
 | beyondtrust_pra.access_session.session.command_shell_recordings.command_shell_recording.download_url | The URL at which the video of the command shell session may be downloaded. | keyword |
@@ -151,11 +151,11 @@ An example event for `access_session` looks as following:
 {
     "@timestamp": "2024-04-04T13:30:00.000Z",
     "agent": {
-        "ephemeral_id": "a11d10e2-15f6-4fe2-b096-28ed0b870085",
-        "id": "3728b9dc-4bc5-4b86-973b-9a2e303a863a",
-        "name": "elastic-agent-24720",
+        "ephemeral_id": "efa67a44-cb94-45ec-ae65-e5aa04cfaeed",
+        "id": "6d3a1abe-7f1c-4196-8c8f-57ba4f0b94e1",
+        "name": "elastic-agent-11622",
         "type": "filebeat",
-        "version": "8.17.0"
+        "version": "8.18.0"
     },
     "beyondtrust_pra": {
         "access_session": {
@@ -191,7 +191,7 @@ An example event for `access_session` looks as following:
                 "private_ip": "1.128.0.2",
                 "public_ip": "175.16.199.0",
                 "seconds_involved": 3600,
-                "session_owner": "1",
+                "session_owner": true,
                 "type": "representative",
                 "username": "admin_user"
             },
@@ -307,7 +307,7 @@ An example event for `access_session` looks as following:
     },
     "data_stream": {
         "dataset": "beyondtrust_pra.access_session",
-        "namespace": "12228",
+        "namespace": "99596",
         "type": "logs"
     },
     "destination": {
@@ -336,9 +336,9 @@ An example event for `access_session` looks as following:
         "version": "8.17.0"
     },
     "elastic_agent": {
-        "id": "3728b9dc-4bc5-4b86-973b-9a2e303a863a",
+        "id": "6d3a1abe-7f1c-4196-8c8f-57ba4f0b94e1",
         "snapshot": false,
-        "version": "8.17.0"
+        "version": "8.18.0"
     },
     "event": {
         "action": "session-start",
@@ -347,7 +347,7 @@ An example event for `access_session` looks as following:
             "session"
         ],
         "dataset": "beyondtrust_pra.access_session",
-        "ingested": "2025-04-15T07:58:33Z",
+        "ingested": "2026-04-21T11:59:30Z",
         "kind": "event",
         "original": "{\"body\":\"Session started by Admin\",\"destination\":{\"gsnumber\":\"C12345\",\"hostname\":\"remote-host\",\"os\":\"Windows 10\",\"private_ip\":\"1.128.0.1\",\"public_ip\":\"81.2.69.192\",\"type\":\"customer\",\"username\":\"remote_user\"},\"encoded_body\":\"U2Vzc2lvbiBzdGFydGVkIGJ5IEFkbWlu\",\"event_type\":\"Session Start\",\"filename\":\"logfile.txt\",\"files\":{\"file\":[{\"filename\":\"logfile.txt\",\"filesize\":\"1024\"}]},\"filesize\":1024,\"performed_by\":{\"display_name\":\"Admin\",\"gsnumber\":\"R56789\",\"hostname\":\"admin-host\",\"id\":\"112233\",\"invited\":1,\"os\":\"Windows 11\",\"private_ip\":\"1.128.0.2\",\"public_ip\":\"175.16.199.0\",\"seconds_involved\":3600,\"session_owner\":1,\"type\":\"representative\",\"username\":\"admin_user\"},\"session\":{\"command_shell_recordings\":{\"command_shell_recording\":[{\"download_url\":\"https://example.com/shell_download/12345\",\"instance\":\"0\",\"view_url\":\"https://example.com/shell_view/12345\"}]},\"custom_attributes\":{\"custom_attribute\":[{\"#text\":\"High\",\"code_name\":\"priority\",\"display_name\":\"priority\"},{\"#text\":\"High\",\"code_name\":\"priority\",\"display_name\":\"priority\"}]},\"duration\":\"01:00:00\",\"end_time\":{\"#text\":\"2024-04-04T14:00:00Z\",\"timestamp\":\"1712239200\"},\"file_delete_count\":0,\"file_move_count\":1,\"file_transfer_count\":3,\"jump_group\":{\"#text\":\"Support Team\",\"id\":\"56789\",\"type\":\"shared\"},\"jumpoint\":{\"#text\":\"Main Jumpoint\",\"id\":\"98765\"},\"lseq\":\"12345\",\"primary_customer\":{\"#text\":\"Remote PC\",\"gsnumber\":\"C12345\"},\"primary_rep\":{\"#text\":\"John Doe\",\"gsnumber\":\"R56789\",\"id\":\"112233\"},\"session_chat_download_url\":\"https://example.com/chat_download/12345\",\"session_chat_view_url\":\"https://example.com/chat_view/12345\",\"session_recording_download_url\":\"https://example.com/recording_download/12345\",\"session_recording_view_url\":\"https://example.com/recording_view/12345\",\"session_type\":\"support2\",\"start_time\":{\"#text\":\"2024-04-04T13:00:00Z\",\"timestamp\":\"1712235600\"}},\"system_information\":{\"category\":[{\"data\":{\"row\":[{\"field\":[{\"#text\":\"remote-host1\",\"name\":\"hostname\"},{\"#text\":\"h1234\",\"name\":\"hostname\"}]},{\"field\":[{\"#text\":\"remote-host2\",\"name\":\"hostname\"},{\"#text\":\"h5647\",\"name\":\"hostname\"}]}]},\"description\":{\"field\":[{\"#text\":\"Hostname\",\"name\":\"hostname\"},{\"#text\":\"Hostid\",\"name\":\"hostid\"}]},\"name\":\"OS Information\"}]},\"timestamp\":\"2024-04-04T13:30:00Z\"}",
         "type": [

--- a/packages/beyondtrust_pra/manifest.yml
+++ b/packages/beyondtrust_pra/manifest.yml
@@ -1,6 +1,6 @@
 name: beyondtrust_pra
 title: "BeyondTrust PRA"
-version: 0.3.3
+version: 0.4.0
 description: "Collect logs from BeyondTrust PRA with Elastic Agent."
 type: integration
 format_version: 3.3.2


### PR DESCRIPTION
## Proposed commit message

```
beyondtrust_pra: change session_owner type from keyword to boolean

It was incorrectly mapped as keyword.

Also, remove GCP from the documentation, this integration uses CEL-only.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/beyondtrust_pra directory.
- Run the following command to run tests.
> elastic-package test

## Related issues

- Closes #18677
