### PR TITLE
aws/config: fix null EvaluationResults crash in CEL program

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.14.1"
+  changes:
+    - description: Fix CEL evaluation failure in AWS Config when GetComplianceDetailsByConfigRule returns null EvaluationResults.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "6.14.0"
   changes:
     - description: Enable agentless deployment for AWS RDS metrics.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix CEL evaluation failure in AWS Config when GetComplianceDetailsByConfigRule returns null EvaluationResults.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18751
 - version: "6.14.0"
   changes:
     - description: Enable agentless deployment for AWS RDS metrics.

--- a/packages/aws/data_stream/config/_dev/deploy/docker/files/config.yml
+++ b/packages/aws/data_stream/config/_dev/deploy/docker/files/config.yml
@@ -187,6 +187,8 @@ rules:
             ]
           }
           `}}
+  # Returns null EvaluationResults to verify the program handles null gracefully
+  # (AWS API can return null instead of an empty array when no results exist).
   - path: /
     methods: ["POST"]
     request_headers:
@@ -200,7 +202,7 @@ rules:
         body: |-
           {{ minify_json `
           {
-            "EvaluationResults": []
+            "EvaluationResults": null
           }
           `}}
   - path: /

--- a/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
+++ b/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
@@ -311,8 +311,8 @@ program: |
         // Response Processing: Successfully got compliance details
         bytes(resp.Body).decode_json().as(body,
           {
-            "events": (has(body.EvaluationResults) && size(body.EvaluationResults) > 0) ?
-              body.EvaluationResults.orValue([]).map(evt,
+            "events": (size(body.?EvaluationResults.orValue([])) > 0) ?
+              body.EvaluationResults.map(evt,
                 {
                   "message": evt.with(
                     {

--- a/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
+++ b/packages/aws/data_stream/config/agent/stream/cel.yml.hbs
@@ -311,7 +311,7 @@ program: |
         // Response Processing: Successfully got compliance details
         bytes(resp.Body).decode_json().as(body,
           {
-            "events": (size(body.?EvaluationResults.orValue([])) > 0) ?
+            "events": (has(body.EvaluationResults) && type(body.EvaluationResults) == list && size(body.EvaluationResults) > 0) ?
               body.EvaluationResults.map(evt,
                 {
                   "message": evt.with(

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.14.0
+version: 6.14.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
aws/config: fix null EvaluationResults crash in CEL program

The GetComplianceDetailsByConfigRule AWS API can return
{"EvaluationResults": null} instead of an empty array when no
compliance results exist for a rule. The CEL program used
has(body.EvaluationResults) && size(body.EvaluationResults) > 0
to check for results, but has() returns true for null values and
size(null) has no overload in CEL, causing a runtime crash.

Add type(body.EvaluationResults) == list into the condition to 
safely handle both missing and null values.

Update the system test mock to return null EvaluationResults for
one config rule, covering this scenario.

```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Added system test scenario passes.
