### PR TITLE
[k8s otel dashboard] Add support for debugging of stopped k8s resources through dashboard.

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.1.0-preview2
+  changes:
+    - description: Use stale-entity filtering on detail dashboard metric panels to preserve visibility of deleted, crashed, and scaled-down resources during drilldown investigation
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 2.1.0-preview1
   changes:
     - description: Improve overview dashboard

--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use stale-entity filtering on detail dashboard metric panels to preserve visibility of deleted, crashed, and scaled-down resources during drilldown investigation
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18711
 - version: 2.1.0-preview1
   changes:
     - description: Improve overview dashboard

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
@@ -58,7 +58,7 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_3c2823c1-c3b5-4ee1-b156-6c1b7c286faf_dashboard",
+                            "destinationRefName": "link_ab6fdd2a-169b-4ed6-82c8-497c4a266df3_dashboard",
                             "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
@@ -138,7 +138,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.pod.name), names = VALUES(k8s.pod.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" pods\"))\n| KEEP name"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS count = COUNT(*), names = VALUES(k8s.pod.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" pods\"))\n| KEEP name"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -148,7 +148,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.pod.name), names = VALUES(k8s.pod.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" pods\"))\n| KEEP name"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS count = COUNT(*), names = VALUES(k8s.pod.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" pods\"))\n| KEEP name"
                             },
                             "visualization": {
                                 "colorMode": "none",
@@ -167,8 +167,7 @@
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    },
-                    "drilldowns": []
+                    }
                 },
                 "gridData": {
                     "h": 3,
@@ -268,8 +267,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Pod phase: Pending/Running/Succeeded/Failed/Unknown.",
-                    "drilldowns": []
+                    "description": "Pod phase: Pending/Running/Succeeded/Failed/Unknown."
                 },
                 "gridData": {
                     "h": 3,
@@ -287,17 +285,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -305,9 +303,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -354,9 +352,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.container.restarts IS NOT NULL\n    AND k8s.pod.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.uid, k8s.container.name\n| STATS restarts = SUM(max_restarts)"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.container.restarts IS NOT NULL\n    AND k8s.pod.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts),\n    last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS restarts = SUM(max_restarts)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -366,7 +364,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.container.restarts IS NOT NULL\n    AND k8s.pod.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.uid, k8s.container.name\n| STATS restarts = SUM(max_restarts)"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.container.restarts IS NOT NULL\n    AND k8s.pod.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts),\n    last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS restarts = SUM(max_restarts)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -520,10 +518,30 @@
                     "attributes": {
                         "references": [],
                         "state": {
-                            "adHocDataViews": {},
+                            "adHocDataViews": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "managed": false,
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
                                 "textBased": {
-                                    "indexPatternRefs": [],
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
                                         "5324aeda-31bb-49b8-8383-1e41599ce41f": {
                                             "allColumns": [
@@ -588,8 +606,9 @@
                                                     }
                                                 }
                                             ],
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.cpu_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.cpu_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -597,9 +616,9 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.cpu_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.cpu_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
                             },
                             "visualization": {
                                 "applyColorTo": "bar",
@@ -654,8 +673,7 @@
                                 "showBar": true
                             }
                         },
-                        "title": "CPU utilization (vs limits)",
-                        "type": "lens",
+                        "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
@@ -848,10 +866,30 @@
                     "attributes": {
                         "references": [],
                         "state": {
-                            "adHocDataViews": {},
+                            "adHocDataViews": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "managed": false,
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
                                 "textBased": {
-                                    "indexPatternRefs": [],
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
                                         "72938f7c-f5ca-480b-bcdd-bce4a68d676a": {
                                             "allColumns": [
@@ -916,8 +954,9 @@
                                                     }
                                                 }
                                             ],
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.memory_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.memory_limit_utilization, @timestamp)\n  BY k8s.pod.name\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -925,9 +964,9 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.memory_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.memory_limit_utilization, @timestamp)\n  BY k8s.pod.name\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
                             },
                             "visualization": {
                                 "applyColorTo": "bar",
@@ -982,8 +1021,7 @@
                                 "showBar": true
                             }
                         },
-                        "title": "Memory utilization (vs limits)",
-                        "type": "lens",
+                        "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
@@ -1102,7 +1140,7 @@
                                             ],
                                             "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
                                             "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS `Memory working set` = SUM(k8s.pod.memory.working_set),\n    `Memory requests` = SUM(k8s.container.memory_request),\n    `Memory limits` = SUM(k8s.container.memory_limit)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Memory working set`, `Memory requests`, `Memory limits`"
