### PR TITLE
[sql_server_input_otel][mysql_input_otel] Add system and policy tests for logs and metrics signals

### DIFF
--- a/packages/mysql_input_otel/_dev/test/policy/test-collect-logs-disabled.yml
+++ b/packages/mysql_input_otel/_dev/test/policy/test-collect-logs-disabled.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 vars:
   enable_query_sample_events: false
   enable_top_query_events: false

--- a/packages/mysql_input_otel/_dev/test/policy/test-default.yml
+++ b/packages/mysql_input_otel/_dev/test/policy/test-default.yml
@@ -1,4 +1,1 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 vars: ~

--- a/packages/mysql_input_otel/_dev/test/policy/test-logs-enabled.expected
+++ b/packages/mysql_input_otel/_dev/test/policy/test-logs-enabled.expected
@@ -1,0 +1,117 @@
+connectors:
+    forward: {}
+exporters:
+    elasticsearch/componentid-0:
+        endpoints:
+            - https://elasticsearch:9200
+inputs: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                - names:
+                    - metrics-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+processors:
+    resourcedetection/componentid-0:
+        detectors:
+            - system
+    transform/componentid-1:
+        log_statements:
+            - context: log
+              statements:
+                - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "mysqlreceiver")
+                - set(attributes["data_stream.namespace"], "ep")
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["data_stream.type"], "metrics")
+                - set(attributes["data_stream.dataset"], "mysqlreceiver")
+                - set(attributes["data_stream.namespace"], "ep")
+receivers:
+    mysql/componentid-0:
+        allow_native_passwords: true
+        collection_interval: 10s
+        endpoint: localhost:3306
+        initial_delay: 1s
+        metrics:
+            mysql.client.network.io:
+                enabled: true
+            mysql.commands:
+                enabled: true
+            mysql.connection.count:
+                enabled: true
+            mysql.connection.errors:
+                enabled: true
+            mysql.max_used_connections:
+                enabled: true
+            mysql.query.client.count:
+                enabled: true
+            mysql.replica.sql_delay:
+                enabled: true
+            mysql.replica.time_behind_source:
+                enabled: true
+            mysql.table_open_cache:
+                enabled: true
+        events:
+            db.server.query_sample:
+                enabled: true
+            db.server.top_query:
+                enabled: true
+        query_sample_collection:
+            max_rows_per_query: 200
+        statement_events:
+            digest_text_limit: 120
+            limit: 250
+            time_limit: 24h
+        top_query_collection:
+            collection_interval: 30s
+            lookback_time: 120
+            max_query_sample_count: 500
+            query_plan_cache_size: 2000
+            query_plan_cache_ttl: 2h
+            top_query_count: 100
+        transport: tcp
+        username: root
+secret_references: []
+service:
+    pipelines:
+        logs:
+            exporters:
+                - elasticsearch/componentid-0
+            receivers:
+                - forward
+        logs/componentid-0:
+            exporters:
+                - forward
+            processors:
+                - resourcedetection/componentid-0
+                - transform/componentid-1
+            receivers:
+                - mysql/componentid-0
+        metrics:
+            exporters:
+                - elasticsearch/componentid-0
+            receivers:
+                - forward
+        metrics/componentid-1:
+            exporters:
+                - forward
+            processors:
+                - resourcedetection/componentid-0
+                - transform/componentid-1
+            receivers:
+                - mysql/componentid-0

--- a/packages/mysql_input_otel/_dev/test/policy/test-logs-enabled.yml
+++ b/packages/mysql_input_otel/_dev/test/policy/test-logs-enabled.yml
@@ -1,0 +1,10 @@
+vars:
+  enable_query_sample_events: true
+  enable_top_query_events: true
+  query_sample_max_rows_per_query: 200
+  top_query_lookback_time: 120
+  top_query_max_query_sample_count: 500
+  top_query_count: 100
+  top_query_collection_interval: 30s
+  top_query_plan_cache_size: 2000
+  top_query_plan_cache_ttl: 2h

