### PR TITLE
cel: work around kibana textarea serialisation behaviour skew

### DIFF
--- a/packages/cel/_dev/test/policy/test-auth-and-headers.yml
+++ b/packages/cel/_dev/test/policy/test-auth-and-headers.yml
@@ -4,10 +4,10 @@ vars:
   password: test
   program: |-
     get("https://api.ipify.org/?format=json").Body.as(body, {
-        "events": [body.decode_json().with({
-            ?"last_requested_at": state.?cursor.last_requested_at
-        })],
-        "cursor": {"last_requested_at": now}
+    "events": [body.decode_json().with({
+    ?"last_requested_at": state.?cursor.last_requested_at
+    })],
+    "cursor": {"last_requested_at": now}
     })
   resource_headers: |-
     "Accept": ["application/json"]

--- a/packages/cel/_dev/test/policy/test-default.yml
+++ b/packages/cel/_dev/test/policy/test-default.yml
@@ -2,10 +2,10 @@ vars:
   url: http://example.com:9001
   program: |-
     get("https://api.ipify.org/?format=json").Body.as(body, {
-        "events": [body.decode_json().with({
-            ?"last_requested_at": state.?cursor.last_requested_at
-        })],
-        "cursor": {"last_requested_at": now}
+    "events": [body.decode_json().with({
+    ?"last_requested_at": state.?cursor.last_requested_at
+    })],
+    "cursor": {"last_requested_at": now}
     })
   interval: 5m
   preserve_original_event: true

--- a/packages/cel/_dev/test/policy/test-headers.yml
+++ b/packages/cel/_dev/test/policy/test-headers.yml
@@ -2,10 +2,10 @@ vars:
   url: http://example.com:9001
   program: |-
     get("https://api.ipify.org/?format=json").Body.as(body, {
-        "events": [body.decode_json().with({
-            ?"last_requested_at": state.?cursor.last_requested_at
-        })],
-        "cursor": {"last_requested_at": now}
+    "events": [body.decode_json().with({
+    ?"last_requested_at": state.?cursor.last_requested_at
+    })],
+    "cursor": {"last_requested_at": now}
     })
   resource_headers: |-
     "Accept": ["application/json"]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
cel: work around kibana textarea serialisation behaviour skew

In elastic/kibana@9417d6cd3932, the behaviour of textarea handling was
changed so that the text's indentation is respected. This is a good
thing, but it causes a differential in behaviour between versions before
that and after. This means that serverless policy tests will fail since
the expectations were constructed with the old, incorrect behaviour.

Work around this by using unindented text for the policy so that
respecting indentation gives the same outcome as not.
```

> [!NOTE]
> No user-facing change, so no changelog entry or version bump.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #18572
- Closes #18573
- Closes #18574

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
