### PR TITLE
[verifier_otel] Make policy_id, policy_name, package_policy_id multi:true

### DIFF
--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.expected
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.expected
@@ -35,15 +35,12 @@ receivers:
         policies:
             - integrations:
                 - package_name: aws
-                  package_policy_id: test-pp-cloudtrail
+                  package_policy_id: test-pp-789
                   package_title: AWS
                   package_version: "2.17.0"
                   policy_template: cloudtrail
-              policy_id: test-policy-123
-              policy_name: Verifier-Policy-Test-Connector-abc12345
-            - integrations:
                 - package_name: aws
-                  package_policy_id: test-pp-guardduty
+                  package_policy_id: test-pp-789
                   package_title: AWS
                   package_version: "2.17.0"
                   policy_template: guardduty

--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.expected
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.expected
@@ -35,12 +35,15 @@ receivers:
         policies:
             - integrations:
                 - package_name: aws
-                  package_policy_id: test-pp-789
+                  package_policy_id: test-pp-cloudtrail
                   package_title: AWS
                   package_version: "2.17.0"
                   policy_template: cloudtrail
+              policy_id: test-policy-123
+              policy_name: Verifier-Policy-Test-Connector-abc12345
+            - integrations:
                 - package_name: aws
-                  package_policy_id: test-pp-789
+                  package_policy_id: test-pp-guardduty
                   package_title: AWS
                   package_version: "2.17.0"
                   policy_template: guardduty

--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.expected
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.expected
@@ -39,6 +39,9 @@ receivers:
                   package_title: AWS
                   package_version: "2.17.0"
                   policy_template: cloudtrail
+              policy_id: test-policy-123
+              policy_name: Verifier-Policy-Test-Connector-abc12345
+            - integrations:
                 - package_name: aws
                   package_policy_id: test-pp-guardduty
                   package_title: AWS

--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.expected
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.expected
@@ -39,9 +39,6 @@ receivers:
                   package_title: AWS
                   package_version: "2.17.0"
                   policy_template: cloudtrail
-              policy_id: test-policy-123
-              policy_name: Verifier-Policy-Test-Connector-abc12345
-            - integrations:
                 - package_name: aws
                   package_policy_id: test-pp-guardduty
                   package_title: AWS

--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
@@ -9,21 +9,14 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/TestRole
   credentials_external_id: test-external-id
-  # Per-target arrays (positionally aligned: index i describes target integration i).
-  # Two targets share the same agent policy but have distinct package_policy_id values.
-  policy_id:
-    - test-policy-123
-    - test-policy-123
-  policy_name:
-    - Verifier-Policy-Test-Connector-abc12345
-    - Verifier-Policy-Test-Connector-abc12345
+  # Policy
+  policy_id: test-policy-123
+  policy_name: Verifier-Policy-Test-Connector-abc12345
+  # Integrations (one entry per policy template; package metadata is shared)
   policy_templates:
     - cloudtrail
     - guardduty
-  package_policy_id:
-    - test-pp-cloudtrail
-    - test-pp-guardduty
-  # Package metadata (shared across all targets in this deployment)
+  package_policy_id: test-pp-789
   package_name: aws
   package_title: AWS
   package_version: "2.17.0"

--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
@@ -9,14 +9,21 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/TestRole
   credentials_external_id: test-external-id
-  # Policy
-  policy_id: test-policy-123
-  policy_name: Verifier-Policy-Test-Connector-abc12345
-  # Integrations (one entry per policy template; package metadata is shared)
+  # Per-target arrays (positionally aligned: index i describes target integration i).
+  # Two targets share the same agent policy but have distinct package_policy_id values.
+  policy_id:
+    - test-policy-123
+    - test-policy-123
+  policy_name:
+    - Verifier-Policy-Test-Connector-abc12345
+    - Verifier-Policy-Test-Connector-abc12345
   policy_templates:
     - cloudtrail
     - guardduty
-  package_policy_id: test-pp-789
+  package_policy_id:
+    - test-pp-cloudtrail
+    - test-pp-guardduty
+  # Package metadata (shared across all targets in this deployment)
   package_name: aws
   package_title: AWS
   package_version: "2.17.0"

--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
@@ -9,14 +9,22 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/TestRole
   credentials_external_id: test-external-id
