### PR TITLE
[mongodb_atlas] Fix source.address handling in alert pipeline

### DIFF
--- a/packages/mongodb_atlas/changelog.yml
+++ b/packages/mongodb_atlas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Fix `source.address` handling in alert pipeline to be ECS-aligned (write parsed IPs to `source.ip`, hostnames to `source.domain`).
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.2.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/mongodb_atlas/changelog.yml
+++ b/packages/mongodb_atlas/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix `source.address` handling in alert pipeline to be ECS-aligned (write parsed IPs to `source.ip`, hostnames to `source.domain`).
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18659
 - version: "1.2.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/mongodb_atlas/data_stream/alert/_dev/test/pipeline/test-alert-logs.json
+++ b/packages/mongodb_atlas/data_stream/alert/_dev/test/pipeline/test-alert-logs.json
@@ -42,6 +42,49 @@
                     "threshold"
                 ]
             }
+        },
+        {
+            "response": {
+                "alertConfigId": "6683cb42d12516670f38a3ef",
+                "clusterName": "IntegrationsDevBuildCluster",
+                "created": "2024-07-02T09:55:24Z",
+                "currentValue": {
+                    "number": 1.2666666666666666,
+                    "units": "RAW"
+                },
+                "eventTypeName": "OUTSIDE_METRIC_THRESHOLD",
+                "groupId": "646f4379c47da356740d14ad",
+                "hostnameAndPort": "10.0.0.5:27017",
+                "id": "6683ce8c9558e8655626e1ee",
+                "lastNotified": "2024-07-02T10:03:21Z",
+                "metricName": "FTS_PROCESS_CPU_USER",
+                "orgId": "646f418c72f24c07d430aaca",
+                "replicaSetName": "atlas-ccx4uc-shard-0",
+                "resolved": "2024-07-02T10:03:21Z",
+                "status": "CLOSED",
+                "updated": "2024-07-02T10:03:21Z",
+                "userAlias": "integrationsdevbuildclu-shard-00-01.q5ljb.mongodb.net",
+                "acknowledgedUntil": "2024-07-05T00:00:00Z",
+                "acknowledgementComment": "Issue acknowledged and being worked on",
+                "acknowledgingUsername": "devOpsUser",
+                "parentClusterId": "exampleParentClusterId123",
+                "clusterId": "exampleClusterId456",
+                "nonRunningHostIds": [
+                    "hostId1",
+                    "hostId2"
+                ],
+                "hostId": "exampleHostId789",
+                "sourceTypeName": "ATLAS_MONITORING_AGENT",
+                "instanceName": "instance123",
+                "processorErrorMsg": "No errors",
+                "processorName": "Processor1",
+                "processorState": "Running",
+                "tags": [
+                    "critical",
+                    "cpu",
+                    "threshold"
+                ]
+            }
         }
     ]
 }

--- a/packages/mongodb_atlas/data_stream/alert/_dev/test/pipeline/test-alert-logs.json-expected.json
+++ b/packages/mongodb_atlas/data_stream/alert/_dev/test/pipeline/test-alert-logs.json-expected.json
@@ -100,6 +100,111 @@
             },
             "source": {
                 "address": "atlas-ccx4uc-shard-00-01.q5ljb.mongodb.net",
+                "domain": "atlas-ccx4uc-shard-00-01.q5ljb.mongodb.net",
+                "port": 27017
+            }
+        },
+        {
+            "@timestamp": "2024-07-02T09:55:24.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "host"
+                ],
+                "id": "6683ce8c9558e8655626e1ee",
+                "kind": "alert",
+                "module": "mongodb_atlas",
+                "type": [
+                    "info"
+                ]
+            },
+            "group": {
+                "id": "646f4379c47da356740d14ad"
+            },
+            "mongodb_atlas": {
+                "alert": {
+                    "acknowledged": {
+                        "comment": "Issue acknowledged and being worked on",
+                        "time": "2024-07-05T00:00:00Z",
+                        "user": {
+                            "name": "devOpsUser"
+                        }
+                    },
+                    "cluster": {
+                        "id": "exampleClusterId456",
+                        "name": "IntegrationsDevBuildCluster",
+                        "parent": {
+                            "id": "exampleParentClusterId123"
+                        }
+                    },
+                    "config": {
+                        "id": "6683cb42d12516670f38a3ef"
+                    },
+                    "event_type": {
+                        "name": "OUTSIDE_METRIC_THRESHOLD"
+                    },
+                    "host": {
+                        "id": "exampleHostId789",
+                        "non_running": {
+                            "ids": [
+                                "hostId1",
+                                "hostId2"
+                            ]
+                        }
+                    },
+                    "host_name_and_port": "10.0.0.5:27017",
+                    "last_notified": {
+                        "time": "2024-07-02T10:03:21Z"
+                    },
+                    "metric": {
+                        "name": "FTS_PROCESS_CPU_USER",
+                        "unit": "RAW",
+                        "value": 1.2666666666666666
+                    },
+                    "processor": {
+                        "error_msg": "No errors",
+                        "instance": {
+                            "name": "instance123"
+                        },
+                        "name": "Processor1",
+                        "state": "Running"
+                    },
+                    "replicaset": {
+                        "name": "atlas-ccx4uc-shard-0"
+                    },
+                    "resolved": {
+                        "time": "2024-07-02T10:03:21Z"
+                    },
+                    "source_type": {
+                        "name": "ATLAS_MONITORING_AGENT"
+                    },
+                    "status": "CLOSED",
+                    "tags": [
+                        "critical",
+                        "cpu",
+                        "threshold"
+                    ],
+                    "updated": {
+                        "time": "2024-07-02T10:03:21Z"
+                    },
+                    "user": {
+                        "alias": "integrationsdevbuildclu-shard-00-01.q5ljb.mongodb.net"
+                    }
+                }
+            },
+            "organization": {
+                "id": "646f418c72f24c07d430aaca"
+            },
+            "related": {
+                "ip": [
+                    "10.0.0.5"
+                ]
+            },
+            "source": {
+                "address": "10.0.0.5",
+                "ip": "10.0.0.5",
                 "port": 27017
             }
         }

