### PR TITLE
cel: add secret_state for encrypted credentials in CEL programs

### DIFF
--- a/packages/cel/_dev/deploy/docker/files/config.yml
+++ b/packages/cel/_dev/deploy/docker/files/config.yml
@@ -23,6 +23,17 @@ rules:
       - status_code: 200
         body: |
           {"message": "success"}
+  - path: /testsecret/api
+    methods: [GET]
+    request_headers:
+      Accept:
+        - "application/json"
+      X-Api-Key:
+        - "test-secret-key"
+    responses:
+      - status_code: 200
+        body: |
+          {"message": "success"}
   - path: /testoauth/token
     methods: [POST]
     query_params:

--- a/packages/cel/_dev/test/policy/test-secret-state.expected
+++ b/packages/cel/_dev/test/policy/test-secret-state.expected
@@ -1,0 +1,49 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: cel
+      name: test-secret-state-cel
+      streams:
+        - data_stream:
+            dataset: cel.cel
+          interval: 1m
+          program: |-
+            request("GET", state.url).with({
+            "Header": {"X-API-Key": [state.secret.api_key]}
+            }).do_request().as(resp, {
+            "events": [resp.Body.decode_json()],
+            "secret": state.secret,
+            })
+          publisher_pipeline.disable_host: true
+          redact.delete: false
+          regexp: null
+          resource.headers: null
+          resource.tracer:
+            enabled: false
+            filename: ../../logs/cel/http-request-trace-*.ndjson
+            maxbackups: 5
+          resource.url: https://server.example.com:8089/api
+          secret_state: ${SECRET_0}
+          tags:
+            - forwarded
+          xsd: null
+      type: cel
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-*-*
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}

--- a/packages/cel/_dev/test/policy/test-secret-state.yml
+++ b/packages/cel/_dev/test/policy/test-secret-state.yml
@@ -1,0 +1,14 @@
+vars:
+  url: http://example.com:9001
+  program: |-
+    request("GET", state.url).with({
+    "Header": {"X-API-Key": [state.secret.api_key]}
+    }).do_request().as(resp, {
+    "events": [resp.Body.decode_json()],
+    "secret": state.secret,
+    })
+  secret_state: |-
+    api_key: my-secret-api-key
+  interval: 5m
+  preserve_original_event: true
+  preserve_duplicate_custom_fields: true

--- a/packages/cel/_dev/test/system/test-secret-state-config.yml
+++ b/packages/cel/_dev/test/system/test-secret-state-config.yml
@@ -1,0 +1,20 @@
+vars:
+  redact_fields: [foo]
+  resource_url: http://{{Hostname}}:{{Port}}/testsecret/api
+  enable_request_tracer: true
+  secret_state: |-
+    api_key: test-secret-key
+  program: |
+    request("GET", state.url).with({
+      "Header": {
+        "Accept": ["application/json"],
+        "X-Api-Key": [state.secret.api_key],
+      }
+    }).do_request().as(resp, resp.StatusCode == 200 ?
+      resp.Body.as(body, {
+        "events": [body.decode_json()],
+        "secret": state.secret,
+      })
+    :
+      {"events": []}
+    )

--- a/packages/cel/agent/input/input.yml.hbs
+++ b/packages/cel/agent/input/input.yml.hbs
@@ -12,6 +12,10 @@ program: {{escape_string program}}
 state:
   {{state}}
 {{/if}}
+{{#if secret_state}}
+secret_state:
+  {{secret_state}}
+{{/if}}
 redact.delete: {{delete_redacted_fields}}
 {{#if redact_fields}}
 redact.fields:

--- a/packages/cel/changelog.yml
+++ b/packages/cel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.20.0"
+  changes:
+    - description: Add secret state configuration for encrypted credentials in CEL programs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18834
 - version: "1.19.0"
   changes:
     - description: Add options for including global HTTP request headers.

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -3,12 +3,12 @@ name: cel
 title: Custom API using Common Expression Language
 description: Collect custom events from an API with Elastic agent
 type: input
-version: "1.19.0"
+version: "1.20.0"
 categories:
   - custom
 conditions:
   kibana:
-    version: "^8.19.0 || ^9.1.0"
+    version: "^8.19.17 || ^9.3.6 || ^9.4.2"
   elastic:
     subscription: "basic"
 policy_templates:
@@ -81,10 +81,23 @@ policy_templates:
         title: Initial CEL evaluation state
         description: |
           State is the initial state to be provided to the program. If it has a cursor field, that field will be overwritten by any stored cursor, but will be available if no stored cursor exists.
+          The state must not contain a `secret` key; use the Secret State field instead.
           More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#input-state-cel).
         show_user: true
         multi: false
         required: false
+      - name: secret_state
+        type: textarea
+        title: Secret CEL evaluation state
+        description: |
+          Secret state holds key-value pairs that are stored encrypted by Fleet and made available to the CEL program at `state.secret`.
+          Use this for API keys, tokens, and other credentials that should not be visible in the integration configuration.
+          Values are automatically redacted in debug logs.
+          More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#secret-state-cel).
+        show_user: true
+        multi: false
+        required: false
+        secret: true
       - name: allowed_environment
         type: text
         title: Allowed environment variables


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
cel: add secret_state for encrypted credentials in CEL programs

Add a secret_state variable (type: textarea, secret: true) that
lets users store API keys and credentials encrypted by Fleet and
reference them in CEL programs as state.secret.<key>. Wire the
variable into the agent input template and add a system test that
validates the secret value reaches the CEL program via a header
check against the mock server.

Requires the matching beats change to accept string values for
secret_state, since Fleet resolves secrets to strings. Bumps
kibana.version to the versions that will include the Fleet fix.
```
> [!NOTE]
> Depends on a workaround in beats for a fleet bug.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Ref elastic/kibana#267859

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
