### PR TITLE
prisma_access: fix wildfire file.name mapping for events with CEF header name

### DIFF
--- a/packages/prisma_access/changelog.yml
+++ b/packages/prisma_access/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.3"
+  changes:
+    - description: Fix wildfire file.name mapping to also check CEF header name field, not only the extensions Name field.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.2"
   changes:
     - description: |

--- a/packages/prisma_access/changelog.yml
+++ b/packages/prisma_access/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix wildfire file.name mapping to also check CEF header name field, not only the extensions Name field.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18695
 - version: "1.7.2"
   changes:
     - description: |

--- a/packages/prisma_access/data_stream/event/_dev/test/pipeline/test-event.json
+++ b/packages/prisma_access/data_stream/event/_dev/test/pipeline/test-event.json
@@ -2604,6 +2604,78 @@
             "event": {
                 "original": "1540 <14>1 2021-03-23T13:19:44.634Z stream-logfwd20-587718190-03011255-ut6o-harness-5vlj logforwarder - panwlogs - CEF:0|Palo Alto Networks|LF|2.0|THREAT|wildfire|1|dtz=UTC rt=Mar 23 2021 13:19:42 deviceExternalId=device-123456789 PanOSConfigVersion=11.1 start=Mar 23 2021 13:19:40 src=192.0.2.10 dst=198.51.100.20 sourceTranslatedAddress=192.0.2.11 destinationTranslatedAddress=198.51.100.21 cs1=allow-web-traffic cs1Label=Rule suser=testuser duser= app=web-browsing PanOSFileURL= cs4=Trusted cs4Label=FromZone cs5=Untrusted cs5Label=ToZone deviceInboundInterface=ethernet1/1 deviceOutboundInterface=ethernet1/2 cn1=123456 cn1Label=SessionID spt=54321 dpt=443 sourceTranslatedPort=54321 destinationTranslatedPort=443 proto=tcp act=allow request=somefile.txt flexString2=server to client flexString2Label=DirectionOfAttack externalId=event-987654321 PanOSFileHash=abc123def456 PanOSApplianceOrCloud=eu.wildfire.paloaltonetworks.com PanOSURLCounter=1 PanOSFileType=pe PanOSReportID=12345 PanOSVirtualSystemName=vsys1 dvchost=PA-5220 PanOSContentVersion=0 PanOSRuleUUID=ec14df0b-c845-4435-87a2-d207730f5ae8 PanOSHTTP2Connection=0 PanOSPartialHash=0 PanOSIsProxy=true cat=wildfire-verdict PanOSThreatID=threat-123456 Name=wildfire"
             }
