### PR TITLE
fix: clear user-facing typo families in docs + packages

### DIFF
--- a/docs/extend/add-data-stream.md
+++ b/docs/extend/add-data-stream.md
@@ -28,7 +28,7 @@ See [data streams](docs-content://reference/fleet/data-streams.md) for more info
 
 ## How to add a data stream [how-to]
 
-1. Boostrap a new data stream
+1. Bootstrap a new data stream
 
 In your package directory, run:
 

--- a/docs/extend/add-mapping.md
+++ b/docs/extend/add-mapping.md
@@ -57,7 +57,7 @@ You can rely on the [ecs@mappings](https://github.com/elastic/elasticsearch/blob
 * If your integration supports older versions (<8.13.0):
 You can import ECS mappings dynamically by setting `import_mappings: true` in the ECS section of the `_dev/build/build.yml` file in the root of the package directory. This introduces a [dynamic mapping](https://github.com/elastic/elastic-package/blob/f439b96a74c27c5adfc3e7810ad584204bfaf85d/internal/builder/_static/ecs_mappings.yaml) with most of the ECS definitions. Using this method means that, just like the previous approach, ECS fields don’t need to be defined in your integration, they are dynamically integrated into the package at build time. Explicitly defined ECS fields can be used and will also overwrite this mechanism.
 
-    An example of the aformentioned `build.yml` file for this method:
+    An example of the aforementioned `build.yml` file for this method:
 
     ```yaml
     dependencies:

--- a/docs/extend/dashboard-guidelines.md
+++ b/docs/extend/dashboard-guidelines.md
@@ -91,7 +91,7 @@ Kibana dashboards offer the possibility to apply margins between visualizations,
 
 ## Visualization Best Practices [_visualization_best_practices]
 
-Following are recommended best practices for designing Kibana vizualizations.
+Following are recommended best practices for designing Kibana visualizations.
 
 
 ### Lens vs TSVB visualizations [_lens_vs_tsvb_visualizations]

--- a/docs/extend/developer-workflow-import-beat.md
+++ b/docs/extend/developer-workflow-import-beat.md
@@ -155,7 +155,7 @@ The order of action items on the checklist is advised to prevent the contributor
     * **title** - human readable variable name
     * **description** - variable description (may contain some details)
     * **type** - field type (according to the reference: text, password, bool, integer)
-    * **multi** - the field has mutliple values.
+    * **multi** - the field has multiple values.
 
 10. Review stream configuration.
 

--- a/docs/extend/general-guidelines.md
+++ b/docs/extend/general-guidelines.md
@@ -59,7 +59,7 @@ As part of the field definition, there are two settings that add metadata which 
 
 The Elasticsearch documentation details the [expected values for these two fields](elasticsearch://reference/elasticsearch/mapping-reference/mapping-field-meta.md).
 
-Other applications, including Kibana, can use the information provided by this metadata when accessing these fields. The `unit` is used when formatting the values of the field, and the `metric_type` can be used to provide better defaults when quering the data.
+Other applications, including Kibana, can use the information provided by this metadata when accessing these fields. The `unit` is used when formatting the values of the field, and the `metric_type` can be used to provide better defaults when querying the data.
 
 
 ### Specify dimensions [_specify_dimensions]
@@ -72,7 +72,7 @@ A field can be configured as a dimension by setting `dimension: true` in its def
 
 Only fields of certain data types can be defined as dimensions. These data types include keywords, IPs and numeric types.
 
-Some guidelines to take into account when chosing dimensions:
+Some guidelines to take into account when choosing dimensions:
 
 * They can affect ingestion performance, it is recommended to have as few dimensions as possible. When selecting dimensions, try to avoid redundant ones, such as unique identifiers and names that refer to the same object.
 * Also be careful with having too few dimensions. There can be only one document with the same timestamp for a given set of dimensions. This can lead to data loss if different objects produce the same dimensions.

--- a/packages/m365_defender/data_stream/event/fields/fields.yml
+++ b/packages/m365_defender/data_stream/event/fields/fields.yml
@@ -21,7 +21,7 @@
           description: City where the account user is located.
         - name: cloud_sid
           type: keyword
-          description: The Microsoft Entra security identifer for the account.
+          description: The Microsoft Entra security identifier for the account.
         - name: company_name
           type: keyword
           description: The company to which the account belongs.

--- a/packages/m365_defender/docs/README.md
+++ b/packages/m365_defender/docs/README.md
@@ -605,7 +605,7 @@ This is the `event` dataset.
 | m365_defender.event.account.assigned_roles | The Microsoft Entra roles assigned to the account. | keyword |
 | m365_defender.event.account.blast_radius | The potential impact of the user account in the org. | keyword |
 | m365_defender.event.account.city | City where the account user is located. | keyword |
-| m365_defender.event.account.cloud_sid | The Microsoft Entra security identifer for the account. | keyword |
+| m365_defender.event.account.cloud_sid | The Microsoft Entra security identifier for the account. | keyword |
 | m365_defender.event.account.company_name | The company to which the account belongs. | keyword |
 | m365_defender.event.account.country | Country/Region where the account user is located. | keyword |
 | m365_defender.event.account.created | Date and time when the account user was created. | date |

--- a/packages/sonicwall_firewall/data_stream/log/fields/package-fields.yml
+++ b/packages/sonicwall_firewall/data_stream/log/fields/package-fields.yml
@@ -27,7 +27,7 @@
       description: CFS blocking code.
     - name: dpi
       type: boolean
-      description: Indicates wether a flow underwent Deep Packet Inspection.
+      description: Indicates whether a flow underwent Deep Packet Inspection.
     - name: event_group_category
       type: keyword
       description: Event group category.

--- a/packages/sonicwall_firewall/docs/README.md
+++ b/packages/sonicwall_firewall/docs/README.md
@@ -382,7 +382,7 @@ The `log` data stream provides events from SonicWall Firewall devices of the fol
 | sonicwall.firewall.appid | Application ID. | keyword |
 | sonicwall.firewall.auditId |  | keyword |
 | sonicwall.firewall.code | CFS blocking code. | keyword |
-| sonicwall.firewall.dpi | Indicates wether a flow underwent Deep Packet Inspection. | boolean |
+| sonicwall.firewall.dpi | Indicates whether a flow underwent Deep Packet Inspection. | boolean |
 | sonicwall.firewall.event_group_category | Event group category. | keyword |
 | sonicwall.firewall.gcat | Event group category (numeric identifier). | keyword |
 | sonicwall.firewall.ipscat | IPS category. | keyword |

--- a/packages/system/data_stream/process/fields/fields.yml
+++ b/packages/system/data_stream/process/fields/fields.yml
@@ -412,15 +412,15 @@
             - name: mem.low.bytes
               type: long
               metric_type: gauge
-              description: memory low threshhold
+              description: memory low threshold
             - name: mem.high.bytes
               type: long
               metric_type: gauge
-              description: memory high threshhold
+              description: memory high threshold
             - name: mem.max.bytes
               type: long
               metric_type: gauge
-              description: memory max threshhold
+              description: memory max threshold
             - name: mem.events
               type: group
               description: number of times the controller tripped a given usage level
@@ -470,15 +470,15 @@
             - name: memsw.low.bytes
               type: long
               metric_type: gauge
-              description: memory low threshhold
+              description: memory low threshold
             - name: memsw.high.bytes
               type: long
               metric_type: gauge
-              description: memory high threshhold
+              description: memory high threshold
             - name: memsw.max.bytes
               type: long
               metric_type: gauge
-              description: memory max threshhold
+              description: memory max threshold
             - name: memsw.failures
               type: long
               metric_type: counter

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -1700,10 +1700,10 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | system.process.cgroup.memory.mem.events.oom | oom threshold | long |  | counter |
 | system.process.cgroup.memory.mem.events.oom_kill | oom killer threshold | long |  | counter |
 | system.process.cgroup.memory.mem.failures | The number of times that the memory limit (mem.limit.bytes) was reached. | long |  | counter |
-| system.process.cgroup.memory.mem.high.bytes | memory high threshhold | long |  | gauge |
+| system.process.cgroup.memory.mem.high.bytes | memory high threshold | long |  | gauge |
 | system.process.cgroup.memory.mem.limit.bytes | The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use. | long |  | gauge |
-| system.process.cgroup.memory.mem.low.bytes | memory low threshhold | long |  | gauge |
-| system.process.cgroup.memory.mem.max.bytes | memory max threshhold | long |  | gauge |
+| system.process.cgroup.memory.mem.low.bytes | memory low threshold | long |  | gauge |
+| system.process.cgroup.memory.mem.max.bytes | memory max threshold | long |  | gauge |
 | system.process.cgroup.memory.mem.usage.bytes | Total memory usage by processes in the cgroup (in bytes). | long |  | gauge |
 | system.process.cgroup.memory.mem.usage.max.bytes | The maximum memory used by processes in the cgroup (in bytes). | long |  | gauge |
 | system.process.cgroup.memory.memsw.events.fail | failed threshold | long |  | counter |
@@ -1713,10 +1713,10 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | system.process.cgroup.memory.memsw.events.oom | oom threshold | long |  | counter |
 | system.process.cgroup.memory.memsw.events.oom_kill | oom killer threshold | long |  | counter |
 | system.process.cgroup.memory.memsw.failures | The number of times that the memory plus swap space limit (memsw.limit.bytes) was reached. | long |  | counter |
-| system.process.cgroup.memory.memsw.high.bytes | memory high threshhold | long |  | gauge |
+| system.process.cgroup.memory.memsw.high.bytes | memory high threshold | long |  | gauge |
 | system.process.cgroup.memory.memsw.limit.bytes | The maximum amount for the sum of memory and swap usage that tasks in the cgroup are allowed to use. | long |  | gauge |
-| system.process.cgroup.memory.memsw.low.bytes | memory low threshhold | long |  | gauge |
-| system.process.cgroup.memory.memsw.max.bytes | memory max threshhold | long |  | gauge |
+| system.process.cgroup.memory.memsw.low.bytes | memory low threshold | long |  | gauge |
+| system.process.cgroup.memory.memsw.max.bytes | memory max threshold | long |  | gauge |
 | system.process.cgroup.memory.memsw.usage.bytes | The sum of current memory usage plus swap space used by processes in the cgroup (in bytes). | long |  | gauge |
 | system.process.cgroup.memory.memsw.usage.max.bytes | The maximum amount of memory and swap space used by processes in the cgroup (in bytes). | long |  | gauge |
 | system.process.cgroup.memory.path | Path to the cgroup relative to the cgroup subsystem's mountpoint. | keyword |  |  |

--- a/packages/tychon/data_stream/systemcerts/fields/fields.yml
+++ b/packages/tychon/data_stream/systemcerts/fields/fields.yml
@@ -216,7 +216,7 @@
               description: List of state or province names (ST, S, or P).
         - name: subject_key_identifier
           type: keyword
-          description: Subject Key identifer
+          description: Subject Key identifier
         - name: version_number
           type: keyword
           description: Version of x509 format.

--- a/packages/tychon/docs/README.md
+++ b/packages/tychon/docs/README.md
@@ -1668,7 +1668,7 @@ TYCHON searches the computer and hard drive for certificate files that stored in
 | tychon.x509.subject.organization | List of organizations (O) of subject. | keyword |
 | tychon.x509.subject.organizational_unit | List of organizational units (OU) of subject. | keyword |
 | tychon.x509.subject.state_or_province | List of state or province names (ST, S, or P). | keyword |
-| tychon.x509.subject_key_identifier | Subject Key identifer | keyword |
+| tychon.x509.subject_key_identifier | Subject Key identifier | keyword |
 | tychon.x509.version_number | Version of x509 format. | keyword |
 
 

--- a/packages/tychon/elasticsearch/transform/systemcerts/fields/fields.yml
+++ b/packages/tychon/elasticsearch/transform/systemcerts/fields/fields.yml
@@ -216,7 +216,7 @@
               description: List of state or province names (ST, S, or P).
         - name: subject_key_identifier
           type: keyword
-          description: Subject Key identifer
+          description: Subject Key identifier
         - name: version_number
           type: keyword
           description: Version of x509 format.


### PR DESCRIPTION
Fixes #18427.

Picked up the **unambiguous** spelling typos listed in the audit (25 line changes across 14 files):

**Contributor-facing docs/extend**
- `docs/extend/add-data-stream.md` — Boostrap → Bootstrap
- `docs/extend/add-mapping.md` — aformentioned → aforementioned
- `docs/extend/dashboard-guidelines.md` — vizualizations → visualizations
- `docs/extend/developer-workflow-import-beat.md` — mutliple → multiple
- `docs/extend/general-guidelines.md` — quering → querying, chosing → choosing

**`identifer` → `identifier` (5 occurrences):** m365_defender × 2, tychon × 3

**`wether` → `whether` (2 occurrences):** sonicwall_firewall (fields.yml + README)

**`threshhold` → `threshold` (12 occurrences):** `system` package memory.{low,high,max} fields (fields.yml × 6, README × 6)

Left out the `dev/testsreporter/github.go` `DRY-RUN> not run command` item — that's a phrasing rewrite, not a clear typo, so better decided by maintainers.

Docs/description only; no schema, config, or logic changes. Fields' YAML keys and IDs are untouched — only the `description:` values.