### PR TITLE
ci: stop running weekends or weekly

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -183,7 +183,7 @@ spec:
       schedules:
         main_daily:
           branch: "main"
-          cronline: "30 0 * * *"
+          cronline: "30 0 * 1-5"
           message: "Run the daily jobs"
           env:
             TEST_PACKAGES_7_BRANCH: "true"
@@ -191,19 +191,19 @@ spec:
             REPUBLISH_PACKAGES: "true"
         main_daily_8_version:
           branch: "main"
-          cronline: "30 1 * * *"
+          cronline: "30 1 * 1-5"
           message: "Run the daily jobs for 8.x"
           env:
             TEST_PACKAGES_8_BRANCH: "true"
         main_daily_9_version:
           branch: "main"
-          cronline: "30 3 * * *"
+          cronline: "30 3 * 1-5"
           message: "Run the daily jobs for 9.x"
           env:
             TEST_PACKAGES_9_BRANCH: "true"
         main_daily_basic_subscription:
           branch: "main"
-          cronline: "30 4 * * *"
+          cronline: "30 4 * 1-5"
           message: "Run the daily jobs for basic subscription"
           env:
             TEST_PACKAGES_BASIC_SUBSCRIPTION: "true"
@@ -256,19 +256,15 @@ spec:
       description: 'Weekly pipeline for the Integrations project'
     spec:
       pipeline_file: ".buildkite/pipeline.schedule-weekly.yml"
-      schedules:
-        main_weekly:
-          branch: "main"
-          cronline: "00 5 * * 1"
-          message: "Run the weekly jobs"
+      # NOTE: Stop running weekly for now
+      #       see https://github.com/elastic/integrations/issues/18868
+      #schedules:
+      #  main_weekly:
+      #    branch: "main"
+      #    cronline: "00 5 * * 1"
+      #    message: "Run the weekly jobs"
       provider_settings:
         trigger_mode: none # don't trigger jobs from github activity
-        build_pull_request_forks: false
-        build_pull_requests: true
-        build_tags: false
-        filter_enabled: true
-        filter_condition: >-
-          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null && build.source == 'api')
       repository: elastic/integrations
       cancel_intermediate_builds: true
       cancel_intermediate_builds_branch_filter: '!main'


### PR DESCRIPTION



## Proposed commit message

Two improvements to the scheduled CI pipelines in this repository:

Remove the weekly scheduled builds — these were introduced to test packages against non-Wolfi Elastic Agent images. Failures from these builds are not monitored: unlike the daily pipelines, they do not open GitHub issues, meaning failures may go unnoticed indefinitely.

Restrict the daily scheduled builds to weekdays (Monday–Friday) — currently all four daily schedules run every day of the week. Since active development occurs on weekdays, running these builds over the weekend provides limited value.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/18868

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
