### PR TITLE
[azure_metrics] Enable agentless deployment mode

### DIFF
--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -89,6 +89,29 @@ A specialized integration specializes in a specific Azure service and comes with
 
 Specialized integrations include the Azure Virtual Machine, Storage Account, Container Registry, and other Container-related metrics integrations.
 
+## How do I deploy this integration?
+
+### Agent-based deployment
+
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](https://www.elastic.co/docs/reference/fleet/install-elastic-agents). You can install only one Elastic Agent per host.
+
+Elastic Agent is required to collect data from Azure Monitor and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
+
+### Agentless deployment
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html).
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments. This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
+## Known limitations & issues
+
+- Missing Lookback Support: The integration currently lacks a lookback window for metric collection. If the Elastic Agent stops or an Agentless deployment restarts, metrics may be missed. A lookback feature is currently in development to address this.
+- Batch API Issue: When Batch API is active (default is inactive), a lack of matching resources in a single integration may cause collection to halt for all integrations.
+  - Fixes Scheduled: 8.19.17, 9.3.6, and 9.4.2.
+  - Workarounds: Disable the Batch API setting, or ensure each integration targets at least one Azure resource.
+
+**What is lookback?** The integration stores the timestamp of the last successful collection. Upon restart, it uses this to backfill any missing data since that point.
+
 ## Setup
 
 To start collecting data with this integration, you need to:

--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -105,10 +105,10 @@ Agentless deployments are only supported in Elastic Serverless and Elastic Cloud
 
 ## Known limitations & issues
 
-- Missing Lookback Support: The integration currently lacks a lookback window for metric collection. If the Elastic Agent stops or an Agentless deployment restarts, metrics may be missed. A lookback feature is currently in development to address this.
-- Batch API Issue: When Batch API is active (default is inactive), a lack of matching resources in a single integration may cause collection to halt for all integrations.
+- Missing Lookback Support: The integration currently lacks a lookback window for metric collection. If the Elastic Agent stops or an Agentless deployment restarts, metrics might be missed. A lookback feature is currently in development to address this.
+- Batch API Issue: When Batch API is active (default is inactive), a lack of matching resources in a single integration can cause collection to halt for all integrations.
   - Fixes Scheduled: 8.19.17, 9.3.6, and 9.4.2.
-  - Workarounds: Disable the Batch API setting, or ensure each integration targets at least one Azure resource.
+  - Workarounds: Turn off the Batch API setting, or ensure each integration targets at least one Azure resource.
 
 **What is lookback?** The integration stores the timestamp of the last successful collection. Upon restart, it uses this to backfill any missing data since that point.
 

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.13.0
+  changes:
+    - description: Enable agentless deployment mode for the integration.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18802
 - version: "1.11.1"
   changes:
     - description: Fix YAML indentation in `compute_vm` stream template so the rendered config parses under stricter YAML parsers (Kibana 9.5+).

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,4 +1,4 @@
-- version: 1.13.0
+- version: 1.12.0
   changes:
     - description: Enable agentless deployment mode for the integration.
       type: enhancement

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -89,6 +89,29 @@ A specialized integration specializes in a specific Azure service and comes with
 
 Specialized integrations include the Azure Virtual Machine, Storage Account, Container Registry, and other Container-related metrics integrations.
 
+## How do I deploy this integration?
+
+### Agent-based deployment
+
+Elastic Agent must be installed. For more details, check the Elastic Agent [installation instructions](https://www.elastic.co/docs/reference/fleet/install-elastic-agents). You can install only one Elastic Agent per host.
+
+Elastic Agent is required to collect data from Azure Monitor and ship the data to Elastic, where the events will then be processed via the integration's ingest pipelines.
+
+### Agentless deployment
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html).
+
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments. This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
+## Known limitations & issues
+
+- Missing Lookback Support: The integration currently lacks a lookback window for metric collection. If the Elastic Agent stops or an Agentless deployment restarts, metrics may be missed. A lookback feature is currently in development to address this.
+- Batch API Issue: When Batch API is active (default is inactive), a lack of matching resources in a single integration may cause collection to halt for all integrations.
+  - Fixes Scheduled: 8.19.17, 9.3.6, and 9.4.2.
+  - Workarounds: Disable the Batch API setting, or ensure each integration targets at least one Azure resource.
+
+**What is lookback?** The integration stores the timestamp of the last successful collection. Upon restart, it uses this to backfill any missing data since that point.
+
 ## Setup
 
 To start collecting data with this integration, you need to:

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -107,7 +107,7 @@ Agentless deployments are only supported in Elastic Serverless and Elastic Cloud
 
 - Missing Lookback Support: The integration currently lacks a lookback window for metric collection. If the Elastic Agent stops or an Agentless deployment restarts, metrics might be missed. A lookback feature is currently in development to address this.
 - Batch API Issue: When Batch API is active (default is inactive), a lack of matching resources in a single integration can cause collection to halt for all integrations.
-  - Fixes Scheduled: 8.19.16, 9.3.5, 9.4.2 and 9.5.0.
+  - Fixes Scheduled: 8.19.17, 9.3.6, and 9.4.2.
   - Workarounds: Turn off the Batch API setting, or ensure each integration targets at least one Azure resource.
 
 **What is lookback?** The integration stores the timestamp of the last successful collection. Upon restart, it uses this to backfill any missing data since that point.

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -105,10 +105,10 @@ Agentless deployments are only supported in Elastic Serverless and Elastic Cloud
 
 ## Known limitations & issues
 
