### PR TITLE
feat(gamepulse): add GamePulse gaming telemetry integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -255,6 +255,7 @@
 /packages/fortinet_fortimail @elastic/integration-experience
 /packages/fortinet_fortimanager @elastic/integration-experience
 /packages/fortinet_fortiproxy @elastic/integration-experience
+/packages/gamepulse @MathewRJ
 /packages/gcp @elastic/security-service-integrations @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services
 /packages/gcp/data_stream/audit @elastic/security-service-integrations
 /packages/gcp/data_stream/billing @elastic/obs-infraobs-integrations

--- a/packages/gamepulse/.elastic-package-ignore
+++ b/packages/gamepulse/.elastic-package-ignore
@@ -1,0 +1,44 @@
+# Exclude archive directories (legacy code and docs, not part of integration)
+archive
+archive/
+docs/archive
+docs/archive/
+
+# Exclude Python virtual environment from package build
+collector/.venv
+collector/.venv/
+collector/.venv/**
+
+# Exclude Claude Code agent harness and skills (directory symlinks cause build failures)
+.claude
+.claude/
+.claude/**
+.agents
+.agents/
+.agents/**
+
+# Exclude eBPF Rust workspace
+ebpf
+ebpf/
+
+# Exclude Rust build artifacts (large — up to 277MB)
+target
+target/
+
+# Exclude Rust source tree
+src
+src/
+
+# Exclude development-only files
+tools
+scripts
+Makefile
+CONTRIBUTING.md
+
+# Exclude dashboards directory (not part of integration package)
+dashboards
+dashboards/
+
+# Exclude packaging directory
+packaging
+packaging/

--- a/packages/gamepulse/LICENSE
+++ b/packages/gamepulse/LICENSE
@@ -1,0 +1,189 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work.
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 GamePulse Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/gamepulse/README.md
+++ b/packages/gamepulse/README.md
@@ -1,0 +1,65 @@
+# GamePulse — Elastic Fleet Integration
+
+Elastic Fleet integration package for [GamePulse](https://github.com/MathewRJ/GamePulse) — real-time gaming telemetry for Elasticsearch.
+
+Captures FPS, frame timing percentiles, GPU/CPU thermals and utilisation, memory, storage, network, audio, power, and kernel-level scheduler/I/O/GPU traces via eBPF.
+
+## Install via Fleet (custom registry)
+
+Add the GamePulse custom package registry to your Fleet instance, then install like any other integration.
+
+**1. Configure Fleet to use the GamePulse registry**
+
+In Kibana: `Fleet → Settings → Package Registry URL`
+
+Set to: `https://MathewRJ.github.io/GamePulse-Integration`
+
+**2. Install the integration**
+
+`Fleet → Integrations → search "GamePulse" → Add GamePulse`
+
+**3. Install the agent binary**
+
+Download the gamepulse-agent for your platform from the [GamePulse releases page](https://github.com/MathewRJ/GamePulse/releases).
+
+**4. Configure the agent**
+
+Create `/etc/gamepulse/gamepulse.toml` (Linux) or `%APPDATA%\gamepulse\gamepulse.toml` (Windows):
+
+```toml
+[elasticsearch]
+url      = "https://your-instance.es.us-central1.gcp.elastic.cloud"
+api_key  = "your-ingest-api-key"
+```
+
+The ingest API key needs `create_doc` + `auto_configure` on `metrics-gamepulse.*` and `logs-gamepulse.*`.
+
+## Data streams
+
+| Stream | Type | Content |
+|---|---|---|
+| `metrics-gamepulse.cpu-*` | metrics | CPU utilisation, temperature, frequency |
+| `metrics-gamepulse.gpu-*` | metrics | GPU utilisation, VRAM, temperature, power |
+| `metrics-gamepulse.frame-*` | metrics | FPS, frame time percentiles, stutter count |
+| `metrics-gamepulse.memory-*` | metrics | RAM usage, swap, process RSS |
+| `metrics-gamepulse.storage-*` | metrics | Disk I/O, latency |
+| `metrics-gamepulse.network-*` | metrics | Bytes/packets in/out |
+| `metrics-gamepulse.audio-*` | metrics | Latency, buffer size, xruns |
+| `metrics-gamepulse.power-*` | metrics | Battery, AC state, TDP |
+| `metrics-gamepulse.ebpf-*` | metrics | Scheduler migrations, GPU fence latency, futex wait |
+| `metrics-gamepulse.session-*` | metrics | Per-session aggregates, game metadata |
+| `logs-gamepulse.events-*` | logs | Game start/end, settings changes |
+
+## Dashboards
+
+Five dashboards are included:
+
+- **Player Overview** — session history, top games by FPS and playtime
+- **Game Performance** — FPS trends, frame timing, stutter analysis
+- **Game Engine** — eBPF kernel traces, shader compile detection
+- **Hardware Environment** — thermal and power headroom
+- **Software Environment** — driver versions, OS context, audio health
+
+## Licence
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/packages/gamepulse/README.md
+++ b/packages/gamepulse/README.md
@@ -47,6 +47,7 @@ The ingest API key needs `create_doc` + `auto_configure` on `metrics-gamepulse.*
 | `metrics-gamepulse.audio-*` | metrics | Latency, buffer size, xruns |
 | `metrics-gamepulse.power-*` | metrics | Battery, AC state, TDP |
 | `metrics-gamepulse.ebpf-*` | metrics | Scheduler migrations, GPU fence latency, futex wait |
+| `metrics-gamepulse.ebpf_thread-*` | metrics | Per-thread runqueue latency, switches, and migrations |
 | `metrics-gamepulse.session-*` | metrics | Per-session aggregates, game metadata |
 | `logs-gamepulse.events-*` | logs | Game start/end, settings changes |
 

--- a/packages/gamepulse/_dev/build/build.yml
+++ b/packages/gamepulse/_dev/build/build.yml
@@ -1,0 +1,4 @@
+dependencies:
+  ecs:
+    reference: "git@v8.17.0"
+    import_mappings: false

--- a/packages/gamepulse/changelog.yml
+++ b/packages/gamepulse/changelog.yml
@@ -1,0 +1,18 @@
+- version: "0.1.1"
+  changes:
+    - description: >
+        Fix Elastic Agent 9.x compatibility: replace logfile input with filestream.
+        Filebeat 9.x removed the log input type; switch policy template and events
+        data stream to filestream with a proper agent stream template.
+      type: bugfix
+      link: https://github.com/MathewRJ/GamePulse-Integration/issues/1
+
+- version: "0.1.0"
+  changes:
+    - description: >
+        Initial integration package scaffolding. Defines 11 data streams (10 TSDS metrics,
+        1 logs) with ECS-compliant gamepulse.* field mappings, TSDS mode, metric_type/unit
+        annotations, and per-data-stream ingest pipelines. Migrated from freestyle ES
+        component templates to elastic-package format.
+      type: enhancement
+      link: https://github.com/MathewRJ/GamePulse/issues/1

--- a/packages/gamepulse/changelog.yml
+++ b/packages/gamepulse/changelog.yml
@@ -6,6 +6,11 @@
         data stream to filestream with a proper agent stream template.
       type: bugfix
       link: https://github.com/MathewRJ/GamePulse-Integration/issues/1
+    - description: >
+        Model eBPF per-thread scheduler metrics as a dedicated TSDB data stream
+        instead of nested fields inside aggregate eBPF documents.
+      type: enhancement
+      link: https://github.com/MathewRJ/GamePulse-Integration/issues/1
 
 - version: "0.1.0"
   changes:

--- a/packages/gamepulse/data_stream/audio/_dev/test/pipeline/test-audio-pipeline.json
+++ b/packages/gamepulse/data_stream/audio/_dev/test/pipeline/test-audio-pipeline.json
@@ -1,0 +1,32 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.audio",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500
+        },
+        "audio": {
+          "backend": "PipeWire",
+          "sample_rate_hz": 48000,
+          "buffer_size": 1024,
+          "latency_ms": 21.3,
+          "xruns": 0
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/audio/_dev/test/pipeline/test-audio-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/audio/_dev/test/pipeline/test-audio-pipeline.json-expected.json
@@ -1,0 +1,32 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.audio",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "audio": {
+                    "backend": "pipewire",
+                    "buffer_size": 1024,
+                    "latency_ms": 21.3,
+                    "sample_rate_hz": 48000,
+                    "xruns": 0
+                },
+                "game": {
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/audio/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/audio/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,22 @@
+---
+description: >
+  Ingest pipeline for GamePulse audio metrics.
+  Sets @timestamp and normalises audio backend name.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - lowercase:
+      field: gamepulse.audio.backend
+      ignore_missing: true
+      description: "Normalise audio backend (PipeWire -> pipewire, PulseAudio -> pulseaudio)"
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-audio"

--- a/packages/gamepulse/data_stream/audio/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/audio/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/audio/fields/fields.yml
+++ b/packages/gamepulse/data_stream/audio/fields/fields.yml
@@ -1,0 +1,63 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+
+# Session context
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+        - name: source
+          type: keyword
+          description: "Detection source: steam | lutris | heroic | bottles | user_specified | auto_detected"
+        - name: launcher
+          type: keyword
+          description: "Human-readable launcher name (e.g. Steam, Lutris, Heroic — Epic)"
+
+    # Audio-specific metrics
+    - name: audio
+      type: group
+      fields:
+        - name: backend
+          type: keyword
+          description: "Audio server backend (pipewire, pulseaudio, alsa, wasapi)"
+        - name: sample_rate_hz
+          type: integer
+          metric_type: gauge
+          description: "Audio sample rate in Hz"
+        - name: buffer_size
+          type: integer
+          metric_type: gauge
+          description: "Audio buffer size in frames"
+        - name: latency_ms
+          type: float
+          metric_type: gauge
+          unit: ms
+          description: "Audio pipeline round-trip latency in milliseconds"
+        - name: xruns
+          type: integer
+          metric_type: counter
+          description: "Cumulative audio buffer underrun/overrun count (xruns). Causes audio glitches."

--- a/packages/gamepulse/data_stream/audio/manifest.yml
+++ b/packages/gamepulse/data_stream/audio/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse Audio Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/audio/sample_event.json
+++ b/packages/gamepulse/data_stream/audio/sample_event.json
@@ -1,0 +1,30 @@
+{
+  "@timestamp": "2026-04-04T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.audio",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "source": "steam",
+      "launcher": "Steam"
+    },
+    "audio": {
+      "backend": "pipewire",
+      "sample_rate_hz": 48000,
+      "buffer_size": 1024,
+      "latency_ms": 21.3,
+      "xruns": 0
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/cpu/_dev/test/pipeline/test-cpu-pipeline.json
+++ b/packages/gamepulse/data_stream/cpu/_dev/test/pipeline/test-cpu-pipeline.json
@@ -1,0 +1,44 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.cpu",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "  Cyberpunk 2077  ",
+          "steam_app_id": 1091500
+        },
+        "cpu": {
+          "total_utilisation_pct": 38.5,
+          "game_utilisation_pct": 22.1,
+          "per_core": [
+            45.2,
+            78.9,
+            34.1,
+            62.3,
+            28.7,
+            41.5,
+            30.2,
+            55.8
+          ],
+          "clock_mhz_avg": 4850,
+          "temperature_c": 68.5,
+          "power_w": 95.2,
+          "governor": "performance",
+          "boost_state": true
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/cpu/_dev/test/pipeline/test-cpu-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/cpu/_dev/test/pipeline/test-cpu-pipeline.json-expected.json
@@ -1,0 +1,44 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.cpu",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "cpu": {
+                    "boost_state": true,
+                    "clock_mhz_avg": 4850,
+                    "game_utilisation_pct": 22.1,
+                    "governor": "performance",
+                    "per_core": [
+                        45.2,
+                        78.9,
+                        34.1,
+                        62.3,
+                        28.7,
+                        41.5,
+                        30.2,
+                        55.8
+                    ],
+                    "power_w": 95.2,
+                    "temperature_c": 68.5,
+                    "total_utilisation_pct": 38.5
+                },
+                "game": {
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/cpu/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/cpu/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,34 @@
+---
+description: >
+  Ingest pipeline for GamePulse CPU metrics.
+  Sets @timestamp and validates CPU utilisation ranges.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+
+  - script:
+      description: "Validate CPU utilisation is 0–100%"
+      lang: painless
+      source: |
+        def total = ctx.gamepulse?.cpu?.total_utilisation_pct;
+        if (total != null && (total < 0 || total > 100)) {
+          throw new Exception('gamepulse.cpu.total_utilisation_pct must be 0-100, got: ' + total);
+        }
+        def game = ctx.gamepulse?.cpu?.game_utilisation_pct;
+        if (game != null && (game < 0 || game > 100)) {
+          throw new Exception('gamepulse.cpu.game_utilisation_pct must be 0-100, got: ' + game);
+        }
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-cpu"

--- a/packages/gamepulse/data_stream/cpu/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/cpu/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/cpu/fields/fields.yml
+++ b/packages/gamepulse/data_stream/cpu/fields/fields.yml
@@ -1,0 +1,76 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+
+# Session context
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+        - name: source
+          type: keyword
+          description: "Detection source: steam | lutris | heroic | bottles | user_specified | auto_detected"
+        - name: launcher
+          type: keyword
+          description: "Human-readable launcher name (e.g. Steam, Lutris, Heroic — Epic)"
+
+    # CPU-specific metrics
+    - name: cpu
+      type: group
+      fields:
+        - name: total_utilisation_pct
+          type: float
+          metric_type: gauge
+          unit: percent
+          description: "Total CPU utilisation across all cores (0–100)"
+        - name: game_utilisation_pct
+          type: float
+          metric_type: gauge
+          unit: percent
+          description: "CPU utilisation attributable to the game process and its threads (0–100)"
+        - name: per_core
+          type: float
+          metric_type: gauge
+          unit: percent
+          description: "Per-core utilisation array (0–100 per element). Index corresponds to logical CPU number."
+        - name: clock_mhz_avg
+          type: integer
+          metric_type: gauge
+          description: "Average CPU clock speed across all active cores in MHz"
+        - name: temperature_c
+          type: float
+          metric_type: gauge
+          description: "CPU package (Tdie/Tctl) temperature in Celsius"
+        - name: power_w
+          type: float
+          metric_type: gauge
+          description: "CPU package power draw in watts (from RAPL or hwmon)"
+        - name: governor
+          type: keyword
+          description: "Active CPU frequency governor (performance, powersave, schedutil, etc.)"
+        - name: boost_state
+          type: boolean
+          description: "True when CPU boost/turbo is enabled"

--- a/packages/gamepulse/data_stream/cpu/manifest.yml
+++ b/packages/gamepulse/data_stream/cpu/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse CPU Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/cpu/sample_event.json
+++ b/packages/gamepulse/data_stream/cpu/sample_event.json
@@ -1,0 +1,50 @@
+{
+  "@timestamp": "2026-04-04T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.cpu",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "source": "steam",
+      "launcher": "Steam"
+    },
+    "cpu": {
+      "total_utilisation_pct": 38.5,
+      "game_utilisation_pct": 22.1,
+      "per_core": [
+        45.2,
+        78.9,
+        34.1,
+        62.3,
+        28.7,
+        41.5,
+        30.2,
+        55.8,
+        22.1,
+        38.4,
+        25.6,
+        44.7,
+        19.3,
+        32.1,
+        21.8,
+        39.0
+      ],
+      "clock_mhz_avg": 4850,
+      "temperature_c": 68.5,
+      "power_w": 95.2,
+      "governor": "performance",
+      "boost_state": true
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/ebpf/_dev/test/pipeline/test-ebpf-pipeline.json
+++ b/packages/gamepulse/data_stream/ebpf/_dev/test/pipeline/test-ebpf-pipeline.json
@@ -1,0 +1,83 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.ebpf",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc",
+        "os": {
+          "kernel": "6.1.82-valve22-1-neptune"
+        }
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001"
+        },
+        "ebpf": {
+          "probe": "schedlatency",
+          "runqueue": {
+            "latency_histogram": {
+              "values": [
+                1,
+                2,
+                4,
+                8,
+                16,
+                32,
+                64,
+                128,
+                256,
+                512,
+                1024,
+                2048,
+                4096,
+                8192,
+                16384,
+                32768
+              ],
+              "counts": [
+                0,
+                124,
+                892,
+                1204,
+                841,
+                341,
+                87,
+                22,
+                8,
+                3,
+                1,
+                0,
+                0,
+                0,
+                0,
+                0
+              ]
+            },
+            "latency_min_us": 1.4,
+            "latency_max_us": 892.1,
+            "latency_avg_us": 18.7,
+            "event_count": 3523
+          },
+          "migration": {
+            "total_count": 142,
+            "ccx_cross_count": 0
+          },
+          "thread_breakdown": [
+            {
+              "comm": "Starfield",
+              "tid": 12345,
+              "runqueue_avg_us": 16.2,
+              "switch_count": 1892,
+              "migration_count": 48
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/ebpf/_dev/test/pipeline/test-ebpf-pipeline.json
+++ b/packages/gamepulse/data_stream/ebpf/_dev/test/pipeline/test-ebpf-pipeline.json
@@ -66,16 +66,7 @@
           "migration": {
             "total_count": 142,
             "ccx_cross_count": 0
-          },
-          "thread_breakdown": [
-            {
-              "comm": "Starfield",
-              "tid": 12345,
-              "runqueue_avg_us": 16.2,
-              "switch_count": 1892,
-              "migration_count": 48
-            }
-          ]
+          }
         }
       }
     }

--- a/packages/gamepulse/data_stream/ebpf/_dev/test/pipeline/test-ebpf-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/ebpf/_dev/test/pipeline/test-ebpf-pipeline.json-expected.json
@@ -1,0 +1,83 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.ebpf",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "ebpf": {
+                    "migration": {
+                        "ccx_cross_count": 0,
+                        "total_count": 142
+                    },
+                    "probe": "schedlatency",
+                    "runqueue": {
+                        "event_count": 3523,
+                        "latency_avg_us": 18.7,
+                        "latency_histogram": {
+                            "counts": [
+                                0,
+                                124,
+                                892,
+                                1204,
+                                841,
+                                341,
+                                87,
+                                22,
+                                8,
+                                3,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ],
+                            "values": [
+                                1,
+                                2,
+                                4,
+                                8,
+                                16,
+                                32,
+                                64,
+                                128,
+                                256,
+                                512,
+                                1024,
+                                2048,
+                                4096,
+                                8192,
+                                16384,
+                                32768
+                            ]
+                        },
+                        "latency_max_us": 892.1,
+                        "latency_min_us": 1.4
+                    },
+                    "thread_breakdown": [
+                        {
+                            "comm": "Starfield",
+                            "migration_count": 48,
+                            "runqueue_avg_us": 16.2,
+                            "switch_count": 1892,
+                            "tid": 12345
+                        }
+                    ]
+                },
+                "session": {
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc",
+                "os": {
+                    "kernel": "6.1.82-valve22-1-neptune"
+                }
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/ebpf/_dev/test/pipeline/test-ebpf-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/ebpf/_dev/test/pipeline/test-ebpf-pipeline.json-expected.json
@@ -57,16 +57,7 @@
                         },
                         "latency_max_us": 892.1,
                         "latency_min_us": 1.4
-                    },
-                    "thread_breakdown": [
-                        {
-                            "comm": "Starfield",
-                            "migration_count": 48,
-                            "runqueue_avg_us": 16.2,
-                            "switch_count": 1892,
-                            "tid": 12345
-                        }
-                    ]
+                    }
                 },
                 "session": {
                     "id": "test-session-001"

--- a/packages/gamepulse/data_stream/ebpf/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/ebpf/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,31 @@
+---
+description: >
+  Ingest pipeline for GamePulse eBPF kernel telemetry metrics.
+  Sets @timestamp and validates probe availability metadata.
+  eBPF data arrives pre-aggregated at 1-second intervals from the Rust/Aya daemon.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+
+  - script:
+      description: "Validate session ID is present"
+      lang: painless
+      source: |
+        def sid = ctx.gamepulse?.session?.id;
+        if (sid == null || sid.isEmpty()) {
+          throw new Exception('gamepulse.session.id is required in eBPF documents');
+        }
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-ebpf"

--- a/packages/gamepulse/data_stream/ebpf/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/ebpf/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/ebpf/fields/fields.yml
+++ b/packages/gamepulse/data_stream/ebpf/fields/fields.yml
@@ -70,24 +70,8 @@
 
         # Per-thread breakdown (top 8 threads by switch count)
         - name: thread_breakdown
-          type: nested
-          description: "Per-thread scheduler stats for the top-8 most-active game threads"
-          fields:
-            - name: comm
-              type: keyword
-              description: "Thread name (comm, max 15 chars)"
-            - name: tid
-              type: long
-              description: "Thread ID"
-            - name: runqueue_avg_us
-              type: double
-              description: "Mean runqueue latency for this thread this second (μs)"
-            - name: switch_count
-              type: long
-              description: "Context switches for this thread this second"
-            - name: migration_count
-              type: long
-              description: "CPU migrations for this thread this second"
+          type: flattened
+          description: "Per-thread scheduler stats for the top-8 most-active game threads (comm, tid, runqueue_avg_us, switch_count, migration_count)"
 
         # Bio probe: block I/O latency
         - name: bio

--- a/packages/gamepulse/data_stream/ebpf/fields/fields.yml
+++ b/packages/gamepulse/data_stream/ebpf/fields/fields.yml
@@ -1,0 +1,373 @@
+# ECS fields
+- name: host.name
+  external: ecs
+  dimension: true
+
+- name: host.os.kernel
+  external: ecs
+
+# Session and eBPF metrics
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+
+    - name: ebpf
+      type: group
+      fields:
+        - name: probe
+          type: keyword
+          description: "Probe name discriminant (e.g. schedlatency)"
+
+        # Scheduler probe: runqueue latency
+        - name: runqueue
+          type: group
+          fields:
+            - name: latency_histogram
+              type: histogram
+              description: >
+                Runqueue wait-time distribution per 1-second window.
+                values: log2 upper-bound buckets in μs (16 values);
+                counts: observations per bucket.
+            - name: latency_min_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Minimum runqueue latency observed this second (μs)"
+            - name: latency_max_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Maximum runqueue latency observed this second (μs)"
+            - name: latency_avg_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Mean runqueue latency observed this second (μs)"
+            - name: event_count
+              type: long
+              metric_type: gauge
+              description: "Context-switch events observed this second"
+
+        # Scheduler probe: CPU migrations
+        - name: migration
+          type: group
+          fields:
+            - name: total_count
+              type: long
+              metric_type: gauge
+              description: "CPU migrations for game threads observed this second"
+            - name: ccx_cross_count
+              type: long
+              metric_type: gauge
+              description: "CCX-boundary migrations (always 0 on single-CCX chips like 9800X3D)"
+
+        # Per-thread breakdown (top 8 threads by switch count)
+        - name: thread_breakdown
+          type: nested
+          description: "Per-thread scheduler stats for the top-8 most-active game threads"
+          fields:
+            - name: comm
+              type: keyword
+              description: "Thread name (comm, max 15 chars)"
+            - name: tid
+              type: long
+              description: "Thread ID"
+            - name: runqueue_avg_us
+              type: double
+              description: "Mean runqueue latency for this thread this second (μs)"
+            - name: switch_count
+              type: long
+              description: "Context switches for this thread this second"
+            - name: migration_count
+              type: long
+              description: "CPU migrations for this thread this second"
+
+        # Bio probe: block I/O latency
+        - name: bio
+          type: group
+          fields:
+            - name: latency_histogram
+              type: histogram
+              description: >
+                Block I/O completion latency distribution per 1-second window.
+                values: log2 upper-bound buckets in μs (16 values);
+                counts: observations per bucket.
+            - name: latency_min_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Minimum block I/O latency observed this second (μs)"
+            - name: latency_max_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Maximum block I/O latency observed this second (μs)"
+            - name: latency_avg_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Mean block I/O latency observed this second (μs)"
+            - name: event_count
+              type: long
+              metric_type: gauge
+              description: "Block I/O completions observed this second"
+            - name: bytes_total
+              type: long
+              metric_type: gauge
+              unit: byte
+              description: "Total bytes transferred across all observed I/O operations"
+
+        # GPU scheduler probe: DRM job scheduling latency
+        - name: gpu_sched
+          type: group
+          fields:
+            - name: latency_histogram
+              type: histogram
+              description: >
+                GPU job scheduling latency distribution per 1-second window.
+                values: log2 upper-bound buckets in μs (16 values);
+                counts: observations per bucket.
+            - name: latency_min_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Minimum GPU scheduling latency observed this second (μs)"
+            - name: latency_max_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Maximum GPU scheduling latency observed this second (μs)"
+            - name: latency_avg_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Mean GPU scheduling latency observed this second (μs)"
+            - name: event_count
+              type: long
+              metric_type: gauge
+              description: "GPU jobs observed this second (all rings: gfx, comp, sdma)"
+
+        # Memory pressure probe
+        - name: mem
+          type: group
+          fields:
+            - name: page_fault_count
+              type: long
+              metric_type: gauge
+              description: "User-space page faults from game threads this second"
+            - name: page_fault_write
+              type: long
+              metric_type: gauge
+              description: "Write (COW/allocation) faults — subset of page_fault_count"
+            - name: direct_reclaim_count
+              type: long
+              metric_type: gauge
+              description: >
+                Direct reclaim events (system-wide) this second.
+                Non-zero indicates memory pressure; game threads stalled waiting for memory.
+
+        # Futex contention probe
+        - name: futex
+          type: group
+          fields:
+            - name: latency_histogram
+              type: histogram
+              description: >
+                Futex wait-time distribution per 1-second window.
+                values: log2 upper-bound buckets in μs (16 values);
+                counts: observations per bucket.
+            - name: latency_min_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Minimum futex operation latency observed this second (μs)"
+            - name: latency_max_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Maximum futex operation latency observed this second (μs)"
+            - name: latency_avg_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Mean futex operation latency observed this second (μs)"
+            - name: event_count
+              type: long
+              metric_type: gauge
+              description: "Futex operations observed this second (game threads)"
+            - name: contended_count
+              type: long
+              metric_type: gauge
+              description: "Futex operations with latency > 1ms (contended acquisitions)"
+
+        # IRQ and softirq latency probe
+        - name: irq
+          type: group
+          fields:
+            - name: hard_irq
+              type: group
+              fields:
+                - name: latency_histogram
+                  type: histogram
+                  description: >
+                    Hard-IRQ handler latency distribution per 1-second window.
+                    values: log2 upper-bound buckets in μs (16 values);
+                    counts: observations per bucket.
+                - name: latency_avg_us
+                  type: double
+                  metric_type: gauge
+                  unit: micros
+                  description: "Mean hard-IRQ handler latency this second (μs)"
+                - name: event_count
+                  type: long
+                  metric_type: gauge
+                  description: "Hard-IRQ handler invocations observed this second"
+            - name: softirq
+              type: group
+              fields:
+                - name: latency_histogram
+                  type: histogram
+                  description: >
+                    Softirq handler latency distribution per 1-second window.
+                    values: log2 upper-bound buckets in μs (16 values);
+                    counts: observations per bucket.
+                - name: latency_avg_us
+                  type: double
+                  metric_type: gauge
+                  unit: micros
+                  description: "Mean softirq handler latency this second (μs)"
+                - name: event_count
+                  type: long
+                  metric_type: gauge
+                  description: "Softirq handler invocations observed this second"
+
+        # VFS read/write latency probe
+        - name: vfs
+          type: group
+          fields:
+            - name: read
+              type: group
+              fields:
+                - name: latency_histogram
+                  type: histogram
+                  description: >
+                    VFS read latency distribution per 1-second window.
+                    values: log2 upper-bound buckets in μs (16 values);
+                    counts: observations per bucket.
+                - name: latency_avg_us
+                  type: double
+                  metric_type: gauge
+                  unit: micros
+                  description: "Mean VFS read latency this second (μs)"
+                - name: event_count
+                  type: long
+                  metric_type: gauge
+                  description: "VFS read operations observed this second (game threads)"
+                - name: bytes_total
+                  type: long
+                  metric_type: gauge
+                  unit: byte
+                  description: "Total bytes read (reserved for future use)"
+            - name: write
+              type: group
+              fields:
+                - name: latency_histogram
+                  type: histogram
+                  description: >
+                    VFS write latency distribution per 1-second window.
+                    values: log2 upper-bound buckets in μs (16 values);
+                    counts: observations per bucket.
+                - name: latency_avg_us
+                  type: double
+                  metric_type: gauge
+                  unit: micros
+                  description: "Mean VFS write latency this second (μs)"
+                - name: event_count
+                  type: long
+                  metric_type: gauge
+                  description: "VFS write operations observed this second (game threads)"
+                - name: bytes_total
+                  type: long
+                  metric_type: gauge
+                  unit: byte
+                  description: "Total bytes written (reserved for future use)"
+
+        # DMA fence wait probe (GPU blocking wait latency)
+        - name: gpu_fence
+          type: group
+          fields:
+            - name: latency_histogram
+              type: histogram
+              description: >
+                DMA fence wait latency distribution per 1-second window.
+                values: log2 upper-bound buckets in μs (16 values);
+                counts: observations per bucket.
+            - name: latency_min_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Minimum fence wait latency observed this second (μs)"
+            - name: latency_max_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Maximum fence wait latency observed this second (μs)"
+            - name: latency_avg_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Mean fence wait latency observed this second (μs)"
+            - name: event_count
+              type: long
+              metric_type: gauge
+              description: "DMA fence waits observed this second"
+            - name: blocked_count
+              type: long
+              metric_type: gauge
+              description: "Fence waits that blocked for > 1ms (frame-impacting)"
+
+        # GPU command submission probe (AMD only)
+        - name: gpu_submit
+          type: group
+          fields:
+            - name: event_count
+              type: long
+              metric_type: gauge
+              description: "amdgpu_cs_ioctl calls (GPU command submissions) observed this second"
+
+        # Cross-probe stutter correlation
+        - name: stutter
+          type: group
+          fields:
+            - name: contributing_probes
+              type: keyword
+              description: "Probes that detected a spike this second (e.g. schedlatency, bio)"
+            - name: sched_max_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Runqueue max latency this window (μs); 0 if sched probe not active"
+            - name: bio_max_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "Block I/O max latency this window (μs); 0 if bio probe not active"
+            - name: gpu_sched_max_us
+              type: double
+              metric_type: gauge
+              unit: micros
+              description: "GPU scheduling max latency this window (μs); 0 if gpu_sched probe not active"
+            - name: mem_pressure
+              type: boolean
+              description: "True if direct memory reclaim was observed this window"
+            - name: severity_score
+              type: byte
+              metric_type: gauge
+              description: "Number of contributing probes: 2=low, 3=medium, 4=high"

--- a/packages/gamepulse/data_stream/ebpf/fields/fields.yml
+++ b/packages/gamepulse/data_stream/ebpf/fields/fields.yml
@@ -68,11 +68,6 @@
               metric_type: gauge
               description: "CCX-boundary migrations (always 0 on single-CCX chips like 9800X3D)"
 
-        # Per-thread breakdown (top 8 threads by switch count)
-        - name: thread_breakdown
-          type: flattened
-          description: "Per-thread scheduler stats for the top-8 most-active game threads (comm, tid, runqueue_avg_us, switch_count, migration_count)"
-
         # Bio probe: block I/O latency
         - name: bio
           type: group

--- a/packages/gamepulse/data_stream/ebpf/manifest.yml
+++ b/packages/gamepulse/data_stream/ebpf/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse eBPF Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/ebpf/sample_event.json
+++ b/packages/gamepulse/data_stream/ebpf/sample_event.json
@@ -30,23 +30,7 @@
       "migration": {
         "total_count": 142,
         "ccx_cross_count": 0
-      },
-      "thread_breakdown": [
-        {
-          "comm": "Cyberpunk2077",
-          "tid": 12345,
-          "runqueue_avg_us": 16.2,
-          "switch_count": 1892,
-          "migration_count": 48
-        },
-        {
-          "comm": "render_thread",
-          "tid": 12346,
-          "runqueue_avg_us": 22.4,
-          "switch_count": 841,
-          "migration_count": 31
-        }
-      ]
+      }
     }
   }
 }

--- a/packages/gamepulse/data_stream/ebpf/sample_event.json
+++ b/packages/gamepulse/data_stream/ebpf/sample_event.json
@@ -1,0 +1,52 @@
+{
+  "@timestamp": "2026-04-08T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.ebpf",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc",
+    "os": {
+      "kernel": "6.1.82-valve22-1-neptune"
+    }
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    },
+    "ebpf": {
+      "probe": "schedlatency",
+      "runqueue": {
+        "latency_histogram": {
+          "values": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768],
+          "counts": [0, 124, 892, 1204, 841, 341, 87, 22, 8, 3, 1, 0, 0, 0, 0, 0]
+        },
+        "latency_min_us": 1.4,
+        "latency_max_us": 892.1,
+        "latency_avg_us": 18.7,
+        "event_count": 3523
+      },
+      "migration": {
+        "total_count": 142,
+        "ccx_cross_count": 0
+      },
+      "thread_breakdown": [
+        {
+          "comm": "Cyberpunk2077",
+          "tid": 12345,
+          "runqueue_avg_us": 16.2,
+          "switch_count": 1892,
+          "migration_count": 48
+        },
+        {
+          "comm": "render_thread",
+          "tid": 12346,
+          "runqueue_avg_us": 22.4,
+          "switch_count": 841,
+          "migration_count": 31
+        }
+      ]
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/ebpf_thread/_dev/test/pipeline/test-ebpf-thread-pipeline.json
+++ b/packages/gamepulse/data_stream/ebpf_thread/_dev/test/pipeline/test-ebpf-thread-pipeline.json
@@ -1,0 +1,34 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.ebpf_thread",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc",
+        "os": {
+          "kernel": "6.1.82-valve22-1-neptune"
+        }
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001"
+        },
+        "ebpf_thread": {
+          "probe": "schedlatency",
+          "rank": 1,
+          "comm": "Starfield",
+          "tid": 12345,
+          "runqueue_min_us": 1.8,
+          "runqueue_max_us": 441.2,
+          "runqueue_avg_us": 16.2,
+          "switch_count": 1892,
+          "migration_count": 48
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/ebpf_thread/_dev/test/pipeline/test-ebpf-thread-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/ebpf_thread/_dev/test/pipeline/test-ebpf-thread-pipeline.json-expected.json
@@ -1,0 +1,34 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.ebpf_thread",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "ebpf_thread": {
+                    "comm": "Starfield",
+                    "migration_count": 48,
+                    "probe": "schedlatency",
+                    "rank": 1,
+                    "runqueue_avg_us": 16.2,
+                    "runqueue_max_us": 441.2,
+                    "runqueue_min_us": 1.8,
+                    "switch_count": 1892,
+                    "tid": 12345
+                },
+                "session": {
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc",
+                "os": {
+                    "kernel": "6.1.82-valve22-1-neptune"
+                }
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/ebpf_thread/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/ebpf_thread/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,25 @@
+---
+description: >
+  Ingest pipeline for GamePulse per-thread eBPF scheduler metrics.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - script:
+      description: "Validate session ID is present"
+      lang: painless
+      source: |
+        def sid = ctx.gamepulse?.session?.id;
+        if (sid == null || sid.isEmpty()) {
+          throw new Exception('gamepulse.session.id is required in eBPF thread documents');
+        }
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-ebpf-thread"

--- a/packages/gamepulse/data_stream/ebpf_thread/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/ebpf_thread/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/ebpf_thread/fields/fields.yml
+++ b/packages/gamepulse/data_stream/ebpf_thread/fields/fields.yml
@@ -1,0 +1,61 @@
+# ECS fields
+- name: host.name
+  external: ecs
+  dimension: true
+
+- name: host.os.kernel
+  external: ecs
+
+# Per-thread eBPF scheduler metrics
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+
+    - name: ebpf_thread
+      type: group
+      fields:
+        - name: probe
+          type: keyword
+          dimension: true
+          description: "Probe name that produced this thread metric"
+        - name: rank
+          type: integer
+          description: "Rank within the 1-second scheduler window by switch count"
+        - name: comm
+          type: keyword
+          dimension: true
+          description: "Thread name (Linux comm, max 15 chars)"
+        - name: tid
+          type: long
+          dimension: true
+          description: "Thread ID"
+        - name: runqueue_min_us
+          type: double
+          metric_type: gauge
+          unit: micros
+          description: "Minimum runqueue latency for this thread in the window"
+        - name: runqueue_max_us
+          type: double
+          metric_type: gauge
+          unit: micros
+          description: "Maximum runqueue latency for this thread in the window"
+        - name: runqueue_avg_us
+          type: double
+          metric_type: gauge
+          unit: micros
+          description: "Mean runqueue latency for this thread in the window"
+        - name: switch_count
+          type: long
+          metric_type: gauge
+          description: "Context switches for this thread in the window"
+        - name: migration_count
+          type: long
+          metric_type: gauge
+          description: "CPU migrations for this thread in the window"

--- a/packages/gamepulse/data_stream/ebpf_thread/manifest.yml
+++ b/packages/gamepulse/data_stream/ebpf_thread/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse eBPF Thread Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/ebpf_thread/sample_event.json
+++ b/packages/gamepulse/data_stream/ebpf_thread/sample_event.json
@@ -1,0 +1,30 @@
+{
+  "@timestamp": "2026-04-08T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.ebpf_thread",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc",
+    "os": {
+      "kernel": "6.1.82-valve22-1-neptune"
+    }
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    },
+    "ebpf_thread": {
+      "probe": "schedlatency",
+      "rank": 1,
+      "comm": "Cyberpunk2077",
+      "tid": 12345,
+      "runqueue_min_us": 1.8,
+      "runqueue_max_us": 441.2,
+      "runqueue_avg_us": 16.2,
+      "switch_count": 1892,
+      "migration_count": 48
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/events/_dev/test/pipeline/test-events-pipeline.json
+++ b/packages/gamepulse/data_stream/events/_dev/test/pipeline/test-events-pipeline.json
@@ -1,0 +1,43 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "logs",
+        "dataset": "gamepulse.events",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "event": {
+        "kind": "event",
+        "category": ["process"],
+        "severity": 2
+      },
+      "message": "Shader compilation completed in 284ms (cache miss)",
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "source": "steam",
+          "launcher": "Steam",
+          "steam_app_id": 1091500
+        },
+        "event": {
+          "kind": "shader_compile",
+          "severity": "info",
+          "duration_ms": 284.0,
+          "shader_compile": {
+            "pipeline_hash": "a4f8e2c1b7d3",
+            "duration_ms": 284.0,
+            "cache_hit": false
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/events/_dev/test/pipeline/test-events-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/events/_dev/test/pipeline/test-events-pipeline.json-expected.json
@@ -1,0 +1,46 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.events",
+                "namespace": "default",
+                "type": "logs"
+            },
+            "event": {
+                "category": ["process"],
+                "kind": "event",
+                "severity": 2,
+                "type": [
+                    "info"
+                ]
+            },
+            "gamepulse": {
+                "event": {
+                    "duration_ms": 284.0,
+                    "kind": "shader_compile",
+                    "severity": "info",
+                    "shader_compile": {
+                        "cache_hit": false,
+                        "duration_ms": 284.0,
+                        "pipeline_hash": "a4f8e2c1b7d3"
+                    }
+                },
+                "game": {
+                    "launcher": "Steam",
+                    "name": "Cyberpunk 2077",
+                    "source": "steam",
+                    "steam_app_id": 1091500
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            },
+            "message": "Shader compilation completed in 284ms (cache miss)"
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/events/agent/stream/filestream.yml.hbs
+++ b/packages/gamepulse/data_stream/events/agent/stream/filestream.yml.hbs
@@ -1,0 +1,10 @@
+paths:
+{{#each paths as |path i|}}
+  - {{path}}
+{{/each}}
+exclude_files: ['.gz$']
+tags: {{to_json tags}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/gamepulse/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,49 @@
+---
+description: >
+  Ingest pipeline for GamePulse discrete events (logs type).
+  Sets @timestamp, validates required event fields, and maps to ECS event fields.
+  This is a logs data stream — events are not periodic measurements.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+
+  - script:
+      description: "Validate required event fields and set ECS event.kind"
+      lang: painless
+      source: |
+        def kind = ctx.gamepulse?.event?.kind;
+        if (kind == null || kind.isEmpty()) {
+          throw new Exception('gamepulse.event.kind is required');
+        }
+        // Map to ECS event.kind
+        if (ctx.event == null) ctx.event = [:];
+        ctx.event.kind = 'event';
+        // Map severity to ECS
+        def severity = ctx.gamepulse?.event?.severity;
+        if (severity == 'error' || severity == 'critical') {
+          ctx.event.type = ['error'];
+        } else {
+          ctx.event.type = ['info'];
+        }
+
+  - lowercase:
+      field: gamepulse.event.kind
+      ignore_missing: true
+
+  - lowercase:
+      field: gamepulse.event.severity
+      ignore_missing: true
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-events"

--- a/packages/gamepulse/data_stream/events/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/events/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/events/fields/fields.yml
+++ b/packages/gamepulse/data_stream/events/fields/fields.yml
@@ -1,0 +1,105 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+
+# ECS event fields
+- name: event.kind
+  external: ecs
+- name: event.category
+  external: ecs
+- name: event.type
+  external: ecs
+- name: event.severity
+  external: ecs
+- name: message
+  external: ecs
+
+# Session context
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: source
+          type: keyword
+          description: >
+            Detection source for this target. One of: steam, lutris, heroic,
+            bottles, user_specified, auto_detected.
+        - name: launcher
+          type: keyword
+          description: >
+            Human-readable launcher name for display (e.g. "Steam", "Lutris",
+            "Heroic — Epic").
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+
+    # Discrete event fields (type: logs — not periodic measurements)
+    - name: event
+      type: group
+      fields:
+        - name: kind
+          type: keyword
+          description: "Event kind (shader_compile, stutter, crash, session_start, session_end)"
+        - name: severity
+          type: keyword
+          description: "Severity level (info, warning, error, critical)"
+        - name: duration_ms
+          type: float
+          description: "Event duration in milliseconds (where applicable)"
+
+        - name: shader_compile
+          type: group
+          description: "Shader compilation event detail (kind = shader_compile)"
+          fields:
+            - name: pipeline_hash
+              type: keyword
+              description: "Shader pipeline hash for deduplication and cache analysis"
+            - name: duration_ms
+              type: float
+              description: "Shader compilation duration in milliseconds"
+            - name: cache_hit
+              type: boolean
+              description: "True if the shader was found in the pipeline cache"
+
+        - name: stutter
+          type: group
+          description: "Stutter event detail (kind = stutter)"
+          fields:
+            - name: frametime_spike_ms
+              type: float
+              description: "Frame time during the stutter spike in milliseconds"
+            - name: dropped_frames
+              type: integer
+              description: "Number of frames dropped or severely delayed"
+            - name: root_cause
+              type: keyword
+              description: "Root cause classification (shader_compile, io_stall, scheduler_migration, unknown)"
+
+        - name: crash
+          type: group
+          description: "Game crash event detail (kind = crash)"
+          fields:
+            - name: signal
+              type: keyword
+              description: "POSIX signal that caused the crash (SIGSEGV, SIGABRT, etc.)"
+            - name: exit_code
+              type: integer
+              description: "Process exit code"
+            - name: module
+              type: keyword
+              description: "Faulting module or library name"

--- a/packages/gamepulse/data_stream/events/manifest.yml
+++ b/packages/gamepulse/data_stream/events/manifest.yml
@@ -1,0 +1,15 @@
+title: "GamePulse Events"
+type: logs
+streams:
+  - input: filestream
+    title: GamePulse Events
+    description: GamePulse game lifecycle events (game start/end, settings changes)
+    vars:
+      - name: paths
+        type: text
+        title: Paths
+        multi: true
+        required: false
+        show_user: true
+        default:
+          - /var/log/gamepulse/*.log

--- a/packages/gamepulse/data_stream/events/sample_event.json
+++ b/packages/gamepulse/data_stream/events/sample_event.json
@@ -10,8 +10,8 @@
   },
   "event": {
     "kind": "event",
-    "category": "process",
-    "type": "info",
+    "category": ["process"],
+    "type": ["info"],
     "severity": 2
   },
   "message": "Shader compilation completed in 284ms (cache miss)",

--- a/packages/gamepulse/data_stream/events/sample_event.json
+++ b/packages/gamepulse/data_stream/events/sample_event.json
@@ -1,0 +1,40 @@
+{
+  "@timestamp": "2026-04-04T20:00:42.000Z",
+  "data_stream": {
+    "type": "logs",
+    "dataset": "gamepulse.events",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "event": {
+    "kind": "event",
+    "category": "process",
+    "type": "info",
+    "severity": 2
+  },
+  "message": "Shader compilation completed in 284ms (cache miss)",
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "source": "steam",
+      "launcher": "Steam"
+    },
+    "event": {
+      "kind": "shader_compile",
+      "severity": "info",
+      "duration_ms": 284.0,
+      "shader_compile": {
+        "pipeline_hash": "a4f8e2c1b7d3",
+        "duration_ms": 284.0,
+        "cache_hit": false
+      }
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/frame/_dev/test/pipeline/test-frame-pipeline.json
+++ b/packages/gamepulse/data_stream/frame/_dev/test/pipeline/test-frame-pipeline.json
@@ -1,0 +1,77 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.frame",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500,
+          "graphics_api": "Vulkan",
+          "upscaler": {
+            "type": "fsr",
+            "quality": "quality"
+          }
+        },
+        "fps": {
+          "current": 87,
+          "avg_1s": 85.4,
+          "low_1pct": 62,
+          "low_01pct": 48,
+          "frametime_ms": 11.7,
+          "frametime_variance": 2.1,
+          "present_mode": "mailbox",
+          "stutter_count": 0
+        },
+        "performance": {
+          "bottleneck": "gpu"
+        }
+      }
+    },
+    {
+      "@timestamp": "2026-04-11T12:00:01.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.frame",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500,
+          "graphics_api": "vulkan"
+        },
+        "fps": {
+          "current": 45,
+          "avg_1s": 44.0,
+          "low_1pct": 30,
+          "low_01pct": 22,
+          "frametime_ms": 22.7,
+          "frametime_variance": 12.5,
+          "stutter_count": 3
+        },
+        "performance": {
+          "bottleneck": "gpu"
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/frame/_dev/test/pipeline/test-frame-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/frame/_dev/test/pipeline/test-frame-pipeline.json-expected.json
@@ -1,0 +1,79 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.frame",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "fps": {
+                    "avg_1s": 85.4,
+                    "current": 87,
+                    "frametime_ms": 11.7,
+                    "frametime_variance": 2.1,
+                    "low_01pct": 48,
+                    "low_1pct": 62,
+                    "present_mode": "mailbox",
+                    "stutter_count": 0,
+                    "stutter_detected": false
+                },
+                "game": {
+                    "graphics_api": "vulkan",
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500,
+                    "upscaler": {
+                        "quality": "quality",
+                        "type": "fsr"
+                    }
+                },
+                "performance": {
+                    "bottleneck": "gpu"
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        },
+        {
+            "@timestamp": "2026-04-11T12:00:01.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.frame",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "fps": {
+                    "avg_1s": 44.0,
+                    "current": 45,
+                    "frametime_ms": 22.7,
+                    "frametime_variance": 12.5,
+                    "low_01pct": 22,
+                    "low_1pct": 30,
+                    "stutter_count": 3,
+                    "stutter_detected": true
+                },
+                "game": {
+                    "graphics_api": "vulkan",
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "performance": {
+                    "bottleneck": "gpu"
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/frame/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/frame/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,51 @@
+---
+description: >
+  Ingest pipeline for GamePulse frame performance metrics.
+  Sets @timestamp, normalises common fields, validates FPS ranges,
+  and derives the stutter_detected flag from frametime variance.
+processors:
+  # --- Shared enrichment (inlined) ---
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+      description: "Set @timestamp to ingest time if not provided by the collector"
+
+  - lowercase:
+      field: gamepulse.game.graphics_api
+      ignore_missing: true
+      description: "Normalise graphics API string (Vulkan -> vulkan)"
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+      description: "Strip whitespace from game name"
+
+  # --- Frame-specific validation and derivation ---
+  - script:
+      description: "Validate FPS and frame time values are non-negative"
+      lang: painless
+      source: |
+        if (ctx.gamepulse?.fps?.current != null && ctx.gamepulse.fps.current < 0) {
+          throw new Exception('gamepulse.fps.current must be >= 0, got: ' + ctx.gamepulse.fps.current);
+        }
+        if (ctx.gamepulse?.fps?.frametime_ms != null && ctx.gamepulse.fps.frametime_ms < 0) {
+          throw new Exception('gamepulse.fps.frametime_ms must be >= 0');
+        }
+
+  - script:
+      description: "Derive stutter_detected flag when frametime variance exceeds 8ms threshold"
+      lang: painless
+      source: |
+        if (ctx.gamepulse == null) ctx.gamepulse = [:];
+        if (ctx.gamepulse.fps == null) ctx.gamepulse.fps = [:];
+        def variance = ctx.gamepulse?.fps?.frametime_variance;
+        ctx.gamepulse.fps.stutter_detected = (variance != null && variance > 8.0);
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-frame"

--- a/packages/gamepulse/data_stream/frame/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/frame/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/frame/fields/fields.yml
+++ b/packages/gamepulse/data_stream/frame/fields/fields.yml
@@ -1,0 +1,98 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+
+# Session context (common across all metric data streams)
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID) for this gaming session"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title as detected by Steam"
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+        - name: source
+          type: keyword
+          description: "Detection source: steam | lutris | heroic | bottles | user_specified | auto_detected"
+        - name: launcher
+          type: keyword
+          description: "Human-readable launcher name (e.g. Steam, Lutris, Heroic — Epic)"
+        - name: graphics_api
+          type: keyword
+          description: "Graphics API in use (vulkan, opengl, dx11, dx12)"
+        - name: upscaler
+          type: group
+          fields:
+            - name: type
+              type: keyword
+              description: "Upscaling technology (fsr, dlss, xess, none)"
+            - name: quality
+              type: keyword
+              description: "Upscaler quality preset (ultra, quality, balanced, performance)"
+
+    # Frame-specific metrics
+    - name: fps
+      type: group
+      fields:
+        - name: current
+          type: integer
+          metric_type: gauge
+          description: "Instantaneous frames per second at collection time"
+        - name: avg_1s
+          type: float
+          metric_type: gauge
+          description: "Average FPS over the last 1-second interval"
+        - name: low_1pct
+          type: integer
+          metric_type: gauge
+          description: "1% low FPS — the bottom percentile of frame times expressed as FPS"
+        - name: low_01pct
+          type: integer
+          metric_type: gauge
+          description: "0.1% low FPS — the extreme bottom percentile of frame times expressed as FPS"
+        - name: frametime_ms
+          type: float
+          metric_type: gauge
+          unit: ms
+          description: "Average frame time in milliseconds over the collection interval"
+        - name: frametime_variance
+          type: float
+          metric_type: gauge
+          unit: ms
+          description: "Frame time variance in milliseconds — indicator of frame pacing inconsistency"
+        - name: present_mode
+          type: keyword
+          description: "Presentation mode (vsync, mailbox, immediate, fifo)"
+        - name: stutter_count
+          type: integer
+          metric_type: gauge
+          description: "Number of stutter events (frame time spikes) detected in this collection interval"
+        - name: stutter_detected
+          type: boolean
+          description: "True when frametime_variance exceeds 8ms threshold (derived by ingest pipeline)"
+
+    - name: performance
+      type: group
+      fields:
+        - name: bottleneck
+          type: keyword
+          description: "Per-tick bottleneck classification (cpu, gpu, memory, storage, none)"

--- a/packages/gamepulse/data_stream/frame/manifest.yml
+++ b/packages/gamepulse/data_stream/frame/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse Frame Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/frame/sample_event.json
+++ b/packages/gamepulse/data_stream/frame/sample_event.json
@@ -1,0 +1,42 @@
+{
+  "@timestamp": "2026-04-04T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.frame",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "graphics_api": "vulkan",
+      "upscaler": {
+        "type": "fsr",
+        "quality": "quality"
+      },
+      "source": "steam",
+      "launcher": "Steam"
+    },
+    "fps": {
+      "current": 87,
+      "avg_1s": 85.4,
+      "low_1pct": 62,
+      "low_01pct": 48,
+      "frametime_ms": 11.7,
+      "frametime_variance": 2.1,
+      "present_mode": "mailbox",
+      "stutter_count": 0,
+      "stutter_detected": false
+    },
+    "performance": {
+      "bottleneck": "gpu"
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/gpu/_dev/test/pipeline/test-gpu-pipeline.json
+++ b/packages/gamepulse/data_stream/gpu/_dev/test/pipeline/test-gpu-pipeline.json
@@ -1,0 +1,68 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.gpu",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500
+        },
+        "gpu": {
+          "utilisation_pct": 94.2,
+          "clock_mhz": 2748,
+          "memory_used_mb": 10240,
+          "memory_total_mb": 16384,
+          "temperature_c": 72.0,
+          "hotspot_c": 84.0,
+          "memory_temperature_c": 78.0,
+          "power_w": 285.4,
+          "fan_pct": 68.0,
+          "fan_speed_rpm": 2340,
+          "voltage": 1.15
+        }
+      }
+    },
+    {
+      "@timestamp": "2026-04-11T12:00:01.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.gpu",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500
+        },
+        "gpu": {
+          "utilisation_pct": 99.0,
+          "clock_mhz": 2800,
+          "memory_used_mb": 15000,
+          "memory_total_mb": 16384,
+          "temperature_c": 85.0,
+          "hotspot_c": 98.0,
+          "power_w": 330.0
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/gpu/_dev/test/pipeline/test-gpu-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/gpu/_dev/test/pipeline/test-gpu-pipeline.json-expected.json
@@ -1,0 +1,70 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.gpu",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "game": {
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "gpu": {
+                    "clock_mhz": 2748,
+                    "fan_pct": 68.0,
+                    "fan_speed_rpm": 2340,
+                    "hotspot_c": 84.0,
+                    "memory_temperature_c": 78.0,
+                    "memory_total_mb": 16384,
+                    "memory_used_mb": 10240,
+                    "power_w": 285.4,
+                    "temperature_c": 72.0,
+                    "thermal_throttle_warning": false,
+                    "utilisation_pct": 94.2,
+                    "voltage": 1.15
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        },
+        {
+            "@timestamp": "2026-04-11T12:00:01.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.gpu",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "game": {
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "gpu": {
+                    "clock_mhz": 2800,
+                    "hotspot_c": 98.0,
+                    "memory_total_mb": 16384,
+                    "memory_used_mb": 15000,
+                    "power_w": 330.0,
+                    "temperature_c": 85.0,
+                    "thermal_throttle_warning": true,
+                    "utilisation_pct": 99.0
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/gpu/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/gpu/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,49 @@
+---
+description: >
+  Ingest pipeline for GamePulse GPU metrics.
+  Sets @timestamp, validates temperature and utilisation ranges,
+  and derives the thermal_throttle_warning flag.
+processors:
+  # --- Shared enrichment (inlined) ---
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+      description: "Set @timestamp to ingest time if not provided by the collector"
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+
+  # --- GPU-specific validation and derivation ---
+  - script:
+      description: "Validate GPU utilisation is 0–100% and temperature is in a plausible range"
+      lang: painless
+      source: |
+        def util = ctx.gamepulse?.gpu?.utilisation_pct;
+        if (util != null && (util < 0 || util > 100)) {
+          throw new Exception('gamepulse.gpu.utilisation_pct must be 0-100, got: ' + util);
+        }
+        def temp = ctx.gamepulse?.gpu?.temperature_c;
+        if (temp != null && (temp < -10 || temp > 150)) {
+          throw new Exception('gamepulse.gpu.temperature_c out of plausible range: ' + temp);
+        }
+
+  - script:
+      description: "Derive thermal_throttle_warning when hotspot or edge temp exceeds 95°C"
+      lang: painless
+      source: |
+        if (ctx.gamepulse == null) ctx.gamepulse = [:];
+        if (ctx.gamepulse.gpu == null) ctx.gamepulse.gpu = [:];
+        def hotspot = ctx.gamepulse?.gpu?.hotspot_c;
+        def edge = ctx.gamepulse?.gpu?.temperature_c;
+        def temp = (hotspot != null) ? hotspot : edge;
+        ctx.gamepulse.gpu.thermal_throttle_warning = (temp != null && temp > 95.0);
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-gpu"

--- a/packages/gamepulse/data_stream/gpu/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/gpu/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/gpu/fields/fields.yml
+++ b/packages/gamepulse/data_stream/gpu/fields/fields.yml
@@ -1,0 +1,93 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+
+# Session context
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+
+    # GPU-specific metrics
+    - name: gpu
+      type: group
+      fields:
+        - name: utilisation_pct
+          type: float
+          metric_type: gauge
+          unit: percent
+          description: "GPU shader engine utilisation percentage (0–100)"
+        - name: clock_mhz
+          type: integer
+          metric_type: gauge
+          description: "Current GPU core clock speed in MHz"
+        - name: memory_used_mb
+          type: integer
+          metric_type: gauge
+          description: "VRAM currently in use, in megabytes"
+        - name: memory_total_mb
+          type: integer
+          metric_type: gauge
+          description: "Total VRAM capacity in megabytes"
+        - name: temperature_c
+          type: float
+          metric_type: gauge
+          description: "GPU edge (die) temperature in Celsius"
+        - name: hotspot_c
+          type: float
+          metric_type: gauge
+          description: "GPU hotspot (junction) temperature in Celsius"
+        - name: memory_temperature_c
+          type: float
+          metric_type: gauge
+          description: "GDDR/HBM memory temperature in Celsius"
+        - name: power_w
+          type: float
+          metric_type: gauge
+          description: "GPU package power draw in watts"
+        - name: fan_pct
+          type: float
+          metric_type: gauge
+          unit: percent
+          description: "GPU fan speed as a percentage of maximum"
+        - name: fan_speed_rpm
+          type: integer
+          metric_type: gauge
+          description: "GPU fan speed in RPM"
+        - name: voltage
+          type: float
+          metric_type: gauge
+          description: "GPU core voltage in volts"
+        - name: thermal_throttle_warning
+          type: boolean
+          description: "True when hotspot or edge temperature exceeds 95°C (derived by ingest pipeline)"
+        - name: temp_source
+          type: keyword
+          description: >
+            Data source for temperature_c. 'hwmon' on Linux (amdgpu sysfs,
+            precise GPU die temperature). 'wmi_acpi' on Windows (ACPI thermal
+            zone — may report ambient, chassis, or GPU die depending on OEM
+            firmware). Present only when temperature_c is present.

--- a/packages/gamepulse/data_stream/gpu/manifest.yml
+++ b/packages/gamepulse/data_stream/gpu/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse GPU Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/gpu/sample_event.json
+++ b/packages/gamepulse/data_stream/gpu/sample_event.json
@@ -1,0 +1,36 @@
+{
+  "@timestamp": "2026-04-04T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.gpu",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500
+    },
+    "gpu": {
+      "utilisation_pct": 94.2,
+      "clock_mhz": 2748,
+      "memory_used_mb": 10240,
+      "memory_total_mb": 16384,
+      "temperature_c": 72.0,
+      "hotspot_c": 84.0,
+      "memory_temperature_c": 78.0,
+      "power_w": 285.4,
+      "fan_pct": 68.0,
+      "fan_speed_rpm": 2340,
+      "voltage": 1.15,
+      "thermal_throttle_warning": false,
+      "temp_source": "hwmon"
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/memory/_dev/test/pipeline/test-memory-pipeline.json
+++ b/packages/gamepulse/data_stream/memory/_dev/test/pipeline/test-memory-pipeline.json
@@ -1,0 +1,36 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.memory",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500
+        },
+        "memory": {
+          "system_used_mb": 18432,
+          "game_rss_mb": 14336,
+          "virtual_mb": 32768,
+          "page_cache_mb": 8192,
+          "shared_mb": 2048,
+          "swap_used_mb": 0,
+          "page_faults_major": 142,
+          "page_faults_minor": 892450,
+          "oom_events": 0
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/memory/_dev/test/pipeline/test-memory-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/memory/_dev/test/pipeline/test-memory-pipeline.json-expected.json
@@ -1,0 +1,36 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.memory",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "game": {
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "memory": {
+                    "game_rss_mb": 14336,
+                    "oom_events": 0,
+                    "page_cache_mb": 8192,
+                    "page_faults_major": 142,
+                    "page_faults_minor": 892450,
+                    "shared_mb": 2048,
+                    "swap_used_mb": 0,
+                    "system_used_mb": 18432,
+                    "virtual_mb": 32768
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/memory/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/memory/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,30 @@
+---
+description: >
+  Ingest pipeline for GamePulse memory metrics.
+  Sets @timestamp and validates memory values are non-negative.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+
+  - script:
+      description: "Validate memory values are non-negative"
+      lang: painless
+      source: |
+        def rss = ctx.gamepulse?.memory?.game_rss_mb;
+        if (rss != null && rss < 0) {
+          throw new Exception('gamepulse.memory.game_rss_mb must be >= 0');
+        }
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-memory"

--- a/packages/gamepulse/data_stream/memory/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/memory/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/memory/fields/fields.yml
+++ b/packages/gamepulse/data_stream/memory/fields/fields.yml
@@ -1,0 +1,79 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+
+# Session context
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+        - name: source
+          type: keyword
+          description: "Detection source: steam | lutris | heroic | bottles | user_specified | auto_detected"
+        - name: launcher
+          type: keyword
+          description: "Human-readable launcher name (e.g. Steam, Lutris, Heroic — Epic)"
+
+    # Memory-specific metrics
+    - name: memory
+      type: group
+      fields:
+        - name: system_used_mb
+          type: integer
+          metric_type: gauge
+          description: "System-wide memory in use in megabytes (excludes buffers/cache)"
+        - name: game_rss_mb
+          type: integer
+          metric_type: gauge
+          description: "Game process resident set size (RSS) in megabytes"
+        - name: virtual_mb
+          type: integer
+          metric_type: gauge
+          description: "Game process virtual memory size in megabytes"
+        - name: page_cache_mb
+          type: integer
+          metric_type: gauge
+          description: "System page cache size in megabytes"
+        - name: shared_mb
+          type: integer
+          metric_type: gauge
+          description: "Shared memory in use in megabytes"
+        - name: swap_used_mb
+          type: integer
+          metric_type: gauge
+          description: "Swap space in use in megabytes (includes zram/zswap)"
+        - name: page_faults_major
+          type: long
+          metric_type: counter
+          description: "Cumulative major page faults for the game process (disk access required)"
+        - name: page_faults_minor
+          type: long
+          metric_type: counter
+          description: "Cumulative minor page faults for the game process (no disk access)"
+        - name: oom_events
+          type: integer
+          metric_type: counter
+          description: "Out-of-memory kill events observed in this interval"

--- a/packages/gamepulse/data_stream/memory/manifest.yml
+++ b/packages/gamepulse/data_stream/memory/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse Memory Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/memory/sample_event.json
+++ b/packages/gamepulse/data_stream/memory/sample_event.json
@@ -1,0 +1,34 @@
+{
+  "@timestamp": "2026-04-04T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.memory",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "source": "steam",
+      "launcher": "Steam"
+    },
+    "memory": {
+      "system_used_mb": 18432,
+      "game_rss_mb": 14336,
+      "virtual_mb": 32768,
+      "page_cache_mb": 8192,
+      "shared_mb": 2048,
+      "swap_used_mb": 0,
+      "page_faults_major": 142,
+      "page_faults_minor": 892450,
+      "oom_events": 0
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/network/_dev/test/pipeline/test-network-pipeline.json
+++ b/packages/gamepulse/data_stream/network/_dev/test/pipeline/test-network-pipeline.json
@@ -1,0 +1,37 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.network",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500
+        },
+        "network": {
+          "rx_mbps": 2.4,
+          "tx_mbps": 0.8,
+          "bandwidth_utilisation_mbps": 3.2,
+          "rx_packets_per_sec": 312.5,
+          "tx_packets_per_sec": 128.7,
+          "tcp_retransmits_per_sec": 0.0,
+          "rtt_ms": 18.4,
+          "packet_loss_pct": 0.0,
+          "connection_type": "Ethernet",
+          "interface": "enp6s0"
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/network/_dev/test/pipeline/test-network-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/network/_dev/test/pipeline/test-network-pipeline.json-expected.json
@@ -1,0 +1,37 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.network",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "game": {
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "network": {
+                    "bandwidth_utilisation_mbps": 3.2,
+                    "connection_type": "ethernet",
+                    "interface": "enp6s0",
+                    "packet_loss_pct": 0.0,
+                    "rtt_ms": 18.4,
+                    "rx_mbps": 2.4,
+                    "rx_packets_per_sec": 312.5,
+                    "tcp_retransmits_per_sec": 0.0,
+                    "tx_mbps": 0.8,
+                    "tx_packets_per_sec": 128.7
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/network/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/network/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,26 @@
+---
+description: >
+  Ingest pipeline for GamePulse network metrics.
+  Sets @timestamp and normalises connection type.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - lowercase:
+      field: gamepulse.network.connection_type
+      ignore_missing: true
+      description: "Normalise connection type (WiFi -> wifi, Ethernet -> ethernet)"
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-network"

--- a/packages/gamepulse/data_stream/network/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/network/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/network/fields/fields.yml
+++ b/packages/gamepulse/data_stream/network/fields/fields.yml
@@ -1,0 +1,83 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+
+# Session context
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+        - name: source
+          type: keyword
+          description: "Detection source: steam | lutris | heroic | bottles | user_specified | auto_detected"
+        - name: launcher
+          type: keyword
+          description: "Human-readable launcher name (e.g. Steam, Lutris, Heroic — Epic)"
+
+    # Network-specific metrics (per-second rates derived from /proc/net/dev deltas)
+    - name: network
+      type: group
+      fields:
+        - name: rx_mbps
+          type: float
+          metric_type: gauge
+          description: "Receive throughput on the primary interface in MB/s"
+        - name: tx_mbps
+          type: float
+          metric_type: gauge
+          description: "Transmit throughput on the primary interface in MB/s"
+        - name: bandwidth_utilisation_mbps
+          type: float
+          metric_type: gauge
+          description: "Combined rx+tx bandwidth utilisation in MB/s"
+        - name: rx_packets_per_sec
+          type: float
+          metric_type: gauge
+          description: "Receive packet rate in packets/s"
+        - name: tx_packets_per_sec
+          type: float
+          metric_type: gauge
+          description: "Transmit packet rate in packets/s"
+        - name: tcp_retransmits_per_sec
+          type: float
+          metric_type: gauge
+          description: "TCP retransmission rate in retransmits/s (from /proc/net/snmp)"
+        - name: rtt_ms
+          type: float
+          metric_type: gauge
+          unit: ms
+          description: "Round-trip time to game server in milliseconds (when available)"
+        - name: packet_loss_pct
+          type: float
+          metric_type: gauge
+          unit: percent
+          description: "Packet loss percentage observed in this interval"
+        - name: connection_type
+          type: keyword
+          description: "Network connection type (ethernet, wifi)"
+        - name: interface
+          type: keyword
+          description: "Active network interface name (e.g. enp6s0, wlan0)"

--- a/packages/gamepulse/data_stream/network/manifest.yml
+++ b/packages/gamepulse/data_stream/network/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse Network Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/network/sample_event.json
+++ b/packages/gamepulse/data_stream/network/sample_event.json
@@ -1,0 +1,35 @@
+{
+  "@timestamp": "2026-04-04T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.network",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "source": "steam",
+      "launcher": "Steam"
+    },
+    "network": {
+      "rx_mbps": 2.4,
+      "tx_mbps": 0.8,
+      "bandwidth_utilisation_mbps": 3.2,
+      "rx_packets_per_sec": 312.5,
+      "tx_packets_per_sec": 128.7,
+      "tcp_retransmits_per_sec": 0.0,
+      "rtt_ms": 18.4,
+      "packet_loss_pct": 0.0,
+      "connection_type": "ethernet",
+      "interface": "enp6s0"
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/power/_dev/test/pipeline/test-power-pipeline.json
+++ b/packages/gamepulse/data_stream/power/_dev/test/pipeline/test-power-pipeline.json
@@ -1,0 +1,30 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.power",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500
+        },
+        "power": {
+          "profile": "performance",
+          "ac_connected": true,
+          "tdp_current_w": 220.0
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/power/_dev/test/pipeline/test-power-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/power/_dev/test/pipeline/test-power-pipeline.json-expected.json
@@ -1,0 +1,30 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.power",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "game": {
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "power": {
+                    "ac_connected": true,
+                    "profile": "performance",
+                    "tdp_current_w": 220.0
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/power/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/power/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,26 @@
+---
+description: >
+  Ingest pipeline for GamePulse power metrics.
+  Sets @timestamp and validates battery percentage is in valid range.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - script:
+      description: "Validate battery percentage is 0–100"
+      lang: painless
+      source: |
+        def pct = ctx.gamepulse?.power?.battery_pct;
+        if (pct != null && (pct < 0 || pct > 100)) {
+          throw new Exception('gamepulse.power.battery_pct must be 0-100, got: ' + pct);
+        }
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-power"

--- a/packages/gamepulse/data_stream/power/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/power/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/power/fields/fields.yml
+++ b/packages/gamepulse/data_stream/power/fields/fields.yml
@@ -1,0 +1,62 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+
+# Session context
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+        - name: source
+          type: keyword
+          description: "Detection source: steam | lutris | heroic | bottles | user_specified | auto_detected"
+        - name: launcher
+          type: keyword
+          description: "Human-readable launcher name (e.g. Steam, Lutris, Heroic — Epic)"
+
+    # Power-specific metrics
+    - name: power
+      type: group
+      fields:
+        - name: profile
+          type: keyword
+          description: "Active power profile (performance, balanced, power-save, custom)"
+        - name: battery_pct
+          type: float
+          metric_type: gauge
+          unit: percent
+          description: "Battery charge level as a percentage (0–100). Null for non-battery devices."
+        - name: battery_rate_w
+          type: float
+          metric_type: gauge
+          description: "Battery charge/discharge rate in watts. Negative = discharging."
+        - name: ac_connected
+          type: boolean
+          description: "True when AC power adapter is connected"
+        - name: tdp_current_w
+          type: float
+          metric_type: gauge
+          description: "Current combined CPU+GPU TDP in watts (relevant for handhelds with TDP limits)"

--- a/packages/gamepulse/data_stream/power/manifest.yml
+++ b/packages/gamepulse/data_stream/power/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse Power Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/power/sample_event.json
+++ b/packages/gamepulse/data_stream/power/sample_event.json
@@ -1,0 +1,27 @@
+{
+  "@timestamp": "2026-04-04T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.power",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "source": "steam",
+      "launcher": "Steam"
+    },
+    "power": {
+      "profile": "performance",
+      "ac_connected": true
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/session/_dev/test/pipeline/test-session-pipeline-lutris.json
+++ b/packages/gamepulse/data_stream/session/_dev/test/pipeline/test-session-pipeline-lutris.json
@@ -1,0 +1,37 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-25T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.session",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "test-host",
+        "os": {
+          "name": "Arch Linux",
+          "type": "Linux"
+        }
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-lutris-001",
+          "agent_version": "0.1.0",
+          "opt_in_public": false,
+          "label": "battle-net-game-test-fixture-20260425-1",
+          "label_source": "auto"
+        },
+        "game": {
+          "name": "Battle.net Game (test fixture)",
+          "source": "lutris",
+          "launcher": "Lutris",
+          "graphics_api": "Vulkan"
+        },
+        "summary": {
+          "ended": false
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/session/_dev/test/pipeline/test-session-pipeline-lutris.json-expected.json
+++ b/packages/gamepulse/data_stream/session/_dev/test/pipeline/test-session-pipeline-lutris.json-expected.json
@@ -1,0 +1,37 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-25T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.session",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "game": {
+                    "graphics_api": "vulkan",
+                    "launcher": "Lutris",
+                    "name": "Battle.net Game (test fixture)",
+                    "source": "lutris"
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-lutris-001",
+                    "label": "battle-net-game-test-fixture-20260425-1",
+                    "label_source": "auto",
+                    "opt_in_public": false
+                },
+                "summary": {
+                    "ended": false
+                }
+            },
+            "host": {
+                "name": "test-host",
+                "os": {
+                    "name": "Arch Linux",
+                    "type": "linux"
+                }
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/session/_dev/test/pipeline/test-session-pipeline.json
+++ b/packages/gamepulse/data_stream/session/_dev/test/pipeline/test-session-pipeline.json
@@ -1,0 +1,77 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.session",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc",
+        "os": {
+          "name": "Arch Linux",
+          "version": "2024.12",
+          "kernel": "6.12.10-2-arch1-1",
+          "type": "Linux",
+          "platform": "arch"
+        }
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0",
+          "opt_in_public": true,
+          "label": "starfield-20260411-1",
+          "label_source": "auto",
+          "sequence_number": 1
+        },
+        "game": {
+          "name": "  Cyberpunk 2077  ",
+          "source": "steam",
+          "launcher": "Steam",
+          "steam_app_id": 1091500,
+          "graphics_api": "Vulkan"
+        },
+        "hardware": {
+          "gpu": {
+            "model": "AMD Radeon RX 9070 XT",
+            "vendor": "AMD",
+            "vram_mb": 16384,
+            "driver_version": "26.0.4",
+            "vulkan_driver": "radv"
+          },
+          "cpu": {
+            "model": "AMD Ryzen 9 9800X3D",
+            "cores": 8,
+            "threads": 16
+          },
+          "ram": {
+            "total_mb": 32768,
+            "type": "ddr5"
+          }
+        },
+        "settings": {
+          "preset": "ultra",
+          "upscaler": {
+            "tech": "fsr",
+            "preset": "quality"
+          },
+          "frame_gen": {
+            "tech": "fsr3"
+          },
+          "features_active": ["ray_tracing", "direct_storage"],
+          "render": {
+            "resolution_output": "3440x1440",
+            "vsync": "off"
+          },
+          "source": "manual",
+          "confidence": "high"
+        },
+        "summary": {
+          "ended": false
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/session/_dev/test/pipeline/test-session-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/session/_dev/test/pipeline/test-session-pipeline.json-expected.json
@@ -1,0 +1,77 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.session",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "game": {
+                    "graphics_api": "vulkan",
+                    "launcher": "Steam",
+                    "name": "Cyberpunk 2077",
+                    "source": "steam",
+                    "steam_app_id": 1091500
+                },
+                "hardware": {
+                    "cpu": {
+                        "cores": 8,
+                        "model": "AMD Ryzen 9 9800X3D",
+                        "threads": 16
+                    },
+                    "gpu": {
+                        "driver_version": "26.0.4",
+                        "model": "AMD Radeon RX 9070 XT",
+                        "vendor": "amd",
+                        "vram_mb": 16384,
+                        "vulkan_driver": "radv"
+                    },
+                    "ram": {
+                        "total_mb": 32768,
+                        "type": "ddr5"
+                    }
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001",
+                    "opt_in_public": true,
+                    "label": "starfield-20260411-1",
+                    "label_source": "auto",
+                    "sequence_number": 1
+                },
+                "settings": {
+                    "preset": "ultra",
+                    "upscaler": {
+                        "tech": "fsr",
+                        "preset": "quality"
+                    },
+                    "frame_gen": {
+                        "tech": "fsr3"
+                    },
+                    "features_active": ["ray_tracing", "direct_storage"],
+                    "render": {
+                        "resolution_output": "3440x1440",
+                        "vsync": "off"
+                    },
+                    "source": "manual",
+                    "confidence": "high"
+                },
+                "summary": {
+                    "ended": false
+                }
+            },
+            "host": {
+                "name": "gaming-pc",
+                "os": {
+                    "kernel": "6.12.10-2-arch1-1",
+                    "name": "Arch Linux",
+                    "platform": "arch",
+                    "type": "linux",
+                    "version": "2024.12"
+                }
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/session/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,49 @@
+---
+description: >
+  Ingest pipeline for GamePulse session documents.
+  Sets @timestamp, validates required identification fields, and normalises
+  hardware vendor strings. Fired once at session start and once at session end.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - script:
+      description: "Validate required session identification fields are present"
+      lang: painless
+      source: |
+        def sid = ctx.gamepulse?.session?.id;
+        if (sid == null || sid.isEmpty()) {
+          throw new Exception('gamepulse.session.id is required');
+        }
+        def name = ctx.gamepulse?.game?.name;
+        if (name == null || name.isEmpty()) {
+          throw new Exception('gamepulse.game.name is required');
+        }
+
+  - lowercase:
+      field: gamepulse.hardware.gpu.vendor
+      ignore_missing: true
+      description: "Normalise GPU vendor (AMD -> amd, NVIDIA -> nvidia)"
+
+  - lowercase:
+      field: gamepulse.game.graphics_api
+      ignore_missing: true
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+
+  - lowercase:
+      field: host.os.type
+      ignore_missing: true
+      description: "Normalise OS type (Linux -> linux, Windows -> windows)"
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-session"

--- a/packages/gamepulse/data_stream/session/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/session/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/session/fields/fields.yml
+++ b/packages/gamepulse/data_stream/session/fields/fields.yml
@@ -1,0 +1,372 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+- name: host.os.name
+  external: ecs
+- name: host.os.version
+  external: ecs
+- name: host.os.kernel
+  external: ecs
+- name: host.os.type
+  external: ecs
+- name: host.os.platform
+  external: ecs
+
+# Session document — captured once per gaming session
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: opt_in_public
+          type: boolean
+          description: "True if the user has opted in to sharing this session's data publicly"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+        - name: label_source
+          type: keyword
+          description: "auto | manual — whether the label was auto-generated or user-supplied"
+        - name: sequence_number
+          type: integer
+          description: "Ordinal session number for this game on this calendar date (auto-labelled sessions only)"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: source
+          type: keyword
+          description: >
+            Detection source for this target. One of: steam, lutris, heroic,
+            bottles, user_specified, auto_detected. Determines which other
+            game.* fields are populated.
+        - name: launcher
+          type: keyword
+          description: >
+            Human-readable launcher name for display (e.g. "Steam", "Lutris",
+            "Heroic — Epic"). Free-form; used by dashboards for grouping.
+            Distinct from `source` which is machine-readable and enumerated.
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+        - name: version
+          type: keyword
+          description: "Game version string (if detectable)"
+        - name: launch_args
+          type: keyword
+          description: "Steam launch arguments configured for this game"
+        - name: graphics_api
+          type: keyword
+          description: "Primary graphics API in use (vulkan, opengl, dx11, dx12)"
+        - name: upscaler
+          type: group
+          fields:
+            - name: type
+              type: keyword
+              description: "Upscaling technology (fsr, dlss, xess, none)"
+            - name: quality
+              type: keyword
+              description: "Upscaler quality preset"
+
+    - name: compatibility
+      type: group
+      fields:
+        - name: proton_version
+          type: keyword
+          description: "Proton version (e.g. 9.0-3, experimental)"
+        - name: wine_version
+          type: keyword
+          description: "Wine version if used directly"
+        - name: dxvk_version
+          type: keyword
+          description: "DXVK version for DX9/DX10/DX11 translation"
+        - name: vkd3d_proton_version
+          type: keyword
+          description: "VKD3D-Proton version for DX12 translation"
+        - name: gamescope_version
+          type: keyword
+          description: "Gamescope compositor version (Steam Deck and desktop)"
+
+    - name: hardware
+      type: group
+      fields:
+        - name: cpu
+          type: group
+          fields:
+            - name: model
+              type: keyword
+              description: "CPU model name (e.g. AMD Ryzen 9 7950X3D)"
+            - name: cores
+              type: integer
+              description: "Physical core count"
+            - name: threads
+              type: integer
+              description: "Logical thread count"
+            - name: base_clock_mhz
+              type: integer
+              description: "CPU base clock speed in MHz"
+            - name: boost_clock_mhz
+              type: integer
+              description: "CPU boost/turbo clock speed in MHz"
+        - name: gpu
+          type: group
+          fields:
+            - name: model
+              type: keyword
+              description: "GPU model name (e.g. AMD Radeon RX 7900 XTX)"
+            - name: vendor
+              type: keyword
+              description: "GPU vendor (amd, nvidia, intel)"
+            - name: vram_mb
+              type: integer
+              description: "Total VRAM in megabytes"
+            - name: driver_version
+              type: keyword
+              description: "GPU driver version string"
+            - name: mesa_version
+              type: keyword
+              description: "Mesa version (Linux open-source driver stack)"
+            - name: vulkan_driver
+              type: keyword
+              description: "Vulkan driver name (radv, amdvlk, nvk, anv)"
+            - name: pcie_gen
+              type: byte
+              description: "PCIe generation (3, 4, 5)"
+            - name: pcie_width
+              type: byte
+              description: "PCIe link width (4, 8, 16)"
+        - name: ram
+          type: group
+          fields:
+            - name: total_mb
+              type: integer
+              description: "Total system RAM in megabytes"
+            - name: speed_mhz
+              type: integer
+              description: "RAM speed in MHz (effective, e.g. 6000 for DDR5-6000)"
+            - name: type
+              type: keyword
+              description: "RAM type (ddr4, ddr5, lpddr5)"
+        - name: storage
+          type: group
+          fields:
+            - name: game_drive
+              type: group
+              fields:
+                - name: type
+                  type: keyword
+                  description: "Drive type (nvme, sata_ssd, hdd, sd_card, emmc)"
+                - name: model
+                  type: keyword
+                  description: "Drive model identifier"
+                - name: firmware
+                  type: keyword
+                  description: "Drive firmware version"
+                - name: interface
+                  type: keyword
+                  description: "Drive interface (nvme, sata, uhs-i, uhs-ii)"
+                - name: nvme_spec
+                  type: keyword
+                  description: "NVMe specification version (1.3, 1.4, 2.0)"
+                - name: capacity_gb
+                  type: integer
+                  description: "Drive capacity in gigabytes"
+                - name: free_gb
+                  type: integer
+                  description: "Free space on the game partition in gigabytes"
+                - name: free_pct
+                  type: float
+                  description: "Free space percentage"
+                - name: temperature_c
+                  type: float
+                  description: "Drive temperature in Celsius at session start"
+                - name: smart_health
+                  type: keyword
+                  description: "SMART health status (passed, failed, unknown)"
+                - name: encrypted
+                  type: boolean
+                  description: "True if the game partition is encrypted"
+            - name: game_filesystem
+              type: group
+              fields:
+                - name: type
+                  type: keyword
+                  description: "Filesystem type (btrfs, ext4, f2fs, ntfs, exfat)"
+                - name: mount_options
+                  type: keyword
+                  description: "Relevant mount options (e.g. noatime,compress=zstd)"
+                - name: compression
+                  type: keyword
+                  description: "Filesystem compression algorithm (zstd, lzo, none)"
+                - name: compression_level
+                  type: byte
+                  description: "Compression level (1–19 for zstd)"
+                - name: block_size
+                  type: integer
+                  description: "Filesystem block size in bytes"
+                - name: trim_enabled
+                  type: boolean
+                  description: "True if TRIM/discard is enabled"
+            - name: io_scheduler
+              type: keyword
+              description: "Block I/O scheduler (none, mq-deadline, kyber, bfq)"
+            - name: read_ahead_kb
+              type: integer
+              description: "Read-ahead buffer size in kilobytes"
+        - name: device
+          type: group
+          fields:
+            - name: type
+              type: keyword
+              description: "Device form factor (desktop, handheld, laptop)"
+            - name: model
+              type: keyword
+              description: "Device model (e.g. Steam Deck OLED)"
+            - name: power_source
+              type: keyword
+              description: "Power source at session start (ac, battery)"
+            - name: tdp_watts
+              type: float
+              description: "Configured TDP limit in watts (relevant for handhelds)"
+        - name: monitors
+          type: group
+          description: "Connected display monitors at session start"
+          fields:
+            - name: name
+              type: keyword
+              description: "Connector name as reported by xrandr (e.g. DP-2, HDMI-1)"
+            - name: resolution_h
+              type: integer
+              description: "Horizontal resolution in pixels"
+            - name: resolution_v
+              type: integer
+              description: "Vertical resolution in pixels"
+            - name: refresh_rate_hz
+              type: float
+              description: "Active refresh rate in Hz"
+            - name: is_primary
+              type: boolean
+              description: "True if this is the primary display"
+            - name: vrr_capable
+              type: boolean
+              description: "True if the monitor reports VRR/FreeSync/G-Sync support"
+            - name: hdr_capable
+              type: boolean
+              description: "True if the monitor reports HDR capability (max bpc > 8)"
+            - name: current_vrr_enabled
+              type: boolean
+              description: "True if variable refresh rate is currently active on this monitor"
+
+    - name: summary
+      type: group
+      description: "Session summary statistics — populated when session ends"
+      fields:
+        - name: ended
+          type: boolean
+          description: "True when this is the session-end summary document"
+        - name: duration_s
+          type: integer
+          metric_type: gauge
+          unit: s
+          description: "Total session duration in seconds"
+        - name: avg_fps
+          type: float
+          metric_type: gauge
+          description: "Average FPS across the entire session"
+        - name: low_1pct_fps
+          type: integer
+          metric_type: gauge
+          description: "1% low FPS across the entire session"
+        - name: peak_gpu_temp_c
+          type: float
+          metric_type: gauge
+          description: "Peak GPU temperature during the session"
+        - name: peak_cpu_temp_c
+          type: float
+          metric_type: gauge
+          description: "Peak CPU temperature during the session"
+        - name: stutter_count
+          type: integer
+          metric_type: gauge
+          description: "Total stutter events during the session"
+        - name: bottleneck_dominant
+          type: keyword
+          description: "Most frequent bottleneck classification during the session"
+        - name: p99_frametime_ms
+          type: float
+          metric_type: gauge
+          unit: ms
+          description: "99th-percentile frame time during the session (approximated from sampled data)"
+        - name: peak_gpu_power_w
+          type: float
+          metric_type: gauge
+          description: "Peak GPU power draw during the session in watts"
+        - name: total_frames
+          type: integer
+          metric_type: gauge
+          description: "Approximate total frames rendered during the session"
+
+    - name: settings
+      type: group
+      description: "In-game graphics settings captured for this session (Tier 1 = manual; Tier 2 = auto-detect)"
+      fields:
+        - name: preset
+          type: keyword
+          description: "Graphics preset: low | medium | high | ultra | custom | unknown"
+        - name: custom_overrides
+          type: boolean
+          description: "True if preset is a named preset but individual settings were overridden"
+        - name: upscaler.tech
+          type: keyword
+          description: "Upscaler technology: dlss | fsr | xess | tsr | tsr-native | none | unknown"
+        - name: upscaler.version
+          type: keyword
+          description: "Upscaler SDK/driver version string"
+        - name: upscaler.preset
+          type: keyword
+          description: "Upscaler quality preset: quality | balanced | performance | ultra_performance | dlaa | native"
+        - name: upscaler.source_res
+          type: keyword
+          description: "Source render resolution before upscaling, e.g. 1920x1080"
+        - name: frame_gen.tech
+          type: keyword
+          description: "Frame generation technology: dlss3 | fsr3 | afmf | lossless-scaling | none"
+        - name: frame_gen.multiplier
+          type: keyword
+          description: "Frame generation multiplier: 2x | 3x | 4x"
+        - name: features_active
+          type: keyword
+          description: "Array of currently active features: ray_tracing, path_tracing, direct_storage, mesh_shaders, mega_geometry, neural_shaders, hdr, vrr"
+        - name: features_available
+          type: keyword
+          description: "Array of features the game/hardware supports even if currently inactive"
+        - name: render.resolution_output
+          type: keyword
+          description: "Output render resolution, e.g. 3440x1440"
+        - name: render.fullscreen_mode
+          type: keyword
+          description: "Display mode: fullscreen | borderless | windowed"
+        - name: render.vsync
+          type: keyword
+          description: "VSync mode: off | on | adaptive | fast"
+        - name: source
+          type: keyword
+          description: "Settings capture tier: manual | dll_scan | etw | game_config | mixed"
+        - name: confidence
+          type: keyword
+          description: "Data confidence: high | medium | low"
+        - name: notes
+          type: keyword
+          description: "User-supplied free-text notes for this session"

--- a/packages/gamepulse/data_stream/session/manifest.yml
+++ b/packages/gamepulse/data_stream/session/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse Session Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/session/sample_event.json
+++ b/packages/gamepulse/data_stream/session/sample_event.json
@@ -1,0 +1,130 @@
+{
+  "@timestamp": "2026-04-04T20:00:00.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.session",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc",
+    "os": {
+      "name": "Arch Linux",
+      "version": "2024.12",
+      "kernel": "6.12.10-2-arch1-1",
+      "type": "linux",
+      "platform": "arch"
+    }
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0",
+      "opt_in_public": true,
+      "label": "cyberpunk-2077-20260404-1",
+      "label_source": "auto",
+      "sequence_number": 1
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "source": "steam",
+      "launcher": "Steam",
+      "version": "2.13",
+      "launch_args": "PROTON_ENABLE_NVAPI=1 %command%",
+      "graphics_api": "vulkan",
+      "upscaler": {
+        "type": "fsr",
+        "quality": "quality"
+      }
+    },
+    "compatibility": {
+      "proton_version": "9.0-3",
+      "dxvk_version": "2.4",
+      "vkd3d_proton_version": "2.13"
+    },
+    "hardware": {
+      "cpu": {
+        "model": "AMD Ryzen 9 7950X3D",
+        "cores": 16,
+        "threads": 32,
+        "base_clock_mhz": 4200,
+        "boost_clock_mhz": 5700
+      },
+      "gpu": {
+        "model": "AMD Radeon RX 7900 XTX",
+        "vendor": "amd",
+        "vram_mb": 24576,
+        "driver_version": "24.3.3",
+        "mesa_version": "24.3.3",
+        "vulkan_driver": "radv",
+        "pcie_gen": 4,
+        "pcie_width": 16
+      },
+      "ram": {
+        "total_mb": 65536,
+        "speed_mhz": 6000,
+        "type": "ddr5"
+      },
+      "storage": {
+        "game_drive": {
+          "type": "nvme",
+          "model": "Samsung 990 Pro 2TB",
+          "firmware": "4B2QGXA7",
+          "interface": "nvme",
+          "nvme_spec": "2.0",
+          "capacity_gb": 2000,
+          "free_gb": 842,
+          "free_pct": 42.1,
+          "temperature_c": 38.0,
+          "smart_health": "passed",
+          "encrypted": false
+        },
+        "game_filesystem": {
+          "type": "btrfs",
+          "mount_options": "noatime,compress=zstd",
+          "compression": "zstd",
+          "compression_level": 3,
+          "block_size": 4096,
+          "trim_enabled": true
+        },
+        "io_scheduler": "none",
+        "read_ahead_kb": 128
+      },
+      "device": {
+        "type": "desktop",
+        "power_source": "ac"
+      },
+      "monitors": [
+        {
+          "name": "DP-2",
+          "resolution_h": 3440,
+          "resolution_v": 1440,
+          "refresh_rate_hz": 119.98,
+          "is_primary": true,
+          "vrr_capable": false,
+          "hdr_capable": false,
+          "current_vrr_enabled": false
+        }
+      ]
+    },
+    "settings": {
+      "preset": "ultra",
+      "upscaler": {
+        "tech": "fsr",
+        "preset": "quality"
+      },
+      "frame_gen": {
+        "tech": "none"
+      },
+      "features_active": ["ray_tracing"],
+      "render": {
+        "vsync": "off"
+      },
+      "source": "manual",
+      "confidence": "high"
+    },
+    "summary": {
+      "ended": false
+    }
+  }
+}

--- a/packages/gamepulse/data_stream/storage/_dev/test/pipeline/test-storage-pipeline.json
+++ b/packages/gamepulse/data_stream/storage/_dev/test/pipeline/test-storage-pipeline.json
@@ -1,0 +1,47 @@
+{
+  "events": [
+    {
+      "@timestamp": "2026-04-11T12:00:00.000Z",
+      "data_stream": {
+        "type": "metrics",
+        "dataset": "gamepulse.storage",
+        "namespace": "default"
+      },
+      "host": {
+        "name": "gaming-pc"
+      },
+      "gamepulse": {
+        "session": {
+          "id": "test-session-001",
+          "agent_version": "0.1.0"
+        },
+        "game": {
+          "name": "Cyberpunk 2077",
+          "steam_app_id": 1091500
+        },
+        "storage": {
+          "read_mbps": 124.7,
+          "write_mbps": 8.3,
+          "read_iops": 1842,
+          "write_iops": 312,
+          "io_latency_read_us": {
+            "avg": 85,
+            "p50": 62,
+            "p95": 210,
+            "p99": 480
+          },
+          "io_latency_write_us": {
+            "avg": 42,
+            "p50": 31,
+            "p95": 98,
+            "p99": 230
+          },
+          "queue_depth_current": 4,
+          "queue_depth_max": 12,
+          "io_wait_pct": 1.2,
+          "drive_temperature_c": 42.0
+        }
+      }
+    }
+  ]
+}

--- a/packages/gamepulse/data_stream/storage/_dev/test/pipeline/test-storage-pipeline.json-expected.json
+++ b/packages/gamepulse/data_stream/storage/_dev/test/pipeline/test-storage-pipeline.json-expected.json
@@ -1,0 +1,47 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-04-11T12:00:00.000Z",
+            "data_stream": {
+                "dataset": "gamepulse.storage",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "gamepulse": {
+                "game": {
+                    "name": "Cyberpunk 2077",
+                    "steam_app_id": 1091500
+                },
+                "session": {
+                    "agent_version": "0.1.0",
+                    "id": "test-session-001"
+                },
+                "storage": {
+                    "drive_temperature_c": 42.0,
+                    "io_latency_read_us": {
+                        "avg": 85,
+                        "p50": 62,
+                        "p95": 210,
+                        "p99": 480
+                    },
+                    "io_latency_write_us": {
+                        "avg": 42,
+                        "p50": 31,
+                        "p95": 98,
+                        "p99": 230
+                    },
+                    "io_wait_pct": 1.2,
+                    "queue_depth_current": 4,
+                    "queue_depth_max": 12,
+                    "read_iops": 1842,
+                    "read_mbps": 124.7,
+                    "write_iops": 312,
+                    "write_mbps": 8.3
+                }
+            },
+            "host": {
+                "name": "gaming-pc"
+            }
+        }
+    ]
+}

--- a/packages/gamepulse/data_stream/storage/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gamepulse/data_stream/storage/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,30 @@
+---
+description: >
+  Ingest pipeline for GamePulse storage metrics.
+  Sets @timestamp and validates throughput/IOPS values are non-negative.
+processors:
+  - set:
+      field: "@timestamp"
+      value: "{{{_ingest.timestamp}}}"
+      if: "ctx['@timestamp'] == null"
+
+  - trim:
+      field: gamepulse.game.name
+      ignore_missing: true
+
+  - script:
+      description: "Validate storage metrics are non-negative"
+      lang: painless
+      source: |
+        def readMbps = ctx.gamepulse?.storage?.read_mbps;
+        if (readMbps != null && readMbps < 0) {
+          throw new Exception('gamepulse.storage.read_mbps must be >= 0');
+        }
+
+on_failure:
+  - set:
+      field: _ingest.pipeline_error
+      value: "{{_ingest.on_failure_message}}"
+  - set:
+      field: _ingest.failed_pipeline
+      value: "gamepulse-storage"

--- a/packages/gamepulse/data_stream/storage/fields/base-fields.yml
+++ b/packages/gamepulse/data_stream/storage/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: "@timestamp"
+  type: date
+  description: Timestamp when the metrics were collected.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type (metrics or logs).
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset name.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/packages/gamepulse/data_stream/storage/fields/fields.yml
+++ b/packages/gamepulse/data_stream/storage/fields/fields.yml
@@ -1,0 +1,134 @@
+# ECS fields used in this data stream
+- name: host.name
+  external: ecs
+  dimension: true
+
+# Session context
+- name: gamepulse
+  type: group
+  fields:
+    - name: session
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          dimension: true
+          description: "Unique session identifier (UUID)"
+        - name: agent_version
+          type: keyword
+          description: "Version of the GamePulse collector agent"
+        - name: label
+          type: keyword
+          description: "Optional user-supplied annotation for this session (e.g. 'after-driver-update')"
+
+    - name: game
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: "Game title"
+        - name: steam_app_id
+          type: long
+          description: "Steam application ID (present only when source == steam)"
+        - name: source
+          type: keyword
+          description: "Detection source: steam | lutris | heroic | bottles | user_specified | auto_detected"
+        - name: launcher
+          type: keyword
+          description: "Human-readable launcher name (e.g. Steam, Lutris, Heroic — Epic)"
+
+    # Storage-specific metrics
+    - name: storage
+      type: group
+      fields:
+        - name: read_mbps
+          type: float
+          metric_type: gauge
+          description: "Storage read throughput for the game drive in MB/s"
+        - name: write_mbps
+          type: float
+          metric_type: gauge
+          description: "Storage write throughput for the game drive in MB/s"
+        - name: read_iops
+          type: long
+          metric_type: gauge
+          description: "Storage read operations per second for the game drive"
+        - name: write_iops
+          type: long
+          metric_type: gauge
+          description: "Storage write operations per second for the game drive"
+        - name: io_latency_read_us
+          type: group
+          fields:
+            - name: avg
+              type: long
+              metric_type: gauge
+              description: "Average read I/O latency in microseconds"
+            - name: p50
+              type: long
+              metric_type: gauge
+              description: "Median read I/O latency in microseconds"
+            - name: p95
+              type: long
+              metric_type: gauge
+              description: "95th percentile read I/O latency in microseconds"
+            - name: p99
+              type: long
+              metric_type: gauge
+              description: "99th percentile read I/O latency in microseconds"
+        - name: io_latency_write_us
+          type: group
+          fields:
+            - name: avg
+              type: long
+              metric_type: gauge
+              description: "Average write I/O latency in microseconds"
+            - name: p50
+              type: long
+              metric_type: gauge
+              description: "Median write I/O latency in microseconds"
+            - name: p95
+              type: long
+              metric_type: gauge
+              description: "95th percentile write I/O latency in microseconds"
+            - name: p99
+              type: long
+              metric_type: gauge
+              description: "99th percentile write I/O latency in microseconds"
+        - name: queue_depth_current
+          type: integer
+          metric_type: gauge
+          description: "Current I/O queue depth"
+        - name: queue_depth_max
+          type: integer
+          metric_type: gauge
+          description: "Maximum I/O queue depth observed in this interval"
+        - name: io_wait_pct
+          type: float
+          metric_type: gauge
+          unit: percent
+          description: "CPU I/O wait percentage (time CPU was idle waiting for I/O)"
+        - name: merged_reads
+          type: long
+          metric_type: counter
+          description: "Cumulative merged read operations (from /proc/diskstats)"
+        - name: merged_writes
+          type: long
+          metric_type: counter
+          description: "Cumulative merged write operations (from /proc/diskstats)"
+        - name: game_process_read_mb
+          type: float
+          metric_type: counter
+          description: "Cumulative megabytes read by the game process (from /proc/{pid}/io)"
+        - name: game_process_write_mb
+          type: float
+          metric_type: counter
+          description: "Cumulative megabytes written by the game process"
+        - name: game_process_read_ops
+          type: long
+          metric_type: counter
+          description: "Cumulative read syscall count by the game process"
+        - name: drive_temperature_c
+          type: float
+          metric_type: gauge
+          description: "Game drive temperature in Celsius (NVMe/SATA SMART)"

--- a/packages/gamepulse/data_stream/storage/manifest.yml
+++ b/packages/gamepulse/data_stream/storage/manifest.yml
@@ -1,0 +1,4 @@
+title: "GamePulse Storage Metrics"
+type: metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/gamepulse/data_stream/storage/sample_event.json
+++ b/packages/gamepulse/data_stream/storage/sample_event.json
@@ -1,0 +1,50 @@
+{
+  "@timestamp": "2026-04-04T20:00:01.000Z",
+  "data_stream": {
+    "type": "metrics",
+    "dataset": "gamepulse.storage",
+    "namespace": "default"
+  },
+  "host": {
+    "name": "gaming-pc"
+  },
+  "gamepulse": {
+    "session": {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "agent_version": "0.1.0"
+    },
+    "game": {
+      "name": "Cyberpunk 2077",
+      "steam_app_id": 1091500,
+      "source": "steam",
+      "launcher": "Steam"
+    },
+    "storage": {
+      "read_mbps": 124.7,
+      "write_mbps": 8.3,
+      "read_iops": 1842,
+      "write_iops": 312,
+      "io_latency_read_us": {
+        "avg": 85,
+        "p50": 62,
+        "p95": 210,
+        "p99": 480
+      },
+      "io_latency_write_us": {
+        "avg": 42,
+        "p50": 31,
+        "p95": 98,
+        "p99": 230
+      },
+      "queue_depth_current": 4,
+      "queue_depth_max": 12,
+      "io_wait_pct": 1.2,
+      "merged_reads": 48921,
+      "merged_writes": 8340,
+      "game_process_read_mb": 2048.5,
+      "game_process_write_mb": 128.2,
+      "game_process_read_ops": 156780,
+      "drive_temperature_c": 42.0
+    }
+  }
+}

--- a/packages/gamepulse/docs/README.md
+++ b/packages/gamepulse/docs/README.md
@@ -28,6 +28,7 @@ Real-time gaming telemetry for Elasticsearch. Captures FPS, frame timing percent
 | `metrics-gamepulse.audio` | Latency, buffer size, xrun count |
 | `metrics-gamepulse.power` | Battery %, charge rate, AC state, TDP |
 | `metrics-gamepulse.ebpf` | Kernel scheduler migrations, GPU fence latency, futex waits |
+| `metrics-gamepulse.ebpf_thread` | Per-thread runqueue latency, switches, and migrations |
 | `metrics-gamepulse.session` | Per-session aggregates, game metadata, settings |
 | `logs-gamepulse.events` | Game start/end events, settings changes |
 

--- a/packages/gamepulse/docs/README.md
+++ b/packages/gamepulse/docs/README.md
@@ -1,0 +1,40 @@
+# GamePulse
+
+Real-time gaming telemetry for Elasticsearch. Captures FPS, frame timing percentiles, GPU/CPU thermals, memory, storage, network, audio, power draw, and kernel-level scheduler/I/O/GPU traces via eBPF — streamed live while you play.
+
+## Requirements
+
+- Elasticsearch 8.13+ or Elastic Cloud Serverless
+- [gamepulse-agent](https://github.com/MathewRJ/GamePulse/releases) installed on the gaming machine
+- An API key with `create_doc` + `auto_configure` on `metrics-gamepulse.*` and `logs-gamepulse.*`
+
+## Setup
+
+1. Install this integration via Fleet
+2. Install the gamepulse-agent binary on your gaming machine
+3. Configure `/etc/gamepulse/gamepulse.toml` with your Elasticsearch URL and API key
+4. Start the agent: `systemctl --user start gamepulse-agent`
+
+## Data streams
+
+| Stream | Content |
+|---|---|
+| `metrics-gamepulse.cpu` | CPU utilisation, temperature, frequency per core |
+| `metrics-gamepulse.gpu` | GPU utilisation, VRAM, temperature, power draw |
+| `metrics-gamepulse.frame` | FPS, frame time percentiles (p50/p95/p99), stutter count |
+| `metrics-gamepulse.memory` | RAM, swap, process RSS |
+| `metrics-gamepulse.storage` | Disk I/O bytes and latency |
+| `metrics-gamepulse.network` | Bytes and packets in/out |
+| `metrics-gamepulse.audio` | Latency, buffer size, xrun count |
+| `metrics-gamepulse.power` | Battery %, charge rate, AC state, TDP |
+| `metrics-gamepulse.ebpf` | Kernel scheduler migrations, GPU fence latency, futex waits |
+| `metrics-gamepulse.session` | Per-session aggregates, game metadata, settings |
+| `logs-gamepulse.events` | Game start/end events, settings changes |
+
+## Dashboards
+
+- **Player Overview** — session history and top games
+- **Game Performance** — FPS trends, frame timing, stutter analysis
+- **Game Engine** — eBPF kernel traces, shader compile detection
+- **Hardware Environment** — thermal and power headroom
+- **Software Environment** — driver versions, OS context, audio health

--- a/packages/gamepulse/img/icon.svg
+++ b/packages/gamepulse/img/icon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- Controller body -->
+  <rect x="4" y="10" width="24" height="14" rx="7" ry="7" fill="#1a1a2e"/>
+  <!-- D-pad horizontal -->
+  <rect x="8" y="15" width="6" height="2" rx="1" fill="#00bcd4"/>
+  <!-- D-pad vertical -->
+  <rect x="10" y="13" width="2" height="6" rx="1" fill="#00bcd4"/>
+  <!-- Face buttons -->
+  <circle cx="21" cy="14.5" r="1.2" fill="#4caf50"/>
+  <circle cx="23.5" cy="16" r="1.2" fill="#f44336"/>
+  <circle cx="21" cy="17.5" r="1.2" fill="#2196f3"/>
+  <circle cx="18.5" cy="16" r="1.2" fill="#ffeb3b"/>
+  <!-- Pulse line -->
+  <polyline points="4,24 8,24 10,20 12,28 14,22 16,26 18,24 28,24"
+            fill="none" stroke="#00e5ff" stroke-width="1.5"
+            stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/gamepulse/kibana/dashboard/gamepulse-gp-command-center.json
+++ b/packages/gamepulse/kibana/dashboard/gamepulse-gp-command-center.json
@@ -1,0 +1,1789 @@
+{
+  "type": "dashboard",
+  "id": "gamepulse-gp-command-center",
+  "attributes": {
+    "title": "GamePulse - Performance Command Center",
+    "description": "Curated 90-day gamer overview: session health, game history, FPS trend, and likely regression causes.",
+    "timeFrom": "now-90d",
+    "timeTo": "now",
+    "timeRestore": true,
+    "optionsJSON": {
+      "autoApplyFilters": true,
+      "hidePanelBorders": false,
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": true,
+      "useMargins": true
+    },
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {}
+    },
+    "panelsJSON": [
+      {
+        "type": "markdown",
+        "panelIndex": "nav-bar",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 3,
+          "i": "nav-bar"
+        },
+        "embeddableConfig": {
+          "content": "**GamePulse** &nbsp;.&nbsp; [Command Center](/app/dashboards#/view/gamepulse-gp-command-center) &nbsp;|&nbsp; [Regression Lab](/app/dashboards#/view/gamepulse-gp-regression-lab) &nbsp;|&nbsp; [Player Overview](/app/dashboards#/view/gamepulse-gp-home) &nbsp;|&nbsp; [Game Performance](/app/dashboards#/view/gamepulse-gp-game-perf) &nbsp;|&nbsp; [Engine](/app/dashboards#/view/gamepulse-gp-engine) &nbsp;|&nbsp; [Hardware](/app/dashboards#/view/gamepulse-gp-hardware) &nbsp;|&nbsp; [Software](/app/dashboards#/view/gamepulse-gp-software) &nbsp;|&nbsp; [Compare](/app/dashboards#/view/828db140-b330-4d26-8045-40a7895bfc41)",
+          "settings": {
+            "open_links_in_new_tab": true
+          }
+        }
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.name",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Game",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-game",
+          "w": 16,
+          "x": 0,
+          "y": 3
+        },
+        "panelIndex": "ctrl-game",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.hardware.gpu.driver_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "GPU Driver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-driver",
+          "w": 16,
+          "x": 16,
+          "y": 3
+        },
+        "panelIndex": "ctrl-driver",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "host.os.kernel",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "OS Kernel",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-kernel",
+          "w": 16,
+          "x": 32,
+          "y": 3
+        },
+        "panelIndex": "ctrl-kernel",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Sessions",
+                          "label": "Sessions Played",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Sessions Played"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-sessions",
+          "w": 12,
+          "x": 0,
+          "y": 7
+        },
+        "panelIndex": "kpi-sessions",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-47a41c3882e1307e6ea2af72476945c677847d9ca0e14fa8b8ca97ba06b98f27": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-47a41c3882e1307e6ea2af72476945c677847d9ca0e14fa8b8ca97ba06b98f27",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Games",
+                          "label": "Games Played",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-47a41c3882e1307e6ea2af72476945c677847d9ca0e14fa8b8ca97ba06b98f27",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.game.name IS NOT NULL | STATS `Games` = COUNT_DISTINCT(gamepulse.game.name)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-47a41c3882e1307e6ea2af72476945c677847d9ca0e14fa8b8ca97ba06b98f27",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.game.name IS NOT NULL | STATS `Games` = COUNT_DISTINCT(gamepulse.game.name)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Games Played"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-games",
+          "w": 12,
+          "x": 12,
+          "y": 7
+        },
+        "panelIndex": "kpi-games",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Hours",
+                          "label": "Total Hours Played",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Hours` = ROUND(SUM(gamepulse.summary.duration_s) / 3600.0, 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Hours` = ROUND(SUM(gamepulse.summary.duration_s) / 3600.0, 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Total Hours Played"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-hours",
+          "w": 12,
+          "x": 24,
+          "y": 7
+        },
+        "panelIndex": "kpi-hours",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Avg FPS",
+                          "label": "Overall Avg FPS",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.avg_fps IS NOT NULL | STATS `Avg FPS` = ROUND(AVG(gamepulse.summary.avg_fps), 0)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.avg_fps IS NOT NULL | STATS `Avg FPS` = ROUND(AVG(gamepulse.summary.avg_fps), 0)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Overall Avg FPS"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-avg-fps",
+          "w": 12,
+          "x": 36,
+          "y": 7
+        },
+        "panelIndex": "kpi-avg-fps",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-frame",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 30
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS (1 s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.avg_1s"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.low_1pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Frames Per Second"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "FPS Over Time \u2014 Each colour is one gaming session. Gaps between sessions are natural play breaks."
+        },
+        "gridData": {
+          "h": 16,
+          "i": "chart-fps-time",
+          "w": 48,
+          "x": 0,
+          "y": 13
+        },
+        "panelIndex": "chart-fps-time",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Avg FPS by GPU Driver Version \u2014 Which driver delivered the best performance? Compare avg FPS and 1% lows across driver versions."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-driver",
+          "w": 24,
+          "x": 0,
+          "y": 29
+        },
+        "panelIndex": "table-fps-driver",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "host.os.kernel"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Avg FPS by Kernel Version \u2014 Kernel scheduler and GPU driver stack differences can affect framerate. Useful for identifying kernel regressions on gaming-tuned builds (CachyOS, Nobara, etc.)."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-kernel",
+          "w": 24,
+          "x": 24,
+          "y": 29
+        },
+        "panelIndex": "table-fps-kernel",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Seconds",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.duration_s"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Total Play Time by Game \u2014 most-played first"
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-hours-game",
+          "w": 24,
+          "x": 0,
+          "y": 39
+        },
+        "panelIndex": "table-hours-game",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "FPS Performance by Game \u2014 highest avg FPS first"
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-game",
+          "w": 24,
+          "x": 24,
+          "y": 39
+        },
+        "panelIndex": "table-fps-game",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7",
+                        "datatable_accessor_metric_8",
+                        "datatable_accessor_metric_9",
+                        "datatable_accessor_metric_10"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Game",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Duration (s)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.duration_s"
+                        },
+                        "datatable_accessor_metric_10": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Proton",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.compatibility.proton_version"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "p99 Frame (ms)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.p99_frametime_ms"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutters",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Bottleneck",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.bottleneck_dominant"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Peak GPU \u00b0C",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.peak_gpu_temp_c"
+                        },
+                        "datatable_accessor_metric_8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_metric_9": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Kernel",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.kernel"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 100
+                          },
+                          "sourceField": "gamepulse.session.id"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_8",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_9",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_10",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Session History \u2014 most recent sessions first (shows all fields for the selected time range)"
+        },
+        "gridData": {
+          "h": 14,
+          "i": "table-sessions",
+          "w": 48,
+          "x": 0,
+          "y": 49
+        },
+        "panelIndex": "table-sessions",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7",
+                        "datatable_accessor_metric_8"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "VRAM (MB)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.vram_mb"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Vendor",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.vendor"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "CPU",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.cpu.model"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "CPU Cores",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.cpu.cores"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "RAM (MB)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.ram.total_mb"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "RAM Type",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.ram.type"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "OS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.name"
+                        },
+                        "datatable_accessor_metric_8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Kernel",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.kernel"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "asc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.model"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_8",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Hardware Profiles \u2014 one row per GPU model seen (most recent first)"
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-hw",
+          "w": 48,
+          "x": 0,
+          "y": 63
+        },
+        "panelIndex": "table-hw",
+        "type": "vis"
+      }
+    ]
+  },
+  "references": [
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-game:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-driver:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-kernel:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-frame",
+      "name": "chart-fps-time:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-hours-game:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-game:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-sessions:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-hw:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-driver:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-kernel:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    }
+  ]
+}

--- a/packages/gamepulse/kibana/dashboard/gamepulse-gp-engine.json
+++ b/packages/gamepulse/kibana/dashboard/gamepulse-gp-engine.json
@@ -1,0 +1,1987 @@
+{
+  "attributes": {
+    "description": "Kernel-level telemetry for game engine optimisation: GPU pipeline latency, CPU scheduler health, I/O and futex contention, stutter scoring. Essential for engine developers, driver authors, and performance engineers.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {}
+    },
+    "optionsJSON": {
+      "autoApplyFilters": true,
+      "hidePanelBorders": false,
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": true,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "content": "**GamePulse** &nbsp;\u00b7&nbsp; [Player Overview](/app/dashboards#/view/gamepulse-gp-home) &nbsp;|&nbsp; [Game Performance](/app/dashboards#/view/gamepulse-gp-game-perf) &nbsp;|&nbsp; [Game Engine](/app/dashboards#/view/gamepulse-gp-engine) &nbsp;|&nbsp; [Hardware](/app/dashboards#/view/gamepulse-gp-hardware) &nbsp;|&nbsp; [Software Env](/app/dashboards#/view/gamepulse-gp-software)",
+          "settings": {
+            "open_links_in_new_tab": true
+          }
+        },
+        "gridData": {
+          "h": 3,
+          "i": "nav-bar",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "nav-bar",
+        "type": "markdown"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.name",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Game",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-game",
+          "w": 12,
+          "x": 0,
+          "y": 3
+        },
+        "panelIndex": "ctrl-game",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.graphics_api",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Graphics API",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-api",
+          "w": 12,
+          "x": 12,
+          "y": 3
+        },
+        "panelIndex": "ctrl-api",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.upscaler.type",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Upscaler",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-upscaler",
+          "w": 12,
+          "x": 24,
+          "y": 3
+        },
+        "panelIndex": "ctrl-upscaler",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.hardware.gpu.driver_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "GPU Driver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-driver",
+          "w": 12,
+          "x": 36,
+          "y": 3
+        },
+        "panelIndex": "ctrl-driver",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.ebpf-default-fc796b398a559e1d0159005d59b56f8a6d0de87775429580e8a6b7c47782b96d": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.ebpf-default-fc796b398a559e1d0159005d59b56f8a6d0de87775429580e8a6b7c47782b96d",
+                  "name": "metrics-gamepulse.ebpf-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.ebpf-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "GPU Fence \u00b5s",
+                          "label": "Avg GPU Fence Latency",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.ebpf-default-fc796b398a559e1d0159005d59b56f8a6d0de87775429580e8a6b7c47782b96d",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.gpu_fence.latency_avg_us` IS NOT NULL | STATS `GPU Fence \u00b5s` = ROUND(AVG(`gamepulse.ebpf.gpu_fence.latency_avg_us`), 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.ebpf-default-fc796b398a559e1d0159005d59b56f8a6d0de87775429580e8a6b7c47782b96d",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.gpu_fence.latency_avg_us` IS NOT NULL | STATS `GPU Fence \u00b5s` = ROUND(AVG(`gamepulse.ebpf.gpu_fence.latency_avg_us`), 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Avg GPU Fence Latency"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-gpu-fence",
+          "w": 8,
+          "x": 0,
+          "y": 7
+        },
+        "panelIndex": "kpi-gpu-fence",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.ebpf-default-bb37c2dab0c7a79322b0fa370af67c35fa7611327b07f3c996134a5ccbc14f8d": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.ebpf-default-bb37c2dab0c7a79322b0fa370af67c35fa7611327b07f3c996134a5ccbc14f8d",
+                  "name": "metrics-gamepulse.ebpf-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.ebpf-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "GPU Sched \u00b5s",
+                          "label": "Avg GPU Sched Latency",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.ebpf-default-bb37c2dab0c7a79322b0fa370af67c35fa7611327b07f3c996134a5ccbc14f8d",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.gpu_sched.latency_avg_us` IS NOT NULL | STATS `GPU Sched \u00b5s` = ROUND(AVG(`gamepulse.ebpf.gpu_sched.latency_avg_us`), 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.ebpf-default-bb37c2dab0c7a79322b0fa370af67c35fa7611327b07f3c996134a5ccbc14f8d",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.gpu_sched.latency_avg_us` IS NOT NULL | STATS `GPU Sched \u00b5s` = ROUND(AVG(`gamepulse.ebpf.gpu_sched.latency_avg_us`), 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Avg GPU Sched Latency"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-gpu-sched",
+          "w": 8,
+          "x": 8,
+          "y": 7
+        },
+        "panelIndex": "kpi-gpu-sched",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.ebpf-default-97bda46bbcb9a5d7e85957db81a4a741356907e9a7d079d88b2d68da660474da": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.ebpf-default-97bda46bbcb9a5d7e85957db81a4a741356907e9a7d079d88b2d68da660474da",
+                  "name": "metrics-gamepulse.ebpf-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.ebpf-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "RQ \u00b5s",
+                          "label": "Avg Runqueue Latency",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.ebpf-default-97bda46bbcb9a5d7e85957db81a4a741356907e9a7d079d88b2d68da660474da",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.runqueue.latency_avg_us` IS NOT NULL | STATS `RQ \u00b5s` = ROUND(AVG(`gamepulse.ebpf.runqueue.latency_avg_us`), 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.ebpf-default-97bda46bbcb9a5d7e85957db81a4a741356907e9a7d079d88b2d68da660474da",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.runqueue.latency_avg_us` IS NOT NULL | STATS `RQ \u00b5s` = ROUND(AVG(`gamepulse.ebpf.runqueue.latency_avg_us`), 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Avg Runqueue Latency"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-runqueue",
+          "w": 8,
+          "x": 16,
+          "y": 7
+        },
+        "panelIndex": "kpi-runqueue",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.ebpf-default-86798affa35e98740bb3acf4e54dd9f9155ed3ae7c700f66548a344e9851758e": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.ebpf-default-86798affa35e98740bb3acf4e54dd9f9155ed3ae7c700f66548a344e9851758e",
+                  "name": "metrics-gamepulse.ebpf-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.ebpf-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "I/O \u00b5s",
+                          "label": "Avg I/O Latency",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.ebpf-default-86798affa35e98740bb3acf4e54dd9f9155ed3ae7c700f66548a344e9851758e",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.bio.latency_avg_us` IS NOT NULL | STATS `I/O \u00b5s` = ROUND(AVG(`gamepulse.ebpf.bio.latency_avg_us`), 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.ebpf-default-86798affa35e98740bb3acf4e54dd9f9155ed3ae7c700f66548a344e9851758e",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.bio.latency_avg_us` IS NOT NULL | STATS `I/O \u00b5s` = ROUND(AVG(`gamepulse.ebpf.bio.latency_avg_us`), 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Avg I/O Latency"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-bio-lat",
+          "w": 8,
+          "x": 24,
+          "y": 7
+        },
+        "panelIndex": "kpi-bio-lat",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.ebpf-default-4e42ae989310967cf4d92c52283a2ec4da67a346b0c5da8eeb46cabd7fe0f06e": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.ebpf-default-4e42ae989310967cf4d92c52283a2ec4da67a346b0c5da8eeb46cabd7fe0f06e",
+                  "name": "metrics-gamepulse.ebpf-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.ebpf-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Futex \u00b5s",
+                          "label": "Avg Futex Latency",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.ebpf-default-4e42ae989310967cf4d92c52283a2ec4da67a346b0c5da8eeb46cabd7fe0f06e",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.futex.latency_avg_us` IS NOT NULL | STATS `Futex \u00b5s` = ROUND(AVG(`gamepulse.ebpf.futex.latency_avg_us`), 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.ebpf-default-4e42ae989310967cf4d92c52283a2ec4da67a346b0c5da8eeb46cabd7fe0f06e",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.futex.latency_avg_us` IS NOT NULL | STATS `Futex \u00b5s` = ROUND(AVG(`gamepulse.ebpf.futex.latency_avg_us`), 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Avg Futex Latency"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-futex-lat",
+          "w": 8,
+          "x": 32,
+          "y": 7
+        },
+        "panelIndex": "kpi-futex-lat",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.ebpf-default-21636e44dc40eeb17c571edc59a1687d8f25dac5c5ae2d767e1935b761a2bff2": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.ebpf-default-21636e44dc40eeb17c571edc59a1687d8f25dac5c5ae2d767e1935b761a2bff2",
+                  "name": "metrics-gamepulse.ebpf-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.ebpf-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Stutter Score",
+                          "label": "Avg Stutter Severity",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.ebpf-default-21636e44dc40eeb17c571edc59a1687d8f25dac5c5ae2d767e1935b761a2bff2",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.stutter.severity_score` IS NOT NULL | STATS `Stutter Score` = ROUND(AVG(`gamepulse.ebpf.stutter.severity_score`), 2)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.ebpf-default-21636e44dc40eeb17c571edc59a1687d8f25dac5c5ae2d767e1935b761a2bff2",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.ebpf-default | WHERE `gamepulse.ebpf.stutter.severity_score` IS NOT NULL | STATS `Stutter Score` = ROUND(AVG(`gamepulse.ebpf.stutter.severity_score`), 2)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Avg Stutter Severity"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-stutter-sev",
+          "w": 8,
+          "x": 40,
+          "y": 7
+        },
+        "panelIndex": "kpi-stutter-sev",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Fence (\u00b5s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.gpu_fence.latency_avg_us"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Sched (\u00b5s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.gpu_sched.latency_avg_us"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Latency (\u00b5s)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Pipeline Latency Over Time \u2014 GPU fence latency = time from command submission to GPU completion (measured by DRM fence callbacks). GPU scheduler latency = time GPU work spends queued waiting for execution. Spikes indicate GPU ring buffer saturation or driver overhead."
+        },
+        "gridData": {
+          "h": 14,
+          "i": "chart-gpu-pipeline",
+          "w": 48,
+          "x": 0,
+          "y": 13
+        },
+        "panelIndex": "chart-gpu-pipeline",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Runqueue Latency (\u00b5s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.runqueue.latency_avg_us"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Runqueue Latency (\u00b5s)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "CPU Scheduler Latency Over Time \u2014 Runqueue latency is the time game threads spend waiting for a CPU core. High values (>200 \u00b5s) indicate CPU saturation, conflicting affinity, or SMT interference. CCX migrations = cross-chiplet scheduler migrations on AMD Zen (expensive cache miss)."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-cpu-sched",
+          "w": 32,
+          "x": 0,
+          "y": 27
+        },
+        "panelIndex": "chart-cpu-sched",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "CCX Migrations/s",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.migration.ccx_cross_count"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Migrations / interval"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "CCX Cross-Node Migrations \u2014 Thread migrations across AMD CCX chiplets cause cache misses. Elevated counts correlate with microstutter in CPU-bound scenarios."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-ccx-migration",
+          "w": 16,
+          "x": 32,
+          "y": 27
+        },
+        "panelIndex": "chart-ccx-migration",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "BIO Latency (\u00b5s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.bio.latency_avg_us"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "BIO Latency (\u00b5s)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Block I/O Latency Over Time \u2014 High I/O latency during gameplay indicates shader cache compilation I/O or asset streaming bottleneck. Correlate with FPS drops on the Game Performance dashboard."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-io-lat",
+          "w": 24,
+          "x": 0,
+          "y": 39
+        },
+        "panelIndex": "chart-io-lat",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Futex Contention/s",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.futex.contended_count"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Futex Waits / interval"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Futex Contention Over Time \u2014 Futex wait counts reflect thread synchronisation overhead. Game engines use futexes for job system barriers; high counts can indicate unbalanced work distribution between render and update threads."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-futex",
+          "w": 24,
+          "x": 24,
+          "y": 39
+        },
+        "panelIndex": "chart-futex",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutter Severity",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.stutter.severity_score"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Stutter Severity Score (0\u20131)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Stutter Severity Score Over Time \u2014 Composite score from frame drops + scheduler misses + I/O spikes. Score > 0.3 is noticeable; > 0.6 is severe. Correlate spikes with GPU pipeline and runqueue panels above."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-stutter-score",
+          "w": 48,
+          "x": 0,
+          "y": 51
+        },
+        "panelIndex": "chart-stutter-score",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7",
+                        "datatable_accessor_metric_8"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Game",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Graphics API",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.graphics_api"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Upscaler",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.upscaler.type"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Upscaler Quality",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.upscaler.quality"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Features",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.settings.features_active"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutters",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_metric_8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Proton",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.compatibility.proton_version"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 50
+                          },
+                          "sourceField": "gamepulse.session.id"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_8",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Engine Profile per Session \u2014 graphics API, upscaler, and eBPF summary"
+        },
+        "gridData": {
+          "h": 12,
+          "i": "table-engine-sessions",
+          "w": 48,
+          "x": 0,
+          "y": 63
+        },
+        "panelIndex": "table-engine-sessions",
+        "type": "vis"
+      }
+    ],
+    "timeFrom": "now-90d",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "GamePulse \u2014 Game Engine"
+  },
+  "id": "gamepulse-gp-engine",
+  "references": [
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-game:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-api:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-upscaler:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-driver:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-gpu-pipeline:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-cpu-sched:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-ccx-migration:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-io-lat:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-futex:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-stutter-score:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-engine-sessions:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "dashboard"
+}

--- a/packages/gamepulse/kibana/dashboard/gamepulse-gp-game-perf.json
+++ b/packages/gamepulse/kibana/dashboard/gamepulse-gp-game-perf.json
@@ -1,0 +1,2148 @@
+{
+  "attributes": {
+    "description": "Deep-dive into performance for any game: FPS trends across sessions, frametime distribution, stutter analysis, and bottleneck identification. Use the filters above to compare specific driver or Proton versions.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {}
+    },
+    "optionsJSON": {
+      "autoApplyFilters": true,
+      "hidePanelBorders": false,
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": true,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "content": "**GamePulse** &nbsp;\u00b7&nbsp; [Player Overview](/app/dashboards#/view/gamepulse-gp-home) &nbsp;|&nbsp; [Game Performance](/app/dashboards#/view/gamepulse-gp-game-perf) &nbsp;|&nbsp; [Game Engine](/app/dashboards#/view/gamepulse-gp-engine) &nbsp;|&nbsp; [Hardware](/app/dashboards#/view/gamepulse-gp-hardware) &nbsp;|&nbsp; [Software Env](/app/dashboards#/view/gamepulse-gp-software)",
+          "settings": {
+            "open_links_in_new_tab": true
+          }
+        },
+        "gridData": {
+          "h": 3,
+          "i": "nav-bar",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "nav-bar",
+        "type": "markdown"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.name",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Game",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-game",
+          "w": 12,
+          "x": 0,
+          "y": 3
+        },
+        "panelIndex": "ctrl-game",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.hardware.gpu.driver_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "GPU Driver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-driver",
+          "w": 12,
+          "x": 12,
+          "y": 3
+        },
+        "panelIndex": "ctrl-driver",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.compatibility.proton_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Proton Ver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-proton",
+          "w": 12,
+          "x": 24,
+          "y": 3
+        },
+        "panelIndex": "ctrl-proton",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "host.os.kernel",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "OS Kernel",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-kernel",
+          "w": 12,
+          "x": 36,
+          "y": 3
+        },
+        "panelIndex": "ctrl-kernel",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Sessions",
+                          "label": "Sessions",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Sessions"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-sessions",
+          "w": 8,
+          "x": 0,
+          "y": 7
+        },
+        "panelIndex": "kpi-sessions",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Avg FPS",
+                          "label": "Avg FPS",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.avg_fps IS NOT NULL | STATS `Avg FPS` = ROUND(AVG(gamepulse.summary.avg_fps), 0)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.avg_fps IS NOT NULL | STATS `Avg FPS` = ROUND(AVG(gamepulse.summary.avg_fps), 0)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Avg FPS"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-avg-fps",
+          "w": 8,
+          "x": 8,
+          "y": 7
+        },
+        "panelIndex": "kpi-avg-fps",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-9fd7df79247cada2e15373a68980cab91e08fc5c71f25a5b39cee1333103af2b": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-9fd7df79247cada2e15373a68980cab91e08fc5c71f25a5b39cee1333103af2b",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "1pct Low",
+                          "label": "1% Low FPS",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-9fd7df79247cada2e15373a68980cab91e08fc5c71f25a5b39cee1333103af2b",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.low_1pct_fps IS NOT NULL | STATS `1pct Low` = ROUND(AVG(gamepulse.summary.low_1pct_fps), 0)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-9fd7df79247cada2e15373a68980cab91e08fc5c71f25a5b39cee1333103af2b",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.low_1pct_fps IS NOT NULL | STATS `1pct Low` = ROUND(AVG(gamepulse.summary.low_1pct_fps), 0)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "1% Low FPS"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-low-fps",
+          "w": 8,
+          "x": 16,
+          "y": 7
+        },
+        "panelIndex": "kpi-low-fps",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-fe4254194b589c4fcfd5c9ccadcd85df39cf48069327199958bb4c96534a3de4": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-fe4254194b589c4fcfd5c9ccadcd85df39cf48069327199958bb4c96534a3de4",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "p99 ms",
+                          "label": "p99 Frametime",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-fe4254194b589c4fcfd5c9ccadcd85df39cf48069327199958bb4c96534a3de4",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.p99_frametime_ms IS NOT NULL | STATS `p99 ms` = ROUND(AVG(gamepulse.summary.p99_frametime_ms), 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-fe4254194b589c4fcfd5c9ccadcd85df39cf48069327199958bb4c96534a3de4",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.p99_frametime_ms IS NOT NULL | STATS `p99 ms` = ROUND(AVG(gamepulse.summary.p99_frametime_ms), 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "p99 Frametime"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-p99-ft",
+          "w": 8,
+          "x": 24,
+          "y": 7
+        },
+        "panelIndex": "kpi-p99-ft",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-ff2c1f06b89bc8c780bff54f4928a0ee4f57cf51721191a6e6f99d8d190ccb5c": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-ff2c1f06b89bc8c780bff54f4928a0ee4f57cf51721191a6e6f99d8d190ccb5c",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Stutters",
+                          "label": "Stutter Events (total)",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-ff2c1f06b89bc8c780bff54f4928a0ee4f57cf51721191a6e6f99d8d190ccb5c",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Stutters` = SUM(gamepulse.summary.stutter_count)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-ff2c1f06b89bc8c780bff54f4928a0ee4f57cf51721191a6e6f99d8d190ccb5c",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Stutters` = SUM(gamepulse.summary.stutter_count)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Stutter Events (total)"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-stutter",
+          "w": 8,
+          "x": 32,
+          "y": 7
+        },
+        "panelIndex": "kpi-stutter",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Hours",
+                          "label": "Total Hours",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Hours` = ROUND(SUM(gamepulse.summary.duration_s) / 3600.0, 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Hours` = ROUND(SUM(gamepulse.summary.duration_s) / 3600.0, 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Total Hours"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-hours",
+          "w": 8,
+          "x": 40,
+          "y": 7
+        },
+        "panelIndex": "kpi-hours",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-frame",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 40
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS (1 s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.avg_1s"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.low_1pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Frames Per Second"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "FPS Over Time \u2014 Each colour = one gaming session. Natural time gaps between sessions preserve chronological context. Compare sessions across driver/Proton versions using the filters above."
+        },
+        "gridData": {
+          "h": 18,
+          "i": "chart-fps-sessions",
+          "w": 48,
+          "x": 0,
+          "y": 13
+        },
+        "panelIndex": "chart-fps-sessions",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-frame",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg Frametime (ms)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.frametime_ms"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "0.1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.low_01pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Frame Time (ms) / 0.1% Low FPS"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Frame Time Over Time \u2014 spikes reveal stutter events. Target: avg frametime \u2264 33 ms for 30 FPS cap, \u2264 16.7 ms for 60 FPS. 0.1% lows (worst frames) amplify hitches invisible in the average."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-frametime",
+          "w": 32,
+          "x": 0,
+          "y": 31
+        },
+        "panelIndex": "chart-frametime",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-frame",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 15
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutter Count",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.fps.stutter_count"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Stutter Events / interval"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Stutter Events Per Interval \u2014 sudden spikes indicate shader compilation hitches, CPU-GPU sync issues, or memory pressure. stutter_detected fires when frametime exceeds 2\u00d7 the rolling average."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-stutter",
+          "w": 16,
+          "x": 32,
+          "y": 31
+        },
+        "panelIndex": "chart-stutter",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Game",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Bottleneck",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.bottleneck_dominant"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutters",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Proton",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.compatibility.proton_version"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Kernel",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.kernel"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 50
+                          },
+                          "sourceField": "gamepulse.session.id"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Dominant Bottleneck by Session \u2014 where was the system limited? GPU-bound means GPU is the constraint; CPU-bound means CPU-side overhead."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "table-bottleneck",
+          "w": 48,
+          "x": 0,
+          "y": 43
+        },
+        "panelIndex": "table-bottleneck",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-gpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Utilisation %",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.utilisation_pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "GPU Utilisation (%)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Utilisation % Over Time \u2014 values consistently below 95% suggest CPU bottleneck or thermal throttling; values at 99\u2013100% indicate GPU-bound."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-gpu-util",
+          "w": 24,
+          "x": 0,
+          "y": 55
+        },
+        "panelIndex": "chart-gpu-util",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-cpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "CPU Util %",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.cpu.total_utilisation_pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "CPU Utilisation (%)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "CPU Utilisation % Over Time \u2014 high CPU load combined with low GPU load confirms CPU-bound workload."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-cpu-util",
+          "w": 24,
+          "x": 24,
+          "y": 55
+        },
+        "panelIndex": "chart-cpu-util",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7",
+                        "datatable_accessor_metric_8",
+                        "datatable_accessor_metric_9",
+                        "datatable_accessor_metric_10",
+                        "datatable_accessor_metric_11",
+                        "datatable_accessor_metric_12",
+                        "datatable_accessor_metric_13"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Game",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Duration (s)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.duration_s"
+                        },
+                        "datatable_accessor_metric_10": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Proton",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.compatibility.proton_version"
+                        },
+                        "datatable_accessor_metric_11": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Kernel",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.kernel"
+                        },
+                        "datatable_accessor_metric_12": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Graphics API",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.graphics_api"
+                        },
+                        "datatable_accessor_metric_13": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Upscaler",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.upscaler.type"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "p99 Frame (ms)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.p99_frametime_ms"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutters",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Bottleneck",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.bottleneck_dominant"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Peak GPU \u00b0C",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.peak_gpu_temp_c"
+                        },
+                        "datatable_accessor_metric_8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Peak GPU W",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.peak_gpu_power_w"
+                        },
+                        "datatable_accessor_metric_9": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 100
+                          },
+                          "sourceField": "gamepulse.session.id"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_8",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_9",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_10",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_11",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_12",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_13",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Per-Session Performance Summary \u2014 complete stats for every session in the selected period"
+        },
+        "gridData": {
+          "h": 14,
+          "i": "table-session-detail",
+          "w": 48,
+          "x": 0,
+          "y": 65
+        },
+        "panelIndex": "table-session-detail",
+        "type": "vis"
+      }
+    ],
+    "timeFrom": "now-90d",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "GamePulse \u2014 Game Performance"
+  },
+  "id": "gamepulse-gp-game-perf",
+  "references": [
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-game:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-driver:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-proton:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-kernel:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-frame",
+      "name": "chart-fps-sessions:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-frame",
+      "name": "chart-frametime:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-frame",
+      "name": "chart-stutter:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-bottleneck:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-gpu",
+      "name": "chart-gpu-util:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-cpu",
+      "name": "chart-cpu-util:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-session-detail:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "dashboard"
+}

--- a/packages/gamepulse/kibana/dashboard/gamepulse-gp-hardware.json
+++ b/packages/gamepulse/kibana/dashboard/gamepulse-gp-hardware.json
@@ -1,0 +1,2612 @@
+{
+  "attributes": {
+    "description": "Full hardware telemetry during gaming sessions: GPU temperature, power, clocks, CPU utilisation and thermals, memory pressure, storage throughput, and power profile. Essential for hardware reviewers, OEM engineers, and thermal analysis.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {}
+    },
+    "optionsJSON": {
+      "autoApplyFilters": true,
+      "hidePanelBorders": false,
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": true,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "content": "**GamePulse** &nbsp;\u00b7&nbsp; [Player Overview](/app/dashboards#/view/gamepulse-gp-home) &nbsp;|&nbsp; [Game Performance](/app/dashboards#/view/gamepulse-gp-game-perf) &nbsp;|&nbsp; [Game Engine](/app/dashboards#/view/gamepulse-gp-engine) &nbsp;|&nbsp; [Hardware](/app/dashboards#/view/gamepulse-gp-hardware) &nbsp;|&nbsp; [Software Env](/app/dashboards#/view/gamepulse-gp-software)",
+          "settings": {
+            "open_links_in_new_tab": true
+          }
+        },
+        "gridData": {
+          "h": 3,
+          "i": "nav-bar",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "nav-bar",
+        "type": "markdown"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.name",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Game",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-game",
+          "w": 16,
+          "x": 0,
+          "y": 3
+        },
+        "panelIndex": "ctrl-game",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.hardware.gpu.driver_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "GPU Driver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-driver",
+          "w": 16,
+          "x": 16,
+          "y": 3
+        },
+        "panelIndex": "ctrl-driver",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "host.os.kernel",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "OS Kernel",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-kernel",
+          "w": 16,
+          "x": 32,
+          "y": 3
+        },
+        "panelIndex": "ctrl-kernel",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-1527a921407922f5fdfe706bf40cfdbbb9b5f2daaeb6b32bf968afa1c04d140e": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-1527a921407922f5fdfe706bf40cfdbbb9b5f2daaeb6b32bf968afa1c04d140e",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "GPU",
+                          "label": "GPU Model",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-1527a921407922f5fdfe706bf40cfdbbb9b5f2daaeb6b32bf968afa1c04d140e",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.gpu.model IS NOT NULL | STATS `GPU` = MAX(gamepulse.hardware.gpu.model)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-1527a921407922f5fdfe706bf40cfdbbb9b5f2daaeb6b32bf968afa1c04d140e",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.gpu.model IS NOT NULL | STATS `GPU` = MAX(gamepulse.hardware.gpu.model)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "GPU Model"
+        },
+        "gridData": {
+          "h": 5,
+          "i": "kpi-gpu-model",
+          "w": 12,
+          "x": 0,
+          "y": 7
+        },
+        "panelIndex": "kpi-gpu-model",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-2f86fed4264ea9c6dd81c5a6b6b77707ab4f4354470b074e7e017648052ca9ae": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-2f86fed4264ea9c6dd81c5a6b6b77707ab4f4354470b074e7e017648052ca9ae",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "CPU",
+                          "label": "CPU Model",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-2f86fed4264ea9c6dd81c5a6b6b77707ab4f4354470b074e7e017648052ca9ae",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.cpu.model IS NOT NULL | STATS `CPU` = MAX(gamepulse.hardware.cpu.model)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-2f86fed4264ea9c6dd81c5a6b6b77707ab4f4354470b074e7e017648052ca9ae",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.cpu.model IS NOT NULL | STATS `CPU` = MAX(gamepulse.hardware.cpu.model)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "CPU Model"
+        },
+        "gridData": {
+          "h": 5,
+          "i": "kpi-cpu-model",
+          "w": 12,
+          "x": 12,
+          "y": 7
+        },
+        "panelIndex": "kpi-cpu-model",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-6be3aeccc5db12b916f74a2a004b1c0342d7e96cb9664f71361c47ef18defe7c": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-6be3aeccc5db12b916f74a2a004b1c0342d7e96cb9664f71361c47ef18defe7c",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "RAM GB",
+                          "label": "System RAM (GB)",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-6be3aeccc5db12b916f74a2a004b1c0342d7e96cb9664f71361c47ef18defe7c",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.ram.total_mb IS NOT NULL | STATS `RAM GB` = ROUND(MAX(gamepulse.hardware.ram.total_mb) / 1024.0, 0)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-6be3aeccc5db12b916f74a2a004b1c0342d7e96cb9664f71361c47ef18defe7c",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.ram.total_mb IS NOT NULL | STATS `RAM GB` = ROUND(MAX(gamepulse.hardware.ram.total_mb) / 1024.0, 0)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "System RAM (GB)"
+        },
+        "gridData": {
+          "h": 5,
+          "i": "kpi-ram-gb",
+          "w": 12,
+          "x": 24,
+          "y": 7
+        },
+        "panelIndex": "kpi-ram-gb",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-80bfee4cb5aac89c526434c48d151b8ebefe70113c5e76c33ea098761d8513ef": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-80bfee4cb5aac89c526434c48d151b8ebefe70113c5e76c33ea098761d8513ef",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "VRAM GB",
+                          "label": "GPU VRAM (GB)",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-80bfee4cb5aac89c526434c48d151b8ebefe70113c5e76c33ea098761d8513ef",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.gpu.vram_mb IS NOT NULL | STATS `VRAM GB` = ROUND(MAX(gamepulse.hardware.gpu.vram_mb) / 1024.0, 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-80bfee4cb5aac89c526434c48d151b8ebefe70113c5e76c33ea098761d8513ef",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.gpu.vram_mb IS NOT NULL | STATS `VRAM GB` = ROUND(MAX(gamepulse.hardware.gpu.vram_mb) / 1024.0, 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "GPU VRAM (GB)"
+        },
+        "gridData": {
+          "h": 5,
+          "i": "kpi-vram-gb",
+          "w": 12,
+          "x": 36,
+          "y": 7
+        },
+        "panelIndex": "kpi-vram-gb",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-gpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Temp (\u00b0C)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.temperature_c"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Hotspot (\u00b0C)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.hotspot_c"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Temperature (\u00b0C)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Temperature Over Time \u2014 Most AMD/NVIDIA GPUs throttle above 100\u00b0C junction / 110\u00b0C hotspot. Watch for gradual temperature rise indicating throttling across a long session."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-gpu-temp",
+          "w": 24,
+          "x": 0,
+          "y": 12
+        },
+        "panelIndex": "chart-gpu-temp",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-gpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Power (W)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.power_w"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Power (W)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Power Draw Over Time \u2014 Sustained high draw near card TDP = power-limited; watch for throttling. Power spikes on Vulkan/DX12 async compute reflect burst workloads."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-gpu-power",
+          "w": 24,
+          "x": 24,
+          "y": 12
+        },
+        "panelIndex": "chart-gpu-power",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-gpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Core Util %",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.utilisation_pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Utilisation (%)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Core Utilisation Over Time \u2014 100% = GPU fully saturated. Sub-100% during gameplay indicates CPU bottleneck or driver overhead. Low + low FPS = likely CPU-bound."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-gpu-util",
+          "w": 24,
+          "x": 0,
+          "y": 24
+        },
+        "panelIndex": "chart-gpu-util",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-gpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Core Clock (MHz)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.clock_mhz"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Clock (MHz)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Core Clock Over Time \u2014 Clock below rated boost speed indicates thermal or power throttling. Sustained clock reduction simultaneous with high temperature = thermal throttle."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-gpu-clock",
+          "w": 24,
+          "x": 24,
+          "y": 24
+        },
+        "panelIndex": "chart-gpu-clock",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-cpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total CPU %",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.cpu.total_utilisation_pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "CPU Utilisation (%)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "CPU Utilisation Over Time \u2014 Total CPU utilisation and per-core load. High total% with low GPU util = CPU bottleneck. Uneven per-core load suggests the game is not using all available cores."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-cpu-util",
+          "w": 24,
+          "x": 0,
+          "y": 34
+        },
+        "panelIndex": "chart-cpu-util",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-cpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "CPU Temp (\u00b0C)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.cpu.temperature_c"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg Clock (MHz)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.cpu.clock_mhz_avg"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Temp (\u00b0C) / Clock (MHz)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "CPU Temperature + Clock Over Time \u2014 Watch for temperature-induced frequency throttling (PROCHOT). Clock drop simultaneous with temp rise = thermal throttle."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-cpu-temp",
+          "w": 24,
+          "x": 24,
+          "y": 34
+        },
+        "panelIndex": "chart-cpu-temp",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-memory",
+                "name": "indexpattern-datasource-layer-area_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "area_0": {
+                      "columnOrder": [
+                        "area_x",
+                        "area_breakdown",
+                        "area_y_0",
+                        "area_y_1"
+                      ],
+                      "columns": {
+                        "area_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "area_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "area_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "area_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "System Used (MB)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.memory.system_used_mb"
+                        },
+                        "area_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Game RSS (MB)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.memory.game_rss_mb"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "area_y_0",
+                      "area_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "area_0",
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "splitAccessors": [
+                      "area_breakdown"
+                    ],
+                    "xAccessor": "area_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "area_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "area_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "area",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Memory (MB)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "System Memory Usage Over Time \u2014 Game RSS = resident set size (physical memory used by the game process). High page cache hit rate is desirable; major page faults indicate RAM pressure."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-memory",
+          "w": 24,
+          "x": 0,
+          "y": 44
+        },
+        "panelIndex": "chart-memory",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-memory",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Swap Used (MB)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.memory.swap_used_mb"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Page Cache (MB)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.memory.page_cache_mb"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Memory (MB)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Swap + Page Cache Over Time \u2014 Swap usage during gaming = system is RAM-constrained. Evicting page cache under memory pressure causes asset re-load stutters."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-swap",
+          "w": 24,
+          "x": 24,
+          "y": 44
+        },
+        "panelIndex": "chart-swap",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-storage",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Read (MB/s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.storage.read_mbps"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Write (MB/s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.storage.write_mbps"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Throughput (MB/s)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Storage Throughput Over Time \u2014 High read throughput during gameplay indicates asset streaming or shader cache loading. NVMe drives should sustain > 1 GB/s; HDD-class storage may bottleneck texture streaming."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-storage",
+          "w": 24,
+          "x": 0,
+          "y": 54
+        },
+        "panelIndex": "chart-storage",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-power",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Battery Draw (W)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.power.battery_rate_w"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Current TDP (W)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.power.tdp_current_w"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Power (W)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Power Profile Over Time \u2014 Battery drain rate, TDP, and power profile. Battery devices: sustained gaming drains ~10\u201325 W on handheld hardware."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-power",
+          "w": 24,
+          "x": 24,
+          "y": 54
+        },
+        "panelIndex": "chart-power",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7",
+                        "datatable_accessor_metric_8",
+                        "datatable_accessor_metric_9",
+                        "datatable_accessor_metric_10"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "VRAM (MB)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.vram_mb"
+                        },
+                        "datatable_accessor_metric_10": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Kernel",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.kernel"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Vendor",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.vendor"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Vulkan Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.vulkan_driver"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "CPU",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.cpu.model"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Cores",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.cpu.cores"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "RAM (MB)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.ram.total_mb"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "RAM Type",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.ram.type"
+                        },
+                        "datatable_accessor_metric_8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Device Type",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.device.type"
+                        },
+                        "datatable_accessor_metric_9": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "OS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.name"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "asc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 10
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.model"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_8",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_9",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_10",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Hardware Configurations Seen \u2014 grouped by GPU model"
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-hw-profile",
+          "w": 48,
+          "x": 0,
+          "y": 64
+        },
+        "panelIndex": "table-hw-profile",
+        "type": "vis"
+      }
+    ],
+    "timeFrom": "now-90d",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "GamePulse \u2014 Hardware Environment"
+  },
+  "id": "gamepulse-gp-hardware",
+  "references": [
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-game:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-driver:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-kernel:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-gpu",
+      "name": "chart-gpu-temp:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-gpu",
+      "name": "chart-gpu-power:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-gpu",
+      "name": "chart-gpu-util:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-gpu",
+      "name": "chart-gpu-clock:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-cpu",
+      "name": "chart-cpu-util:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-cpu",
+      "name": "chart-cpu-temp:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-memory",
+      "name": "chart-memory:indexpattern-datasource-layer-area_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-memory",
+      "name": "chart-swap:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-storage",
+      "name": "chart-storage:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-power",
+      "name": "chart-power:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-hw-profile:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "dashboard"
+}

--- a/packages/gamepulse/kibana/dashboard/gamepulse-gp-home.json
+++ b/packages/gamepulse/kibana/dashboard/gamepulse-gp-home.json
@@ -1,0 +1,1489 @@
+{
+  "attributes": {
+    "description": "Your gaming life at a glance: sessions played, hours logged, FPS trends, and current hardware. Start here, drill down with the navigation links above.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {}
+    },
+    "optionsJSON": {
+      "autoApplyFilters": true,
+      "hidePanelBorders": false,
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": true,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "content": "**GamePulse** &nbsp;\u00b7&nbsp; [Player Overview](/app/dashboards#/view/gamepulse-gp-home) &nbsp;|&nbsp; [Game Performance](/app/dashboards#/view/gamepulse-gp-game-perf) &nbsp;|&nbsp; [Game Engine](/app/dashboards#/view/gamepulse-gp-engine) &nbsp;|&nbsp; [Hardware](/app/dashboards#/view/gamepulse-gp-hardware) &nbsp;|&nbsp; [Software Env](/app/dashboards#/view/gamepulse-gp-software)",
+          "settings": {
+            "open_links_in_new_tab": true
+          }
+        },
+        "gridData": {
+          "h": 3,
+          "i": "nav-bar",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "nav-bar",
+        "type": "markdown"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.name",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Game",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-game",
+          "w": 16,
+          "x": 0,
+          "y": 3
+        },
+        "panelIndex": "ctrl-game",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.hardware.gpu.driver_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "GPU Driver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-driver",
+          "w": 16,
+          "x": 16,
+          "y": 3
+        },
+        "panelIndex": "ctrl-driver",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "host.os.kernel",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "OS Kernel",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-kernel",
+          "w": 16,
+          "x": 32,
+          "y": 3
+        },
+        "panelIndex": "ctrl-kernel",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Sessions",
+                          "label": "Sessions Played",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Sessions Played"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-sessions",
+          "w": 12,
+          "x": 0,
+          "y": 7
+        },
+        "panelIndex": "kpi-sessions",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-47a41c3882e1307e6ea2af72476945c677847d9ca0e14fa8b8ca97ba06b98f27": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-47a41c3882e1307e6ea2af72476945c677847d9ca0e14fa8b8ca97ba06b98f27",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Games",
+                          "label": "Games Played",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-47a41c3882e1307e6ea2af72476945c677847d9ca0e14fa8b8ca97ba06b98f27",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.game.name IS NOT NULL | STATS `Games` = COUNT_DISTINCT(gamepulse.game.name)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-47a41c3882e1307e6ea2af72476945c677847d9ca0e14fa8b8ca97ba06b98f27",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.game.name IS NOT NULL | STATS `Games` = COUNT_DISTINCT(gamepulse.game.name)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Games Played"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-games",
+          "w": 12,
+          "x": 12,
+          "y": 7
+        },
+        "panelIndex": "kpi-games",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Hours",
+                          "label": "Total Hours Played",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Hours` = ROUND(SUM(gamepulse.summary.duration_s) / 3600.0, 1)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-cc6af882c8e13cb1762ed6d2855c1de6a59f522847ce1c3f8d9ec470adae1a98",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Hours` = ROUND(SUM(gamepulse.summary.duration_s) / 3600.0, 1)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Total Hours Played"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-hours",
+          "w": 12,
+          "x": 24,
+          "y": 7
+        },
+        "panelIndex": "kpi-hours",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Avg FPS",
+                          "label": "Overall Avg FPS",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.avg_fps IS NOT NULL | STATS `Avg FPS` = ROUND(AVG(gamepulse.summary.avg_fps), 0)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-faab828ab2fe9b68adc7e70fbcedde8362188d29dfcb60500aba6e7acc37520b",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true AND gamepulse.summary.avg_fps IS NOT NULL | STATS `Avg FPS` = ROUND(AVG(gamepulse.summary.avg_fps), 0)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Overall Avg FPS"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-avg-fps",
+          "w": 12,
+          "x": 36,
+          "y": 7
+        },
+        "panelIndex": "kpi-avg-fps",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-frame",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 30
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS (1 s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.avg_1s"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.low_1pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Frames Per Second"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "FPS Over Time \u2014 Each colour is one gaming session. Gaps between sessions are natural play breaks."
+        },
+        "gridData": {
+          "h": 16,
+          "i": "chart-fps-time",
+          "w": 48,
+          "x": 0,
+          "y": 13
+        },
+        "panelIndex": "chart-fps-time",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Seconds",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.duration_s"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Total Play Time by Game \u2014 most-played first"
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-hours-game",
+          "w": 24,
+          "x": 0,
+          "y": 29
+        },
+        "panelIndex": "table-hours-game",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "FPS Performance by Game \u2014 highest avg FPS first"
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-game",
+          "w": 24,
+          "x": 24,
+          "y": 29
+        },
+        "panelIndex": "table-fps-game",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7",
+                        "datatable_accessor_metric_8",
+                        "datatable_accessor_metric_9",
+                        "datatable_accessor_metric_10"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Game",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Duration (s)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.duration_s"
+                        },
+                        "datatable_accessor_metric_10": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Proton",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.compatibility.proton_version"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "p99 Frame (ms)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.p99_frametime_ms"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutters",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Bottleneck",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.bottleneck_dominant"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Peak GPU \u00b0C",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.peak_gpu_temp_c"
+                        },
+                        "datatable_accessor_metric_8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_metric_9": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Kernel",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.kernel"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 100
+                          },
+                          "sourceField": "gamepulse.session.id"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_8",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_9",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_10",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Session History \u2014 most recent sessions first (shows all fields for the selected time range)"
+        },
+        "gridData": {
+          "h": 14,
+          "i": "table-sessions",
+          "w": 48,
+          "x": 0,
+          "y": 39
+        },
+        "panelIndex": "table-sessions",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7",
+                        "datatable_accessor_metric_8"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "VRAM (MB)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.vram_mb"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Vendor",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.vendor"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "CPU",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.cpu.model"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "CPU Cores",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.cpu.cores"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "RAM (MB)",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.ram.total_mb"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "RAM Type",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.ram.type"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "OS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.name"
+                        },
+                        "datatable_accessor_metric_8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Kernel",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.kernel"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "asc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 5
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.model"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_8",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Hardware Profiles \u2014 one row per GPU model seen (most recent first)"
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-hw",
+          "w": 48,
+          "x": 0,
+          "y": 53
+        },
+        "panelIndex": "table-hw",
+        "type": "vis"
+      }
+    ],
+    "timeFrom": "now-90d",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "GamePulse \u2014 Player Overview"
+  },
+  "id": "gamepulse-gp-home",
+  "references": [
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-game:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-driver:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-kernel:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-frame",
+      "name": "chart-fps-time:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-hours-game:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-game:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-sessions:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-hw:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "dashboard"
+}

--- a/packages/gamepulse/kibana/dashboard/gamepulse-gp-regression-lab.json
+++ b/packages/gamepulse/kibana/dashboard/gamepulse-gp-regression-lab.json
@@ -1,0 +1,2904 @@
+{
+  "type": "dashboard",
+  "id": "gamepulse-gp-regression-lab",
+  "attributes": {
+    "title": "GamePulse - Regression Lab",
+    "description": "Curated 90-day regression dashboard for driver, Proton, kernel, hardware, and low-level causality checks.",
+    "timeFrom": "now-90d",
+    "timeTo": "now",
+    "timeRestore": true,
+    "optionsJSON": {
+      "autoApplyFilters": true,
+      "hidePanelBorders": false,
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": true,
+      "useMargins": true
+    },
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {}
+    },
+    "panelsJSON": [
+      {
+        "type": "markdown",
+        "panelIndex": "nav-bar",
+        "gridData": {
+          "x": 0,
+          "y": 0,
+          "w": 48,
+          "h": 3,
+          "i": "nav-bar"
+        },
+        "embeddableConfig": {
+          "content": "**GamePulse** &nbsp;.&nbsp; [Command Center](/app/dashboards#/view/gamepulse-gp-command-center) &nbsp;|&nbsp; [Regression Lab](/app/dashboards#/view/gamepulse-gp-regression-lab) &nbsp;|&nbsp; [Player Overview](/app/dashboards#/view/gamepulse-gp-home) &nbsp;|&nbsp; [Game Performance](/app/dashboards#/view/gamepulse-gp-game-perf) &nbsp;|&nbsp; [Engine](/app/dashboards#/view/gamepulse-gp-engine) &nbsp;|&nbsp; [Hardware](/app/dashboards#/view/gamepulse-gp-hardware) &nbsp;|&nbsp; [Software](/app/dashboards#/view/gamepulse-gp-software) &nbsp;|&nbsp; [Compare](/app/dashboards#/view/828db140-b330-4d26-8045-40a7895bfc41)",
+          "settings": {
+            "open_links_in_new_tab": true
+          }
+        }
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.name",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Game",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-game",
+          "w": 12,
+          "x": 0,
+          "y": 3
+        },
+        "panelIndex": "ctrl-game",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.hardware.gpu.driver_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "GPU Driver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-driver",
+          "w": 12,
+          "x": 12,
+          "y": 3
+        },
+        "panelIndex": "ctrl-driver",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.compatibility.proton_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Proton Ver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-proton",
+          "w": 12,
+          "x": 24,
+          "y": 3
+        },
+        "panelIndex": "ctrl-proton",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "host.os.kernel",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "OS Kernel",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-kernel",
+          "w": 12,
+          "x": 36,
+          "y": 3
+        },
+        "panelIndex": "ctrl-kernel",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-dd7385d11db16b3460125de5a71af003c322e3993f4be67c779e68178a47bca1": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-dd7385d11db16b3460125de5a71af003c322e3993f4be67c779e68178a47bca1",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Drivers",
+                          "label": "GPU Driver Versions Tested",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-dd7385d11db16b3460125de5a71af003c322e3993f4be67c779e68178a47bca1",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.gpu.driver_version IS NOT NULL | STATS `Drivers` = COUNT_DISTINCT(gamepulse.hardware.gpu.driver_version)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-dd7385d11db16b3460125de5a71af003c322e3993f4be67c779e68178a47bca1",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.gpu.driver_version IS NOT NULL | STATS `Drivers` = COUNT_DISTINCT(gamepulse.hardware.gpu.driver_version)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "GPU Driver Versions Tested"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-drivers",
+          "w": 8,
+          "x": 0,
+          "y": 7
+        },
+        "panelIndex": "kpi-drivers",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-15be1e492cddd0dc5a01ccdb86b885e40d9d2a0876c2dfca566fa6d9fdbca834": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-15be1e492cddd0dc5a01ccdb86b885e40d9d2a0876c2dfca566fa6d9fdbca834",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Proton Versions",
+                          "label": "Proton Versions Tested",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-15be1e492cddd0dc5a01ccdb86b885e40d9d2a0876c2dfca566fa6d9fdbca834",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.compatibility.proton_version IS NOT NULL | STATS `Proton Versions` = COUNT_DISTINCT(gamepulse.compatibility.proton_version)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-15be1e492cddd0dc5a01ccdb86b885e40d9d2a0876c2dfca566fa6d9fdbca834",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.compatibility.proton_version IS NOT NULL | STATS `Proton Versions` = COUNT_DISTINCT(gamepulse.compatibility.proton_version)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Proton Versions Tested"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-protons",
+          "w": 8,
+          "x": 8,
+          "y": 7
+        },
+        "panelIndex": "kpi-protons",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-765ab1f6a035749215233c5fa63a40378b34b025541cee2513ee0a9e67dbbdcb": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-765ab1f6a035749215233c5fa63a40378b34b025541cee2513ee0a9e67dbbdcb",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Kernels",
+                          "label": "Kernels Tested",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-765ab1f6a035749215233c5fa63a40378b34b025541cee2513ee0a9e67dbbdcb",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE host.os.kernel IS NOT NULL | STATS `Kernels` = COUNT_DISTINCT(host.os.kernel)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-765ab1f6a035749215233c5fa63a40378b34b025541cee2513ee0a9e67dbbdcb",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE host.os.kernel IS NOT NULL | STATS `Kernels` = COUNT_DISTINCT(host.os.kernel)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Kernels Tested"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-kernels",
+          "w": 8,
+          "x": 16,
+          "y": 7
+        },
+        "panelIndex": "kpi-kernels",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-1de0e3305c304428edfcde8b18d94a03dee86ec7a0b7b20234e31c710aadd0e7": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-1de0e3305c304428edfcde8b18d94a03dee86ec7a0b7b20234e31c710aadd0e7",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Peak FPS",
+                          "label": "Peak Avg FPS Seen",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-1de0e3305c304428edfcde8b18d94a03dee86ec7a0b7b20234e31c710aadd0e7",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.avg_fps IS NOT NULL | STATS `Peak FPS` = ROUND(MAX(gamepulse.summary.avg_fps), 0)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-1de0e3305c304428edfcde8b18d94a03dee86ec7a0b7b20234e31c710aadd0e7",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.avg_fps IS NOT NULL | STATS `Peak FPS` = ROUND(MAX(gamepulse.summary.avg_fps), 0)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Peak Avg FPS Seen"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-best-fps",
+          "w": 8,
+          "x": 24,
+          "y": 7
+        },
+        "panelIndex": "kpi-best-fps",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Sessions",
+                          "label": "Total Sessions",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Total Sessions"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-sessions",
+          "w": 8,
+          "x": 32,
+          "y": 7
+        },
+        "panelIndex": "kpi-sessions",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.audio-default-a713573d408e97e440f40be55edfa87919d2ecde621e213dd05ce1eaac4fa9ed": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.audio-default-a713573d408e97e440f40be55edfa87919d2ecde621e213dd05ce1eaac4fa9ed",
+                  "name": "metrics-gamepulse.audio-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.audio-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Audio Backends",
+                          "label": "Audio Backends",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.audio-default-a713573d408e97e440f40be55edfa87919d2ecde621e213dd05ce1eaac4fa9ed",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.audio-default | WHERE gamepulse.audio.backend IS NOT NULL | STATS `Audio Backends` = COUNT_DISTINCT(gamepulse.audio.backend)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.audio-default-a713573d408e97e440f40be55edfa87919d2ecde621e213dd05ce1eaac4fa9ed",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.audio-default | WHERE gamepulse.audio.backend IS NOT NULL | STATS `Audio Backends` = COUNT_DISTINCT(gamepulse.audio.backend)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Audio Backends"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-audio",
+          "w": 8,
+          "x": 40,
+          "y": 7
+        },
+        "panelIndex": "kpi-audio",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-frame",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 30
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS (1 s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.avg_1s"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Frames Per Second"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "FPS Over Time Coloured by GPU Driver \u2014 Each session coloured by the driver version running at the time. Driver updates that improve or regress FPS are visible as colour-shifted bands. Use the Game filter above to focus on a single title."
+        },
+        "gridData": {
+          "h": 14,
+          "i": "chart-fps-by-driver",
+          "w": 48,
+          "x": 0,
+          "y": 13
+        },
+        "panelIndex": "chart-fps-by-driver",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Avg FPS by GPU Driver Version \u2014 Which driver delivered the best performance? Compare avg FPS and 1% lows across driver versions."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-driver",
+          "w": 24,
+          "x": 0,
+          "y": 27
+        },
+        "panelIndex": "table-fps-driver",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.compatibility.proton_version"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Avg FPS by Proton Version \u2014 Which Proton/Wine version delivered the best compatibility and performance? Shows only sessions where Proton was active."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-proton",
+          "w": 24,
+          "x": 24,
+          "y": 27
+        },
+        "panelIndex": "table-fps-proton",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "host.os.kernel"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Avg FPS by Kernel Version \u2014 Kernel scheduler and GPU driver stack differences can affect framerate. Useful for identifying kernel regressions on gaming-tuned builds (CachyOS, Nobara, etc.)."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-kernel",
+          "w": 24,
+          "x": 0,
+          "y": 37
+        },
+        "panelIndex": "table-fps-kernel",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "secondaryFields": [
+                              "gamepulse.compatibility.proton_version",
+                              "gamepulse.hardware.gpu.driver_version"
+                            ],
+                            "size": 50
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Compatibility Matrix \u2014 Game \u00d7 Proton Version \u00d7 GPU Driver. Each row = one combination tested. Useful for validating compatibility before recommending a software stack for a specific title."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-compat",
+          "w": 24,
+          "x": 24,
+          "y": 37
+        },
+        "panelIndex": "table-compat",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-gpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Temp (\u00b0C)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.temperature_c"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Hotspot (\u00b0C)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.hotspot_c"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Temperature (\u00b0C)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Temperature Over Time \u2014 Most AMD/NVIDIA GPUs throttle above 100\u00b0C junction / 110\u00b0C hotspot. Watch for gradual temperature rise indicating throttling across a long session."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-gpu-temp",
+          "w": 24,
+          "x": 0,
+          "y": 47
+        },
+        "panelIndex": "chart-gpu-temp",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-gpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Power (W)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.gpu.power_w"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Power (W)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Power Draw Over Time \u2014 Sustained high draw near card TDP = power-limited; watch for throttling. Power spikes on Vulkan/DX12 async compute reflect burst workloads."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-gpu-power",
+          "w": 24,
+          "x": 24,
+          "y": 47
+        },
+        "panelIndex": "chart-gpu-power",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-cpu",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total CPU %",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.cpu.total_utilisation_pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "CPU Utilisation (%)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "CPU Utilisation Over Time \u2014 Total CPU utilisation and per-core load. High total% with low GPU util = CPU bottleneck. Uneven per-core load suggests the game is not using all available cores."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-cpu-util",
+          "w": 24,
+          "x": 0,
+          "y": 57
+        },
+        "panelIndex": "chart-cpu-util",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-memory",
+                "name": "indexpattern-datasource-layer-area_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "area_0": {
+                      "columnOrder": [
+                        "area_x",
+                        "area_breakdown",
+                        "area_y_0",
+                        "area_y_1"
+                      ],
+                      "columns": {
+                        "area_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "area_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "area_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "area_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "System Used (MB)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.memory.system_used_mb"
+                        },
+                        "area_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Game RSS (MB)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.memory.game_rss_mb"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "area_y_0",
+                      "area_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "area_0",
+                    "layerType": "data",
+                    "seriesType": "area",
+                    "splitAccessors": [
+                      "area_breakdown"
+                    ],
+                    "xAccessor": "area_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "area_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "area_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "area",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Memory (MB)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "System Memory Usage Over Time \u2014 Game RSS = resident set size (physical memory used by the game process). High page cache hit rate is desirable; major page faults indicate RAM pressure."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-memory",
+          "w": 24,
+          "x": 24,
+          "y": 57
+        },
+        "panelIndex": "chart-memory",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Fence (\u00b5s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.gpu_fence.latency_avg_us"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Sched (\u00b5s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.gpu_sched.latency_avg_us"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Latency (\u00b5s)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "GPU Pipeline Latency Over Time \u2014 GPU fence latency = time from command submission to GPU completion (measured by DRM fence callbacks). GPU scheduler latency = time GPU work spends queued waiting for execution. Spikes indicate GPU ring buffer saturation or driver overhead."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-gpu-pipeline",
+          "w": 48,
+          "x": 0,
+          "y": 67
+        },
+        "panelIndex": "chart-gpu-pipeline",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutter Severity",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.stutter.severity_score"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Stutter Severity Score (0\u20131)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Stutter Severity Score Over Time \u2014 Composite score from frame drops + scheduler misses + I/O spikes. Score > 0.3 is noticeable; > 0.6 is severe. Correlate spikes with GPU pipeline and runqueue panels above."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-stutter-score",
+          "w": 48,
+          "x": 0,
+          "y": 79
+        },
+        "panelIndex": "chart-stutter-score",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Runqueue Latency (\u00b5s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.runqueue.latency_avg_us"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Runqueue Latency (\u00b5s)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "CPU Scheduler Latency Over Time \u2014 Runqueue latency is the time game threads spend waiting for a CPU core. High values (>200 \u00b5s) indicate CPU saturation, conflicting affinity, or SMT interference. CCX migrations = cross-chiplet scheduler migrations on AMD Zen (expensive cache miss)."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-cpu-sched",
+          "w": 24,
+          "x": 0,
+          "y": 91
+        },
+        "panelIndex": "chart-cpu-sched",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-ebpf",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "BIO Latency (\u00b5s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.ebpf.bio.latency_avg_us"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "BIO Latency (\u00b5s)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Block I/O Latency Over Time \u2014 High I/O latency during gameplay indicates shader cache compilation I/O or asset streaming bottleneck. Correlate with FPS drops on the Game Performance dashboard."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "chart-io-lat",
+          "w": 24,
+          "x": 24,
+          "y": 91
+        },
+        "panelIndex": "chart-io-lat",
+        "type": "vis"
+      }
+    ]
+  },
+  "references": [
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-game:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-driver:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-proton:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-kernel:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-frame",
+      "name": "chart-fps-by-driver:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-driver:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-proton:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-kernel:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-compat:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-gpu",
+      "name": "chart-gpu-temp:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-gpu",
+      "name": "chart-gpu-power:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-cpu",
+      "name": "chart-cpu-util:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-memory",
+      "name": "chart-memory:indexpattern-datasource-layer-area_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-gpu-pipeline:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-cpu-sched:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-io-lat:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-ebpf",
+      "name": "chart-stutter-score:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    }
+  ]
+}

--- a/packages/gamepulse/kibana/dashboard/gamepulse-gp-software.json
+++ b/packages/gamepulse/kibana/dashboard/gamepulse-gp-software.json
@@ -1,0 +1,2413 @@
+{
+  "attributes": {
+    "description": "Software stack regression analysis: compare FPS across GPU driver versions, Proton versions, and kernels. Compatibility matrix for game \u00d7 software stack combinations. Essential for distribution maintainers, driver authors, and Proton developers.",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {}
+    },
+    "optionsJSON": {
+      "autoApplyFilters": true,
+      "hidePanelBorders": false,
+      "hidePanelTitles": false,
+      "syncColors": true,
+      "syncCursor": true,
+      "syncTooltips": true,
+      "useMargins": true
+    },
+    "panelsJSON": [
+      {
+        "embeddableConfig": {
+          "content": "**GamePulse** &nbsp;\u00b7&nbsp; [Player Overview](/app/dashboards#/view/gamepulse-gp-home) &nbsp;|&nbsp; [Game Performance](/app/dashboards#/view/gamepulse-gp-game-perf) &nbsp;|&nbsp; [Game Engine](/app/dashboards#/view/gamepulse-gp-engine) &nbsp;|&nbsp; [Hardware](/app/dashboards#/view/gamepulse-gp-hardware) &nbsp;|&nbsp; [Software Env](/app/dashboards#/view/gamepulse-gp-software)",
+          "settings": {
+            "open_links_in_new_tab": true
+          }
+        },
+        "gridData": {
+          "h": 3,
+          "i": "nav-bar",
+          "w": 48,
+          "x": 0,
+          "y": 0
+        },
+        "panelIndex": "nav-bar",
+        "type": "markdown"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.game.name",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Game",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-game",
+          "w": 12,
+          "x": 0,
+          "y": 3
+        },
+        "panelIndex": "ctrl-game",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.hardware.gpu.driver_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "GPU Driver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-driver",
+          "w": 12,
+          "x": 12,
+          "y": 3
+        },
+        "panelIndex": "ctrl-driver",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "gamepulse.compatibility.proton_version",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "Proton Ver",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-proton",
+          "w": 12,
+          "x": 24,
+          "y": 3
+        },
+        "panelIndex": "ctrl-proton",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "dataViewRefName": "optionsListDataView",
+          "exclude": false,
+          "exists_selected": false,
+          "field_name": "host.os.kernel",
+          "ignore_validations": false,
+          "run_past_timeout": false,
+          "search_technique": "wildcard",
+          "selected_options": [],
+          "single_select": false,
+          "sort": {
+            "by": "_count",
+            "direction": "desc"
+          },
+          "title": "OS Kernel",
+          "use_global_filters": true
+        },
+        "gridData": {
+          "h": 4,
+          "i": "ctrl-kernel",
+          "w": 12,
+          "x": 36,
+          "y": 3
+        },
+        "panelIndex": "ctrl-kernel",
+        "type": "options_list_control"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-dd7385d11db16b3460125de5a71af003c322e3993f4be67c779e68178a47bca1": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-dd7385d11db16b3460125de5a71af003c322e3993f4be67c779e68178a47bca1",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Drivers",
+                          "label": "GPU Driver Versions Tested",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-dd7385d11db16b3460125de5a71af003c322e3993f4be67c779e68178a47bca1",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.gpu.driver_version IS NOT NULL | STATS `Drivers` = COUNT_DISTINCT(gamepulse.hardware.gpu.driver_version)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-dd7385d11db16b3460125de5a71af003c322e3993f4be67c779e68178a47bca1",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.hardware.gpu.driver_version IS NOT NULL | STATS `Drivers` = COUNT_DISTINCT(gamepulse.hardware.gpu.driver_version)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "GPU Driver Versions Tested"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-drivers",
+          "w": 8,
+          "x": 0,
+          "y": 7
+        },
+        "panelIndex": "kpi-drivers",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-15be1e492cddd0dc5a01ccdb86b885e40d9d2a0876c2dfca566fa6d9fdbca834": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-15be1e492cddd0dc5a01ccdb86b885e40d9d2a0876c2dfca566fa6d9fdbca834",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Proton Versions",
+                          "label": "Proton Versions Tested",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-15be1e492cddd0dc5a01ccdb86b885e40d9d2a0876c2dfca566fa6d9fdbca834",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.compatibility.proton_version IS NOT NULL | STATS `Proton Versions` = COUNT_DISTINCT(gamepulse.compatibility.proton_version)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-15be1e492cddd0dc5a01ccdb86b885e40d9d2a0876c2dfca566fa6d9fdbca834",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.compatibility.proton_version IS NOT NULL | STATS `Proton Versions` = COUNT_DISTINCT(gamepulse.compatibility.proton_version)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Proton Versions Tested"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-protons",
+          "w": 8,
+          "x": 8,
+          "y": 7
+        },
+        "panelIndex": "kpi-protons",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-765ab1f6a035749215233c5fa63a40378b34b025541cee2513ee0a9e67dbbdcb": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-765ab1f6a035749215233c5fa63a40378b34b025541cee2513ee0a9e67dbbdcb",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Kernels",
+                          "label": "Kernels Tested",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-765ab1f6a035749215233c5fa63a40378b34b025541cee2513ee0a9e67dbbdcb",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE host.os.kernel IS NOT NULL | STATS `Kernels` = COUNT_DISTINCT(host.os.kernel)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-765ab1f6a035749215233c5fa63a40378b34b025541cee2513ee0a9e67dbbdcb",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE host.os.kernel IS NOT NULL | STATS `Kernels` = COUNT_DISTINCT(host.os.kernel)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Kernels Tested"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-kernels",
+          "w": 8,
+          "x": 16,
+          "y": 7
+        },
+        "panelIndex": "kpi-kernels",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-1de0e3305c304428edfcde8b18d94a03dee86ec7a0b7b20234e31c710aadd0e7": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-1de0e3305c304428edfcde8b18d94a03dee86ec7a0b7b20234e31c710aadd0e7",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Peak FPS",
+                          "label": "Peak Avg FPS Seen",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-1de0e3305c304428edfcde8b18d94a03dee86ec7a0b7b20234e31c710aadd0e7",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.avg_fps IS NOT NULL | STATS `Peak FPS` = ROUND(MAX(gamepulse.summary.avg_fps), 0)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-1de0e3305c304428edfcde8b18d94a03dee86ec7a0b7b20234e31c710aadd0e7",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.avg_fps IS NOT NULL | STATS `Peak FPS` = ROUND(MAX(gamepulse.summary.avg_fps), 0)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Peak Avg FPS Seen"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-best-fps",
+          "w": 8,
+          "x": 24,
+          "y": 7
+        },
+        "panelIndex": "kpi-best-fps",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "metrics-gamepulse.session-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.session-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Sessions",
+                          "label": "Total Sessions",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.session-default-9e326534e7ff024899bbfebddef4f0476e65c87f723fd4fc482d1334889f6352",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.session-default | WHERE gamepulse.summary.ended == true | STATS `Sessions` = COUNT(*)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Total Sessions"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-sessions",
+          "w": 8,
+          "x": 32,
+          "y": 7
+        },
+        "panelIndex": "kpi-sessions",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [],
+            "state": {
+              "adHocDataViews": {
+                "metrics-gamepulse.audio-default-a713573d408e97e440f40be55edfa87919d2ecde621e213dd05ce1eaac4fa9ed": {
+                  "allowHidden": false,
+                  "allowNoIndex": false,
+                  "fieldAttrs": {},
+                  "fieldFormats": {},
+                  "id": "metrics-gamepulse.audio-default-a713573d408e97e440f40be55edfa87919d2ecde621e213dd05ce1eaac4fa9ed",
+                  "name": "metrics-gamepulse.audio-default",
+                  "runtimeFieldMap": {},
+                  "sourceFilters": [],
+                  "title": "metrics-gamepulse.audio-default",
+                  "type": "esql"
+                }
+              },
+              "datasourceStates": {
+                "textBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columns": [
+                        {
+                          "columnId": "metric_accessor_metric",
+                          "customLabel": true,
+                          "fieldName": "Audio Backends",
+                          "label": "Audio Backends",
+                          "meta": {
+                            "type": "number"
+                          }
+                        }
+                      ],
+                      "index": "metrics-gamepulse.audio-default-a713573d408e97e440f40be55edfa87919d2ecde621e213dd05ce1eaac4fa9ed",
+                      "query": {
+                        "esql": "FROM metrics-gamepulse.audio-default | WHERE gamepulse.audio.backend IS NOT NULL | STATS `Audio Backends` = COUNT_DISTINCT(gamepulse.audio.backend)"
+                      }
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [
+                {
+                  "id": "metrics-gamepulse.audio-default-a713573d408e97e440f40be55edfa87919d2ecde621e213dd05ce1eaac4fa9ed",
+                  "name": "indexpattern-datasource-layer-layer_0",
+                  "type": "index-pattern"
+                }
+              ],
+              "query": {
+                "esql": "FROM metrics-gamepulse.audio-default | WHERE gamepulse.audio.backend IS NOT NULL | STATS `Audio Backends` = COUNT_DISTINCT(gamepulse.audio.backend)"
+              },
+              "visualization": {
+                "layerId": "layer_0",
+                "layerType": "data",
+                "metricAccessor": "metric_accessor_metric",
+                "primaryAlign": "center",
+                "primaryPosition": "bottom",
+                "showBar": false,
+                "subtitle": "",
+                "titlesTextAlign": "center",
+                "valueFontMode": "default"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsMetric"
+          },
+          "title": "Audio Backends"
+        },
+        "gridData": {
+          "h": 6,
+          "i": "kpi-audio",
+          "w": 8,
+          "x": 40,
+          "y": 7
+        },
+        "panelIndex": "kpi-audio",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-frame",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 30
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS (1 s)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.fps.avg_1s"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Frames Per Second"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "FPS Over Time Coloured by GPU Driver \u2014 Each session coloured by the driver version running at the time. Driver updates that improve or regress FPS are visible as colour-shifted bands. Use the Game filter above to focus on a single title."
+        },
+        "gridData": {
+          "h": 16,
+          "i": "chart-fps-by-driver",
+          "w": 48,
+          "x": 0,
+          "y": 13
+        },
+        "panelIndex": "chart-fps-by-driver",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Avg FPS by GPU Driver Version \u2014 Which driver delivered the best performance? Compare avg FPS and 1% lows across driver versions."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-driver",
+          "w": 24,
+          "x": 0,
+          "y": 29
+        },
+        "panelIndex": "table-fps-driver",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "gamepulse.compatibility.proton_version"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Avg FPS by Proton Version \u2014 Which Proton/Wine version delivered the best compatibility and performance? Shows only sessions where Proton was active."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-proton",
+          "w": 24,
+          "x": 24,
+          "y": 29
+        },
+        "panelIndex": "table-fps-proton",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "host.os.kernel"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Avg FPS by Kernel Version \u2014 Kernel scheduler and GPU driver stack differences can affect framerate. Useful for identifying kernel regressions on gaming-tuned builds (CachyOS, Nobara, etc.)."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-fps-kernel",
+          "w": 24,
+          "x": 0,
+          "y": 39
+        },
+        "panelIndex": "table-fps-kernel",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "1% Low FPS",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.summary.low_1pct_fps"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Total Stutters",
+                          "operationType": "sum",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Sessions",
+                          "operationType": "count",
+                          "params": {
+                            "emptyAsNull": false
+                          },
+                          "sourceField": "___records___"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "datatable_accessor_metric_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "secondaryFields": [
+                              "gamepulse.compatibility.proton_version",
+                              "gamepulse.hardware.gpu.driver_version"
+                            ],
+                            "size": 50
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Compatibility Matrix \u2014 Game \u00d7 Proton Version \u00d7 GPU Driver. Each row = one combination tested. Useful for validating compatibility before recommending a software stack for a specific title."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "table-compat",
+          "w": 24,
+          "x": 24,
+          "y": 39
+        },
+        "panelIndex": "table-compat",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-audio",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Audio Latency (ms)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.audio.latency_ms"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Latency (ms)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Audio Latency Over Time \u2014 High audio latency (> 20 ms) causes audio\u2013video desync. PipeWire with low-latency mode should maintain \u2264 5 ms buffer."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-audio-latency",
+          "w": 24,
+          "x": 0,
+          "y": 49
+        },
+        "panelIndex": "chart-audio-latency",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-audio",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Audio Xruns",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.audio.xruns"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Xrun Events / interval"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Audio Buffer Underruns (xruns) Over Time \u2014 xruns = audio buffer underrun events that cause pops/crackles. High rates indicate CPU overload or IRQ latency issues."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-audio-xruns",
+          "w": 24,
+          "x": 24,
+          "y": 49
+        },
+        "panelIndex": "chart-audio-xruns",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-network",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0",
+                        "line_y_1"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "RTT (ms)",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.network.rtt_ms"
+                        },
+                        "line_y_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Packet Loss %",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.network.packet_loss_pct"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0",
+                      "line_y_1"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      },
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_1"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "RTT (ms) / Loss (%)"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "Network RTT + Packet Loss \u2014 For online games: high RTT (> 50 ms) causes lag; packet loss > 1% causes rubber-banding and disconnects. Shows per-session network health."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-network",
+          "w": 32,
+          "x": 0,
+          "y": 59
+        },
+        "panelIndex": "chart-network",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-network",
+                "name": "indexpattern-datasource-layer-line_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "line_0": {
+                      "columnOrder": [
+                        "line_x",
+                        "line_breakdown",
+                        "line_y_0"
+                      ],
+                      "columns": {
+                        "line_breakdown": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "columnId": "line_y_0",
+                              "type": "column"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 20
+                          },
+                          "sourceField": "session_label"
+                        },
+                        "line_x": {
+                          "customLabel": false,
+                          "dataType": "date",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "date_histogram",
+                          "params": {
+                            "dropPartials": false,
+                            "ignoreTimeRange": false,
+                            "includeEmptyRows": false,
+                            "interval": "auto"
+                          },
+                          "sourceField": "@timestamp"
+                        },
+                        "line_y_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "TCP Retransmits/s",
+                          "operationType": "average",
+                          "sourceField": "gamepulse.network.tcp_retransmits_per_sec"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "axisTitlesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "curveType": "LINEAR",
+                "gridlinesVisibilitySettings": {
+                  "x": false,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "hideEndzones": true,
+                "labelsOrientation": {
+                  "x": 0,
+                  "yLeft": 0,
+                  "yRight": 0
+                },
+                "layers": [
+                  {
+                    "accessors": [
+                      "line_y_0"
+                    ],
+                    "colorMapping": {
+                      "assignments": [],
+                      "colorMode": {
+                        "type": "categorical"
+                      },
+                      "paletteId": "elastic_line_optimized",
+                      "specialAssignments": [
+                        {
+                          "color": {
+                            "type": "loop"
+                          },
+                          "rules": [
+                            {
+                              "type": "other"
+                            }
+                          ],
+                          "touched": false
+                        }
+                      ]
+                    },
+                    "layerId": "line_0",
+                    "layerType": "data",
+                    "seriesType": "line",
+                    "splitAccessors": [
+                      "line_breakdown"
+                    ],
+                    "xAccessor": "line_x",
+                    "yConfig": [
+                      {
+                        "axisMode": "left",
+                        "forAccessor": "line_y_0"
+                      }
+                    ]
+                  }
+                ],
+                "legend": {
+                  "isVisible": true,
+                  "maxLines": 2,
+                  "position": "right"
+                },
+                "pointVisibility": "auto",
+                "preferredSeriesType": "line",
+                "showCurrentTimeMarker": false,
+                "tickLabelsVisibilitySettings": {
+                  "x": true,
+                  "yLeft": true,
+                  "yRight": true
+                },
+                "xExtent": {
+                  "mode": "dataBounds",
+                  "niceValues": false
+                },
+                "yLeftExtent": {
+                  "mode": "full",
+                  "niceValues": true
+                },
+                "yLeftScale": "linear",
+                "yTitle": "Retransmits / second"
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsXY"
+          },
+          "title": "TCP Retransmits Per Second \u2014 Elevated retransmits indicate congested or unreliable network path. Correlate with RTT spikes above to distinguish latency from packet loss."
+        },
+        "gridData": {
+          "h": 10,
+          "i": "chart-tcp-retrans",
+          "w": 16,
+          "x": 32,
+          "y": 59
+        },
+        "panelIndex": "chart-tcp-retrans",
+        "type": "vis"
+      },
+      {
+        "embeddableConfig": {
+          "attributes": {
+            "references": [
+              {
+                "id": "gp-dv-session",
+                "name": "indexpattern-datasource-layer-layer_0",
+                "type": "index-pattern"
+              }
+            ],
+            "state": {
+              "adHocDataViews": {},
+              "datasourceStates": {
+                "formBased": {
+                  "layers": {
+                    "layer_0": {
+                      "columnOrder": [
+                        "datatable_accessor_row_0",
+                        "datatable_accessor_metric_0",
+                        "datatable_accessor_metric_1",
+                        "datatable_accessor_metric_2",
+                        "datatable_accessor_metric_3",
+                        "datatable_accessor_metric_4",
+                        "datatable_accessor_metric_5",
+                        "datatable_accessor_metric_6",
+                        "datatable_accessor_metric_7",
+                        "datatable_accessor_metric_8"
+                      ],
+                      "columns": {
+                        "datatable_accessor_metric_0": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Game",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.name"
+                        },
+                        "datatable_accessor_metric_1": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Proton",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.compatibility.proton_version"
+                        },
+                        "datatable_accessor_metric_2": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "DXVK",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.compatibility.dxvk_version"
+                        },
+                        "datatable_accessor_metric_3": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "VKD3D-Proton",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.compatibility.vkd3d_proton_version"
+                        },
+                        "datatable_accessor_metric_4": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Steam AppID",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.game.steam_app_id"
+                        },
+                        "datatable_accessor_metric_5": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "GPU Driver",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.hardware.gpu.driver_version"
+                        },
+                        "datatable_accessor_metric_6": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Kernel",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "host.os.kernel"
+                        },
+                        "datatable_accessor_metric_7": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Avg FPS",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.avg_fps"
+                        },
+                        "datatable_accessor_metric_8": {
+                          "customLabel": true,
+                          "dataType": "number",
+                          "isBucketed": false,
+                          "label": "Stutters",
+                          "operationType": "last_value",
+                          "params": {
+                            "showArrayValues": false,
+                            "sortField": "@timestamp"
+                          },
+                          "sourceField": "gamepulse.summary.stutter_count"
+                        },
+                        "datatable_accessor_row_0": {
+                          "customLabel": false,
+                          "dataType": "string",
+                          "isBucketed": true,
+                          "label": "",
+                          "operationType": "terms",
+                          "params": {
+                            "orderBy": {
+                              "type": "alphabetical"
+                            },
+                            "orderDirection": "desc",
+                            "parentFormat": {
+                              "id": "terms"
+                            },
+                            "size": 50
+                          },
+                          "sourceField": "gamepulse.session.id"
+                        }
+                      },
+                      "ignoreGlobalFilters": false,
+                      "sampling": 1
+                    }
+                  }
+                }
+              },
+              "filters": [],
+              "internalReferences": [],
+              "query": {
+                "language": "kuery",
+                "query": ""
+              },
+              "visualization": {
+                "columns": [
+                  {
+                    "columnId": "datatable_accessor_row_0",
+                    "isMetric": false,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_0",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_1",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_2",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_3",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_4",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_5",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_6",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_7",
+                    "isMetric": true,
+                    "isTransposed": false
+                  },
+                  {
+                    "columnId": "datatable_accessor_metric_8",
+                    "isMetric": true,
+                    "isTransposed": false
+                  }
+                ],
+                "headerRowHeight": "custom",
+                "headerRowHeightLines": 1,
+                "layerId": "layer_0",
+                "layerType": "data",
+                "rowHeight": "custom",
+                "rowHeightLines": 1
+              }
+            },
+            "title": "",
+            "visualizationType": "lnsDatatable"
+          },
+          "title": "Proton/Wine Environment per Session \u2014 Full compatibility layer metadata: DXVK version, VKD3D, Steam app ID, WINE_PREFIX."
+        },
+        "gridData": {
+          "h": 12,
+          "i": "table-proton-env",
+          "w": 48,
+          "x": 0,
+          "y": 69
+        },
+        "panelIndex": "table-proton-env",
+        "type": "vis"
+      }
+    ],
+    "timeFrom": "now-90d",
+    "timeRestore": true,
+    "timeTo": "now",
+    "title": "GamePulse \u2014 Software Environment"
+  },
+  "id": "gamepulse-gp-software",
+  "references": [
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-game:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-driver:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-proton:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "ctrl-kernel:optionsListDataView",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-frame",
+      "name": "chart-fps-by-driver:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-driver:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-proton:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-fps-kernel:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-compat:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-audio",
+      "name": "chart-audio-latency:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-audio",
+      "name": "chart-audio-xruns:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-network",
+      "name": "chart-network:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-network",
+      "name": "chart-tcp-retrans:indexpattern-datasource-layer-line_0",
+      "type": "index-pattern"
+    },
+    {
+      "id": "gp-dv-session",
+      "name": "table-proton-env:indexpattern-datasource-layer-layer_0",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "dashboard"
+}

--- a/packages/gamepulse/manifest.yml
+++ b/packages/gamepulse/manifest.yml
@@ -1,0 +1,40 @@
+format_version: "3.0.0"
+name: gamepulse
+title: "GamePulse"
+version: 0.1.1
+description: >
+  Gaming telemetry for Elastic: FPS, GPU/CPU metrics, frame timing percentiles,
+  and kernel-level scheduler, I/O, and GPU fence tracing via eBPF.
+  Understand why games perform the way they do — down to scheduler migrations and
+  shader compilation stutters.
+type: integration
+categories:
+  - monitoring
+  - observability
+conditions:
+  kibana:
+    version: "^8.13.0 || ^9.0.0"
+  elastic:
+    subscription: basic
+owner:
+  github: MathewRJ
+  type: community
+icons:
+  - src: img/icon.svg
+    title: GamePulse
+    type: image/svg+xml
+
+policy_templates:
+  - name: gamepulse
+    title: GamePulse Gaming Telemetry
+    description: >
+      Collect gaming performance metrics and kernel telemetry via eBPF.
+      Covers CPU, GPU, frame timing, memory, storage, network, audio, power,
+      session lifecycle, discrete events, and scheduler/I/O/GPU kernel probes.
+    inputs:
+      - type: filestream
+        title: Collect GamePulse events
+        description: >
+          Optional: collect GamePulse event logs from disk. The gamepulse-agent
+          sends metrics directly to Elasticsearch — this input is only needed
+          if you also want file-based event capture.


### PR DESCRIPTION
## What does this PR do?

Adds the **GamePulse** integration — a gaming performance telemetry agent that collects CPU, GPU, memory, frame timing, storage, network, audio, power, session lifecycle, discrete events, and kernel-level eBPF scheduler/I/O/GPU fence metrics, shipping them directly to Elasticsearch via Fleet.

## Why is it important?

Gaming is one of the largest consumer workloads on Linux (Steam Deck, desktop gaming rigs) and Windows, yet there is no existing Elastic integration for gaming performance telemetry. GamePulse fills that gap, providing frame-time analysis, stutter detection, and hardware bottleneck identification in Kibana.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and my integration follows the best practices.
- [x] [Unit tests](https://github.com/elastic/integrations/blob/main/docs/testing_and_validation.md) were added for the ingest pipeline (all 11 data streams have pipeline tests; 24/24 pass).
- [x] An [*ingest pipeline*](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md#ingest-pipeline) is defined for every data stream that requires data transformation.
- [x] Fields follow ECS where applicable (`event.*`, `host.*`, `service.*`, `ecs.version`).
- [x] All fields are documented in `fields/fields.yml` and `fields/base-fields.yml`.
- [x] `elastic-package check` passes.
- [x] `elastic-package test pipeline` passes (all 24 test cases).
- [ ] Screenshots — placeholder `img/screenshots/.gitkeep` is present; real screenshots will be added before merge if reviewers request them (dashboards are live on Elastic Cloud and can be captured).

## Checklist for the reviewer

- Does the integration follow the [package spec](https://github.com/elastic/package-spec)?
- Are the ingest pipelines correct and efficient?
- Are the ECS mappings appropriate?
- Are the dashboards useful and well-designed?

## Data streams

| Data stream | Type | Description |
|---|---|---|
| `gamepulse.cpu` | metrics | Per-core and aggregate CPU utilization, frequency, temperature, scheduler stats |
| `gamepulse.gpu` | metrics | GPU utilization, VRAM, temperature, power, clock speed |
| `gamepulse.memory` | metrics | RAM/swap usage, page faults, memory pressure |
| `gamepulse.frame` | metrics | Per-frame FPS, frame time, 1%/0.1% lows, stutter classification |
| `gamepulse.session` | metrics | Session lifecycle: start, end, duration, game name, launcher |
| `gamepulse.storage` | metrics | Read/write throughput, IOPS, latency |
| `gamepulse.network` | metrics | Network throughput, packet loss, latency |
| `gamepulse.audio` | metrics | Audio buffer underruns, latency |
| `gamepulse.power` | metrics | System and component power draw |
| `gamepulse.events` | logs | Discrete events: shader compile, VRR toggle, driver crash, process lifecycle |
| `gamepulse.ebpf` | metrics | Kernel-level eBPF scheduler migrations, I/O wait, GPU fence timing |

## Agent

The gamepulse-agent binary is distributed separately at https://github.com/MathewRJ/GamePulse. It supports Linux (Arch/AUR, Debian/Ubuntu deb, Fedora rpm) and Windows (winget).