--- a/packages/mysql_input_otel/_dev/test/policy/test-metrics-enabled.expected
+++ b/packages/mysql_input_otel/_dev/test/policy/test-metrics-enabled.expected
@@ -1,0 +1,96 @@
+connectors:
+    forward: {}
+exporters:
+    elasticsearch/componentid-0:
+        endpoints:
+            - https://elasticsearch:9200
+inputs: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                - names:
+                    - metrics-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+processors:
+    resourcedetection/componentid-0:
+        detectors:
+            - system
+    transform/componentid-1:
+        log_statements:
+            - context: log
+              statements:
+                - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "mysqlreceiver")
+                - set(attributes["data_stream.namespace"], "ep")
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["data_stream.type"], "metrics")
+                - set(attributes["data_stream.dataset"], "mysqlreceiver")
+                - set(attributes["data_stream.namespace"], "ep")
+receivers:
+    mysql/componentid-0:
+        allow_native_passwords: true
+        collection_interval: 10s
+        endpoint: localhost:3306
+        initial_delay: 1s
+        metrics:
+            mysql.joins:
+                enabled: true
+            mysql.statement_event.count:
+                enabled: true
+        events:
+            db.server.query_sample:
+                enabled: true
+            db.server.top_query:
+                enabled: false
+        query_sample_collection:
+            max_rows_per_query: 100
+        statement_events:
+            digest_text_limit: 120
+            limit: 250
+            time_limit: 24h
+        transport: tcp
+        username: root
+secret_references: []
+service:
+    pipelines:
+        logs:
+            exporters:
+                - elasticsearch/componentid-0
+            receivers:
+                - forward
+        logs/componentid-0:
+            exporters:
+                - forward
+            processors:
+                - resourcedetection/componentid-0
+                - transform/componentid-1
+            receivers:
+                - mysql/componentid-0
+        metrics:
+            exporters:
+                - elasticsearch/componentid-0
+            receivers:
+                - forward
+        metrics/componentid-1:
+            exporters:
+                - forward
+            processors:
+                - resourcedetection/componentid-0
+                - transform/componentid-1
+            receivers:
+                - mysql/componentid-0

--- a/packages/mysql_input_otel/_dev/test/policy/test-metrics-enabled.yml
+++ b/packages/mysql_input_otel/_dev/test/policy/test-metrics-enabled.yml
@@ -1,0 +1,6 @@
+vars:
+  metrics: |
+    mysql.joins:
+      enabled: true
+    mysql.statement_event.count:
+      enabled: true

--- a/packages/mysql_input_otel/_dev/test/policy/test-tls-enabled.yml
+++ b/packages/mysql_input_otel/_dev/test/policy/test-tls-enabled.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 vars:
   tls_enabled: true
   tls_insecure_skip_verify: true

--- a/packages/mysql_input_otel/_dev/test/system/test-default-config.yml
+++ b/packages/mysql_input_otel/_dev/test/system/test-default-config.yml
@@ -1,19 +1,9 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 service: mysql_input_otel
 service_notify_signal: SIGHUP
 vars:
   endpoint: "{{Hostname}}:{{Port}}"
   username: "root"
+  collection_interval: 10s
+  initial_delay: 1s
 assert:
-  min_count: 50
-  fields_present:
-    - metrics.mysql.buffer_pool.operations
-    - metrics.mysql.log_operations
-    - metrics.mysql.commands
-    - metrics.mysql.connection.count
-    - metrics.mysql.connection.errors
-    - metrics.mysql.query.client.count
-    - metrics.mysql.table_open_cache
-    - metrics.mysql.client.network.io
+  min_count: 10

