### PR TITLE
proofpoint_on_demand: add optional sinceTime backfill for message and mail streams

### DIFF
--- a/packages/proofpoint_on_demand/changelog.yml
+++ b/packages/proofpoint_on_demand/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Add optional sinceTime backfill support for message and mail streams via url_program re-evaluation on reconnect.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18833
+    - description: Remove unnecessary bytes() wrapping from CEL programs in all streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18833
 - version: "1.9.1"
   changes:
     - description: Revert 1.9.0 sinceTime cursor use which causes data delay and potential duplication.

--- a/packages/proofpoint_on_demand/data_stream/audit/agent/stream/websocket.yml.hbs
+++ b/packages/proofpoint_on_demand/data_stream/audit/agent/stream/websocket.yml.hbs
@@ -3,7 +3,7 @@ auth.bearer_token: {{access_token}}
 redact:
   fields: ~
 program: |
-  bytes(state.response).decode_json().as(body,{
+  state.response.decode_json().as(body,{
     "events": {
       "message":  body.encode_json(),
     }

--- a/packages/proofpoint_on_demand/data_stream/mail/agent/stream/websocket.yml.hbs
+++ b/packages/proofpoint_on_demand/data_stream/mail/agent/stream/websocket.yml.hbs
@@ -1,11 +1,23 @@
 url: {{url}}/v1/stream?cid={{cluster_id}}&type=maillog
+{{#if initial_since_time}}
+url_program: |
+  has(state.?cursor.last_timestamp) ?
+    state.url+"&sinceTime="+state.cursor.last_timestamp
+  :
+    state.url+"&sinceTime={{initial_since_time}}"
+{{/if}}
 auth.bearer_token: {{access_token}}
 redact:
   fields: ~
 program: |
-  bytes(state.response).decode_json().as(body,{
+  state.response.decode_json().as(body,{
+{{#if initial_since_time}}
+    "cursor": {
+      "last_timestamp": body.ts,
+    },
+{{/if}}
     "events": {
-      "message":  body.encode_json(),
+      "message": body.encode_json(),
     }
   })
 {{#if max_reconnect_attempts}}

--- a/packages/proofpoint_on_demand/data_stream/mail/manifest.yml
+++ b/packages/proofpoint_on_demand/data_stream/mail/manifest.yml
@@ -6,6 +6,20 @@ streams:
     description: Collecting Proofpoint On Demand Mail logs via Websocket.
     template_path: websocket.yml.hbs
     vars:
+      - name: initial_since_time
+        type: text
+        title: Initial Since Time
+        description: >-
+          Optional ISO 8601 timestamp (e.g. 2026-04-28T14:00:00-0500) to
+          backfill message and mail data after an extended outage. The agent
+          includes this timestamp on the first connection, then tracks
+          position via cursor. The Proofpoint API ignores sinceTime when it
+          is less than one hour old, so normal operation automatically uses
+          real-time streaming. Clear the agent's cursor state to trigger
+          another backfill.
+        multi: false
+        required: false
+        show_user: false
       - name: keep_alive
         type: bool
         title: Keep Alive

--- a/packages/proofpoint_on_demand/data_stream/message/agent/stream/websocket.yml.hbs
+++ b/packages/proofpoint_on_demand/data_stream/message/agent/stream/websocket.yml.hbs
@@ -1,11 +1,23 @@
 url: {{url}}/v1/stream?cid={{cluster_id}}&type=message
+{{#if initial_since_time}}
+url_program: |
+  has(state.?cursor.last_timestamp) ?
+    state.url+"&sinceTime="+state.cursor.last_timestamp
+  :
+    state.url+"&sinceTime={{initial_since_time}}"
+{{/if}}
 auth.bearer_token: {{access_token}}
 redact:
   fields: ~
 program: |
-  bytes(state.response).decode_json().as(body,{
+  state.response.decode_json().as(body,{
+{{#if initial_since_time}}
+    "cursor": {
+      "last_timestamp": body.ts,
+    },
+{{/if}}
     "events": {
-      "message":  body.encode_json(),
+      "message": body.encode_json(),
     }
   })
 {{#if max_reconnect_attempts}}

--- a/packages/proofpoint_on_demand/data_stream/message/manifest.yml
+++ b/packages/proofpoint_on_demand/data_stream/message/manifest.yml
@@ -6,6 +6,20 @@ streams:
     description: Collecting Proofpoint On Demand Message logs via Websocket.
     template_path: websocket.yml.hbs
     vars:
+      - name: initial_since_time
+        type: text
+        title: Initial Since Time
+        description: >-
+          Optional ISO 8601 timestamp (e.g. 2026-04-28T14:00:00-0500) to
+          backfill message and mail data after an extended outage. The agent
+          includes this timestamp on the first connection, then tracks
+          position via cursor. The Proofpoint API ignores sinceTime when it
+          is less than one hour old, so normal operation automatically uses
+          real-time streaming. Clear the agent's cursor state to trigger
+          another backfill.
+        multi: false
+        required: false
+        show_user: false
       - name: keep_alive
         type: bool
         title: Keep Alive

--- a/packages/proofpoint_on_demand/manifest.yml
+++ b/packages/proofpoint_on_demand/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.1.4
 name: proofpoint_on_demand
 title: Proofpoint On Demand
-version: "1.9.1"
+version: "1.10.0"
 description: Collect logs from Proofpoint On Demand with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: "^8.19.0 || ^9.1.0"
+    version: "^8.19.16 || ^9.3.5 || ^9.4.0"
   elastic:
     subscription: basic
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
proofpoint_on_demand: add optional sinceTime backfill for message and mail streams

Add an initial_since_time configuration variable that enables
cursor-driven sinceTime on the message and mail WebSocket streams.
When set, url_program appends sinceTime from the cursor on each
reconnect (or falls back to the configured value on the first
connection). The Proofpoint API ignores sinceTime when it is less
than one hour old, so normal operation remains real-time streaming.

Also remove unnecessary bytes conversions from CEL programs in all
three data streams.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #14241
- Closes #18380

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