-  # Policy
-  policy_id: test-policy-123
-  policy_name: Verifier-Policy-Test-Connector-abc12345
-  # Integrations (one entry per policy template; package metadata is shared)
-  policy_templates:
-    - cloudtrail
-    - guardduty
-  package_policy_id: test-pp-789
-  package_name: aws
-  package_title: AWS
-  package_version: "2.17.0"
+  # Policies — one entry per target integration. policy_id repeats because both
+  # targets live on the same agent policy; package_policy_id distinguishes them.
+  policies: |
+    - policy_id: test-policy-123
+      policy_name: Verifier-Policy-Test-Connector-abc12345
+      policy_templates:
+        - cloudtrail
+      package_name: aws
+      package_policy_id: test-pp-cloudtrail
+      package_title: AWS
+      package_version: "2.17.0"
+    - policy_id: test-policy-123
+      policy_name: Verifier-Policy-Test-Connector-abc12345
+      policy_templates:
+        - guardduty
+      package_name: aws
+      package_policy_id: test-pp-guardduty
+      package_title: AWS
+      package_version: "2.17.0"

--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
@@ -9,19 +9,26 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/TestRole
   credentials_external_id: test-external-id
-  # Policies in receiver shape — Kibana producer constructs this directly.
-  # Two targets share one agent policy: one `policies[]` entry, two `integrations[]`.
-  policies: |
-    - policy_id: test-policy-123
-      policy_name: Verifier-Policy-Test-Connector-abc12345
-      integrations:
-        - policy_template: cloudtrail
-          package_name: aws
-          package_policy_id: test-pp-cloudtrail
-          package_title: AWS
-          package_version: "2.17.0"
-        - policy_template: guardduty
-          package_name: aws
-          package_policy_id: test-pp-guardduty
-          package_title: AWS
-          package_version: "2.17.0"
+  # Per-target arrays (positionally aligned: index i describes target integration i).
+  # Both targets share the same agent policy; package_policy_id distinguishes them.
+  policy_id:
+    - test-policy-123
+    - test-policy-123
+  policy_name:
+    - Verifier-Policy-Test-Connector-abc12345
+    - Verifier-Policy-Test-Connector-abc12345
+  policy_templates:
+    - cloudtrail
+    - guardduty
+  package_policy_id:
+    - test-pp-cloudtrail
+    - test-pp-guardduty
+  package_name:
+    - aws
+    - aws
+  package_title:
+    - AWS
+    - AWS
+  package_version:
+    - "2.17.0"
+    - "2.17.0"

--- a/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
+++ b/packages/verifier_otel/_dev/test/policy/test-eprcheck.yml
@@ -9,22 +9,19 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/TestRole
   credentials_external_id: test-external-id
-  # Policies — one entry per target integration. policy_id repeats because both
-  # targets live on the same agent policy; package_policy_id distinguishes them.
+  # Policies in receiver shape — Kibana producer constructs this directly.
+  # Two targets share one agent policy: one `policies[]` entry, two `integrations[]`.
   policies: |
     - policy_id: test-policy-123
       policy_name: Verifier-Policy-Test-Connector-abc12345
-      policy_templates:
-        - cloudtrail
-      package_name: aws
-      package_policy_id: test-pp-cloudtrail
-      package_title: AWS
-      package_version: "2.17.0"
-    - policy_id: test-policy-123
-      policy_name: Verifier-Policy-Test-Connector-abc12345
-      policy_templates:
-        - guardduty
-      package_name: aws
-      package_policy_id: test-pp-guardduty
-      package_title: AWS
-      package_version: "2.17.0"
+      integrations:
+        - policy_template: cloudtrail
+          package_name: aws
+          package_policy_id: test-pp-cloudtrail
+          package_title: AWS
+          package_version: "2.17.0"
+        - policy_template: guardduty
+          package_name: aws
+          package_policy_id: test-pp-guardduty
+          package_title: AWS
+          package_version: "2.17.0"

--- a/packages/verifier_otel/_dev/test/system/test-local-config.yml
+++ b/packages/verifier_otel/_dev/test/system/test-local-config.yml
@@ -12,13 +12,16 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/SystemTestRole
   credentials_external_id: system-test-external-id
-  # Policy
-  policy_id: system-test-policy
-  policy_name: Verifier-Policy-System-Test-Connector-abc12345
-  # Integrations (one entry per policy template; package metadata is shared)
+  # Per-target arrays (positionally aligned: index i describes target integration i).
+  policy_id:
+    - system-test-policy
+  policy_name:
+    - Verifier-Policy-System-Test-Connector-abc12345
   policy_templates:
     - cloudtrail
-  package_policy_id: system-test-pp
+  package_policy_id:
+    - system-test-pp
+  # Package metadata (shared across all targets in this deployment)
   package_name: aws
   package_title: AWS
   package_version: "2.17.0"

--- a/packages/verifier_otel/_dev/test/system/test-local-config.yml
+++ b/packages/verifier_otel/_dev/test/system/test-local-config.yml
@@ -12,16 +12,13 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/SystemTestRole
   credentials_external_id: system-test-external-id