+                                                "esql": "TS metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set),\n    `Memory requests` = AVG(k8s.container.memory_request),\n    `Memory limits` = AVG(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name,\n     timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| STATS `Memory working set` = MAX(`Memory working set`),\n    `Memory requests` = SUM(`Memory requests`),\n    `Memory limits` = SUM(`Memory limits`)\n  BY k8s.pod.name, timestamp\n| STATS `Memory working set` = SUM(`Memory working set`),\n    `Memory requests` = SUM(`Memory requests`),\n    `Memory limits` = SUM(`Memory limits`)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, `Memory working set`, `Memory requests`, `Memory limits`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1112,7 +1150,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS `Memory working set` = SUM(k8s.pod.memory.working_set),\n    `Memory requests` = SUM(k8s.container.memory_request),\n    `Memory limits` = SUM(k8s.container.memory_limit)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Memory working set`, `Memory requests`, `Memory limits`"
+                                "esql": "TS metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set),\n    `Memory requests` = AVG(k8s.container.memory_request),\n    `Memory limits` = AVG(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name,\n     timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| STATS `Memory working set` = MAX(`Memory working set`),\n    `Memory requests` = SUM(`Memory requests`),\n    `Memory limits` = SUM(`Memory limits`)\n  BY k8s.pod.name, timestamp\n| STATS `Memory working set` = SUM(`Memory working set`),\n    `Memory requests` = SUM(`Memory requests`),\n    `Memory limits` = SUM(`Memory limits`)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, `Memory working set`, `Memory requests`, `Memory limits`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1202,17 +1240,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1220,9 +1258,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -1253,9 +1291,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.cpu_limit IS NOT NULL\n| STATS cpu_limit = MAX(k8s.container.cpu_limit)\n  BY k8s.pod.name, k8s.container.name\n| STATS total_cores = SUM(cpu_limit)\n| EVAL total_cores = ROUND(total_cores, 2)\n| KEEP total_cores"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.cpu_limit IS NOT NULL\n| STATS cpu_limit = MAX(k8s.container.cpu_limit),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cores = SUM(cpu_limit)\n| EVAL total_cores = ROUND(total_cores, 2)\n| KEEP total_cores"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1265,7 +1303,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.cpu_limit IS NOT NULL\n| STATS cpu_limit = MAX(k8s.container.cpu_limit)\n  BY k8s.pod.name, k8s.container.name\n| STATS total_cores = SUM(cpu_limit)\n| EVAL total_cores = ROUND(total_cores, 2)\n| KEEP total_cores"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.cpu_limit IS NOT NULL\n| STATS cpu_limit = MAX(k8s.container.cpu_limit),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cores = SUM(cpu_limit)\n| EVAL total_cores = ROUND(total_cores, 2)\n| KEEP total_cores"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -1357,7 +1395,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS capacity = SUM(k8s.volume.capacity),\n    available = SUM(k8s.volume.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| EVAL `Volume Usage` = capacity - available\n| SORT timestamp\n| KEEP timestamp, `Volume Usage`"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS cap = MAX(k8s.volume.capacity),\n    avail = MAX(k8s.volume.available)\n  BY k8s.pod.name, k8s.volume.name,\n    timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| STATS `Volume Usage` = SUM(cap) - SUM(avail)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, `Volume Usage`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1367,7 +1405,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS capacity = SUM(k8s.volume.capacity),\n    available = SUM(k8s.volume.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| EVAL `Volume Usage` = capacity - available\n| SORT timestamp\n| KEEP timestamp, `Volume Usage`"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS cap = MAX(k8s.volume.capacity),\n    avail = MAX(k8s.volume.available)\n  BY k8s.pod.name, k8s.volume.name,\n    timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| STATS `Volume Usage` = SUM(cap) - SUM(avail)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, `Volume Usage`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1503,7 +1541,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n    AND k8s.container.name IS NOT NULL\n| EVAL container_id = CONCAT(k8s.pod.name, \"/\", k8s.container.name)\n| STATS `Container Count` = COUNT_DISTINCT(container_id)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Container Count`"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n  AND container.cpu.usage IS NOT NULL\n| EVAL container_id = CONCAT(k8s.pod.name, \"/\", k8s.container.name)\n| STATS `Container Count` = COUNT_DISTINCT(container_id)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Container Count`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1513,7 +1551,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n    AND k8s.container.name IS NOT NULL\n| EVAL container_id = CONCAT(k8s.pod.name, \"/\", k8s.container.name)\n| STATS `Container Count` = COUNT_DISTINCT(container_id)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Container Count`"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n  AND container.cpu.usage IS NOT NULL\n| EVAL container_id = CONCAT(k8s.pod.name, \"/\", k8s.container.name)\n| STATS `Container Count` = COUNT_DISTINCT(container_id)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Container Count`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1647,7 +1685,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n  AND k8s.volume.available IS NOT NULL\n| STATS avail = MAX(k8s.volume.available),\n    cap = MAX(k8s.volume.capacity)\n  BY k8s.pod.name, k8s.volume.name\n| STATS total_avail = SUM(avail),\n    total_cap = SUM(cap)\n| EVAL utilization = ROUND(1.0 - TO_DOUBLE(total_avail) / TO_DOUBLE(total_cap), 4)\n| KEEP utilization"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n  AND k8s.volume.available IS NOT NULL\n| STATS avail = LAST(k8s.volume.available, @timestamp),\n    cap = LAST(k8s.volume.capacity, @timestamp),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_avail = SUM(avail),\n    total_cap = SUM(cap)\n| EVAL utilization = ROUND(1.0 - TO_DOUBLE(total_avail) / TO_DOUBLE(total_cap), 4)\n| KEEP utilization"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1657,7 +1695,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n  AND k8s.volume.available IS NOT NULL\n| STATS avail = MAX(k8s.volume.available),\n    cap = MAX(k8s.volume.capacity)\n  BY k8s.pod.name, k8s.volume.name\n| STATS total_avail = SUM(avail),\n    total_cap = SUM(cap)\n| EVAL utilization = ROUND(1.0 - TO_DOUBLE(total_avail) / TO_DOUBLE(total_cap), 4)\n| KEEP utilization"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n  AND k8s.volume.available IS NOT NULL\n| STATS avail = LAST(k8s.volume.available, @timestamp),\n    cap = LAST(k8s.volume.capacity, @timestamp),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_avail = SUM(avail),\n    total_cap = SUM(cap)\n| EVAL utilization = ROUND(1.0 - TO_DOUBLE(total_avail) / TO_DOUBLE(total_cap), 4)\n| KEEP utilization"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -1691,17 +1729,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1709,9 +1747,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -1737,9 +1775,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.memory_limit IS NOT NULL\n| STATS mem_limit = MAX(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name\n| STATS total_limit = SUM(mem_limit)\n| KEEP total_limit"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.memory_limit IS NOT NULL\n| STATS mem_limit = MAX(k8s.container.memory_limit),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(mem_limit)\n| KEEP total_limit"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1749,7 +1787,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.memory_limit IS NOT NULL\n| STATS mem_limit = MAX(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name\n| STATS total_limit = SUM(mem_limit)\n| KEEP total_limit"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.memory_limit IS NOT NULL\n| STATS mem_limit = MAX(k8s.container.memory_limit),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(mem_limit)\n| KEEP total_limit"
                             },
                             "visualization": {
                                 "color": "#61A2FF",
@@ -1781,17 +1819,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1799,9 +1837,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -1827,9 +1865,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS cap = MAX(k8s.volume.capacity)\n  BY k8s.pod.name, k8s.volume.name\n| STATS total_cap = SUM(cap)\n| KEEP total_cap"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS cap = MAX(k8s.volume.capacity),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap)\n| KEEP total_cap"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1839,7 +1877,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS cap = MAX(k8s.volume.capacity)\n  BY k8s.pod.name, k8s.volume.name\n| STATS total_cap = SUM(cap)\n| KEEP total_cap"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS cap = MAX(k8s.volume.capacity),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap)\n| KEEP total_cap"
                             },
                             "visualization": {
                                 "color": "#61A2FF",
@@ -2117,17 +2155,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -2135,9 +2173,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -2218,9 +2256,9 @@
                                                     "label": "Direction"
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.pod.network.io IS NOT NULL\n| STATS\n    `Throughput` = SUM(RATE(k8s.pod.network.io))\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), direction\n| EVAL direction = CASE(direction == \"receive\", \"Network In\", direction == \"transmit\", \"Network Out\", direction)\n| SORT timestamp\n| KEEP timestamp, direction, `Throughput`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.network.io IS NOT NULL\n| STATS\n    `Throughput` = SUM(RATE(k8s.pod.network.io))\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), direction\n| EVAL direction = CASE(direction == \"receive\", \"Network In\", direction == \"transmit\", \"Network Out\", direction)\n| SORT timestamp\n| KEEP timestamp, direction, `Throughput`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2230,7 +2268,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.pod.network.io IS NOT NULL\n| STATS\n    `Throughput` = SUM(RATE(k8s.pod.network.io))\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), direction\n| EVAL direction = CASE(direction == \"receive\", \"Network In\", direction == \"transmit\", \"Network Out\", direction)\n| SORT timestamp\n| KEEP timestamp, direction, `Throughput`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.network.io IS NOT NULL\n| STATS\n    `Throughput` = SUM(RATE(k8s.pod.network.io))\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), direction\n| EVAL direction = CASE(direction == \"receive\", \"Network In\", direction == \"transmit\", \"Network Out\", direction)\n| SORT timestamp\n| KEEP timestamp, direction, `Throughput`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2634,7 +2672,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| INLINE STATS latest_ts = MAX(CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name, k8s.container.name\n| EVAL ready_val = CASE(@timestamp == latest_ts, k8s.container.ready, NULL)\n| STATS\n    ready_num    = MAX(ready_val),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS\n    ready_num    = LAST(k8s.container.ready, CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL)),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit),\n    last_seen    = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2644,7 +2682,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| INLINE STATS latest_ts = MAX(CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name, k8s.container.name\n| EVAL ready_val = CASE(@timestamp == latest_ts, k8s.container.ready, NULL)\n| STATS\n    ready_num    = MAX(ready_val),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit)\n  BY k8s.pod.name, k8s.container.name\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS\n    ready_num    = LAST(k8s.container.ready, CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL)),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit),\n    last_seen    = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
@@ -3000,18 +3038,18 @@
                 "title": "Containers in pod"
             }
         ],
-        "timeFrom": "now-15m",
+        "timeFrom": "2026-04-27T02:33:37.888Z",
         "timeRestore": true,
-        "timeTo": "now",
+        "timeTo": "2026-04-27T09:26:28.926Z",
         "title": "[OTEL][Kubernetes] Pod Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-14T04:50:07.562Z",
+    "created_at": "2026-04-21T06:44:36.263Z",
     "id": "kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-pod-back-link:link_3c2823c1-c3b5-4ee1-b156-6c1b7c286faf_dashboard",
+            "name": "v3-pod-back-link:link_ab6fdd2a-169b-4ed6-82c8-497c4a266df3_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
@@ -58,7 +58,7 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_ab6fdd2a-169b-4ed6-82c8-497c4a266df3_dashboard",
+                            "destinationRefName": "link_72995b34-850a-4aec-bcb7-2cf694d13086_dashboard",
                             "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
@@ -177,7 +177,7 @@
                     "y": 0
                 },
                 "panelIndex": "v3-pd-header-name",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -277,7 +277,7 @@
                     "y": 0
                 },
                 "panelIndex": "v3-pd-header-status",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -373,14 +373,16 @@
                                 "layerId": "4af3de89-68a8-8e1f-ccb7-4e6febd43855",
                                 "layerType": "data",
                                 "metricAccessor": "2999510e-3669-b52d-dfab-8810af241dd4",
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Total container restarts for this pod. MAX(k8s.container.restarts)."
+                    "description": "Total container restarts for this pod. MAX(k8s.container.restarts).",
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 3,
@@ -390,7 +392,7 @@
                     "y": 0
                 },
                 "panelIndex": "v2-pod-detail-restarts",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -511,7 +513,7 @@
                     "y": 0
                 },
                 "panelIndex": "v4-pd-logs-card",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -670,13 +672,15 @@
                                     "type": "palette"
                                 },
                                 "progressDirection": "horizontal",
-                                "showBar": true
+                                "showBar": true,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
+                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -688,7 +692,7 @@
                     "y": 0
                 },
                 "panelIndex": "v4-pd-cpu-gauge",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -859,7 +863,7 @@
                     "y": 0
                 },
                 "panelIndex": "v4-pd-cpu-ts",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1018,13 +1022,15 @@
                                     "type": "palette"
                                 },
                                 "progressDirection": "horizontal",
-                                "showBar": true
+                                "showBar": true,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
+                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -1036,7 +1042,7 @@
                     "y": 0
                 },
                 "panelIndex": "v4-pd-mem-gauge",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1232,7 +1238,7 @@
                     "y": 0
                 },
                 "panelIndex": "v4-pd-mem-ts",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1312,13 +1318,15 @@
                                 "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
                                 "layerType": "data",
                                 "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 5,
@@ -1329,7 +1337,7 @@
                     "y": 5
                 },
                 "panelIndex": "v4-pd-cpu-limit",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1483,7 +1491,7 @@
                     "y": 10
                 },
                 "panelIndex": "97863656-e046-4954-b9d9-93fadafeb3f9",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1629,7 +1637,7 @@
                     "y": 10
                 },
                 "panelIndex": "1633d880-4700-4397-ac93-106e71ba34a0",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1702,13 +1710,15 @@
                                 "color": "#61A2FF",
                                 "layerId": "ca04349e-a75e-4404-87ae-a78f02decc60",
                                 "layerType": "data",