+        },
+        {
+            "@timestamp": "2026-04-29T06:11:21.031Z",
+            "cef": {
+              "device": {
+                "event_class_id": "THREAT",
+                "product": "LF",
+                "vendor": "Palo Alto Networks",
+                "version": "2.0"
+              },
+              "extensions": {
+                "PanOSApplianceOrCloud": "eu.wildfire.paloaltonetworks.com",
+                "PanOSConfigVersion": "11.1",
+                "PanOSContentVersion": "0",
+                "PanOSDestinationDynamicAddressGroup": "",
+                "PanOSDestinationEDL": "",
+                "PanOSEmailSubject": "",
+                "PanOSEndpointSerialNumber": "",
+                "PanOSFileHash": "abc123def456",
+                "PanOSFileType": "pe",
+                "PanOSFileURL": "",
+                "PanOSHTTP2Connection": "0",
+                "PanOSHostID": "",
+                "PanOSIsProxy": "false",
+                "PanOSPartialHash": "0",
+                "PanOSRecipientEmail": "",
+                "PanOSReportID": "12345",
+                "PanOSRuleUUID": "e669cd76-5792-4dc3-9c63-8d0f38c4aeba",
+                "PanOSSenderEmail": "",
+                "PanOSSourceDynamicAddressGroup": "",
+                "PanOSSourceEDL": "",
+                "PanOSThreatID": "Windows Dynamic Link Library (DLL)(52019)",
+                "PanOSURLCounter": "3",
+                "PanOSVirtualSystemName": "",
+                "applicationProtocol": "web-browsing",
+                "destinationAddress": "198.51.100.20",
+                "destinationPort": 80,
+                "destinationTranslatedAddress": "198.51.100.21",
+                "destinationTranslatedPort": 80,
+                "deviceAction": "allow",
+                "deviceCustomNumber1": 34532657,
+                "deviceCustomNumber1Label": "SessionID",
+                "deviceCustomString1": "UG-Web-Browsing",
+                "deviceCustomString1Label": "Rule",
+                "deviceCustomString4": "Trusted",
+                "deviceCustomString4Label": "FromZone",
+                "deviceCustomString5": "Untrusted",
+                "deviceCustomString5Label": "ToZone",
+                "deviceEventCategory": "Windows Dynamic Link Library (DLL)",
+                "deviceExternalId": "device-123456789",
+                "deviceHostName": "XXXXX",
+                "deviceInboundInterface": "ethernet1/1",
+                "deviceOutboundInterface": "ethernet1/2",
+                "deviceReceiptTime": "2026-04-28T06:19:12.000Z",
+                "deviceTimeZone": "UTC",
+                "externalId": "event-987654321",
+                "flexString2": "server to client",
+                "flexString2Label": "DirectionOfAttack",
+                "requestUrl": "somefile.txt",
+                "sourceAddress": "192.0.2.10",
+                "sourcePort": 60453,
+                "sourceTranslatedAddress": "192.0.2.11",
+                "sourceTranslatedPort": 9765,
+                "sourceUserName": "user@xxx",
+                "startTime": "2026-04-28T06:19:08.000Z",
+                "transportProtocol": "tcp"
+              },
+              "name": "wildfire",
+              "severity": "1",
+              "version": "0"
+            },
+            "message": "1545 <14>1 2026-04-28T06:19:14.022Z stream-logfwd20-54d65ca2--03220318-srwa-harness-256r logforwarder - panwlogs - CEF:0|Palo Alto Networks|LF|2.0|THREAT|wildfire|1|dtz=UTC rt=Apr 28 2026 06:19:12 deviceExternalId=device-123456789 PanOSConfigVersion=11.1 start=Apr 28 2026 06:19:08 src=192.0.2.10 dst=198.51.100.20 sourceTranslatedAddress=192.0.2.11 destinationTranslatedAddress=198.51.100.21 cs1=UG-Web-Browsing cs1Label=Rule suser=user@xxx duser= app=web-browsing PanOSFileURL= cs4=Trusted cs4Label=FromZone cs5=Untrusted cs5Label=ToZone deviceInboundInterface=ethernet1/1 deviceOutboundInterface=ethernet1/2 cn1=34532657 cn1Label=SessionID spt=60453 dpt=80 sourceTranslatedPort=9765 destinationTranslatedPort=80 proto=tcp act=allow request=somefile.txt flexString2=server to client flexString2Label=DirectionOfAttack externalId=event-987654321 PanOSFileHash=abc123def456 PanOSApplianceOrCloud=eu.wildfire.paloaltonetworks.com PanOSURLCounter=3 PanOSFileType=pe PanOSSenderEmail= PanOSEmailSubject= PanOSRecipientEmail= PanOSReportID=12345 PanOSVirtualSystemName= dvchost=XXXXX PanOSContentVersion=0 PanOSRuleUUID=e669cd76-5792-4dc3-9c63-8d0f38c4aeba PanOSHTTP2Connection=0 PanOSSourceEDL= PanOSDestinationEDL= PanOSHostID= PanOSEndpointSerialNumber= PanOSSourceDynamicAddressGroup= PanOSDestinationDynamicAddressGroup= PanOSPartialHash=0 PanOSIsProxy=false cat=Windows Dynamic Link Library (DLL) PanOSThreatID=Windows Dynamic Link Library (DLL)(52019)"
         }
     ]
 }

--- a/packages/prisma_access/data_stream/event/_dev/test/pipeline/test-event.json-expected.json
+++ b/packages/prisma_access/data_stream/event/_dev/test/pipeline/test-event.json-expected.json
@@ -5916,6 +5916,212 @@
                     }
                 }
             }
