### PR TITLE
[CI] Skip kubeletstats_input_otel-0.1.0 from build and publish pipeline

### DIFF
--- a/.buildkite/pipeline.publish.yml
+++ b/.buildkite/pipeline.publish.yml
@@ -38,6 +38,9 @@ steps:
       ARTIFACTS_FOLDER: "artifacts-to-sign"
       # by default it will publish packages
       DRY_RUN: "${DRY_RUN:-false}"
+      # Comma-separated list of package zip filenames to skip (e.g. "foo-1.0.0.zip,bar-2.0.0.zip")
+      # kubeletstats_input_otel-0.1.0 was deleted but it is kept in the repository for now, in case it is needed to release a new version if needed
+      SKIP_PACKAGES: "kubeletstats_input_otel-0.1.0.zip"
     depends_on:
       - step: "check"
         allow_failure: false

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -23,6 +23,9 @@
         "^.buildkite/pipeline.schedule-daily.yml$",
         "^.buildkite/pipeline.schedule-weekly.yml$",
         "^.buildkite/pipeline.backport.yml$",
+        "^.buildkite/scripts/backport_branch.sh$",
+        "^.buildkite/pipeline.publish.yml$",
+        "^.buildkite/scripts/build_packages.sh$",
         "^.buildkite/pull-requests.json$"
       ],
       "always_require_ci_on_changed": []

--- a/.buildkite/scripts/build_packages.sh
+++ b/.buildkite/scripts/build_packages.sh
@@ -5,9 +5,15 @@ source .buildkite/scripts/common.sh
 set -euo pipefail
 
 SKIP_PUBLISHING=${SKIP_PUBLISHING:-"false"}
+# Comma-separated list of package zip filenames to skip (e.g. "foo-1.0.0.zip,bar-2.0.0.zip")
+SKIP_PACKAGES=${SKIP_PACKAGES:-""}
 ARTIFACTS_FOLDER=${ARTIFACTS_FOLDER:-"packageArtifacts"}
 BUILD_PACKAGES_FOLDER="build/packages"
 DRY_RUN=${DRY_RUN:-"true"}