-                                "metricAccessor": "utilization"
+                                "metricAccessor": "utilization",
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
+                    "drilldowns": [],
                     "hide_title": true,
                     "title": "Volume utilization"
                 },
@@ -1721,7 +1731,7 @@
                     "y": 10
                 },
                 "panelIndex": "c43f87bc-a64c-49eb-b103-f53dd8ef759b",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1793,13 +1803,15 @@
                                 "color": "#61A2FF",
                                 "layerId": "0de1cb25-05bc-46e8-91bc-acbe36433638",
                                 "layerType": "data",
-                                "metricAccessor": "total_limit"
+                                "metricAccessor": "total_limit",
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
+                    "drilldowns": [],
                     "title": ""
                 },
                 "gridData": {
@@ -1811,7 +1823,7 @@
                     "y": 5
                 },
                 "panelIndex": "cf0099b0-4701-406f-9436-53dc9a58af45",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1883,13 +1895,15 @@
                                 "color": "#61A2FF",
                                 "layerId": "e9cbf807-725a-496c-95ea-4462c11f6ebb",
                                 "layerType": "data",
-                                "metricAccessor": "total_cap"
+                                "metricAccessor": "total_cap",
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
+                    "drilldowns": [],
                     "title": ""
                 },
                 "gridData": {
@@ -1901,7 +1915,7 @@
                     "y": 15
                 },
                 "panelIndex": "b7944b7b-1576-457f-95ac-770bf98d8ccc",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -2147,7 +2161,7 @@
                     "y": 0
                 },
                 "panelIndex": "v2-pod-detail-memory-decomp",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -2367,7 +2381,7 @@
                     "y": 0
                 },
                 "panelIndex": "v2-pod-detail-network-io",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -2846,7 +2860,7 @@
                     "y": 0
                 },
                 "panelIndex": "7dad193d-fd5e-416d-8e59-63301bc8f9da",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -3006,12 +3020,9 @@
                     "y": 0
                 },
                 "panelIndex": "be254895-5146-4aa9-8def-d8854fb01d6a",
-                "type": "lens"
+                "type": "vis"
             }
         ],
-        "pinned_panels": {
-            "panels": {}
-        },
         "sections": [
             {
                 "collapsed": false,
@@ -3038,18 +3049,18 @@
                 "title": "Containers in pod"
             }
         ],
-        "timeFrom": "2026-04-27T02:33:37.888Z",
+        "timeFrom": "2026-05-03T16:31:34.018Z",
         "timeRestore": true,
-        "timeTo": "2026-04-27T09:26:28.926Z",
+        "timeTo": "2026-05-07T09:11:15.618Z",
         "title": "[OTEL][Kubernetes] Pod Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-21T06:44:36.263Z",
+    "created_at": "2026-05-04T03:38:22.097Z",
     "id": "kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-pod-back-link:link_ab6fdd2a-169b-4ed6-82c8-497c4a266df3_dashboard",
+            "name": "v3-pod-back-link:link_72995b34-850a-4aec-bcb7-2cf694d13086_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
@@ -88,7 +88,7 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_d7c1ba62-e32f-4de2-9020-16788bf86ece_dashboard",
+                            "destinationRefName": "link_cba4cd76-0d62-4d04-bcf2-c782c8bbff3a_dashboard",
                             "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
