### PR TITLE
Update CODEOWNERS for kubernetes_otel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -338,7 +338,7 @@
 /packages/kubeletstats_input_otel @elastic/ecosystem
 /packages/kubernetes @elastic/obs-ds-hosted-services
 /packages/kubernetes/kibana @elastic/obs-ds-hosted-services
-/packages/kubernetes_otel @elastic/obs-ds-hosted-services
+/packages/kubernetes_otel @elastic/obs-infraobs-integrations
 /packages/lastpass @elastic/security-service-integrations
 /packages/linux @elastic/elastic-agent-data-plane
 /packages/lmd @elastic/sec-applied-ml @elastic/kibana-management

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -31,5 +31,5 @@ icons:
     title: Sample logo
     type: image/svg+xml
 owner:
-  github: elastic/obs-ds-hosted-services
+  github: elastic/obs-infraobs-integrations
   type: elastic


### PR DESCRIPTION
Update packages/kubernetes_otel ownership to @elastic/obs-infraobs-integrations, as discussed offline.