+        },
+        {
+            "@timestamp": "2026-04-28T06:19:08.000Z",
+            "destination": {
+                "ip": [
+                    "198.51.100.20"
+                ],
+                "nat": {
+                    "ip": "198.51.100.21",
+                    "port": 80
+                },
+                "port": 80
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "allow",
+                "category": [
+                    "network",
+                    "threat"
+                ],
+                "created": "2026-04-28T06:19:12.000Z",
+                "id": "event-987654321",
+                "kind": "alert",
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "file": {
+                "name": [
+                    "somefile.txt"
+                ]
+            },
+            "message": "1545 <14>1 2026-04-28T06:19:14.022Z stream-logfwd20-54d65ca2--03220318-srwa-harness-256r logforwarder - panwlogs - CEF:0|Palo Alto Networks|LF|2.0|THREAT|wildfire|1|dtz=UTC rt=Apr 28 2026 06:19:12 deviceExternalId=device-123456789 PanOSConfigVersion=11.1 start=Apr 28 2026 06:19:08 src=192.0.2.10 dst=198.51.100.20 sourceTranslatedAddress=192.0.2.11 destinationTranslatedAddress=198.51.100.21 cs1=UG-Web-Browsing cs1Label=Rule suser=user@xxx duser= app=web-browsing PanOSFileURL= cs4=Trusted cs4Label=FromZone cs5=Untrusted cs5Label=ToZone deviceInboundInterface=ethernet1/1 deviceOutboundInterface=ethernet1/2 cn1=34532657 cn1Label=SessionID spt=60453 dpt=80 sourceTranslatedPort=9765 destinationTranslatedPort=80 proto=tcp act=allow request=somefile.txt flexString2=server to client flexString2Label=DirectionOfAttack externalId=event-987654321 PanOSFileHash=abc123def456 PanOSApplianceOrCloud=eu.wildfire.paloaltonetworks.com PanOSURLCounter=3 PanOSFileType=pe PanOSSenderEmail= PanOSEmailSubject= PanOSRecipientEmail= PanOSReportID=12345 PanOSVirtualSystemName= dvchost=XXXXX PanOSContentVersion=0 PanOSRuleUUID=e669cd76-5792-4dc3-9c63-8d0f38c4aeba PanOSHTTP2Connection=0 PanOSSourceEDL= PanOSDestinationEDL= PanOSHostID= PanOSEndpointSerialNumber= PanOSSourceDynamicAddressGroup= PanOSDestinationDynamicAddressGroup= PanOSPartialHash=0 PanOSIsProxy=false cat=Windows Dynamic Link Library (DLL) PanOSThreatID=Windows Dynamic Link Library (DLL)(52019)",
+            "network": {
+                "application": "web-browsing",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "ethernet1/2"
+                    }
+                },
+                "hostname": "XXXXX",
+                "ingress": {
+                    "interface": {
+                        "name": "ethernet1/1"
+                    }
+                },
+                "product": "Prisma Access",
+                "serial_number": [
+                    "device-123456789"
+                ],
+                "type": "firewall",
+                "vendor": "Palo Alto Networks",
+                "version": "11.1"
+            },
+            "prisma_access": {
+                "event": {
+                    "appliance_or_cloud": "eu.wildfire.paloaltonetworks.com",
+                    "application": {
+                        "protocol": "web-browsing"
+                    },
+                    "cef": {
+                        "device": {
+                            "product": "LF",
+                            "vendor": "Palo Alto Networks",
+                            "version": "2.0"
+                        },
+                        "name": "wildfire",
+                        "severity": 1,
+                        "version": "0"
+                    },
+                    "class_id": "THREAT",
+                    "config_version": "11.1",
+                    "content_version": "0",
+                    "destination": {
+                        "address": {
+                            "value": "198.51.100.20"
+                        },
+                        "port": 80,
+                        "translated": {
+                            "address": "198.51.100.21",
+                            "port": 80
+                        }
+                    },
+                    "device": {
+                        "action": "allow",
+                        "event": {
+                            "category": "Windows Dynamic Link Library (DLL)"
+                        },
+                        "external_id": "device-123456789",
+                        "host_name": "XXXXX",
+                        "inbound_interface": "ethernet1/1",
+                        "outbound_interface": "ethernet1/2",
+                        "receipt_time": "2026-04-28T06:19:12.000Z",
+                        "time_zone": "UTC"
+                    },
+                    "direction_of_attack": "server to client",
+                    "external_id": "event-987654321",
+                    "file": {
+                        "hash": "abc123def456",
+                        "type": "pe"
+                    },
+                    "from_zone": "Trusted",
+                    "http2_connection": "0",
+                    "is_proxy": false,
+                    "label": {
+                        "cs1": "Rule",
+                        "cs4": "FromZone",
+                        "cs5": "ToZone",
+                        "flex_string": "DirectionOfAttack"
+                    },
+                    "partial_hash": "0",
+                    "report_id": "12345",
+                    "request": {
+                        "url": "somefile.txt"
+                    },
+                    "rule": {
+                        "uuid": "e669cd76-5792-4dc3-9c63-8d0f38c4aeba",
+                        "value": "UG-Web-Browsing"
+                    },
+                    "session": {
+                        "id": "34532657"
+                    },
+                    "source": {
+                        "address": {
+                            "value": "192.0.2.10"
+                        },
+                        "port": 60453,
+                        "translated": {
+                            "address": "192.0.2.11",
+                            "port": 9765
+                        },
+                        "user": {
+                            "name": "user@xxx"
+                        }
+                    },
+                    "start_time": "2026-04-28T06:19:08.000Z",
+                    "threat": {
+                        "id": "Windows Dynamic Link Library (DLL)(52019)"
+                    },
+                    "to_zone": "Untrusted",
+                    "transport_protocol": "tcp",
+                    "url": {
+                        "counter": 3
+                    }
+                }
+            },
+            "related": {
+                "hash": [
+                    "abc123def456",
+                    "0"
+                ],
+                "hosts": [
+                    "XXXXX"
+                ],
+                "ip": [
+                    "198.51.100.20",
+                    "198.51.100.21",
+                    "192.0.2.10",
+                    "192.0.2.11"
+                ],
+                "user": [
+                    "user@xxx"
+                ]
+            },
+            "rule": {
+                "name": "UG-Web-Browsing",
+                "uuid": [
+                    "e669cd76-5792-4dc3-9c63-8d0f38c4aeba"
+                ]
+            },
+            "source": {
+                "ip": [
+                    "192.0.2.10"
+                ],
+                "nat": {
+                    "ip": "192.0.2.11",
+                    "port": 9765
+                },
+                "port": 60453,
+                "user": {
+                    "name": [
+                        "user@xxx"
+                    ]
+                }
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "threat": {
+                "indicator": {
+                    "file": {
+                        "hash": {
+                            "sha256": "abc123def456"
+                        },
+                        "name": "somefile.txt",
+                        "type": "pe"
+                    }
+                }
+            }
         }
     ]
 }