@@ -226,17 +226,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -244,9 +244,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -264,9 +264,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.deployment.name\n| WHERE @timestamp == latest_ts\n| STATS available = MAX(k8s.deployment.available)"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.available IS NOT NULL\n| STATS available = LAST(k8s.deployment.available, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS available = SUM(available)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -276,7 +276,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.deployment.name\n| WHERE @timestamp == latest_ts\n| STATS available = MAX(k8s.deployment.available)"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.available IS NOT NULL\n| STATS available = LAST(k8s.deployment.available, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS available = SUM(available)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -327,8 +327,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "description": "Available replicas for this deployment. MAX(k8s.deployment.available).",
-                    "hide_title": true,
-                    "title": ""
+                    "hide_title": true
                 },
                 "gridData": {
                     "h": 4,
@@ -346,17 +345,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -364,9 +363,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -384,9 +383,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.deployment.name\n| WHERE @timestamp == latest_ts\n| STATS desired = MAX(k8s.deployment.desired)"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| STATS desired = LAST(k8s.deployment.desired, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS desired = SUM(desired)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -396,7 +395,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.deployment.name\n| WHERE @timestamp == latest_ts\n| STATS desired = MAX(k8s.deployment.desired)"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| STATS desired = LAST(k8s.deployment.desired, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS desired = SUM(desired)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -432,23 +431,29 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
                             "datasourceStates": {
                                 "textBased": {
-                                    "indexPatternRefs": [],
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
                                         "48bf04fd-0ec2-9a2b-b498-bad9c61750cb": {
                                             "columns": [
@@ -464,9 +469,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n| STATS pod_count = COUNT_DISTINCT(k8s.pod.uid)\n"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| STATS desired = LAST(k8s.deployment.desired, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = SUM(desired)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -474,9 +479,9 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n| STATS pod_count = COUNT_DISTINCT(k8s.pod.uid)\n"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| STATS desired = LAST(k8s.deployment.desired, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = SUM(desired)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -489,7 +494,6 @@
                             }
                         },
                         "title": "",
-                        "type": "lens",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
@@ -512,17 +516,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -530,9 +534,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -550,9 +554,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts) BY k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS restarts = LAST(k8s.container.restarts, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_restarts = SUM(restarts)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -560,9 +564,9 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts) BY k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS restarts = LAST(k8s.container.restarts, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_restarts = SUM(restarts)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -575,7 +579,6 @@
                             }
                         },
                         "title": "",
-                        "type": "lens",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
@@ -638,7 +641,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name), names = VALUES(k8s.deployment.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" deployments\"))\n| KEEP name"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS names = VALUES(k8s.deployment.name)\n| EVAL count = MV_COUNT(names),\n       name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" deployments\"))\n| KEEP name"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -648,7 +651,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name), names = VALUES(k8s.deployment.name)\n| EVAL name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" deployments\"))\n| KEEP name"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n| STATS names = VALUES(k8s.deployment.name)\n| EVAL count = MV_COUNT(names),\n       name = CASE(count == 1, MV_FIRST(names), CONCAT(TO_STRING(count), \" deployments\"))\n| KEEP name"
                             },
                             "visualization": {
                                 "colorMode": "none",
@@ -667,8 +670,7 @@
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    },
-                    "drilldowns": []
+                    }
                 },
                 "gridData": {
                     "h": 3,
@@ -686,23 +688,29 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
                             "datasourceStates": {
                                 "textBased": {
-                                    "indexPatternRefs": [],
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
                                         "4af3de89-68a8-8e1f-ccb7-4e6febd43855": {
                                             "columns": [
@@ -736,9 +744,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.cpu_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val\n"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.cpu_limit_utilization, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -746,9 +754,9 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.cpu_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val\n"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.cpu_limit_utilization, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
                             },
                             "visualization": {
                                 "applyColorTo": "bar",
@@ -803,8 +811,7 @@
                                 "showBar": true
                             }
                         },
-                        "title": "CPU utilization",
-                        "type": "lens",
+                        "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
@@ -828,23 +835,29 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
                             "datasourceStates": {
                                 "textBased": {
-                                    "indexPatternRefs": [],
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
                                         "4af3de89-68a8-8e1f-ccb7-4e6febd43855": {
                                             "columns": [
@@ -878,9 +891,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.memory_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val\n"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.memory_limit_utilization, @timestamp) BY k8s.pod.name\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -888,9 +901,9 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.memory_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val\n"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.memory_limit_utilization, @timestamp) BY k8s.pod.name\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
                             },
                             "visualization": {
                                 "applyColorTo": "bar",
@@ -945,8 +958,7 @@
                                 "showBar": true
                             }
                         },
-                        "title": "Memory limit utilization",
-                        "type": "lens",
+                        "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
@@ -970,17 +982,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -988,9 +1000,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -1025,9 +1037,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage) BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `CPU usage`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `CPU usage`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1037,7 +1049,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage) BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `CPU usage`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `CPU usage`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1104,17 +1116,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1122,9 +1134,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -1158,9 +1170,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set) BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Memory working set`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Memory working set`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1170,7 +1182,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set) BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Memory working set`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Memory working set`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1295,7 +1307,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.volume.available IS NOT NULL AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = MAX(k8s.volume.available),\n        cap_per = MAX(k8s.volume.capacity)\n    BY k8s.pod.uid, k8s.volume.name\n| STATS avail = SUM(avail_per), cap = SUM(cap_per)\n| EVAL utilization = 1.0 - TO_DOUBLE(avail) / TO_DOUBLE(cap), max_val = 1.0\n| KEEP utilization, max_val"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = LAST(k8s.volume.available, @timestamp),\n        cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS avail = SUM(avail_per), cap = SUM(cap_per)\n| EVAL utilization = 1.0 - TO_DOUBLE(avail) / TO_DOUBLE(cap),\n        max_val = 1.0\n| KEEP utilization, max_val"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1305,7 +1317,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.volume.available IS NOT NULL AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = MAX(k8s.volume.available),\n        cap_per = MAX(k8s.volume.capacity)\n    BY k8s.pod.uid, k8s.volume.name\n| STATS avail = SUM(avail_per), cap = SUM(cap_per)\n| EVAL utilization = 1.0 - TO_DOUBLE(avail) / TO_DOUBLE(cap), max_val = 1.0\n| KEEP utilization, max_val"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = LAST(k8s.volume.available, @timestamp),\n        cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS avail = SUM(avail_per), cap = SUM(cap_per)\n| EVAL utilization = 1.0 - TO_DOUBLE(avail) / TO_DOUBLE(cap),\n        max_val = 1.0\n| KEEP utilization, max_val"
                             },
                             "visualization": {
                                 "applyColorTo": "bar",
@@ -1440,7 +1452,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.volume.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = AVG(k8s.volume.available),\n        cap_per = AVG(k8s.volume.capacity)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid, k8s.volume.name\n| STATS available = SUM(avail_per),\n        capacity = SUM(cap_per)\n    BY timestamp\n| EVAL `Volume usage` = capacity - available\n| SORT timestamp\n| KEEP timestamp, `Volume usage`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = AVG(k8s.volume.available),\n        cap_per = AVG(k8s.volume.capacity)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid, k8s.volume.name\n| STATS available = SUM(avail_per),\n        capacity = SUM(cap_per)\n    BY timestamp\n| EVAL `Volume usage` = capacity - available\n| SORT timestamp\n| KEEP timestamp, `Volume usage`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1450,7 +1462,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.volume.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = AVG(k8s.volume.available),\n        cap_per = AVG(k8s.volume.capacity)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid, k8s.volume.name\n| STATS available = SUM(avail_per),\n        capacity = SUM(cap_per)\n    BY timestamp\n| EVAL `Volume usage` = capacity - available\n| SORT timestamp\n| KEEP timestamp, `Volume usage`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = AVG(k8s.volume.available),\n        cap_per = AVG(k8s.volume.capacity)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid, k8s.volume.name\n| STATS available = SUM(avail_per),\n        capacity = SUM(cap_per)\n    BY timestamp\n| EVAL `Volume usage` = capacity - available\n| SORT timestamp\n| KEEP timestamp, `Volume usage`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1557,7 +1569,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.container.cpu_limit IS NOT NULL\n| STATS limit_per = MAX(k8s.container.cpu_limit)\n    BY k8s.pod.uid, k8s.container.name\n| STATS total_limit = SUM(limit_per)\n| EVAL total_cores = ROUND(total_limit, 2)\n| KEEP total_cores"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.container.cpu_limit IS NOT NULL\n| STATS limit_per = LAST(k8s.container.cpu_limit, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(limit_per)\n| EVAL total_cores = ROUND(total_limit, 2)\n| KEEP total_cores"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1567,7 +1579,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.container.cpu_limit IS NOT NULL\n| STATS limit_per = MAX(k8s.container.cpu_limit)\n    BY k8s.pod.uid, k8s.container.name\n| STATS total_limit = SUM(limit_per)\n| EVAL total_cores = ROUND(total_limit, 2)\n| KEEP total_cores"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.container.cpu_limit IS NOT NULL\n| STATS limit_per = LAST(k8s.container.cpu_limit, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(limit_per)\n| EVAL total_cores = ROUND(total_limit, 2)\n| KEEP total_cores"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -1649,7 +1661,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.memory_limit IS NOT NULL\n| STATS limit_per = MAX(k8s.container.memory_limit)\n    BY k8s.pod.uid, k8s.container.name\n| STATS total_limit = SUM(limit_per)\n| EVAL total_gb = ROUND(total_limit, 2)\n| KEEP total_gb"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.memory_limit IS NOT NULL\n| STATS limit_per = LAST(k8s.container.memory_limit, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(limit_per)\n| EVAL total_gb = ROUND(total_limit, 2)\n| KEEP total_gb"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1659,7 +1671,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.memory_limit IS NOT NULL\n| STATS limit_per = MAX(k8s.container.memory_limit)\n    BY k8s.pod.uid, k8s.container.name\n| STATS total_limit = SUM(limit_per)\n| EVAL total_gb = ROUND(total_limit, 2)\n| KEEP total_gb"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.memory_limit IS NOT NULL\n| STATS limit_per = LAST(k8s.container.memory_limit, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(limit_per)\n| EVAL total_gb = ROUND(total_limit, 2)\n| KEEP total_gb"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -1741,7 +1753,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS cap_per = MAX(k8s.volume.capacity)\n    BY k8s.pod.uid, k8s.volume.name\n| STATS total_cap = SUM(cap_per)\n| EVAL total_gb = ROUND(total_cap, 2)\n| KEEP total_gb"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap_per)\n| EVAL total_gb = ROUND(total_cap, 2)\n| KEEP total_gb"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1751,7 +1763,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS cap_per = MAX(k8s.volume.capacity)\n    BY k8s.pod.uid, k8s.volume.name\n| STATS total_cap = SUM(cap_per)\n| EVAL total_gb = ROUND(total_cap, 2)\n| KEEP total_gb"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap_per)\n| EVAL total_gb = ROUND(total_cap, 2)\n| KEEP total_gb"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -1785,17 +1797,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1803,9 +1815,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -1833,9 +1845,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.uid IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS `Pod count` = COUNT_DISTINCT(k8s.pod.uid)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Pod count`"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS `Pod count` = COUNT_DISTINCT(k8s.pod.uid)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Pod count`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1845,7 +1857,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.pod.uid IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS `Pod count` = COUNT_DISTINCT(k8s.pod.uid)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Pod count`"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS `Pod count` = COUNT_DISTINCT(k8s.pod.uid)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Pod count`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1932,17 +1944,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1950,9 +1962,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -2007,9 +2019,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, desired, available"
+                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, desired, available"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2019,7 +2031,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, desired, available"
+                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, desired, available"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2092,17 +2104,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -2110,9 +2122,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -2155,9 +2167,9 @@
                                                     "label": "Direction"
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.network.io IS NOT NULL\n| STATS\n    `Throughput` = SUM(RATE(k8s.pod.network.io))\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), direction\n| EVAL direction = CASE(direction == \"receive\", \"Network In\", direction == \"transmit\", \"Network Out\", direction)\n| SORT timestamp\n| KEEP timestamp, direction, `Throughput`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.network.io IS NOT NULL\n| STATS\n    `Throughput` = SUM(RATE(k8s.pod.network.io))\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), direction\n| EVAL direction = CASE(direction == \"receive\", \"Network In\", direction == \"transmit\", \"Network Out\", direction)\n| SORT timestamp\n| KEEP timestamp, direction, `Throughput`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2167,7 +2179,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.network.io IS NOT NULL\n| STATS\n    `Throughput` = SUM(RATE(k8s.pod.network.io))\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), direction\n| EVAL direction = CASE(direction == \"receive\", \"Network In\", direction == \"transmit\", \"Network Out\", direction)\n| SORT timestamp\n| KEEP timestamp, direction, `Throughput`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.network.io IS NOT NULL\n| STATS\n    `Throughput` = SUM(RATE(k8s.pod.network.io))\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), direction\n| EVAL direction = CASE(direction == \"receive\", \"Network In\", direction == \"transmit\", \"Network Out\", direction)\n| SORT timestamp\n| KEEP timestamp, direction, `Throughput`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2274,17 +2286,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -2292,9 +2304,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -2340,9 +2352,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS `CPU limit utilization` = AVG(k8s.pod.cpu_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `CPU limit utilization`"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS `CPU limit utilization` = AVG(k8s.pod.cpu_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `CPU limit utilization`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2352,7 +2364,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS `CPU limit utilization` = AVG(k8s.pod.cpu_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `CPU limit utilization`"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS `CPU limit utilization` = AVG(k8s.pod.cpu_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `CPU limit utilization`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2443,17 +2455,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -2461,9 +2473,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -2509,9 +2521,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS `Memory limit utilization` = AVG(k8s.pod.memory_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Memory limit utilization`"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS `Memory limit utilization` = AVG(k8s.pod.memory_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Memory limit utilization`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2521,7 +2533,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS `Memory limit utilization` = AVG(k8s.pod.memory_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Memory limit utilization`"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS `Memory limit utilization` = AVG(k8s.pod.memory_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Memory limit utilization`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2612,17 +2624,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -2630,9 +2642,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -2670,9 +2682,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2682,7 +2694,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2921,7 +2933,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| INLINE STATS phase_latest = MAX(CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name\n| EVAL phase_val = CASE(@timestamp == phase_latest, k8s.pod.phase, NULL)\n| STATS\n    phase_num      = MAX(phase_val),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2931,7 +2943,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| INLINE STATS phase_latest = MAX(CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name\n| EVAL phase_val = CASE(@timestamp == phase_latest, k8s.pod.phase, NULL)\n| STATS\n    phase_num      = MAX(phase_val),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
@@ -3176,18 +3188,18 @@
                 "title": "Pods in deployment"
             }
         ],
-        "timeFrom": "now-15m",
+        "timeFrom": "now-30d/d",
         "timeRestore": true,
         "timeTo": "now",
         "title": "[OTEL][Kubernetes] Deployment Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-13T08:16:02.703Z",
+    "created_at": "2026-04-27T12:05:39.531Z",
     "id": "kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-deployment-back-link:link_d7c1ba62-e32f-4de2-9020-16788bf86ece_dashboard",
+            "name": "v3-deployment-back-link:link_cba4cd76-0d62-4d04-bcf2-c782c8bbff3a_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
@@ -88,7 +88,7 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_cba4cd76-0d62-4d04-bcf2-c782c8bbff3a_dashboard",
+                            "destinationRefName": "link_243b4837-67bf-42ba-9008-1d6d1726618f_dashboard",
                             "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
@@ -218,7 +218,7 @@
                     "y": 0
                 },
                 "panelIndex": "v4-wd-logs-card",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -319,7 +319,8 @@
                                     },
                                     "type": "palette"
                                 },
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
@@ -327,6 +328,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "description": "Available replicas for this deployment. MAX(k8s.deployment.available).",
+                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -337,7 +339,7 @@
                     "y": 3
                 },
                 "panelIndex": "6fa9715d-bfa4-4dc0-aead-b410aa40c2b6",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -404,7 +406,8 @@
                                 "layerId": "c5786785-92b9-d1a2-111a-dd75d9ba7934",
                                 "layerType": "data",
                                 "metricAccessor": "7138585c-d40c-b657-cf06-816942450421",
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
@@ -412,6 +415,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "description": "Desired replicas for this deployment. MAX(k8s.deployment.desired).",
+                    "drilldowns": [],
                     "hide_title": true,
                     "title": ""
                 },
