### PR TITLE
[fix] Fix failing netbox system tests

### DIFF
--- a/packages/netbox/data_stream/devices/_dev/test/system/test-default-config.yml
+++ b/packages/netbox/data_stream/devices/_dev/test/system/test-default-config.yml
@@ -4,6 +4,7 @@ vars:
   url: http://{{Hostname}}:{{Port}}
   token: --token--
   enable_request_tracer: true
+  disable_keep_alive: false
 data_stream:
   vars:
     preserve_original_event: true

--- a/packages/netbox/data_stream/ips/_dev/test/system/test-default-config.yml
+++ b/packages/netbox/data_stream/ips/_dev/test/system/test-default-config.yml
@@ -4,6 +4,7 @@ vars:
   url: http://{{Hostname}}:{{Port}}
   token: --token--
   enable_request_tracer: true
+  disable_keep_alive: false
 data_stream:
   vars:
     preserve_original_event: true


### PR DESCRIPTION
## Proposed commit message

Fixes broken system tests for netbox integration for the `devices` and `ips` data streams by adding the required `disable_keep_alive` property into each test's config.

The `disable_keep_alive` key is required: https://github.com/elastic/integrations/blob/main/packages/netbox/manifest.yml#L84-L86 and ommiting it causes system tests to fail with errors

```
ERROR: could not add data stream config to policy: could not create package policy (req {"name":"netbox-devices-47415","description":"","namespace":"47415","policy_id":"62ee41fa-2eb1-417e-b19a-373e670b72a4","package":{"name":"netbox","version":"0.1.0"},"inputs":{"netbox-httpjson":{"enabled":true,"vars":{"enable_request_tracer":true,"token":"--token--","url":"http://svc-netbox_mock:8080"},"streams":{"netbox.devices":{"enabled":true,"vars":{"limit":2,"preserve_original_event":true}},"netbox.ips":{"enabled":false}}}},"force":false}); API status code = 400; response body = {"statusCode":400,"error":"Bad Request","message":"Package policy is invalid: inputs.httpjson.vars.disable_keep_alive: [\"Disable HTTP Keep-Alives is required\"]"}
```

## How to test this PR locally

1. From the repo root `cd packages/netbox`
2. Start the stack `elastic-package up -d`
3. Run system tests `elastic-package test system`
4. Notice they all pass
5. Remove `disable_keep_alive` property from `packages/netbox/data_stream/devices/_dev/test/system/test-default-config.yml` and `packages/netbox/data_stream/ips/_dev/test/system/test-default-config.yml`
6. Run the system tests again `elastic-package test system`
7. Notice the tests fail with the error mentioned above

## Related PRs experiencing the same falure

- https://github.com/elastic/integrations/pull/18881#issuecomment-4400908801
- https://github.com/elastic/integrations/pull/18828#issuecomment-4390689619