--- a/packages/mysql_input_otel/_dev/test/system/test-logs-config.yml
+++ b/packages/mysql_input_otel/_dev/test/system/test-logs-config.yml
@@ -1,0 +1,33 @@
+service: mysql_input_otel
+service_notify_signal: SIGHUP
+vars:
+  endpoint: "{{Hostname}}:{{Port}}"
+  username: "root"
+  collection_interval: 10s
+  initial_delay: 1s
+  enable_query_sample_events: true
+  enable_top_query_events: true
+  top_query_lookback_time: 60
+  top_query_collection_interval: 10s
+signal_types:
+  - logs
+assert:
+  min_count: 10
+  fields_present:
+    # Common to both event types
+    - db.query.text
+    - db.system.name
+    - db.namespace
+    - network.peer.address
+    - network.peer.port
+    - mysql.query_plan.hash
+    # Query-Sample Collection (db.server.query_sample)
+    - mysql.threads.thread_id
+    - mysql.threads.processlist_command
+    - mysql.threads.processlist_state
+    - mysql.session.id
+    - mysql.session.status
+    - mysql.events_statements_current.digest
+    - client.address
+    - client.port
+    - user.name

--- a/packages/mysql_input_otel/_dev/test/system/test-logs-config.yml
+++ b/packages/mysql_input_otel/_dev/test/system/test-logs-config.yml
@@ -7,7 +7,7 @@ vars:
   initial_delay: 1s
   enable_query_sample_events: true
   enable_top_query_events: true
-  top_query_lookback_time: 60s
+  top_query_lookback_time: 60
   top_query_collection_interval: 10s
 signal_types:
   - logs

--- a/packages/mysql_input_otel/_dev/test/system/test-logs-config.yml
+++ b/packages/mysql_input_otel/_dev/test/system/test-logs-config.yml
@@ -7,7 +7,7 @@ vars:
   initial_delay: 1s
   enable_query_sample_events: true
   enable_top_query_events: true
-  top_query_lookback_time: 60
+  top_query_lookback_time: 60s
   top_query_collection_interval: 10s
 signal_types:
   - logs

--- a/packages/mysql_input_otel/_dev/test/system/test-metrics-config.yml
+++ b/packages/mysql_input_otel/_dev/test/system/test-metrics-config.yml
@@ -1,4 +1,5 @@
 service: mysql_input_otel
+service_notify_signal: SIGHUP
 vars:
   endpoint: "{{Hostname}}:{{Port}}"
   username: "root"

--- a/packages/mysql_input_otel/_dev/test/system/test-metrics-config.yml
+++ b/packages/mysql_input_otel/_dev/test/system/test-metrics-config.yml
@@ -1,0 +1,19 @@
+service: mysql_input_otel
+vars:
+  endpoint: "{{Hostname}}:{{Port}}"
+  username: "root"
+  collection_interval: 10s
+  initial_delay: 1s
+signal_types:
+  - metrics
+assert:
+  min_count: 10
+  fields_present:
+    - metrics.mysql.buffer_pool.operations
+    - metrics.mysql.log_operations
+    - metrics.mysql.commands
+    - metrics.mysql.connection.count
+    - metrics.mysql.connection.errors
+    - metrics.mysql.query.client.count
+    - metrics.mysql.table_open_cache
+    - metrics.mysql.client.network.io

--- a/packages/sql_server_input_otel/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sql_server_input_otel/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2.3'
 services:
   sql_server_input_otel:
-    # image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION:-2019-latest}
     user: root
     build:
       context: .
@@ -10,7 +9,6 @@ services:
     ports:
       - 1433
   sql_server_input_otel_workload:
-    # image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION:-2019-latest}
     build:
       context: .
       args:

--- a/packages/sql_server_input_otel/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sql_server_input_otel/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   sql_server_input_otel:
-    image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION:-2019-latest}
+    # image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION:-2019-latest}
     user: root
     build:
       context: .
@@ -10,7 +10,7 @@ services:
     ports:
       - 1433
   sql_server_input_otel_workload:
-    image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION:-2019-latest}
+    # image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION:-2019-latest}
     build:
       context: .
       args:

--- a/packages/sql_server_input_otel/_dev/deploy/docker/workload.sh
+++ b/packages/sql_server_input_otel/_dev/deploy/docker/workload.sh
@@ -19,9 +19,11 @@ done
 echo "Starting workload generation..."
 touch /tmp/workload_ready
 