@@ -423,7 +427,7 @@
                     "y": 3
                 },
                 "panelIndex": "5fdcf3cd-b110-4042-a8e1-9652813771ce",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -490,7 +494,8 @@
                                 "layerId": "48bf04fd-0ec2-9a2b-b498-bad9c61750cb",
                                 "layerType": "data",
                                 "metricAccessor": "602bb36a-b2d9-5e22-bbe6-6f8321bf6cf4",
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
@@ -498,6 +503,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "description": "Pod count for this deployment. COUNT_DISTINCT(k8s.pod.uid).",
+                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -508,7 +514,7 @@
                     "y": 3
                 },
                 "panelIndex": "v2-deploy-detail-pods",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -575,7 +581,8 @@
                                 "layerId": "b8e82f89-e3b7-c30e-2126-19983e1fe23b",
                                 "layerType": "data",
                                 "metricAccessor": "04502b61-dc7e-1c36-d570-d3e1b897a44d",
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
@@ -583,6 +590,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "description": "Total container restarts. MAX(k8s.container.restarts) per pod+container, then SUM.",
+                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -593,7 +601,7 @@
                     "y": 3
                 },
                 "panelIndex": "v2-deploy-detail-restarts",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -680,7 +688,7 @@
                     "y": 0
                 },
                 "panelIndex": "v3-wd-header-name",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -808,7 +816,8 @@
                                     "type": "palette"
                                 },
                                 "progressDirection": "horizontal",
-                                "showBar": true
+                                "showBar": true,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
@@ -816,6 +825,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "description": "CPU utilization for this deployment.",
+                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -827,7 +837,7 @@
                     "y": 5
                 },
                 "panelIndex": "v3-wd-cpu-card",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -955,7 +965,8 @@
                                     "type": "palette"
                                 },
                                 "progressDirection": "horizontal",
-                                "showBar": true
+                                "showBar": true,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
@@ -963,6 +974,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "description": "Memory utilization for this deployment.",
+                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -974,7 +986,7 @@
                     "y": 5
                 },
                 "panelIndex": "v3-wd-memory-card",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1108,7 +1120,7 @@
                     "y": 0
                 },
                 "panelIndex": "v3-wd-cpu-time",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1241,7 +1253,7 @@
                     "y": 0
                 },
                 "panelIndex": "v3-wd-memory-time",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1369,7 +1381,8 @@
                                     "type": "palette"
                                 },
                                 "progressDirection": "horizontal",
-                                "showBar": true
+                                "showBar": true,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
@@ -1377,6 +1390,7 @@
                         "visualizationType": "lnsMetric"
                     },
                     "description": "Volume utilization for this deployment.",
+                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -1388,7 +1402,7 @@
                     "y": 15
                 },
                 "panelIndex": "v3-wd-volume-gauge",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1521,7 +1535,7 @@
                     "y": 10
                 },
                 "panelIndex": "v3-wd-volume-time",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1588,13 +1602,15 @@
                                 "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
                                 "layerType": "data",
                                 "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 5,
@@ -1605,7 +1621,7 @@
                     "y": 0
                 },
                 "panelIndex": "v4-wd-cpu-limit",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1680,13 +1696,15 @@
                                 "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
                                 "layerType": "data",
                                 "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 5,
@@ -1697,7 +1715,7 @@
                     "y": 0
                 },
                 "panelIndex": "v4-wd-mem-limit",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1772,13 +1790,15 @@
                                 "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
                                 "layerType": "data",
                                 "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 5,
@@ -1789,7 +1809,7 @@
                     "y": 10
                 },
                 "panelIndex": "v4-wd-vol-cap",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1936,7 +1956,7 @@
                     "y": 10
                 },
                 "panelIndex": "61ce689b-d715-46cf-a04d-7be064e85854",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -2096,7 +2116,7 @@
                     "y": 0
                 },
                 "panelIndex": "v2-deploy-detail-replica-trend",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -2278,7 +2298,7 @@
                     "y": 12
                 },
                 "panelIndex": "v3-wd-network-io",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -2447,7 +2467,7 @@
                     "y": 0
                 },
                 "panelIndex": "10f3645c-3a60-47c5-95dd-2f748342a1e8",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -2616,7 +2636,7 @@
                     "y": 0
                 },
                 "panelIndex": "1bdbdcf2-9127-41aa-ab09-056b9e0b38f1",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -2777,7 +2797,7 @@
                     "y": 12
                 },
                 "panelIndex": "0a52eeb2-d717-41a4-a401-47adf15824ea",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -3156,12 +3176,9 @@
                     "y": 0
                 },
                 "panelIndex": "d4f41df0-258f-4758-96a0-69a880eeedef",
-                "type": "lens"
+                "type": "vis"
             }
         ],
