### PR TITLE
[O365_metrics] Enable Agentless Deployment

### DIFF
--- a/packages/o365_metrics/_dev/build/docs/README.md
+++ b/packages/o365_metrics/_dev/build/docs/README.md
@@ -37,6 +37,22 @@ The following data can be collected with the Microsoft Office 365 Metrics integr
 | Entra Agent | [agent](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/whatis-aadc-admin-agent) | Microsoft 365 Entra Agent metrics | No aggregation | RBAC role
 | Entra Alerts |  [alerts](https://learn.microsoft.com/en-us/entra/permissions-management/ui-triggers) | Microsoft 365 Entra Alerts metrics | No aggregation | RBAC role
 
+
+
+## How do I deploy this integration?
+
+### Agent-based deployment
+
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](https://www.elastic.co/docs/reference/fleet/install-elastic-agents). You can install only one Elastic Agent per host.
+
+Elastic Agent is required to collect data from Microsoft O365 and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
+
+### Agentless deployment
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html)
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments. This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## What do I need to use this integration?
 
 To use this package you need to enable datastreams you want to collect metrics for and register an application in [Microsoft Entra ID (formerly known as Azure Active Directory)](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id).

--- a/packages/o365_metrics/changelog.yml
+++ b/packages/o365_metrics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: tba
+      link: https://github.com/elastic/integrations/pull/18776
 - version: "1.1.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/o365_metrics/changelog.yml
+++ b/packages/o365_metrics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: tba
 - version: "1.1.1"
   changes:
     - description: Remove duplicate security-solution-default tag references

--- a/packages/o365_metrics/docs/README.md
+++ b/packages/o365_metrics/docs/README.md
@@ -37,6 +37,22 @@ The following data can be collected with the Microsoft Office 365 Metrics integr
 | Entra Agent | [agent](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/whatis-aadc-admin-agent) | Microsoft 365 Entra Agent metrics | No aggregation | RBAC role
 | Entra Alerts |  [alerts](https://learn.microsoft.com/en-us/entra/permissions-management/ui-triggers) | Microsoft 365 Entra Alerts metrics | No aggregation | RBAC role
 
+
+
+## How do I deploy this integration?
+
+### Agent-based deployment
+
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](https://www.elastic.co/docs/reference/fleet/install-elastic-agents). You can install only one Elastic Agent per host.
+
+Elastic Agent is required to collect data from Microsoft O365 and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
+
+### Agentless deployment
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html)
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments. This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## What do I need to use this integration?
 
 To use this package you need to enable datastreams you want to collect metrics for and register an application in [Microsoft Entra ID (formerly known as Azure Active Directory)](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id).

--- a/packages/o365_metrics/manifest.yml
+++ b/packages/o365_metrics/manifest.yml
@@ -1,9 +1,9 @@
 name: o365_metrics
 title: Microsoft Office 365 Metrics
-version: "1.1.1"
+version: "1.2.0"
 description: Collect metrics from Microsoft Office 365 with Elastic Agent.
 type: integration
-format_version: "3.0.2"
+format_version: "3.3.2"
 categories:
   - observability
   - security
@@ -56,6 +56,14 @@ policy_templates:
   - name: o365
     title: Office 365 metrics
     description: Collect metrics from Office 365
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-infraobs-integrations
     inputs:
       - type: cel
         title: "Collect Office 365 metrics via Microsoft Graph API using CEL Input"


### PR DESCRIPTION

- Enhancement


## Proposed commit message

Enable Agentless deployment mode for O365_metrics integration package.



## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