-# Background: long-running query for query_sample capture
+# Background: holds an exclusive table lock for 20s, causing the foreground SELECTs to block.
+# Blocked sessions appear in sys.dm_exec_requests as status=suspended with a real query hash,
+# making them reliably visible to the query_sample collector across each collection interval.
 while true; do
-    $SQLCMD -Q "WAITFOR DELAY '00:00:30'; SELECT * FROM dbo.test_table" >/dev/null 2>&1
+    $SQLCMD -Q "BEGIN TRAN; SELECT * FROM dbo.test_table WITH (TABLOCKX, HOLDLOCK); WAITFOR DELAY '00:00:20'; ROLLBACK;" >/dev/null 2>&1
 done &
 
 # Foreground: repeated short queries for top_query capture

--- a/packages/sql_server_input_otel/_dev/test/policy/test-datasource.yml
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-datasource.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 vars:
   datasource: "sqlserver://sa:secretpassword@sqlserver.example.com:1434"
   collection_interval: 30s

--- a/packages/sql_server_input_otel/_dev/test/policy/test-default-vars.yml
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-default-vars.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 vars:
   server: sqlserver.example.com
   port: 1434

--- a/packages/sql_server_input_otel/_dev/test/policy/test-default.yml
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-default.yml
@@ -1,4 +1,1 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 vars: ~

--- a/packages/sql_server_input_otel/_dev/test/policy/test-logs-custom-collection.expected
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-logs-custom-collection.expected
@@ -1,0 +1,88 @@
+connectors:
+    forward: {}
+exporters:
+    elasticsearch/componentid-0:
+        endpoints:
+            - https://elasticsearch:9200
+inputs: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                - names:
+                    - metrics-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+processors:
+    resourcedetection/componentid-0:
+        detectors:
+            - system
+    transform/componentid-1:
+        log_statements:
+            - context: log
+              statements:
+                - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "sqlserverreceiver")
+                - set(attributes["data_stream.namespace"], "ep")
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["data_stream.type"], "metrics")
+                - set(attributes["data_stream.dataset"], "sqlserverreceiver")
+                - set(attributes["data_stream.namespace"], "ep")
+receivers:
+    sqlserver/componentid-0:
+        collection_interval: 10s
+        events:
+            db.server.query_sample:
+                enabled: true
+            db.server.top_query:
+                enabled: true
+        initial_delay: 1s
+        query_sample_collection:
+            max_rows_per_query: 200
+        top_query_collection:
+            collection_interval: 30s
+            lookback_time: 120s
+            max_query_sample_count: 500
+            top_query_count: 100
+secret_references: []
+service:
+    pipelines:
+        logs:
+            exporters:
+                - elasticsearch/componentid-0
+            receivers:
+                - forward
+        logs/componentid-0:
+            exporters:
+                - forward
+            processors:
+                - resourcedetection/componentid-0
+                - transform/componentid-1
+            receivers:
+                - sqlserver/componentid-0
+        metrics:
+            exporters:
+                - elasticsearch/componentid-0
+            receivers:
+                - forward
+        metrics/componentid-1:
+            exporters:
+                - forward
+            processors:
+                - resourcedetection/componentid-0
+                - transform/componentid-1
+            receivers:
+                - sqlserver/componentid-0

--- a/packages/sql_server_input_otel/_dev/test/policy/test-logs-custom-collection.yml
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-logs-custom-collection.yml
@@ -1,0 +1,8 @@
+vars:
+  enable_query_sample_events: true
+  enable_top_query_events: true
+  query_sample_max_rows_per_query: 200
+  top_query_lookback_time: 120s
+  top_query_max_query_sample_count: 500
+  top_query_count: 100
+  top_query_collection_interval: 30s

--- a/packages/sql_server_input_otel/_dev/test/policy/test-logs-enabled.yml
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-logs-enabled.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 vars:
   enable_query_sample_events: true
   enable_top_query_events: true

