### PR TITLE
[atlassian_bitbucket] Add Agentless Deployment

### DIFF
--- a/packages/atlassian_bitbucket/_dev/build/docs/README.md
+++ b/packages/atlassian_bitbucket/_dev/build/docs/README.md
@@ -4,6 +4,11 @@ The Bitbucket integration collects audit logs from the audit log files or the [a
 
 For more information on auditing in Bitbucket and how it can be configured, see [View and configure the audit log](https://confluence.atlassian.com/bitbucketserver/view-and-configure-the-audit-log-776640417.html) on Atlassian's website.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Logs
 
 ### Audit

--- a/packages/atlassian_bitbucket/changelog.yml
+++ b/packages/atlassian_bitbucket/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add Agentless deployment support.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18614
 - version: "2.6.0"
   changes:
     - description: Prevent updating fleet health status to degraded.

--- a/packages/atlassian_bitbucket/changelog.yml
+++ b/packages/atlassian_bitbucket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.0"
+  changes:
+    - description: Add Agentless deployment support.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.6.0"
   changes:
     - description: Prevent updating fleet health status to degraded.

--- a/packages/atlassian_bitbucket/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/atlassian_bitbucket/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/atlassian_bitbucket/data_stream/audit/manifest.yml
+++ b/packages/atlassian_bitbucket/data_stream/audit/manifest.yml
@@ -49,7 +49,6 @@ streams:
   - input: httpjson
     title: Bitbucket audit logs via Bitbucket audit API
     description: Collect Bitbucket audit logs via Bitbucket audit API
-    enabled: false
     template_path: httpjson.yml.hbs
     vars:
       - name: api_url

--- a/packages/atlassian_bitbucket/data_stream/audit/manifest.yml
+++ b/packages/atlassian_bitbucket/data_stream/audit/manifest.yml
@@ -49,6 +49,7 @@ streams:
   - input: httpjson
     title: Bitbucket audit logs via Bitbucket audit API
     description: Collect Bitbucket audit logs via Bitbucket audit API
+    enabled: false
     template_path: httpjson.yml.hbs
     vars:
       - name: api_url

--- a/packages/atlassian_bitbucket/docs/README.md
+++ b/packages/atlassian_bitbucket/docs/README.md
@@ -4,6 +4,11 @@ The Bitbucket integration collects audit logs from the audit log files or the [a
 
 For more information on auditing in Bitbucket and how it can be configured, see [View and configure the audit log](https://confluence.atlassian.com/bitbucketserver/view-and-configure-the-audit-log-776640417.html) on Atlassian's website.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Logs
 
 ### Audit

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.2"
+format_version: "3.3.2"
 name: atlassian_bitbucket
 title: Atlassian Bitbucket
-version: "2.6.0"
+version: "2.7.0"
 description: Collect logs from Atlassian Bitbucket with Elastic Agent.
 type: integration
 categories:
@@ -19,6 +19,14 @@ policy_templates:
   - name: audit
     title: Audit Logs
     description: Collect audit logs from Atlassian Bitbucket with Elastic Agent.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: logfile
         title: "Collect Bitbucket audit logs via log files"

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - productivity_security
 conditions:
   kibana:
-    version: "^8.19.4 || ~9.0.7 || ^9.1.4"
+    version: "^8.19.16 || ^9.3.5 || ^9.4.1"
 icons:
   - src: /img/bitbucket-logo.svg
     title: Bitbucket Logo

--- a/packages/atlassian_bitbucket/manifest.yml
+++ b/packages/atlassian_bitbucket/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - productivity_security
 conditions:
   kibana:
-    version: "^8.19.16 || ^9.3.5 || ^9.4.1"
+    version: "^8.19.16 || ~9.3.5 || ^9.4.1"
 icons:
   - src: /img/bitbucket-logo.svg
     title: Bitbucket Logo


### PR DESCRIPTION
## Proposed commit message

```
atlassian_bitbucket: add agentless deployment

Add agentless support and update the supported Kibana version range.
While enabling agentless support, a UI rendering issue was identified in integrations where
all data stream inputs are configured with enabled: false in their manifest. This issue is being
addressed in Kibana PR [1]. To incorporate the fix, the Kibana version constraint has been updated
to ^8.19.16 || ~9.3.5 || ^9.4.1.
 
[1] https://github.com/elastic/kibana/pull/265106
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/atlassian_bitbucket directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes https://github.com/elastic/integrations/issues/18385