-        "pinned_panels": {
-            "panels": {}
-        },
         "sections": [
             {
                 "collapsed": false,
@@ -3194,12 +3211,12 @@
         "title": "[OTEL][Kubernetes] Deployment Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-27T12:05:39.531Z",
+    "created_at": "2026-05-04T03:38:32.518Z",
     "id": "kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-deployment-back-link:link_cba4cd76-0d62-4d04-bcf2-c782c8bbff3a_dashboard",
+            "name": "v3-deployment-back-link:link_243b4837-67bf-42ba-9008-1d6d1726618f_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
@@ -59,37 +59,37 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_a8411d40-0bc2-4026-ba66-c79f0f2d97e2_dashboard",
+                            "destinationRefName": "link_9cb93eb8-1cbd-45b0-abed-81f2d39be12e_dashboard",
                             "label": "Overview",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_73ed7c58-f56e-4887-8f96-f752b2ad9a4c_dashboard",
+                            "destinationRefName": "link_4a291441-67be-4294-8d51-c6ead68cc34f_dashboard",
                             "label": "Clusters",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_722b24a3-628d-4b9b-8b72-bb611a4e7184_dashboard",
+                            "destinationRefName": "link_3bf2331e-af35-4f14-9502-bd53c97126e3_dashboard",
                             "label": "Nodes",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_cb5f2169-b798-4985-a4ab-3b46493817bf_dashboard",
+                            "destinationRefName": "link_99e7d263-4651-4fdd-8223-ba9c8aaeff65_dashboard",
                             "label": "Namespaces",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_156cd235-fa72-4942-a2aa-b3d5e93523b6_dashboard",
+                            "destinationRefName": "link_1920018b-8fcb-4bd9-b7a7-f2e84c663bac_dashboard",
                             "label": "Workload resources",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_ea77e832-1682-4ba8-ac68-4e82f231aafb_dashboard",
+                            "destinationRefName": "link_56f6642e-c5a3-44e4-9cd5-911974fec39a_dashboard",
                             "label": "Pods",
                             "options": {},
                             "type": "dashboardLink"
@@ -444,7 +444,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| INLINE STATS phase_latest = MAX(CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name\n| EVAL phase_val = CASE(@timestamp == phase_latest, k8s.pod.phase, NULL)\n| STATS\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    cpu_usage        = AVG(k8s.pod.cpu.usage),\n    memory_ws        = AVG(k8s.pod.memory.working_set),\n    phase_num        = MAX(phase_val),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    mem_limit        = MAX(k8s.container.memory_limit)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS\n    cpu_usage        =  LAST(k8s.pod.cpu.usage, @timestamp),\n    memory_ws        = LAST(k8s.pod.memory.working_set, @timestamp),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -454,7 +454,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| INLINE STATS phase_latest = MAX(CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL))\n    BY k8s.pod.name\n| EVAL phase_val = CASE(@timestamp == phase_latest, k8s.pod.phase, NULL)\n| STATS\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    cpu_usage        = AVG(k8s.pod.cpu.usage),\n    memory_ws        = AVG(k8s.pod.memory.working_set),\n    phase_num        = MAX(phase_val),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    mem_limit        = MAX(k8s.container.memory_limit)\n  BY k8s.namespace.name, k8s.pod.name\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS\n    cpu_usage        =  LAST(k8s.pod.cpu.usage, @timestamp),\n    memory_ws        = LAST(k8s.pod.memory.working_set, @timestamp),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
@@ -697,17 +697,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -715,9 +715,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -791,9 +791,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    rss = SUM(k8s.pod.memory.rss),\n    working_set = SUM(k8s.pod.memory.working_set),\n    available = SUM(k8s.pod.memory.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, rss, working_set, available"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    rss = AVG(k8s.pod.memory.rss),\n    working_set = AVG(k8s.pod.memory.working_set),\n    available = AVG(k8s.pod.memory.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid\n| STATS\n    rss = SUM(rss),\n    working_set = SUM(working_set),\n    available = SUM(available)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, rss, working_set, available"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -803,7 +803,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    rss = SUM(k8s.pod.memory.rss),\n    working_set = SUM(k8s.pod.memory.working_set),\n    available = SUM(k8s.pod.memory.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, rss, working_set, available"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    rss = AVG(k8s.pod.memory.rss),\n    working_set = AVG(k8s.pod.memory.working_set),\n    available = AVG(k8s.pod.memory.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid\n| STATS\n    rss = SUM(rss),\n    working_set = SUM(working_set),\n    available = SUM(available)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, rss, working_set, available"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -867,7 +867,7 @@
                     "sectionId": "v3-pods-per-pod-metrics",
                     "w": 24,
                     "x": 0,
-                    "y": 16
+                    "y": 19
                 },
                 "panelIndex": "v2-pods-alt-memory-decomp",
                 "type": "lens"
@@ -918,7 +918,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS pod_count = COUNT_DISTINCT(k8s.pod.uid)"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = COUNT(*)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -928,7 +928,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS pod_count = COUNT_DISTINCT(k8s.pod.uid)"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = COUNT(*)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -943,7 +943,8 @@
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 4,
@@ -1002,7 +1003,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL AND k8s.pod.phase IS NOT NULL\n| STATS running_count = COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 2\n| STATS running_count = COUNT(*)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1012,7 +1013,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL AND k8s.pod.phase IS NOT NULL\n| STATS running_count = COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 2\n| STATS running_count = COUNT(*)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -1062,7 +1063,8 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2."
+                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2.",
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 4,
@@ -1121,7 +1123,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL AND k8s.pod.phase IS NOT NULL\n| STATS pending_count = COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 1\n| STATS pending_count = COUNT(*)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1131,7 +1133,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL AND k8s.pod.phase IS NOT NULL\n| STATS pending_count = COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 1\n| STATS pending_count = COUNT(*)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -1181,7 +1183,8 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1."
+                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1.",
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 4,
@@ -1240,7 +1243,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL AND k8s.pod.phase IS NOT NULL\n| STATS failed_count = COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4\n"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 4\n| STATS failed_count = COUNT(*)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1250,7 +1253,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL AND k8s.pod.phase IS NOT NULL\n| STATS failed_count = COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4\n"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 4\n| STATS failed_count = COUNT(*)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
@@ -1300,7 +1303,8 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4."
+                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4.",
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 4,
@@ -1316,403 +1320,493 @@
             {
                 "embeddableConfig": {
                     "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-60f1880d-7789-4647-8ec2-75cc1c8c3e1e",
-                                "type": "index-pattern"
-                            }
-                        ],
+                        "references": [],
                         "state": {
+                            "adHocDataViews": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "managed": false,
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
-                                "formBased": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
-                                        "60f1880d-7789-4647-8ec2-75cc1c8c3e1e": {
-                                            "columnOrder": [
-                                                "col-split",
-                                                "col-ts",
-                                                "col-metric"
-                                            ],
-                                            "columns": {
-                                                "col-metric": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "CPU usage",
-                                                    "operationType": "max",
+                                        "72a6879b-4d06-4a9a-9b2b-a1407f141fbb": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Memory working set",
+                                                    "customLabel": false,
+                                                    "fieldName": "Memory working set",
+                                                    "inMetricDimension": true,
+                                                    "label": "Memory working set",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
                                                     "params": {
-                                                        "emptyAsNull": true,
                                                         "format": {
-                                                            "id": "number",
+                                                            "id": "bytes",
                                                             "params": {
-                                                                "decimals": 4
+                                                                "decimals": 2
                                                             }
                                                         }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "k8s.pod.cpu.usage"
-                                                },
-                                                "col-split": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Pod",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "col-metric",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "k8s.pod.name"
-                                                },
-                                                "col-ts": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
+                                                    }
                                                 }
+                                            ],
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "query": {
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp ASC, `Memory working set` DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, `Memory working set`"
                                             },
-                                            "incompleteColumns": {}
+                                            "timeField": "@timestamp"
                                         }
                                     }
                                 }
                             },
                             "filters": [],
+                            "needsRefresh": false,
                             "query": {
-                                "language": "kuery",
-                                "query": ""
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp ASC, `Memory working set` DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, `Memory working set`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
                                 },
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "col-metric"
+                                            "Memory working set"
                                         ],
-                                        "layerId": "60f1880d-7789-4647-8ec2-75cc1c8c3e1e",
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "elastic_line_optimized",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "72a6879b-4d06-4a9a-9b2b-a1407f141fbb",
                                         "layerType": "data",
                                         "seriesType": "line",
-                                        "showGridlines": false,
                                         "splitAccessors": [
-                                            "col-split"
+                                            "k8s.pod.name"
                                         ],
-                                        "xAccessor": "col-ts"
+                                        "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "layout": "list",
                                     "position": "bottom"
                                 },
                                 "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "Top 10 pods by CPU usage",
-                        "type": "lens",
+                        "title": "",
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "CPU usage per namespace (cores).\n\nShows the 10 namespaces consuming the most CPU."
+                    "description": "Memory working set per namespace.\n\nShows the 10 namespaces consuming the most memory.",
+                    "title": "Top 10 pods by memory working set usage"
                 },
                 "gridData": {
-                    "h": 12,
-                    "i": "v3-pods-top5-cpu",
+                    "h": 15,
+                    "i": "a6929d90-b57f-4558-8418-4cdcc8ba1e3a",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 24,
+                    "x": 24,
+                    "y": 4
+                },
+                "panelIndex": "a6929d90-b57f-4558-8418-4cdcc8ba1e3a",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "managed": false,
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "a9390c0b-daa3-4ca8-893d-6b6775b34bb5": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "CPU usage",
+                                                    "customLabel": false,
+                                                    "fieldName": "CPU usage",
+                                                    "inMetricDimension": true,
+                                                    "label": "CPU usage",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "query": {
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp ASC, `CPU usage` DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, `CPU usage`"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp ASC, `CPU usage` DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, `CPU usage`"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "CPU usage"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "elastic_line_optimized",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "a9390c0b-daa3-4ca8-893d-6b6775b34bb5",
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "splitAccessors": [
+                                            "k8s.pod.name"
+                                        ],
+                                        "xAccessor": "timestamp"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "layout": "list",
+                                    "position": "bottom",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "CPU usage per namespace (cores).\n\nShows the 10 namespaces consuming the most CPU.",
+                    "title": "Top 10 pods by CPU usage"
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "d3e5c442-b7c7-4291-8c4d-d0f7a0d99111",
                     "sectionId": "v3-pods-per-pod-metrics",
                     "w": 24,
                     "x": 0,
                     "y": 4
                 },
-                "panelIndex": "v3-pods-top5-cpu",
+                "panelIndex": "d3e5c442-b7c7-4291-8c4d-d0f7a0d99111",
                 "type": "lens"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-42287005-f1c0-4f0a-b7bc-241f2ab6c50b",
-                                "type": "index-pattern"
-                            }
-                        ],
+                        "references": [],
                         "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
-                                "formBased": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
-                                        "42287005-f1c0-4f0a-b7bc-241f2ab6c50b": {
-                                            "columnOrder": [
-                                                "col-split",
-                                                "col-ts",
-                                                "col-metric"
-                                            ],
-                                            "columns": {
-                                                "col-metric": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Memory working set",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "k8s.pod.memory.working_set"
+                                        "c907c7dd-5808-4280-9edf-1c709a95093f": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
                                                 },
-                                                "col-split": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Pod",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "col-metric",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "k8s.pod.name"
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
                                                 },
-                                                "col-ts": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
+                                                {
+                                                    "columnId": "total_restarts",
+                                                    "customLabel": false,
+                                                    "fieldName": "total_restarts",
+                                                    "inMetricDimension": true,
+                                                    "label": "total_restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
                                                 }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, k8s.pod.name\n| WHERE total_restarts \u003e 0\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, total_restarts"
                                             },