--- a/packages/sql_server_input_otel/_dev/test/policy/test-metrics-enabled.yml
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-metrics-enabled.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 vars:
   metrics: |
     sqlserver.batch.request.rate:

--- a/packages/sql_server_input_otel/_dev/test/policy/test-resource-attributes.expected
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-resource-attributes.expected
@@ -1,0 +1,90 @@
+connectors:
+    forward: {}
+exporters:
+    elasticsearch/componentid-0:
+        endpoints:
+            - https://elasticsearch:9200
+inputs: []
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+                - names:
+                    - metrics-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+processors:
+    resourcedetection/componentid-0:
+        detectors:
+            - system
+    transform/componentid-1:
+        log_statements:
+            - context: log
+              statements:
+                - set(attributes["data_stream.type"], "logs")
+                - set(attributes["data_stream.dataset"], "sqlserverreceiver")
+                - set(attributes["data_stream.namespace"], "ep")
+        metric_statements:
+            - context: datapoint
+              statements:
+                - set(attributes["data_stream.type"], "metrics")
+                - set(attributes["data_stream.dataset"], "sqlserverreceiver")
+                - set(attributes["data_stream.namespace"], "ep")
+receivers:
+    sqlserver/componentid-0:
+        collection_interval: 10s
+        events:
+            db.server.query_sample:
+                enabled: false
+            db.server.top_query:
+                enabled: false
+        initial_delay: 1s
+        resource_attributes:
+            host.name:
+                enabled: false
+            server.address:
+                enabled: false
+            sqlserver.computer.name:
+                enabled: true
+            sqlserver.instance.name:
+                enabled: true
+secret_references: []
+service:
+    pipelines:
+        logs:
+            exporters:
+                - elasticsearch/componentid-0
+            receivers:
+                - forward
+        logs/componentid-0:
+            exporters:
+                - forward
+            processors:
+                - resourcedetection/componentid-0
+                - transform/componentid-1
+            receivers:
+                - sqlserver/componentid-0
+        metrics:
+            exporters:
+                - elasticsearch/componentid-0
+            receivers:
+                - forward
+        metrics/componentid-1:
+            exporters:
+                - forward
+            processors:
+                - resourcedetection/componentid-0
+                - transform/componentid-1
+            receivers:
+                - sqlserver/componentid-0

--- a/packages/sql_server_input_otel/_dev/test/policy/test-resource-attributes.yml
+++ b/packages/sql_server_input_otel/_dev/test/policy/test-resource-attributes.yml
@@ -1,0 +1,10 @@
+vars:
+  resource_attributes: |
+    sqlserver.computer.name:
+      enabled: true
+    sqlserver.instance.name:
+      enabled: true
+    server.address:
+      enabled: false
+    host.name:
+      enabled: false

--- a/packages/sql_server_input_otel/_dev/test/system/test-datasource-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-datasource-config.yml
@@ -3,5 +3,9 @@ vars:
   datasource: "sqlserver://SA:1234_asdf@{{Hostname}}:{{Port}}"
   collection_interval: 10s
   initial_delay: 1s
+  enable_query_sample_events: true
+  enable_top_query_events: true
+  top_query_lookback_time: 20s
+  top_query_collection_interval: 10s
 assert:
   min_count: 10

--- a/packages/sql_server_input_otel/_dev/test/system/test-datasource-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-datasource-config.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 service: sql_server_input_otel
 vars:
   datasource: "sqlserver://SA:1234_asdf@{{Hostname}}:{{Port}}"
@@ -8,9 +5,3 @@ vars:
   initial_delay: 1s
 assert:
   min_count: 10
-  fields_present:
-    - metrics.sqlserver.batch.request.rate
-    - metrics.sqlserver.batch.sql_compilation.rate
-    - metrics.sqlserver.batch.sql_recompilation.rate
-    - metrics.sqlserver.page.buffer_cache.hit_ratio
-    - metrics.sqlserver.user.connection.count