--- a/packages/prisma_access/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/prisma_access/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -3827,16 +3827,16 @@ processors:
       tag: set_file_name_from_request_url_for_wildfire
       value: "{{{prisma_access.event.request.url}}}"
       allow_duplicates: false
-      if: ctx.cef?.device?.event_class_id == 'THREAT' && (ctx.cef?.extensions?.Name == 'wildfire' || ctx.cef?.extensions?.Name == 'wildfire-virus') && ctx.prisma_access?.event?.request?.url != null
+      if: ctx.cef?.device?.event_class_id == 'THREAT' && (['wildfire', 'wildfire-virus'].contains(ctx.cef?.extensions?.Name) || ['wildfire', 'wildfire-virus'].contains(ctx.cef?.name)) && ctx.prisma_access?.event?.request?.url != null
   - set:
       field: threat.indicator.file.name
       tag: set_threat_indicator_file_name_for_wildfire
       copy_from: prisma_access.event.request.url
       ignore_empty_value: true
-      if: ctx.cef?.device?.event_class_id == 'THREAT' && (ctx.cef?.extensions?.Name == 'wildfire' || ctx.cef?.extensions?.Name == 'wildfire-virus')
+      if: ctx.cef?.device?.event_class_id == 'THREAT' && (['wildfire', 'wildfire-virus'].contains(ctx.cef?.extensions?.Name) || ['wildfire', 'wildfire-virus'].contains(ctx.cef?.name))
   - uri_parts:
       field: prisma_access.event.request.url
-      if: ctx.prisma_access?.event?.request?.url != null && ctx.prisma_access.event.request.url != '' && !(ctx.cef?.device?.event_class_id == 'THREAT' && (ctx.cef?.extensions?.Name == 'wildfire' || ctx.cef?.extensions?.Name == 'wildfire-virus'))
+      if: ctx.prisma_access?.event?.request?.url != null && ctx.prisma_access.event.request.url != '' && !(ctx.cef?.device?.event_class_id == 'THREAT' && (['wildfire', 'wildfire-virus'].contains(ctx.cef?.extensions?.Name) || ['wildfire', 'wildfire-virus'].contains(ctx.cef?.name)))
       tag: uri_parts_processor
       ignore_failure: true
   - set:
@@ -3844,7 +3844,7 @@ processors:
       tag: set_http_request_url_from_event_request_url
       copy_from: prisma_access.event.request.url
       ignore_empty_value: true
-      if: "!(ctx.cef?.device?.event_class_id == 'THREAT' && (ctx.cef?.extensions?.Name == 'wildfire' || ctx.cef?.extensions?.Name == 'wildfire-virus'))"
+      if: "!(ctx.cef?.device?.event_class_id == 'THREAT' && (['wildfire', 'wildfire-virus'].contains(ctx.cef?.extensions?.Name) || ['wildfire', 'wildfire-virus'].contains(ctx.cef?.name)))"
   - convert:
       field: cef.extensions.PanOSRootCNLength
       tag: convert_extension_PanOSRootCNLength_to_long

--- a/packages/prisma_access/manifest.yml
+++ b/packages/prisma_access/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: prisma_access
 title: Palo Alto Prisma Access
-version: "1.7.2"
+version: "1.7.3"
 description: Collect logs from Palo Alto Prisma Access with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

## Proposed commit message
```
prisma_access: fix wildfire file.name mapping for events with CEF header name

The wildfire-specific processors that map the CEF request field to
file.name instead of url.full only checked cef.extensions.Name. Real
customer logs carry the event name in the CEF header (cef.name), not
as an extension field. The conditions now check both locations so the
mapping works regardless of where the CEF parser places the name.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Pipeline tests run successfully populating `file.name` and not `url.*` fields