-                                            "incompleteColumns": {}
+                                            "timeField": "@timestamp"
                                         }
                                     }
                                 }
                             },
                             "filters": [],
+                            "needsRefresh": false,
                             "query": {
-                                "language": "kuery",
-                                "query": ""
+                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, k8s.pod.name\n| WHERE total_restarts \u003e 0\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, total_restarts"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
                                 },
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "col-metric"
+                                            "total_restarts"
                                         ],
-                                        "layerId": "42287005-f1c0-4f0a-b7bc-241f2ab6c50b",
-                                        "layerType": "data",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessors": [
-                                            "col-split"
-                                        ],
-                                        "xAccessor": "col-ts"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "bottom"
-                                },
-                                "preferredSeriesType": "line",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "Top 10 pods by memory working set usage",
-                        "type": "lens",
-                        "version": 2,
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "Memory working set per namespace.\n\nShows the 10 namespaces consuming the most memory."
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "v3-pods-top5-memory",
-                    "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 24,
-                    "x": 24,
-                    "y": 4
-                },
-                "panelIndex": "v3-pods-top5-memory",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-7a95af72-5859-4154-b1e0-f13ff6becfa4",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "7a95af72-5859-4154-b1e0-f13ff6becfa4": {
-                                            "columnOrder": [
-                                                "col-split",
-                                                "col-ts",
-                                                "col-metric"
-                                            ],
-                                            "columns": {
-                                                "col-metric": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Container restarts",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "k8s.container.restarts"
-                                                },
-                                                "col-split": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Pod",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "col-metric",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "k8s.pod.name"
-                                                },
-                                                "col-ts": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                }
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
                                             },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": "k8s.container.restarts \u003e 0"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "col-metric"
-                                        ],
-                                        "layerId": "7a95af72-5859-4154-b1e0-f13ff6becfa4",
+                                            "paletteId": "elastic_line_optimized",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "c907c7dd-5808-4280-9edf-1c709a95093f",
                                         "layerType": "data",
                                         "seriesType": "line",
-                                        "showGridlines": false,
                                         "splitAccessors": [
-                                            "col-split"
+                                            "k8s.pod.name"
                                         ],
-                                        "xAccessor": "col-ts"
+                                        "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "layout": "list",
                                     "position": "bottom"
                                 },
                                 "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "Top 10 pods by container restarts",
-                        "type": "lens",
+                        "title": "",
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "Container restarts per pod.\n\nShows the 10 pods with the most container restarts."
+                    "description": "Container restarts per pod.\n\nShows the 10 pods with the most container restarts.",
+                    "title": "Top 10 pods by container restarts"
                 },
                 "gridData": {
-                    "h": 12,
-                    "i": "v3-pods-top5-restarts",
+                    "h": 15,
+                    "i": "6da0c918-ddda-4d63-990b-c64ec4798c18",
                     "sectionId": "v3-pods-per-pod-metrics",
                     "w": 24,
                     "x": 24,
-                    "y": 16
+                    "y": 19
                 },
-                "panelIndex": "v3-pods-top5-restarts",
+                "panelIndex": "6da0c918-ddda-4d63-990b-c64ec4798c18",
                 "type": "lens"
             }
         ],
@@ -1729,43 +1823,43 @@
                 "title": "Pods metrics"
             }
         ],
-        "timeFrom": "now-15m",
+        "timeFrom": "now-30m",
         "timeRestore": true,
         "timeTo": "now",
         "title": "[OTEL][Kubernetes] Pods"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-14T05:38:13.579Z",
+    "created_at": "2026-04-29T07:01:10.181Z",
     "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v2-pods-alt-nav:link_a8411d40-0bc2-4026-ba66-c79f0f2d97e2_dashboard",
+            "name": "v2-pods-alt-nav:link_9cb93eb8-1cbd-45b0-abed-81f2d39be12e_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e",
-            "name": "v2-pods-alt-nav:link_73ed7c58-f56e-4887-8f96-f752b2ad9a4c_dashboard",
+            "name": "v2-pods-alt-nav:link_4a291441-67be-4294-8d51-c6ead68cc34f_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0c88decf-de83-47a4-a5df-0a79dc8daff5",
-            "name": "v2-pods-alt-nav:link_722b24a3-628d-4b9b-8b72-bb611a4e7184_dashboard",
+            "name": "v2-pods-alt-nav:link_3bf2331e-af35-4f14-9502-bd53c97126e3_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-c0765efe-f172-42c4-a2ea-f4552b6f42dc",
-            "name": "v2-pods-alt-nav:link_cb5f2169-b798-4985-a4ab-3b46493817bf_dashboard",
+            "name": "v2-pods-alt-nav:link_99e7d263-4651-4fdd-8223-ba9c8aaeff65_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
-            "name": "v2-pods-alt-nav:link_156cd235-fa72-4942-a2aa-b3d5e93523b6_dashboard",
+            "name": "v2-pods-alt-nav:link_1920018b-8fcb-4bd9-b7a7-f2e84c663bac_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
-            "name": "v2-pods-alt-nav:link_ea77e832-1682-4ba8-ac68-4e82f231aafb_dashboard",
+            "name": "v2-pods-alt-nav:link_56f6642e-c5a3-44e4-9cd5-911974fec39a_dashboard",
             "type": "dashboard"
         },
         {
@@ -1787,21 +1881,6 @@
             "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
             "name": "37c11d30-5003-4f4b-ba20-06cdad3441c7:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
             "type": "dashboard"
-        },
-        {
-            "id": "metrics-*",
-            "name": "v3-pods-top5-cpu:indexpattern-datasource-layer-60f1880d-7789-4647-8ec2-75cc1c8c3e1e",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "v3-pods-top5-memory:indexpattern-datasource-layer-42287005-f1c0-4f0a-b7bc-241f2ab6c50b",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "v3-pods-top5-restarts:indexpattern-datasource-layer-7a95af72-5859-4154-b1e0-f13ff6becfa4",
-            "type": "index-pattern"
         },
         {
             "id": "metrics-*",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
@@ -59,37 +59,37 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_9cb93eb8-1cbd-45b0-abed-81f2d39be12e_dashboard",
+                            "destinationRefName": "link_d6f374ec-b6bc-4e72-ac41-ac1c7b010ff3_dashboard",
                             "label": "Overview",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_4a291441-67be-4294-8d51-c6ead68cc34f_dashboard",
+                            "destinationRefName": "link_8220bcd9-d1e9-4eef-9630-d1e0e39b3ecf_dashboard",
                             "label": "Clusters",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_3bf2331e-af35-4f14-9502-bd53c97126e3_dashboard",
+                            "destinationRefName": "link_430960d7-9a6f-4e22-8205-91e9790b9743_dashboard",
                             "label": "Nodes",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_99e7d263-4651-4fdd-8223-ba9c8aaeff65_dashboard",
+                            "destinationRefName": "link_7411c5c2-4b46-4dd8-9e4a-b75bbbccd879_dashboard",
                             "label": "Namespaces",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_1920018b-8fcb-4bd9-b7a7-f2e84c663bac_dashboard",
+                            "destinationRefName": "link_a10b1fac-9b66-4151-8d2f-cc09b0880a37_dashboard",
                             "label": "Workload resources",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_56f6642e-c5a3-44e4-9cd5-911974fec39a_dashboard",
+                            "destinationRefName": "link_926ecc46-ffd2-4dda-a358-7bd122d6524b_dashboard",
                             "label": "Pods",
                             "options": {},
                             "type": "dashboardLink"
@@ -444,7 +444,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS\n    cpu_usage        =  LAST(k8s.pod.cpu.usage, @timestamp),\n    memory_ws        = LAST(k8s.pod.memory.working_set, @timestamp),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND @timestamp \u003e ?_tend - 5 minutes\n| STATS\n    cpu_usage        = MAX(k8s.pod.cpu.usage),\n    memory_ws        = MAX(k8s.pod.memory.working_set),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -454,7 +454,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n| STATS\n    cpu_usage        =  LAST(k8s.pod.cpu.usage, @timestamp),\n    memory_ws        = LAST(k8s.pod.memory.working_set, @timestamp),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND @timestamp \u003e ?_tend - 5 minutes\n| STATS\n    cpu_usage        = MAX(k8s.pod.cpu.usage),\n    memory_ws        = MAX(k8s.pod.memory.working_set),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
@@ -943,8 +943,7 @@
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    },
-                    "drilldowns": []
+                    }
                 },
                 "gridData": {
                     "h": 4,
@@ -1063,8 +1062,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2.",
-                    "drilldowns": []
+                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2."
                 },
                 "gridData": {
                     "h": 4,
@@ -1183,8 +1181,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1.",
-                    "drilldowns": []
+                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1."
                 },
                 "gridData": {
                     "h": 4,
@@ -1303,8 +1300,7 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4.",
-                    "drilldowns": []
+                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4."
                 },
                 "gridData": {
                     "h": 4,
@@ -1823,43 +1819,43 @@
                 "title": "Pods metrics"
             }
         ],
