### PR TITLE
feat: add cursor tracking to agentless_hello_world generic data stream

### DIFF
--- a/packages/agentless_hello_world/changelog.yml
+++ b/packages/agentless_hello_world/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.3.0"
+  changes:
+    - description: Add cursor tracking (request_count, last_collected) to the generic data stream for testing cursor persistence across restart modes.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.2.0"
   changes:
     - description: Add mock counter metrics data stream with constant and spike modes for high-rate ingestion testing.

--- a/packages/agentless_hello_world/changelog.yml
+++ b/packages/agentless_hello_world/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add cursor tracking (request_count, last_collected) to the generic data stream for testing cursor persistence across restart modes.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/18611
 - version: "0.2.0"
   changes:
     - description: Add mock counter metrics data stream with constant and spike modes for high-rate ingestion testing.

--- a/packages/agentless_hello_world/data_stream/generic/_dev/test/pipeline/test-hello-world.json
+++ b/packages/agentless_hello_world/data_stream/generic/_dev/test/pipeline/test-hello-world.json
@@ -5,6 +5,10 @@
         "response": {
           "status_code": 200
         }
+      },
+      "cursor": {
+        "request_count": 42,
+        "last_collected": "2025-10-23T11:25:00.000Z"
       }
     }
   ]

--- a/packages/agentless_hello_world/data_stream/generic/_dev/test/pipeline/test-hello-world.json-expected.json
+++ b/packages/agentless_hello_world/data_stream/generic/_dev/test/pipeline/test-hello-world.json-expected.json
@@ -6,6 +6,10 @@
                     "status_code": 200
                 }
             },
+            "cursor": {
+                "request_count": 42,
+                "last_collected": "2025-10-23T11:25:00.000Z"
+            },
             "ecs": {
                 "version": "9.1.0"
             },

--- a/packages/agentless_hello_world/data_stream/generic/agent/stream/cel.yml.hbs
+++ b/packages/agentless_hello_world/data_stream/generic/agent/stream/cel.yml.hbs
@@ -4,6 +4,9 @@ resource.timeout: 15s
 resource.url: "{{url}}"
 state:
   url: "{{url}}"
+  cursor:
+    request_count: 0
+    last_collected: "1970-01-01T00:00:00Z"
 program: |
   request("GET", state.url)
     .do_request()
@@ -12,9 +15,17 @@ program: |
             "http": {
               "response": {
                 "status_code": resp.StatusCode
+              }
+            },
+            "cursor": {
+              "request_count": int(state.cursor.request_count) + 1,
+              "last_collected": now
             }
-          }
-        }]
+        }],
+        "cursor": {
+          "request_count": int(state.cursor.request_count) + 1,
+          "last_collected": now
+        }
     })
 tags:
   - agentless-hello-world

--- a/packages/agentless_hello_world/data_stream/generic/agent/stream/cel.yml.hbs
+++ b/packages/agentless_hello_world/data_stream/generic/agent/stream/cel.yml.hbs
@@ -10,22 +10,26 @@ state:
 program: |
   request("GET", state.url)
     .do_request()
-    .as(resp, {
-        "events": [{
-            "http": {
-              "response": {
-                "status_code": resp.StatusCode
-              }
-            },
+    .as(resp,
+      now.as(collected_at,
+        (int(state.cursor.request_count) + 1).as(new_count, {
+            "events": [{
+                "http": {
+                  "response": {
+                    "status_code": resp.StatusCode
+                  }
+                },
+                "cursor": {
+                  "request_count": new_count,
+                  "last_collected": collected_at
+                }
+            }],
             "cursor": {
-              "request_count": int(state.cursor.request_count) + 1,
-              "last_collected": now
+              "request_count": new_count,
+              "last_collected": collected_at
             }
-        }],
-        "cursor": {
-          "request_count": int(state.cursor.request_count) + 1,
-          "last_collected": now
-        }
-    })
+        })
+      )
+    )
 tags:
   - agentless-hello-world

--- a/packages/agentless_hello_world/data_stream/generic/fields/fields.yml
+++ b/packages/agentless_hello_world/data_stream/generic/fields/fields.yml
@@ -1,2 +1,8 @@
 - name: http.response.status_code
   external: ecs
+- name: cursor.request_count
+  type: long
+  description: Incrementing counter tracking how many collection cycles have run. Resets to 0 if cursor state is lost.
+- name: cursor.last_collected
+  type: date
+  description: Timestamp of the last successful collection cycle. Resets to epoch if cursor state is lost.

--- a/packages/agentless_hello_world/data_stream/generic/sample_event.json
+++ b/packages/agentless_hello_world/data_stream/generic/sample_event.json
@@ -55,6 +55,10 @@
             "version": "20230201"
         }
     },
+    "cursor": {
+        "last_collected": "2025-10-23T11:25:00.349Z",
+        "request_count": 1
+    },
     "http": {
         "response": {
             "status_code": 418

--- a/packages/agentless_hello_world/manifest.yml
+++ b/packages/agentless_hello_world/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: agentless_hello_world
 title: Agentless Hello World
-version: "0.2.0"
+version: "0.3.0"
 description: A sample integration to exercise the Agentless infrastructure by fetching https://epr.elastic.co every minute. Optionally includes a counter data stream for high-rate mock metric ingestion testing.
 type: integration
 categories:


### PR DESCRIPTION
## Summary

- Adds `cursor.request_count` (incrementing integer) and `cursor.last_collected` (timestamp) fields to the `agentless_hello_world` generic data stream's CEL program
- Both values are emitted inside each event document and persisted via the CEL cursor mechanism
- This enables testing whether cursor state survives across beats-process-to-receivers mode restarts

## How to verify

After deploying, query the logs index to see cursor values incrementing:

```
FROM logs-agentless_hello_world.generic-*
| SORT @timestamp DESC
| KEEP @timestamp, cursor.request_count, cursor.last_collected, http.response.status_code
| LIMIT 20
```

- **Cursor preserved**: `cursor.request_count` continues from where it left off after restart
- **Cursor lost**: `cursor.request_count` resets to 1

## Changes

- `data_stream/generic/agent/stream/cel.yml.hbs` — added `state.cursor` with `request_count` and `last_collected`; emit in events and persist via CEL cursor
- `data_stream/generic/fields/fields.yml` — added `cursor.request_count` (long) and `cursor.last_collected` (date)
- `data_stream/generic/sample_event.json` — updated with cursor fields
- `data_stream/generic/_dev/test/pipeline/` — updated pipeline test input and expected output
- `manifest.yml` — bumped version to 0.3.0
- `changelog.yml` — added 0.3.0 entry


Made with [Cursor](https://cursor.com)