+
+is_skipped_package() {
+    [[ ",${SKIP_PACKAGES}," == *",${1},"* ]]
+}
 
 skipPublishing() {
     if [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
@@ -63,6 +69,12 @@ build_packages() {
         name=$(cat manifest.yml | yq .name)
 
         local package_zip="${name}-${version}.zip"
+
+        if is_skipped_package "${package_zip}" ; then
+            echo "Skipping. ${package_zip} is in the skip list"
+            popd > /dev/null
+            continue
+        fi
 
         if is_already_published "${package_zip}" ; then
             echo "Skipping. ${package_zip} already published"

--- a/.buildkite/scripts/build_packages.sh
+++ b/.buildkite/scripts/build_packages.sh
@@ -95,12 +95,12 @@ build_packages() {
 
 if [ "${SKIP_PUBLISHING}" == "true" ] ; then
     echo "packageStoragePublish: skipping because SKIP_PUBLISHING environment variable is ${SKIP_PUBLISHING}"
-    exit 0
+    # exit 0
 fi
 
 if skipPublishing ; then
     echo "packageStoragePublish: not the main branch or a backport branch, nothing will be published"
-    exit 0
+    # exit 0
 fi
 
 add_bin_path
@@ -127,6 +127,7 @@ cd "${WORKSPACE}" || exit 1
 mkdir -p "${ARTIFACTS_FOLDER}"
 cp "${BUILD_PACKAGES_FOLDER}"/*.zip "${ARTIFACTS_FOLDER}"/
 
+DRY_RUN=true
 if [ "${DRY_RUN}" == "true" ]; then
     echo "DRY_RUN enabled. Publish packages steps skipped."
     exit 0

--- a/.buildkite/scripts/build_packages.sh
+++ b/.buildkite/scripts/build_packages.sh
@@ -95,12 +95,12 @@ build_packages() {
 
 if [ "${SKIP_PUBLISHING}" == "true" ] ; then
     echo "packageStoragePublish: skipping because SKIP_PUBLISHING environment variable is ${SKIP_PUBLISHING}"
-    # exit 0
+    exit 0
 fi
 
 if skipPublishing ; then
     echo "packageStoragePublish: not the main branch or a backport branch, nothing will be published"
-    # exit 0
+    exit 0
 fi
 
 add_bin_path
@@ -127,7 +127,6 @@ cd "${WORKSPACE}" || exit 1
 mkdir -p "${ARTIFACTS_FOLDER}"
 cp "${BUILD_PACKAGES_FOLDER}"/*.zip "${ARTIFACTS_FOLDER}"/
 
-DRY_RUN=true
 if [ "${DRY_RUN}" == "true" ]; then
     echo "DRY_RUN enabled. Publish packages steps skipped."
     exit 0

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -757,7 +757,25 @@ is_pr_affected() {
     # Example:
     # https://buildkite.com/elastic/integrations/builds/25606
     # https://github.com/elastic/integrations/pull/13810
-    if git diff --name-only "${commit_merge}" "${to}" | grep -E -v '^(packages/|\.github/(CODEOWNERS|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE|workflows/)|CODE_OF_CONDUCT\.md|README\.md|docs/|catalog-info\.yaml|\.buildkite/(pull-requests\.json|pipeline\.schedule-daily\.yml|pipeline\.schedule-weekly\.yml|pipeline\.backport\.yml|scripts/packages/.+\.sh|scripts/backport_branch\.sh))' > /dev/null; then
+    local non_package_patterns=(
+        'packages/'
+        '\.github/(CODEOWNERS|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE|workflows/)'
+        'CODE_OF_CONDUCT\.md'
+        'README\.md'
+        'docs/'
+        'catalog-info\.yaml'
+        '\.buildkite/pull-requests\.json'
+        '\.buildkite/pipeline\.schedule-daily\.yml'
+        '\.buildkite/pipeline\.schedule-weekly\.yml'
+        '\.buildkite/pipeline\.backport\.yml'
+        '\.buildkite/pipeline\.publish\.yml'
+        '\.buildkite/scripts/packages/.+\.sh'
+        '\.buildkite/scripts/backport_branch\.sh'
+        '\.buildkite/scripts/build_packages\.sh'
+    )
+    local non_package_regex
+    non_package_regex="^($(IFS='|'; echo "${non_package_patterns[*]}"))"
+    if git diff --name-only "${commit_merge}" "${to}" | grep -E -v "${non_package_regex}" > /dev/null; then
         echo "[${package}] PR is affected: found non-package files"
         return 0
     fi

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -772,7 +772,6 @@ is_pr_affected() {
         '\.buildkite/scripts/packages/.+\.sh'
         '\.buildkite/scripts/backport_branch\.sh'
         '\.buildkite/scripts/build_packages\.sh'
-        '\.buildkite/scripts/common\.sh'
     )
     local non_package_regex
     non_package_regex="^($(IFS='|'; echo "${non_package_patterns[*]}"))"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -172,8 +172,8 @@ with_docker_compose_plugin() {
     local DOCKER_CONFIG="$HOME/.docker/cli-plugins"
     mkdir -p "$DOCKER_CONFIG"
 
-    retry 5 curl -SL -o ${DOCKER_CONFIG}/docker-compose "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-${platform_type_lowercase}-${hw_type}"
-    chmod +x ${DOCKER_CONFIG}/docker-compose
+    retry 5 curl -SL -o "${DOCKER_CONFIG}/docker-compose" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-${platform_type_lowercase}-${hw_type}"
+    chmod +x "${DOCKER_CONFIG}/docker-compose"
     docker compose version
 }
 

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -772,6 +772,7 @@ is_pr_affected() {
         '\.buildkite/scripts/packages/.+\.sh'
         '\.buildkite/scripts/backport_branch\.sh'
         '\.buildkite/scripts/build_packages\.sh'
+        '\.buildkite/scripts/common\.sh'
     )
     local non_package_regex
     non_package_regex="^($(IFS='|'; echo "${non_package_patterns[*]}"))"


### PR DESCRIPTION
## Proposed commit message

Add SKIP_PACKAGES support to build_packages.sh, allowing a comma-separated list of package zip filenames to be excluded from the build and publish pipeline. Set kubeletstats_input_otel-0.1.0.zip as the initial skip entry in pipeline.publish.yml.

**WHAT:** Adds a `SKIP_PACKAGES` mechanism to `.buildkite/scripts/build_packages.sh` that allows specific package zip filenames to be excluded from the build and publish pipeline. The variable accepts a comma-separated list of zip filenames (e.g. `foo-1.0.0.zip,bar-2.0.0.zip`). The initial value set in `pipeline.publish.yml` skips `kubeletstats_input_otel-0.1.0.zip`.

Refactored the command used to check whether or not non-package files have been modified in order to trigger the packages. Now the list of paths are defined in a list to be easier to update if needed.

**WHY:** The `kubeletstats_input_otel` package has been removed from the repository but its directory is kept temporarily in case a new version needs to be released. To avoid accidentally publishing the stale `0.1.0` artifact in the meantime, it is explicitly skipped via `SKIP_PACKAGES`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [x] Verify that `kubeletstats_input_otel-0.1.0.zip` is no longer built or published in CI after this change. https://buildkite.com/elastic/integrations-publish/builds/5261

Output:
```
Package kubeletstats_input_otel: check
Skipping. kubeletstats_input_otel-0.1.0.zip is in the skip list
```

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).