-        "timeFrom": "now-30m",
+        "timeFrom": "now-24h/h",
         "timeRestore": true,
         "timeTo": "now",
         "title": "[OTEL][Kubernetes] Pods"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-29T07:01:10.181Z",
+    "created_at": "2026-04-30T04:47:20.996Z",
     "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v2-pods-alt-nav:link_9cb93eb8-1cbd-45b0-abed-81f2d39be12e_dashboard",
+            "name": "v2-pods-alt-nav:link_d6f374ec-b6bc-4e72-ac41-ac1c7b010ff3_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e",
-            "name": "v2-pods-alt-nav:link_4a291441-67be-4294-8d51-c6ead68cc34f_dashboard",
+            "name": "v2-pods-alt-nav:link_8220bcd9-d1e9-4eef-9630-d1e0e39b3ecf_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0c88decf-de83-47a4-a5df-0a79dc8daff5",
-            "name": "v2-pods-alt-nav:link_3bf2331e-af35-4f14-9502-bd53c97126e3_dashboard",
+            "name": "v2-pods-alt-nav:link_430960d7-9a6f-4e22-8205-91e9790b9743_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-c0765efe-f172-42c4-a2ea-f4552b6f42dc",
-            "name": "v2-pods-alt-nav:link_99e7d263-4651-4fdd-8223-ba9c8aaeff65_dashboard",
+            "name": "v2-pods-alt-nav:link_7411c5c2-4b46-4dd8-9e4a-b75bbbccd879_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
-            "name": "v2-pods-alt-nav:link_1920018b-8fcb-4bd9-b7a7-f2e84c663bac_dashboard",
+            "name": "v2-pods-alt-nav:link_a10b1fac-9b66-4151-8d2f-cc09b0880a37_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
-            "name": "v2-pods-alt-nav:link_56f6642e-c5a3-44e4-9cd5-911974fec39a_dashboard",
+            "name": "v2-pods-alt-nav:link_926ecc46-ffd2-4dda-a358-7bd122d6524b_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
@@ -59,37 +59,37 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_d6f374ec-b6bc-4e72-ac41-ac1c7b010ff3_dashboard",
+                            "destinationRefName": "link_b716e95e-38bd-46f5-a4b9-86e2bef5d9a9_dashboard",
                             "label": "Overview",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_8220bcd9-d1e9-4eef-9630-d1e0e39b3ecf_dashboard",
+                            "destinationRefName": "link_0e2908a4-4b83-4c99-b10d-88a345a61a5e_dashboard",
                             "label": "Clusters",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_430960d7-9a6f-4e22-8205-91e9790b9743_dashboard",
+                            "destinationRefName": "link_482fd898-9655-4bfa-803a-a7fb5e1a2099_dashboard",
                             "label": "Nodes",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_7411c5c2-4b46-4dd8-9e4a-b75bbbccd879_dashboard",
+                            "destinationRefName": "link_2b6f6b33-9a22-46c9-ad1b-9b21e8fb3626_dashboard",
                             "label": "Namespaces",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_a10b1fac-9b66-4151-8d2f-cc09b0880a37_dashboard",
+                            "destinationRefName": "link_dc931af3-f804-4def-bfd1-372f4224af2a_dashboard",
                             "label": "Workload resources",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_926ecc46-ffd2-4dda-a358-7bd122d6524b_dashboard",
+                            "destinationRefName": "link_7e2f1926-8938-4099-81cb-a54638b5bae4_dashboard",
                             "label": "Pods",
                             "options": {},
                             "type": "dashboardLink"
@@ -689,7 +689,7 @@
                     "y": 2
                 },
                 "panelIndex": "37c11d30-5003-4f4b-ba20-06cdad3441c7",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -870,7 +870,7 @@
                     "y": 19
                 },
                 "panelIndex": "v2-pods-alt-memory-decomp",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -937,13 +937,15 @@
                                 "layerId": "d2b1c7a4-12c4-4163-8356-9fb68be35302",
                                 "layerType": "data",
                                 "metricAccessor": "35dbcc0a-ac9f-4b99-89a8-e4efa05fad92",
-                                "showBar": false
+                                "subtitle": "Last value",
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 4,
@@ -954,7 +956,7 @@
                     "y": 0
                 },
                 "panelIndex": "v3-pods-health-total",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1055,14 +1057,16 @@
                                     },
                                     "type": "palette"
                                 },
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2."
+                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2.",
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 4,
@@ -1073,7 +1077,7 @@
                     "y": 0
                 },
                 "panelIndex": "61c96cc1-a2d5-4575-a0d4-a9d1c3e364b7",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1174,14 +1178,16 @@
                                     },
                                     "type": "palette"
                                 },
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1."
+                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1.",
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 4,
@@ -1192,7 +1198,7 @@
                     "y": 0
                 },
                 "panelIndex": "592fd6a5-5450-49bb-ba05-44307c0ae776",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1293,14 +1299,16 @@
                                     },
                                     "type": "palette"
                                 },
-                                "showBar": false
+                                "showBar": false,
+                                "subtitle": "Last value"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4."
+                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4.",
+                    "drilldowns": []
                 },
                 "gridData": {
                     "h": 4,
@@ -1311,7 +1319,7 @@
                     "y": 0
                 },
                 "panelIndex": "0a6c7edb-c74a-45d5-8aef-7508a1125879",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1480,7 +1488,7 @@
                     "y": 4
                 },
                 "panelIndex": "a6929d90-b57f-4558-8418-4cdcc8ba1e3a",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1642,7 +1650,7 @@
                     "y": 4
                 },
                 "panelIndex": "d3e5c442-b7c7-4291-8c4d-d0f7a0d99111",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1803,12 +1811,9 @@
                     "y": 19
                 },
                 "panelIndex": "6da0c918-ddda-4d63-990b-c64ec4798c18",
-                "type": "lens"
+                "type": "vis"
             }
         ],
-        "pinned_panels": {
-            "panels": {}
-        },
         "sections": [
             {
                 "collapsed": false,
@@ -1825,37 +1830,37 @@
         "title": "[OTEL][Kubernetes] Pods"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-30T04:47:20.996Z",
+    "created_at": "2026-05-04T03:38:28.228Z",
     "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v2-pods-alt-nav:link_d6f374ec-b6bc-4e72-ac41-ac1c7b010ff3_dashboard",
+            "name": "v2-pods-alt-nav:link_b716e95e-38bd-46f5-a4b9-86e2bef5d9a9_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e",
-            "name": "v2-pods-alt-nav:link_8220bcd9-d1e9-4eef-9630-d1e0e39b3ecf_dashboard",
+            "name": "v2-pods-alt-nav:link_0e2908a4-4b83-4c99-b10d-88a345a61a5e_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0c88decf-de83-47a4-a5df-0a79dc8daff5",
-            "name": "v2-pods-alt-nav:link_430960d7-9a6f-4e22-8205-91e9790b9743_dashboard",
+            "name": "v2-pods-alt-nav:link_482fd898-9655-4bfa-803a-a7fb5e1a2099_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-c0765efe-f172-42c4-a2ea-f4552b6f42dc",
-            "name": "v2-pods-alt-nav:link_7411c5c2-4b46-4dd8-9e4a-b75bbbccd879_dashboard",
+            "name": "v2-pods-alt-nav:link_2b6f6b33-9a22-46c9-ad1b-9b21e8fb3626_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
-            "name": "v2-pods-alt-nav:link_a10b1fac-9b66-4151-8d2f-cc09b0880a37_dashboard",
+            "name": "v2-pods-alt-nav:link_dc931af3-f804-4def-bfd1-372f4224af2a_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
-            "name": "v2-pods-alt-nav:link_926ecc46-ffd2-4dda-a358-7bd122d6524b_dashboard",
+            "name": "v2-pods-alt-nav:link_7e2f1926-8938-4099-81cb-a54638b5bae4_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 2.1.0-preview1
+version: 2.1.0-preview2
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:


### PR DESCRIPTION

- Enhancement

## Proposed commit message

Detail dashboards (pods, pod-details, deployment) are the end of the drilldown chain. Users arrive here specifically to investigate a resource - often one that's crashed, deleted, scaled down, or failed. A timestamp pre-filter would eliminate all their documents, making the sing-mentric panel show N/A. This enhancement offers insights into such k8s resources

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Integration test (Small & Large cluster) 

## How to test this PR locally

- 1elastic-package build && elastic-package stack up -v -d --services package-registry`


## Screenshots

### Dashboard - Pod detail
<img width="3456" height="3522" alt="screencapture-localhost-5605-app-dashboards-2026-05-07-14_55_23" src="https://github.com/user-attachments/assets/1581b68a-11eb-44e2-afbc-ef2081844833" />

----
### Dashboard - Deployment details

<img width="3456" height="4306" alt="screencapture-localhost-5605-app-dashboards-2026-05-07-14_53_43" src="https://github.com/user-attachments/assets/341bcc4e-7560-467f-9a7e-f9a2007e2b38" />

----

#### Dashboard - Pod

<img width="3456" height="3634" alt="screencapture-localhost-5605-app-dashboards-2026-05-07-14_52_57" src="https://github.com/user-attachments/assets/93318d7b-c462-445c-a3af-b444c88f113b" />