-- Missing Lookback Support: The integration currently lacks a lookback window for metric collection. If the Elastic Agent stops or an Agentless deployment restarts, metrics may be missed. A lookback feature is currently in development to address this.
-- Batch API Issue: When Batch API is active (default is inactive), a lack of matching resources in a single integration may cause collection to halt for all integrations.
+- Missing Lookback Support: The integration currently lacks a lookback window for metric collection. If the Elastic Agent stops or an Agentless deployment restarts, metrics might be missed. A lookback feature is currently in development to address this.
+- Batch API Issue: When Batch API is active (default is inactive), a lack of matching resources in a single integration can cause collection to halt for all integrations.
   - Fixes Scheduled: 8.19.17, 9.3.6, and 9.4.2.
-  - Workarounds: Disable the Batch API setting, or ensure each integration targets at least one Azure resource.
+  - Workarounds: Turn off the Batch API setting, or ensure each integration targets at least one Azure resource.
 
 **What is lookback?** The integration stores the timestamp of the last successful collection. Upon restart, it uses this to backfill any missing data since that point.
 

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -107,7 +107,7 @@ Agentless deployments are only supported in Elastic Serverless and Elastic Cloud
 
 - Missing Lookback Support: The integration currently lacks a lookback window for metric collection. If the Elastic Agent stops or an Agentless deployment restarts, metrics might be missed. A lookback feature is currently in development to address this.
 - Batch API Issue: When Batch API is active (default is inactive), a lack of matching resources in a single integration can cause collection to halt for all integrations.
-  - Fixes Scheduled: 8.19.17, 9.3.6, and 9.4.2.
+  - Fixes Scheduled: 8.19.16, 9.3.5, 9.4.2 and 9.5.0.
   - Workarounds: Turn off the Batch API setting, or ensure each integration targets at least one Azure resource.
 
 **What is lookback?** The integration stores the timestamp of the last successful collection. Upon restart, it uses this to backfill any missing data since that point.

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -106,6 +106,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -135,6 +136,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -164,6 +166,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -195,6 +198,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -226,6 +230,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -257,6 +262,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -288,6 +294,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -317,6 +324,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -106,7 +106,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -136,7 +135,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -166,7 +164,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -198,7 +195,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -230,7 +226,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -262,7 +257,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -294,7 +288,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services
@@ -324,7 +317,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        release: beta
         organization: observability
         division: engineering
         team: obs-hosted-services

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: "1.11.1"
+version: "1.12.0"
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:
@@ -13,7 +13,7 @@ screenshots:
     title: Azure VM metrics overview
     size: 5120x2562
     type: image/png
-format_version: 3.1.2
+format_version: 3.4.0
 categories:
   - cloud
   - observability
@@ -101,6 +101,14 @@ policy_templates:
         title: "Collect Azure Monitor metrics"
         description: "Collecting Collects Azure Monitor metrics"
         input_group: metrics
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-hosted-services
     icons:
       - src: /img/monitor_logo.png
         title: logo azure
@@ -122,6 +130,14 @@ policy_templates:
         title: "Collect Azure Virtual Machines metrics"
         description: "Collecting Azure Virtual Machines metrics"
         input_group: metrics
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-hosted-services
     icons:
       - src: /img/compute_vm_logo.png
         title: logo azure
@@ -143,6 +159,14 @@ policy_templates:
         title: "Collect Azure Virtual Machines Scaleset metrics"
         description: "Collecting Azure Virtual Machines Scaleset metrics"
         input_group: metrics
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-hosted-services
     icons:
       - src: /img/compute_vm_scaleset_logo.png
         title: logo azure
@@ -166,6 +190,14 @@ policy_templates:
         title: "Collect Azure Container Registry metrics"
         description: "Collecting Azure Container Registry metrics"
         input_group: metrics
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-hosted-services
     icons:
       - src: /img/container_registry_logo.png
         title: logo azure
@@ -189,6 +221,14 @@ policy_templates:
         title: "Collect Azure Container Instance metrics"
         description: "Collecting Azure Container Instance metrics"
         input_group: metrics
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-hosted-services
     icons:
       - src: /img/container_instance_logo.png
         title: logo azure
@@ -212,6 +252,14 @@ policy_templates:
         title: "Collect Azure Container Service metrics"
         description: "Collecting Azure Container Service metrics"
         input_group: metrics
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-hosted-services
     icons:
       - src: /img/container_service_logo.png
         title: logo azure
@@ -235,6 +283,14 @@ policy_templates:
         title: "Collect Azure Database Account metrics"
         description: "Collecting Azure Database Account metrics"
         input_group: metrics
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-hosted-services
     icons:
       - src: /img/database_account_logo.png
         title: logo azure
@@ -256,6 +312,14 @@ policy_templates:
         title: "Collect Azure Storage Account metrics"
         description: "Collecting Azure Storage Account metrics"
         input_group: metrics
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: observability
+        division: engineering
+        team: obs-hosted-services
     icons:
       - src: /img/storage_account_logo.png
         title: logo azure


### PR DESCRIPTION
## Summary

- Enables agentless deployment mode for all `azure_metrics` policy templates (Monitor, VM, VM Scaleset, Container Registry/Instance/Service, Database Account, Storage Account).
- Bumps package version to `1.12.0` and `format_version` to `3.4.0`.

## Test plan

- [x] `elastic-package check` passes for `packages/azure_metrics`.
- [x] Spin up a serverless project and verify the integration is offered in agentless mode.
- [x] Confirm metrics flow end-to-end for at least one policy template via agentless.