--- a/packages/mongodb_atlas/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mongodb_atlas/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -127,19 +127,27 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
+      description: Copy source.address to either source.ip or source.domain
+      tag: convert_source_address
       field: source.address
+      target_field: source.ip
       type: ip
       ignore_missing: true
       on_failure:
-        - append:
-            field: related.hosts
-            value: '{{{source.address}}}'
-            allow_duplicates: false
+        - set:
+            field: source.domain
+            copy_from: source.address
+            ignore_empty_value: true
   - append:
       field: related.ip
-      value: '{{{source.address}}}'
+      value: '{{{source.ip}}}'
       allow_duplicates: false
-      if : "ctx.related?.hosts == null"
+      if: ctx.source?.ip != null
+  - append:
+      field: related.hosts
+      value: '{{{source.domain}}}'
+      allow_duplicates: false
+      if: ctx.source?.domain != null
   - rename:
       field: response.lastNotified
       target_field: mongodb_atlas.alert.last_notified.time

--- a/packages/mongodb_atlas/manifest.yml
+++ b/packages/mongodb_atlas/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: mongodb_atlas
 title: "MongoDB Atlas"
-version: 1.2.0
+version: 1.2.1
 source:
   license: "Elastic-2.0"
 description: This Elastic integration collects logs and metrics from MongoDB Atlas instance.


### PR DESCRIPTION
## Summary

The MongoDB Atlas `alert` ingest pipeline grokked the host portion of
`response.hostnameAndPort` into `source.address` and then ran
`convert: type: ip` **in place** on that same field. This caused two problems:

- **Mapping corruption / indexing failures.** When the conversion succeeded,
  the document's `source.address` value became an `ip`-typed value. After
  data-stream rollover, `source.address` could be dynamically mapped as
  `ip`, and subsequent FQDN events were rejected with mapper/parsing errors
  (issue #18441).
- **`related.ip` polluted with hostnames.** `related.ip` was appended from
  `source.address` (gated on `related.hosts == null`), so its semantics
  depended on the side effect of the in-place convert rather than on whether
  the value was actually an IP.

Per ECS, `source.address` should stay as the raw value (hostname, FQDN, or
IP), parseable IPs belong in `source.ip`, and hostnames/FQDNs belong in
`source.domain`.

## Changes

- **`data_stream/alert/elasticsearch/ingest_pipeline/default.yml`** —
  Replaced the in-place `convert` + `related.ip` blocks with the
  ECS-aligned pattern (mirrors
  `packages/opencanary/data_stream/events/elasticsearch/ingest_pipeline/default.yml`):
  - `convert source.address → target_field: source.ip, type: ip`
  - `on_failure: set source.domain copy_from source.address`
  - `append related.ip` gated on `ctx.source?.ip != null`
  - `append related.hosts` gated on `ctx.source?.domain != null`
  - `source.address` is no longer mutated.

- **`data_stream/alert/_dev/test/pipeline/test-alert-logs.json`** —
  Added a second event with an IPv4 `hostnameAndPort` (`10.0.0.5:27017`) so
  the test suite exercises the IP branch (it was previously FQDN-only).

- **`data_stream/alert/_dev/test/pipeline/test-alert-logs.json-expected.json`** —
  Updated the FQDN expectation to include `source.domain`; added a new
  expectation for the IPv4 event asserting raw `source.address`,
  `source.ip`, and `related.ip` (and no `source.domain` / `related.hosts`).


## Behavior matrix

| Input `hostnameAndPort` | `source.address` | `source.ip` | `source.domain` | `related.ip` | `related.hosts` |
| --- | --- | --- | --- | --- | --- |
| `host.example.com:27017` | `host.example.com` | — | `host.example.com` | — | `[host.example.com]` |
| `10.0.0.5:27017` | `10.0.0.5` | `10.0.0.5` | — | `[10.0.0.5]` | — |

## Notes

- IPv6 inputs are still not handled by the existing
  `%{HOSTNAME:source.address}` grok pattern (it only matches IPv4 and
  hostnames) — that's a pre-existing limitation and out of scope for this
  bugfix.
- `fields/fields.yml` description for
  `mongodb_atlas.alert.host_name_and_port` is left unchanged.

## Test plan

- [x] `elastic-package test pipeline --data-streams alert -v` passes (FQDN
      and new IPv4 fixture).
- [x] `elastic-package check`, `elastic-package format`,
      `elastic-package lint` are clean.
- [x] Manual: ingest a synthetic alert with FQDN
      `hostnameAndPort` and confirm the destination index does not map
      `source.address` as `ip` (it should stay `keyword`).
- [x] Manual: ingest a synthetic alert with IPv4 `hostnameAndPort` and
      confirm `source.ip` is populated and `related.ip` contains the IP.

## Related issues

- Closes https://github.com/elastic/integrations/issues/18441