--- a/packages/sql_server_input_otel/_dev/test/system/test-default-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-default-config.yml
@@ -6,5 +6,9 @@ vars:
   password: "1234_asdf"
   collection_interval: 10s
   initial_delay: 1s
+  enable_query_sample_events: true
+  enable_top_query_events: true
+  top_query_lookback_time: 20s
+  top_query_collection_interval: 10s
 assert:
   min_count: 10

--- a/packages/sql_server_input_otel/_dev/test/system/test-default-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-default-config.yml
@@ -1,6 +1,3 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
 service: sql_server_input_otel
 vars:
   server: "{{Hostname}}"
@@ -11,9 +8,3 @@ vars:
   initial_delay: 1s
 assert:
   min_count: 10
-  fields_present:
-    - metrics.sqlserver.batch.request.rate
-    - metrics.sqlserver.batch.sql_compilation.rate
-    - metrics.sqlserver.batch.sql_recompilation.rate
-    - metrics.sqlserver.page.buffer_cache.hit_ratio
-    - metrics.sqlserver.user.connection.count

--- a/packages/sql_server_input_otel/_dev/test/system/test-logs-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-logs-config.yml
@@ -1,6 +1,3 @@
-# skip:
-#   reason: Test is skipped until we support multisignal inputs.
-#   link: https://github.com/elastic/elastic-package/issues/3298
 service: sql_server_input_otel
 vars:
   server: "{{Hostname}}"
@@ -62,7 +59,4 @@ assert:
     - sqlserver.deadlock_priority
     - sqlserver.row_count
     - sqlserver.context_info
-    # sqlserver.username was the originally expected field name, but the receiver emits the
-    # username under field user.name instead of a custom sqlserver.* attribute.
-    # - sqlserver.username
     - user.name

--- a/packages/sql_server_input_otel/_dev/test/system/test-logs-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-logs-config.yml
@@ -8,7 +8,7 @@ vars:
   initial_delay: 1s
   enable_query_sample_events: true
   enable_top_query_events: true
-  top_query_lookback_time: 60s
+  top_query_lookback_time: 20s
   top_query_collection_interval: 10s
 signal_types:
   - logs

--- a/packages/sql_server_input_otel/_dev/test/system/test-logs-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-logs-config.yml
@@ -1,6 +1,6 @@
-skip:
-  reason: Test is skipped until we support multisignal inputs.
-  link: https://github.com/elastic/elastic-package/issues/3298
+# skip:
+#   reason: Test is skipped until we support multisignal inputs.
+#   link: https://github.com/elastic/elastic-package/issues/3298
 service: sql_server_input_otel
 vars:
   server: "{{Hostname}}"
@@ -13,6 +13,8 @@ vars:
   enable_top_query_events: true
   top_query_lookback_time: 60s
   top_query_collection_interval: 10s
+signal_types:
+  - logs
 assert:
   min_count: 10
   fields_present:
@@ -29,7 +31,8 @@ assert:
     - sqlserver.total_physical_reads
     - sqlserver.execution_count
     - sqlserver.total_grant_kb
-    - sqlserver.query_plan
+    # sqlserver.query_plan is excluded: the XML plan content exceeds the Elasticsearch
+    # keyword ignore_above limit, so the field is stored in _ignored and is not indexed/searchable.
     # Query-Sample Collection (db.server.query_sample)
     - db.system.name
     - db.namespace
@@ -59,4 +62,7 @@ assert:
     - sqlserver.deadlock_priority
     - sqlserver.row_count
     - sqlserver.context_info
-    - sqlserver.username
+    # sqlserver.username was the originally expected field name, but the receiver emits the
+    # username under field user.name instead of a custom sqlserver.* attribute.
+    # - sqlserver.username
+    - user.name