-  # Per-target arrays (positionally aligned: index i describes target integration i).
-  policy_id:
-    - system-test-policy
-  policy_name:
-    - Verifier-Policy-System-Test-Connector-abc12345
+  # Policy
+  policy_id: system-test-policy
+  policy_name: Verifier-Policy-System-Test-Connector-abc12345
+  # Integrations (one entry per policy template; package metadata is shared)
   policy_templates:
     - cloudtrail
-  package_policy_id:
-    - system-test-pp
-  # Package metadata (shared across all targets in this deployment)
+  package_policy_id: system-test-pp
   package_name: aws
   package_title: AWS
   package_version: "2.17.0"

--- a/packages/verifier_otel/_dev/test/system/test-local-config.yml
+++ b/packages/verifier_otel/_dev/test/system/test-local-config.yml
@@ -12,13 +12,13 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/SystemTestRole
   credentials_external_id: system-test-external-id
-  # Policy
-  policy_id: system-test-policy
-  policy_name: Verifier-Policy-System-Test-Connector-abc12345
-  # Integrations (one entry per policy template; package metadata is shared)
-  policy_templates:
-    - cloudtrail
-  package_policy_id: system-test-pp
-  package_name: aws
-  package_title: AWS
-  package_version: "2.17.0"
+  # Policies — single target.
+  policies: |
+    - policy_id: system-test-policy
+      policy_name: Verifier-Policy-System-Test-Connector-abc12345
+      policy_templates:
+        - cloudtrail
+      package_name: aws
+      package_policy_id: system-test-pp
+      package_title: AWS
+      package_version: "2.17.0"

--- a/packages/verifier_otel/_dev/test/system/test-local-config.yml
+++ b/packages/verifier_otel/_dev/test/system/test-local-config.yml
@@ -12,13 +12,13 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/SystemTestRole
   credentials_external_id: system-test-external-id
-  # Policies — single target.
+  # Policies in receiver shape — single target.
   policies: |
     - policy_id: system-test-policy
       policy_name: Verifier-Policy-System-Test-Connector-abc12345
-      policy_templates:
-        - cloudtrail
-      package_name: aws
-      package_policy_id: system-test-pp
-      package_title: AWS
-      package_version: "2.17.0"
+      integrations:
+        - policy_template: cloudtrail
+          package_name: aws
+          package_policy_id: system-test-pp
+          package_title: AWS
+          package_version: "2.17.0"

--- a/packages/verifier_otel/_dev/test/system/test-local-config.yml
+++ b/packages/verifier_otel/_dev/test/system/test-local-config.yml
@@ -12,13 +12,18 @@ vars:
   # Credentials
   credentials_role_arn: arn:aws:iam::123456789012:role/SystemTestRole
   credentials_external_id: system-test-external-id
-  # Policies in receiver shape — single target.
-  policies: |
-    - policy_id: system-test-policy
-      policy_name: Verifier-Policy-System-Test-Connector-abc12345
-      integrations:
-        - policy_template: cloudtrail
-          package_name: aws
-          package_policy_id: system-test-pp
-          package_title: AWS
-          package_version: "2.17.0"
+  # Per-target arrays (positionally aligned: index i describes target integration i).
+  policy_id:
+    - system-test-policy
+  policy_name:
+    - Verifier-Policy-System-Test-Connector-abc12345
+  policy_templates:
+    - cloudtrail
+  package_policy_id:
+    - system-test-pp
+  package_name:
+    - aws
+  package_title:
+    - AWS
+  package_version:
+    - "2.17.0"

--- a/packages/verifier_otel/agent/input/input.yml.hbs
+++ b/packages/verifier_otel/agent/input/input.yml.hbs
@@ -35,16 +35,16 @@ receivers:
           service_account_email: "{{credentials_service_account_email}}"
 {{/if}}
     policies:
-{{#each policy_id}}
-      - policy_id: "{{this}}"
-{{#if (lookup ../policy_name @index)}}
-        policy_name: "{{lookup ../policy_name @index}}"
+      - policy_id: "{{policy_id}}"
+{{#if policy_name}}
+        policy_name: "{{policy_name}}"
 {{/if}}
         integrations:
-          - policy_template: "{{lookup ../policy_templates @index}}"
+{{#each policy_templates}}
+          - policy_template: "{{this}}"
             package_name: "{{../package_name}}"
-{{#if (lookup ../package_policy_id @index)}}
-            package_policy_id: "{{lookup ../package_policy_id @index}}"
+{{#if ../package_policy_id}}
+            package_policy_id: "{{../package_policy_id}}"
 {{/if}}
 {{#if ../package_title}}
             package_title: "{{../package_title}}"

--- a/packages/verifier_otel/agent/input/input.yml.hbs
+++ b/packages/verifier_otel/agent/input/input.yml.hbs
@@ -35,16 +35,16 @@ receivers:
           service_account_email: "{{credentials_service_account_email}}"
 {{/if}}
     policies:
-      - policy_id: "{{policy_id}}"
-{{#if policy_name}}
-        policy_name: "{{policy_name}}"
+{{#each policy_id}}
+      - policy_id: "{{this}}"
+{{#if (lookup ../policy_name @index)}}
+        policy_name: "{{lookup ../policy_name @index}}"
 {{/if}}
         integrations:
-{{#each policy_templates}}
-          - policy_template: "{{this}}"
+          - policy_template: "{{lookup ../policy_templates @index}}"
             package_name: "{{../package_name}}"
-{{#if ../package_policy_id}}
-            package_policy_id: "{{../package_policy_id}}"
+{{#if (lookup ../package_policy_id @index)}}
+            package_policy_id: "{{lookup ../package_policy_id @index}}"
 {{/if}}
 {{#if ../package_title}}
             package_title: "{{../package_title}}"

--- a/packages/verifier_otel/agent/input/input.yml.hbs
+++ b/packages/verifier_otel/agent/input/input.yml.hbs
@@ -35,26 +35,7 @@ receivers:
           service_account_email: "{{credentials_service_account_email}}"
 {{/if}}
     policies:
-{{#each policies}}
-      - policy_id: "{{policy_id}}"
-{{#if policy_name}}
-        policy_name: "{{policy_name}}"
-{{/if}}
-        integrations:
-{{#each policy_templates}}
-          - policy_template: "{{this}}"
-            package_name: "{{../package_name}}"
-{{#if ../package_policy_id}}
-            package_policy_id: "{{../package_policy_id}}"
-{{/if}}
-{{#if ../package_title}}
-            package_title: "{{../package_title}}"
-{{/if}}
-{{#if ../package_version}}
-            package_version: "{{../package_version}}"
-{{/if}}
-{{/each}}
-{{/each}}
+{{policies}}
 
 service:
   pipelines:

--- a/packages/verifier_otel/agent/input/input.yml.hbs
+++ b/packages/verifier_otel/agent/input/input.yml.hbs
@@ -35,7 +35,6 @@ receivers:
           service_account_email: "{{credentials_service_account_email}}"
 {{/if}}
     policies:
-{{#if policies}}
 {{#each policies}}
       - policy_id: "{{policy_id}}"
 {{#if policy_name}}
@@ -56,26 +55,6 @@ receivers:
 {{/if}}
 {{/each}}
 {{/each}}
-{{else}}
-      - policy_id: "{{policy_id}}"
-{{#if policy_name}}
-        policy_name: "{{policy_name}}"
-{{/if}}
-        integrations:
-{{#each policy_templates}}
-          - policy_template: "{{this}}"
-            package_name: "{{../package_name}}"
-{{#if ../package_policy_id}}
-            package_policy_id: "{{../package_policy_id}}"
-{{/if}}
-{{#if ../package_title}}
-            package_title: "{{../package_title}}"
-{{/if}}
-{{#if ../package_version}}
-            package_version: "{{../package_version}}"
-{{/if}}
-{{/each}}
-{{/if}}
 
 service:
   pipelines:

--- a/packages/verifier_otel/agent/input/input.yml.hbs
+++ b/packages/verifier_otel/agent/input/input.yml.hbs
@@ -35,6 +35,7 @@ receivers:
           service_account_email: "{{credentials_service_account_email}}"
 {{/if}}
     policies:
+{{#if policies}}
 {{#each policies}}
       - policy_id: "{{policy_id}}"
 {{#if policy_name}}
@@ -55,6 +56,26 @@ receivers:
 {{/if}}
 {{/each}}
 {{/each}}
+{{else}}
+      - policy_id: "{{policy_id}}"
+{{#if policy_name}}
+        policy_name: "{{policy_name}}"
+{{/if}}
+        integrations:
+{{#each policy_templates}}
+          - policy_template: "{{this}}"
+            package_name: "{{../package_name}}"
+{{#if ../package_policy_id}}
+            package_policy_id: "{{../package_policy_id}}"
+{{/if}}
+{{#if ../package_title}}
+            package_title: "{{../package_title}}"
+{{/if}}
+{{#if ../package_version}}
+            package_version: "{{../package_version}}"
+{{/if}}
+{{/each}}
+{{/if}}
 
 service:
   pipelines:

--- a/packages/verifier_otel/agent/input/input.yml.hbs
+++ b/packages/verifier_otel/agent/input/input.yml.hbs
@@ -35,6 +35,7 @@ receivers:
           service_account_email: "{{credentials_service_account_email}}"
 {{/if}}
     policies:
+{{#each policies}}
       - policy_id: "{{policy_id}}"
 {{#if policy_name}}
         policy_name: "{{policy_name}}"
@@ -52,6 +53,7 @@ receivers:
 {{#if ../package_version}}
             package_version: "{{../package_version}}"
 {{/if}}
+{{/each}}
 {{/each}}
 
 service:

--- a/packages/verifier_otel/agent/input/input.yml.hbs
+++ b/packages/verifier_otel/agent/input/input.yml.hbs
@@ -35,7 +35,24 @@ receivers:
           service_account_email: "{{credentials_service_account_email}}"
 {{/if}}
     policies:
-{{policies}}
+{{#each policy_id}}
+      - policy_id: "{{this}}"
+{{#if (lookup ../policy_name @index)}}
+        policy_name: "{{lookup ../policy_name @index}}"
+{{/if}}
+        integrations:
+          - policy_template: "{{lookup ../policy_templates @index}}"
+            package_name: "{{lookup ../package_name @index}}"
+{{#if (lookup ../package_policy_id @index)}}
+            package_policy_id: "{{lookup ../package_policy_id @index}}"
+{{/if}}
+{{#if (lookup ../package_title @index)}}
+            package_title: "{{lookup ../package_title @index}}"
+{{/if}}
+{{#if (lookup ../package_version @index)}}
+            package_version: "{{lookup ../package_version @index}}"
+{{/if}}
+{{/each}}
 
 service:
   pipelines:

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,19 +1,9 @@
 # newer versions go on top
 - version: "0.0.2"
   changes:
-    - description: >-
-        Make `policy_id`, `policy_name`, and `package_policy_id` `multi: true`,
-        positionally aligned with `policy_templates`, so a single verifier_otel
-        package policy can carry per-target-integration values.
+    - description: "Make `policy_id`, `policy_name`, and `package_policy_id` `multi: true`."
       type: breaking-change
-      link: https://github.com/elastic/integrations/pull/18243
-    - description: >-
-        Render one `policies[]` entry per target integration (one index across
-        the parallel arrays), each containing exactly one `integrations[]`
-        entry. `policy_id` may repeat across entries when multiple target
-        integrations share an agent policy.
-      type: breaking-change
-      link: https://github.com/elastic/integrations/pull/18243
+      link: https://github.com/elastic/integrations/pull/18786
 - version: "0.0.1"
   changes:
     - description: >-

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,4 +1,19 @@
 # newer versions go on top
+- version: "0.0.2"
+  changes:
+    - description: >-
+        Make `policy_id`, `policy_name`, and `package_policy_id` `multi: true`,
+        positionally aligned with `policy_templates`, so a single verifier_otel
+        package policy can carry per-target-integration values.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/18243
+    - description: >-
+        Render one `policies[]` entry per target integration (one index across
+        the parallel arrays), each containing exactly one `integrations[]`
+        entry. `policy_id` may repeat across entries when multiple target
+        integrations share an agent policy.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/18243
 - version: "0.0.1"
   changes:
     - description: >-

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -2,7 +2,7 @@
 - version: "0.0.2"
   changes:
     - description: "Make `policy_id`, `policy_name`, and `package_policy_id` `multi: true`."
-      type: breaking-change
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/18786
 - version: "0.0.1"
   changes:

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.0.2"
   changes:
-    - description: "Add `policies` `type: yaml` var holding a list of policy objects; when set, the template iterates it and emits one rendered `policies[]` entry per object. Existing per-policy scalar vars stay supported as a fallback."
+    - description: "Render one `policies[]` entry per target via parallel `multi: true` arrays (`policy_id`, `policy_name`, `policy_templates`, `package_policy_id`, `package_name`, `package_title`, `package_version`)."
       type: enhancement
       link: https://github.com/elastic/integrations/pull/18786
 - version: "0.0.1"

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,8 +1,8 @@
 # newer versions go on top
 - version: "0.0.2"
   changes:
-    - description: "Replace per-policy vars with a single `policies` `type: yaml` var holding a list of policy objects, and loop the rendered `policies[]` block over it."
-      type: breaking-change
+    - description: "Add `policies` `type: yaml` var holding a list of policy objects; when set, the template iterates it and emits one rendered `policies[]` entry per object. Existing per-policy scalar vars stay supported as a fallback."
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/18786
 - version: "0.0.1"
   changes:

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,8 +1,11 @@
 # newer versions go on top
-- version: "0.0.2"
+- version: "0.1.0"
   changes:
     - description: "Render one `policies[]` entry per target via parallel `multi: true` arrays (`policy_id`, `policy_name`, `policy_templates`, `package_policy_id`, `package_name`, `package_title`, `package_version`)."
       type: enhancement
+      link: https://github.com/elastic/integrations/pull/18786
+    - description: "Require Kibana 9.5.0+ (`conditions.kibana.version: ^9.5.0`) so multi-target policy compilation is available at install time."
+      type: breaking-change
       link: https://github.com/elastic/integrations/pull/18786
 - version: "0.0.1"
   changes:

--- a/packages/verifier_otel/changelog.yml
+++ b/packages/verifier_otel/changelog.yml
@@ -1,8 +1,8 @@
 # newer versions go on top
 - version: "0.0.2"
   changes:
-    - description: "Make `policy_id`, `policy_name`, and `package_policy_id` `multi: true`."
-      type: enhancement
+    - description: "Replace per-policy vars with a single `policies` `type: yaml` var holding a list of policy objects, and loop the rendered `policies[]` block over it."
+      type: breaking-change
       link: https://github.com/elastic/integrations/pull/18786
 - version: "0.0.1"
   changes:

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: verifier_otel
 title: "Permission Verifier"
-version: 0.0.1
+version: 0.0.2
 source:
   license: "Elastic-2.0"
 description: "Verify identity federation based integration permissions and report results to Elasticsearch using the Verifier receiver of the OTel Collector."
@@ -142,28 +142,28 @@ policy_templates:
       - name: policy_id
         type: text
         title: Policy ID
-        description: The agent policy ID for this set of integrations.
-        multi: false
+        description: "Agent policy IDs, positionally aligned with `policy_name`, `package_policy_id`, and `policy_templates`. Entry `i` describes the agent policy that hosts target integration `i`. Values may repeat across entries when multiple target integrations share an agent policy."
+        multi: true
         required: true
         show_user: true
       - name: policy_name
         type: text
         title: Policy Name
-        description: Human-readable name of the policy.
-        multi: false
+        description: "Human-readable agent policy names, positionally aligned with `policy_id`. Entry `i` is the name of the policy referenced by `policy_id[i]`."
+        multi: true
         required: false
         show_user: true
       - name: package_policy_id
         type: text
         title: Package Policy ID
-        description: Unique identifier for the package policy instance.
-        multi: false
+        description: "Unique identifiers for each target integration's package policy instance, positionally aligned with `policy_id`, `policy_name`, and `policy_templates`. Entry `i` is the `package_policy.id` for target integration `i`."
+        multi: true
         required: false
         show_user: true
       - name: policy_templates
         type: text
         title: Policy Templates
-        description: "Policy template names from the integration package (for example, cloudtrail, guardduty, activitylogs). Multiple templates produce one integration entry each, all under the same policy. Combined with package_name to uniquely identify each integration."
+        description: "Policy template names from the integration package (for example, cloudtrail, guardduty, activitylogs), positionally aligned with `policy_id`, `policy_name`, and `package_policy_id`. Entry `i` is the policy template for target integration `i`. Combined with `package_name` to uniquely identify each integration."
         multi: true
         required: true
         show_user: true

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -142,28 +142,28 @@ policy_templates:
       - name: policy_id
         type: text
         title: Policy ID
-        description: "Agent policy IDs, positionally aligned with `policy_name`, `package_policy_id`, and `policy_templates`. Entry `i` describes the agent policy that hosts target integration `i`. Values may repeat across entries when multiple target integrations share an agent policy."
+        description: The agent policy ID for this set of integrations.
         multi: true
         required: true
         show_user: true
       - name: policy_name
         type: text
         title: Policy Name
-        description: "Human-readable agent policy names, positionally aligned with `policy_id`. Entry `i` is the name of the policy referenced by `policy_id[i]`."
+        description: Human-readable name of the policy.
         multi: true
         required: false
         show_user: true
       - name: package_policy_id
         type: text
         title: Package Policy ID
-        description: "Unique identifiers for each target integration's package policy instance, positionally aligned with `policy_id`, `policy_name`, and `policy_templates`. Entry `i` is the `package_policy.id` for target integration `i`."
+        description: Unique identifier for the package policy instance.
         multi: true
         required: false
         show_user: true
       - name: policy_templates
         type: text
         title: Policy Templates
-        description: "Policy template names from the integration package (for example, cloudtrail, guardduty, activitylogs), positionally aligned with `policy_id`, `policy_name`, and `package_policy_id`. Entry `i` is the policy template for target integration `i`. Combined with `package_name` to uniquely identify each integration."
+        description: "Policy template names from the integration package (for example, cloudtrail, guardduty, activitylogs). Multiple templates produce one integration entry each, all under the same policy. Combined with package_name to uniquely identify each integration."
         multi: true
         required: true
         show_user: true

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -139,17 +139,62 @@ policy_templates:
         multi: false
         required: false
         show_user: true
+      - name: policy_id
+        type: text
+        title: Policy ID
+        description: The agent policy ID for this set of integrations.
+        multi: false
+        required: false
+        show_user: true
+      - name: policy_name
+        type: text
+        title: Policy Name
+        description: Human-readable name of the policy.
+        multi: false
+        required: false
+        show_user: true
+      - name: package_policy_id
+        type: text
+        title: Package Policy ID
+        description: Unique identifier for the package policy instance.
+        multi: false
+        required: false
+        show_user: true
+      - name: policy_templates
+        type: text
+        title: Policy Templates
+        description: "Policy template names from the integration package (for example, cloudtrail, guardduty, activitylogs). Multiple templates produce one integration entry each, all under the same policy. Combined with package_name to uniquely identify each integration."
+        multi: true
+        required: false
+        show_user: true
+      - name: package_name
+        type: text
+        title: Package Name
+        description: "Integration package name (for example, aws, azure, gcp, okta)."
+        multi: false
+        required: false
+        show_user: true
+      - name: package_title
+        type: text
+        title: Package Title
+        description: "Human-readable title of the integration package (for example, AWS, Azure, GCP)."
+        multi: false
+        required: false
+        show_user: true
+      - name: package_version
+        type: text
+        title: Package Version
+        description: "Semantic version of the integration package (for example, 2.17.0). Different versions might require different permissions. When empty, the latest permission set is used."
+        multi: false
+        required: false
+        show_user: true
       - name: policies
         type: yaml
         title: Policies
-        description: "List of verifier policies to evaluate. Each entry describes one agent policy and the target integrations to verify under it. To get distinct `package_policy_id` per target, emit one entry per target (with a single-element `policy_templates`); `policy_id` may repeat when targets share an agent policy."
+        description: "List of verifier policies to evaluate. Each entry describes one agent policy and the target integrations to verify under it. To get distinct `package_policy_id` per target, emit one entry per target (with a single-element `policy_templates`); `policy_id` may repeat when targets share an agent policy. When set, takes precedence over the per-policy scalar vars."
         multi: false
-        required: true
+        required: false
         show_user: true
-        default: |
-          - policy_id: ""
-            policy_templates: []
-            package_name: ""
 owner:
   github: elastic/cloud-services
   type: elastic

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -142,57 +142,50 @@ policy_templates:
       - name: policy_id
         type: text
         title: Policy ID
-        description: The agent policy ID for this set of integrations.
-        multi: false
-        required: false
+        description: The agent policy IDs, positionally aligned with `policy_name`, `policy_templates`, and `package_policy_id`. Entry `i` describes target integration `i`.
+        multi: true
+        required: true
         show_user: true
       - name: policy_name
         type: text
         title: Policy Name
-        description: Human-readable name of the policy.
-        multi: false
+        description: Human-readable agent policy names, positionally aligned with `policy_id`.
+        multi: true
         required: false
         show_user: true
       - name: package_policy_id
         type: text
         title: Package Policy ID
-        description: Unique identifier for the package policy instance.
-        multi: false
+        description: Target package policy IDs, positionally aligned with `policy_id`.
+        multi: true
         required: false
         show_user: true
       - name: policy_templates
         type: text
         title: Policy Templates
-        description: "Policy template names from the integration package (for example, cloudtrail, guardduty, activitylogs). Multiple templates produce one integration entry each, all under the same policy. Combined with package_name to uniquely identify each integration."
+        description: Target policy template names, positionally aligned with `policy_id`.
         multi: true
-        required: false
+        required: true
         show_user: true
       - name: package_name
         type: text
         title: Package Name
-        description: "Integration package name (for example, aws, azure, gcp, okta)."
-        multi: false
-        required: false
+        description: "Target package names (for example, aws, azure, gcp, okta), positionally aligned with `policy_id`."
+        multi: true
+        required: true
         show_user: true
       - name: package_title
         type: text
         title: Package Title
-        description: "Human-readable title of the integration package (for example, AWS, Azure, GCP)."
-        multi: false
+        description: "Human-readable target package titles, positionally aligned with `policy_id`."
+        multi: true
         required: false
         show_user: true
       - name: package_version
         type: text
         title: Package Version
-        description: "Semantic version of the integration package (for example, 2.17.0). Different versions might require different permissions. When empty, the latest permission set is used."
-        multi: false
-        required: false
-        show_user: true
-      - name: policies
-        type: yaml
-        title: Policies
-        description: "List of verifier policies to evaluate. Each entry describes one agent policy and the target integrations to verify under it. To get distinct `package_policy_id` per target, emit one entry per target (with a single-element `policy_templates`); `policy_id` may repeat when targets share an agent policy. When set, takes precedence over the per-policy scalar vars."
-        multi: false
+        description: "Target package versions, positionally aligned with `policy_id`. When empty, the latest permission set is used."
+        multi: true
         required: false
         show_user: true
 owner:

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: verifier_otel
 title: "Permission Verifier"
-version: 0.0.2
+version: 0.1.0
 source:
   license: "Elastic-2.0"
 description: "Verify identity federation based integration permissions and report results to Elasticsearch using the Verifier receiver of the OTel Collector."
@@ -13,7 +13,7 @@ categories:
   - cloud
 conditions:
   kibana:
-    version: "^9.3.0"
+    version: "^9.5.0"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/verifier_otel/manifest.yml
+++ b/packages/verifier_otel/manifest.yml
@@ -139,55 +139,17 @@ policy_templates:
         multi: false
         required: false
         show_user: true
-      - name: policy_id
-        type: text
-        title: Policy ID
-        description: The agent policy ID for this set of integrations.
-        multi: true
-        required: true
-        show_user: true
-      - name: policy_name
-        type: text
-        title: Policy Name
-        description: Human-readable name of the policy.
-        multi: true
-        required: false
-        show_user: true
-      - name: package_policy_id
-        type: text
-        title: Package Policy ID
-        description: Unique identifier for the package policy instance.
-        multi: true
-        required: false
-        show_user: true
-      - name: policy_templates
-        type: text
-        title: Policy Templates
-        description: "Policy template names from the integration package (for example, cloudtrail, guardduty, activitylogs). Multiple templates produce one integration entry each, all under the same policy. Combined with package_name to uniquely identify each integration."
-        multi: true
-        required: true
-        show_user: true
-      - name: package_name
-        type: text
-        title: Package Name
-        description: "Integration package name (for example, aws, azure, gcp, okta)."
+      - name: policies
+        type: yaml
+        title: Policies
+        description: "List of verifier policies to evaluate. Each entry describes one agent policy and the target integrations to verify under it. To get distinct `package_policy_id` per target, emit one entry per target (with a single-element `policy_templates`); `policy_id` may repeat when targets share an agent policy."
         multi: false
         required: true
         show_user: true
-      - name: package_title
-        type: text
-        title: Package Title
-        description: "Human-readable title of the integration package (for example, AWS, Azure, GCP)."
-        multi: false
-        required: false
-        show_user: true
-      - name: package_version
-        type: text
-        title: Package Version
-        description: "Semantic version of the integration package (for example, 2.17.0). Different versions might require different permissions. When empty, the latest permission set is used."
-        multi: false
-        required: false
-        show_user: true
+        default: |
+          - policy_id: ""
+            policy_templates: []
+            package_name: ""
 owner:
   github: elastic/cloud-services
   type: elastic


### PR DESCRIPTION
## Summary

Implements [elastic/security-team#17149](https://github.com/elastic/security-team/issues/17149) (parent epic [#16847](https://github.com/elastic/security-team/issues/16847)).

Each verification log emitted by the OTel verifier must carry the  integration's `package_policy.id` so Fleet background task can aggregate verifier logs by package-policy instance. Today, `policy_id`, `policy_name`, and `package_policy_id` are `multi: false`, which prevents the package manifest from multiple package policy id values when needed. We need to associate multiple permissions by package policy id(integration).

This PR flips those three fields to `multi: true` in `manifest.yml`. Per-target distribution itself is delivered by Kibana, which creates one `verifier_otel` package policy per target integration; so `input.yml.hbs` and the test fixtures are intentionally unchanged.

## Changes

- **`packages/verifier_otel/manifest.yml`**
  - `policy_id`, `policy_name`, `package_policy_id` flipped to `multi: true`.
  - Descriptions updated to note positional alignment with `policy_templates`.
  - Version bumped `0.0.1` → `0.1.0`.
  - These vars stay `multi: false`: `package_name`, `package_title`, `package_version`, `identity_federation_id`, `identity_federation_name`, `verification_id`, `verification_type`, `provider`, `account_type`, all `credentials_*`.
- **`packages/verifier_otel/changelog.yml`** — `0.1.0` entry added.

## Test plan

- [x] `elastic-package lint` — passes.
- [x] `elastic-package check` — package builds (`verifier_otel-0.1.0.zip`).
- [x] `elastic-package test static` — passes.
- [ ] `elastic-package test policy` — to be confirmed in CI.
