### PR TITLE
Revert "proofpoint_on_demand: add sinceTime cursor to message stream (#17508)"

### DIFF
--- a/packages/proofpoint_on_demand/changelog.yml
+++ b/packages/proofpoint_on_demand/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Revert 1.9.0 sinceTime cursor use which causes data delay and potential duplication.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18684
 - version: "1.9.0"
   changes:
     - description: Use sinceTime cursor for message data stream to resume from last position on reconnection.

--- a/packages/proofpoint_on_demand/data_stream/message/agent/stream/websocket.yml.hbs
+++ b/packages/proofpoint_on_demand/data_stream/message/agent/stream/websocket.yml.hbs
@@ -1,17 +1,9 @@
 url: {{url}}/v1/stream?cid={{cluster_id}}&type=message
-url_program: |
-  has(state.?cursor.last_timestamp) ?
-    state.url+"&sinceTime="+state.cursor.last_timestamp
-  :
-    state.url
 auth.bearer_token: {{access_token}}
 redact:
   fields: ~
 program: |
   bytes(state.response).decode_json().as(body,{
-    "cursor": {
-      "last_timestamp": body.ts,
-    },
     "events": {
       "message":  body.encode_json(),
     }

--- a/packages/proofpoint_on_demand/manifest.yml
+++ b/packages/proofpoint_on_demand/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: proofpoint_on_demand
 title: Proofpoint On Demand
-version: "1.9.0"
+version: "1.9.1"
 description: Collect logs from Proofpoint On Demand with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
Revert "proofpoint_on_demand: add sinceTime cursor to message stream (#17508)"

This reverts commit 8243a0bff40f59f46e8afb8e1d43f8f23d0e3ec6.

The sinceTime parameter was intended to resume streaming from the last
known position, but any sinceTime on the Proofpoint PoD Log API
switches the connection from real-time streaming to historical/archive
data mode, delivering batched data with at least 30 minutes of
staleness. This does not cause data loss, but will result in delay and
potential document duplication between index rollovers.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