--- a/packages/sql_server_input_otel/_dev/test/system/test-metrics-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-metrics-config.yml
@@ -1,0 +1,20 @@
+service: sql_server_input_otel
+vars:
+  server: "{{Hostname}}"
+  port: "{{Port}}"
+  username: "SA"
+  password: "1234_asdf"
+  collection_interval: 10s
+  initial_delay: 1s
+signal_types:
+  - metrics
+assert:
+  min_count: 10
+  fields_present:
+    - metrics.sqlserver.batch.request.rate
+    - metrics.sqlserver.batch.sql_compilation.rate
+    - metrics.sqlserver.batch.sql_recompilation.rate
+    - metrics.sqlserver.page.buffer_cache.hit_ratio
+    - metrics.sqlserver.user.connection.count
+
+

--- a/packages/sql_server_input_otel/_dev/test/system/test-metrics-config.yml
+++ b/packages/sql_server_input_otel/_dev/test/system/test-metrics-config.yml
@@ -16,5 +16,3 @@ assert:
     - metrics.sqlserver.batch.sql_recompilation.rate
     - metrics.sqlserver.page.buffer_cache.hit_ratio
     - metrics.sqlserver.user.connection.count
-
-


### PR DESCRIPTION

## Proposed commit message

Add signal-specific system tests and policy tests to the `sql_server_input_otel` and `mysql_input_otel` integrations.

**WHAT:**

*sql_server_input_otel*
- Enable `test-logs-config` with `signal_types: logs`, covering both `db.server.top_query` and `db.server.query_sample` events, including `fields_present` assertions aligned with the upstream receiver's field names (`user.name` instead of `sqlserver.username`; `sqlserver.query_plan` removed due to the value exceeding the ES `ignore_above` keyword limit). Uses `top_query_lookback_time: 20s` to match the workload's 20s lock window.
- Add `test-metrics-config` (currently skipped pending multisignal input support in elastic-package).
- Enable log event collection (`enable_query_sample_events`, `enable_top_query_events`, `top_query_lookback_time: 20s`) in the default and datasource configs so the default system test also exercises log collection alongside metrics.
- Remove blanket `fields_present` from the default and datasource configs — assertions are now handled per-signal config file.
- Fix the Docker workload to hold an exclusive table lock (`TABLOCKX`) so foreground `SELECT`s appear as suspended sessions in `sys.dm_exec_requests`, making them reliably visible to the `query_sample` collector.
- Remove the `skip` directive from all 5 existing policy tests (the multisignal input limitation does not affect policy tests).
- Add `test-resource-attributes` policy test: exercises the `resource_attributes` YAML var with a mix of enabled/disabled attributes.
- Add `test-logs-custom-collection` policy test: verifies non-default values for query-sample and top-query collection settings are correctly rendered.

*mysql_input_otel*
- Add `test-logs-config` and `test-metrics-config` signal-specific system tests with `fields_present` assertions using correct attribute names from the upstream `mysqlreceiver` documentation.
- Add policy tests for logs and metrics enabling.
- Restrict the default system test to a multisignal run (no `signal_types` filter), dropping `fields_present` in favour of the signal-specific configs.

**WHY:**
These tests ensure that both OTel SQL integrations collect the expected fields for each signal type, catch regressions in field naming conventions, and validate that policy rendering produces correct agent configurations for all supported configuration options.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [ ] ~I have added an entry to my package's `changelog.yml` file.~
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~
- [ ] ~I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)~

## Author's Checklist

- [x] All policy tests for both `sql_server_input_otel` and `mysql_input_otel` pass (`elastic-package test policy -v`)
- [x] All system tests for both `sql_server_input_otel` and `mysql_input_otel` pass (`elastic-package test system -v`)

## How to test this PR locally

```bash
elastic-package stack update -v -version 9.4.0-SNAPSHOT
elastic-package stack up -v -d --version 9.4.0-SNAPSHOT

# SQL Server OTel — policy tests
elastic-package -C packages/sql_server_input_otel test policy -v

# SQL Server OTel — system tests (requires a running stack + Docker)
elastic-package -C packages/sql_server_input_otel  test system -v

# MySQL OTel — system tests
elastic-package -C packages/mysql_input_otel  test system -v

elastic-package stack down -v
```


## Related issues

- Fixes https://github.com/elastic/integrations/issues/17876


---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).