### PR TITLE
aws: fix NextToken invalidation in paginated queries

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.14.2"
+  changes:
+    - description: Fix NextToken invalidation in Security Hub, GuardDuty, and Inspector by removing the upper time bound from paginated queries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18830
 - version: "6.14.1"
   changes:
     - description: Handle null EvaluationResults in AWS Config GetComplianceDetailsByConfigRule response.

--- a/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
@@ -31,9 +31,10 @@ request.transforms:
       target: body.findingCriteria.criterion.updatedAt.greaterThan
       value: '[[((parseDate .cursor.last_execution_datetime)).UnixMilli]]'
       default: '[[((now (parseDuration "-{{initial_interval}}"))).UnixMilli]]'
-  - set:
-      target: body.findingCriteria.criterion.updatedAt.lessThan
-      value: '[[((now)).UnixMilli]]'
+{{!-- The upper time bound (lessThan) has been removed from updatedAt because httpjson
+      re-evaluates (now) on every pagination page, which can change the query and
+      invalidate the NextToken. A CEL rewrite can reintroduce the upper bound safely
+      since it can pin the value once per collection interval. --}}
   - set:
       target: header.Authorization
       value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/guardduty/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "guardduty")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/guardduty/aws4_request") (hash "sha256" "POST\n" "/detector/{{detector_id}}/findings\n" "\n" "host:guardduty.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'

--- a/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
@@ -27,10 +27,14 @@ request.transforms:
       target: body.sortCriteria
       value: '{"field":"LAST_OBSERVED_AT","sortOrder":"ASC"}'
       value_type: json
+{{!-- The upper time bound (endInclusive) has been removed from lastObservedAt because
+      httpjson re-evaluates (now) on every pagination page. When the value changes, AWS
+      rejects the nextToken. A CEL rewrite can reintroduce the upper bound safely since
+      it can pin the value once per collection interval. --}}
   - set:
       target: body.filterCriteria.lastObservedAt
-      value: '[{ "startInclusive": [[mul (div (toInt .cursor.last_observe_datetime) 1000) 1000]], "endInclusive": [[mul (div (toInt (now).Unix) 1000) 1000]] }]'
-      default: '[{ "startInclusive": [[mul (div (toInt (now (parseDuration "-{{initial_interval}}")).Unix) 1000) 1000]], "endInclusive": [[mul (div (toInt (now).Unix) 1000) 1000]] }]'
+      value: '[{ "startInclusive": [[mul (div (toInt .cursor.last_observe_datetime) 1000) 1000]] }]'
+      default: '[{ "startInclusive": [[mul (div (toInt (now (parseDuration "-{{initial_interval}}")).Unix) 1000) 1000]] }]'
       value_type: json
   - set:
       target: header.Authorization

--- a/packages/aws/data_stream/securityhub_findings/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/securityhub_findings/agent/stream/httpjson.yml.hbs
@@ -27,10 +27,14 @@ request.transforms:
       target: body.SortCriteria
       value: '[{"Field":"UpdatedAt","SortOrder":"asc"}]'
       value_type: json
+{{!-- The upper time bound (End) has been removed from UpdatedAt because httpjson
+      re-evaluates (now) on every pagination page. When the value crosses an hour
+      boundary, AWS rejects the NextToken. A CEL rewrite can reintroduce the upper
+      bound safely since it can pin the value once per collection interval. --}}
   - set:
       target: body.Filters.UpdatedAt
-      value: '[{ "Start": "[[formatDate (parseDate .cursor.last_execution_datetime "RFC3339") "2006-01-02T15"]]", "End": "[[formatDate (now) "2006-01-02T15"]]" }]'
-      default: '[{ "Start": "[[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15"]]", "End": "[[formatDate (now) "2006-01-02T15"]]" }]'
+      value: '[{ "Start": "[[formatDate (parseDate .cursor.last_execution_datetime "RFC3339") "2006-01-02T15"]]" }]'
+      default: '[{ "Start": "[[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15"]]" }]'
       value_type: json
   - set:
       target: header.Authorization

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.14.1
+version: 6.14.2
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
aws: fix NextToken invalidation in paginated queries

Remove the upper time bound from Security Hub, GuardDuty, and
Inspector httpjson templates. The httpjson input re-evaluates
request.transforms on every pagination page, so (now) in the
filter body changes between pages. When the value crosses a time
boundary, AWS rejects the NextToken with "Input Query has changed".

The lower bound from the cursor remains stable during pagination
and provides sufficient windowing. A CEL rewrite can reintroduce
the upper bound safely since it can pin the value once per
collection interval.

Without an upper bound, findings created during pagination could
extend the result set. Since results are sorted ascending by update
time, new findings appear at the tail. The creation rate would need
to exceed the pagination rate (~60 findings/second at 100 per page)
to cause unbounded pagination. Security Hub, GuardDuty, and
Inspector finding rates are orders of magnitude below this.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
