### PR TITLE
[m365_defender] Unique `entity_id` values

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "5.13.1"
+  changes:
+    - description: Unique `entity_id` values to avoid irrelevant documents in the Event Analyzer.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18891
 - version: "5.13.0"
   changes:
     - description: Add timestamp range filter and storage tier exclusion to latest transform source queries to reduce scan scope and improve performance.

--- a/packages/m365_defender/data_stream/alert/_dev/test/pipeline/test-alert.log-expected.json
+++ b/packages/m365_defender/data_stream/alert/_dev/test/pipeline/test-alert.log-expected.json
@@ -203,7 +203,7 @@
                     "powershell.exe  -NoExit -ExecutionPolicy Bypass -WindowStyle Hidden $ErrorActionPreference= 'silentlycontinue';(New-Object System.Net.WebClient).DownloadFile('http://127.0.0.1/1.exe', 'C:\\\\test-WDATP-test\\\\invoice.exe');Start-Process 'C:\\\\test-WDATP-test\\\\invoice.exe'"
                 ],
                 "entity_id": [
-                    "8224"
+                    "rVnodapfrTDpseiB0HSKS88ozVs="
                 ],
                 "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "hash": {
@@ -219,7 +219,7 @@
                 ],
                 "parent": {
                     "entity_id": [
-                        "5772"
+                        "zogwXHGFe3FclpZDb7EC8VkjELw="
                     ],
                     "executable": "C:\\Windows\\System32\\cmd.exe",
                     "pid": [
@@ -508,7 +508,7 @@
                     "powershell.exe  -NoExit -ExecutionPolicy Bypass -WindowStyle Hidden $ErrorActionPreference= 'silentlycontinue';(New-Object System.Net.WebClient).DownloadFile('http://127.0.0.1/1.exe', 'C:\\\\test-WDATP-test\\\\invoice.exe');Start-Process 'C:\\\\test-WDATP-test\\\\invoice.exe'"
                 ],
                 "entity_id": [
-                    "8224"
+                    "mEduHGao/Bxr3ydQddVjif+e5JU="
                 ],
                 "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "hash": {
@@ -524,7 +524,7 @@
                 ],
                 "parent": {
                     "entity_id": [
-                        "5772"
+                        "q+HpjZ9DnrUoFj5nLaWFfIk08TY="
                     ],
                     "executable": "C:\\Windows\\System32\\cmd.exe",
                     "pid": [
@@ -819,7 +819,7 @@
                     "powershell.exe  -NoExit -ExecutionPolicy Bypass -WindowStyle Hidden $ErrorActionPreference= 'silentlycontinue';(New-Object System.Net.WebClient).DownloadFile('http://127.0.0.1/1.exe', 'C:\\\\test-WDATP-test\\\\invoice.exe');Start-Process 'C:\\\\test-WDATP-test\\\\invoice.exe'"
                 ],
                 "entity_id": [
-                    "8224"
+                    "mEduHGao/Bxr3ydQddVjif+e5JU="
                 ],
                 "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "hash": {
@@ -835,7 +835,7 @@
                 ],
                 "parent": {
                     "entity_id": [
-                        "5772"
+                        "q+HpjZ9DnrUoFj5nLaWFfIk08TY="
                     ],
                     "executable": "C:\\Windows\\System32\\cmd.exe",
                     "pid": [
@@ -1126,7 +1126,7 @@
                     "powershell.exe  -NoExit -ExecutionPolicy Bypass -WindowStyle Hidden $ErrorActionPreference= 'silentlycontinue';(New-Object System.Net.WebClient).DownloadFile('http://127.0.0.1/1.exe', 'C:\\\\test-WDATP-test\\\\invoice.exe');Start-Process 'C:\\\\test-WDATP-test\\\\invoice.exe'"
                 ],
                 "entity_id": [
-                    "8224"
+                    "mEduHGao/Bxr3ydQddVjif+e5JU="
                 ],
                 "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "hash": {
@@ -1142,7 +1142,7 @@
                 ],
                 "parent": {
                     "entity_id": [
-                        "5772"
+                        "q+HpjZ9DnrUoFj5nLaWFfIk08TY="
                     ],
                     "executable": "C:\\Windows\\System32\\cmd.exe",
                     "pid": [

--- a/packages/m365_defender/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -2373,6 +2373,8 @@ processors:
         def fileSize = new HashSet();
         def processPid = new HashSet();
         def processParentPid = new HashSet();
+        def processEntityId = new HashSet();
+        def processParentEntityId = new HashSet();
 
         for (evidence in ctx.json.evidence) {
           maybeAddExecutable(processExecutable, evidence?.image_file);
@@ -2392,6 +2394,12 @@ processors:
             if (evidence?.parent_process?.id != null) {
               processParentPid.add(evidence.parent_process.id);
             }
+            if (evidence?.process?.id != null && evidence?.process?.creation_datetime != null && evidence?.mde_device_id != null) {
+              processEntityId.add(evidence.process.id + '|' + evidence.process.creation_datetime + '|' + evidence.mde_device_id);
+            }
+            if (evidence?.parent_process?.id != null && evidence?.parent_process?.creation_datetime != null && evidence?.mde_device_id != null) {
+              processParentEntityId.add(evidence.parent_process.id + '|' + evidence.parent_process.creation_datetime + '|' + evidence.mde_device_id);
+            }
           }
         }
 
@@ -2407,6 +2415,12 @@ processors:
         }
         if (!processParentPid.isEmpty()) {
           ctx.process.parent.pid = convertToOrderedArray(processParentPid);
+        }
+        if (!processEntityId.isEmpty()) {
+          ctx.process.entity_id = convertToOrderedArray(processEntityId);
+        }
+        if (!processParentEntityId.isEmpty()) {
+          ctx.process.parent.entity_id = convertToOrderedArray(processParentEntityId);
         }
         if (!processExecutable.isEmpty()) {
           def execList = new ArrayList(processExecutable);
@@ -2641,25 +2655,27 @@ processors:
           ctx.process.user.name = convertToOrderedArray(processUserName);
         }
   - foreach:
-      field: process.pid
-      tag: foreach_process_pid
-      if: ctx.process?.pid instanceof List
+      field: process.parent.entity_id
+      tag: foreach_fingerprint_parent_process_entity_id
+      if: ctx.process?.parent?.entity_id instanceof List
       processor:
-        append:
-          field: process.entity_id
-          tag: append_process_pid_to_entity_id
-          value: '{{{_ingest._value}}}'
-          allow_duplicates: false
+        fingerprint:
+          fields:
+            - _ingest._value
+          tag: fingerprint_parent_process_entity_id
+          target_field: _ingest._value
+          ignore_missing: true
   - foreach:
-      field: process.parent.pid
-      tag: foreach_process_parent_pid
-      if: ctx.process?.parent?.pid instanceof List
+      field: process.entity_id
+      tag: foreach_fingerprint_process_entity_id
+      if: ctx.process?.entity_id instanceof List
       processor:
-        append:
-          field: process.parent.entity_id
-          tag: append_process_parent_pid_to_entity_id
-          value: '{{{_ingest._value}}}'
-          allow_duplicates: false
+        fingerprint:
+          fields:
+            - _ingest._value
+          tag: fingerprint_process_entity_id
+          target_field: _ingest._value
+          ignore_missing: true
   - foreach:
       field: json.evidence
       tag: foreach_evidence_remove_fields

--- a/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-alert.log-expected.json
+++ b/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-alert.log-expected.json
@@ -473,7 +473,7 @@
                 ],
                 "args_count": 6,
                 "command_line": "tar -df alternatives.tar.0 -C /var/lib/dpkg alternatives",
-                "entity_id": "216032",
+                "entity_id": "vhRr+4jfPR2WxTNPulnM8uREqLI=",
                 "executable": "/usr/bin/tar",
                 "hash": {
                     "md5": "a2952b0188d52b53bac2707cd465499d",
@@ -491,7 +491,7 @@
                         "status": "Unknown"
                     },
                     "command_line": "/bin/sh /usr/libexec/dpkg/dpkg-db-backup",
-                    "entity_id": "216032",
+                    "entity_id": "zLqW1HNhmlwmllqL+BPGhS+UsZQ=",
                     "executable": "/usr/bin/dash",
                     "group_leader": {
                         "name": "dash",
@@ -734,7 +734,7 @@
                 ],
                 "args_count": 3,
                 "command_line": "python -m detection_rules",
-                "entity_id": "225349",
+                "entity_id": "pnXgNUR2vwGuWbfUhjvis4VtYGE=",
                 "executable": "/usr/bin/python3.12",
                 "hash": {
                     "md5": "4c1306feb059d94fc543e5606b99f9d0",
@@ -751,7 +751,7 @@
                         "status": "Unknown"
                     },
                     "command_line": "-zsh",
-                    "entity_id": "225349",
+                    "entity_id": "EvLA7kdPybXD6PQLtK5vPvyzBVk=",
                     "executable": "/usr/bin/zsh",
                     "group_leader": {
                         "name": "zsh",

--- a/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-cloud.log-expected.json
+++ b/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-cloud.log-expected.json
@@ -182,11 +182,9 @@
                 ],
                 "args_count": 7,
                 "command_line": "nginx: master process nginx -g daemon off;",
-                "entity_id": "1",
                 "executable": "/usr/sbin",
                 "name": "nginx",
                 "parent": {
-                    "entity_id": "100",
                     "name": "containerd-shim",
                     "pid": 100
                 },

--- a/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-device.log-expected.json
+++ b/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-device.log-expected.json
@@ -87,7 +87,7 @@
                 ],
                 "args_count": 2,
                 "command_line": "\"backgroundTaskHost.exe\" -ServerName:App.AppXmtcan0h2tfbfy7k9kn8hbxb6dmzz1zh0.mca",
-                "entity_id": "4248",
+                "entity_id": "utLjuzbrOqM8u+fh65n5nL10vuE=",
                 "executable": "c:\\windows\\system32\\backgroundtaskhost.exe",
                 "hash": {
                     "md5": "b7f884c1b74a263f746ee12a5f7c9f6a",
@@ -96,7 +96,7 @@
                 },
                 "name": "backgroundtaskhost.exe",
                 "parent": {
-                    "entity_id": "948",
+                    "entity_id": "NiMtqsyPROomWoEGyFit5a9MVk8=",
                     "name": "svchost.exe",
                     "pid": 948,
                     "start": "2022-11-07T16:34:27.011Z"
@@ -339,7 +339,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "WaAppAgent.exe",
-                "entity_id": "5692",
+                "entity_id": "YH37lPKF1VorpRY2deuyPRlixKg=",
                 "executable": "c:\\windowsazure\\guestagent_2.7.41491.1057_2022-11-07_163802\\waappagent.exe",
                 "hash": {
                     "md5": "b7f884c1b74a263f746ee12a5f7c9f6a",
@@ -348,7 +348,7 @@
                 },
                 "name": "WaAppAgent.exe",
                 "parent": {
-                    "entity_id": "812",
+                    "entity_id": "Q3FwNC2Q7hswER3S6seL0MHhRQk=",
                     "name": "services.exe",
                     "pid": 812,
                     "start": "2022-11-07T16:34:26.543Z"
@@ -512,11 +512,11 @@
                 ],
                 "args_count": 1,
                 "command_line": "WaAppAgent.exe",
-                "entity_id": "5692",
+                "entity_id": "YH37lPKF1VorpRY2deuyPRlixKg=",
                 "executable": "c:\\windowsazure\\guestagent_2.7.41491.1057_2022-11-07_163802\\waappagent.exe",
                 "name": "waappagent.exe",
                 "parent": {
-                    "entity_id": "812",
+                    "entity_id": "Q3FwNC2Q7hswER3S6seL0MHhRQk=",
                     "name": "services.exe",
                     "pid": 812,
                     "start": "2022-11-07T16:34:26.543Z"
@@ -679,11 +679,11 @@
                 ],
                 "args_count": 11,
                 "command_line": "mscorsvw.exe -StartupEvent 1ec -InterruptEvent 0 -NGENProcess 1dc -Pipe 1e8 -Comment \"NGen Worker Process\"",
-                "entity_id": "5664",
+                "entity_id": "CHTQaf4rpg91atBq++Ahpfp8ZRk=",
                 "executable": "c:\\windows\\microsoft.net\\framework64\\v4.0.30319\\mscorsvw.exe",
                 "name": "mscorsvw.exe",
                 "parent": {
-                    "entity_id": "2040",
+                    "entity_id": "lr/N+DmXFQRbg9sJMdoKwPPJx3M=",
                     "name": "ngen.exe",
                     "pid": 2040,
                     "start": "2024-05-08T15:33:47.298Z"
@@ -846,11 +846,11 @@
                 ],
                 "args_count": 11,
                 "command_line": "mscorsvw.exe -StartupEvent 1ec -InterruptEvent 0 -NGENProcess 1dc -Pipe 1e8 -Comment \"NGen Worker Process\"",
-                "entity_id": "5664",
+                "entity_id": "CHTQaf4rpg91atBq++Ahpfp8ZRk=",
                 "executable": "c:\\windows\\microsoft.net\\framework64\\v4.0.30319\\mscorsvw.exe",
                 "name": "mscorsvw.exe",
                 "parent": {
-                    "entity_id": "2040",
+                    "entity_id": "lr/N+DmXFQRbg9sJMdoKwPPJx3M=",
                     "name": "ngen.exe",
                     "pid": 2040,
                     "start": "2024-05-08T15:33:47.298Z"
@@ -1066,9 +1066,7 @@
                 "protocol": "ntlm"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -1196,9 +1194,7 @@
                 "direction": "unknown"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -1363,9 +1359,7 @@
                 "transport": "udp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -1630,7 +1624,7 @@
                 ],
                 "args_count": 2,
                 "command_line": "smartscreen.exe -Embedding",
-                "entity_id": "6412",
+                "entity_id": "5YTBgeW5XB4iF3Eit+kqNtYx7kk=",
                 "executable": "C:\\Windows\\System32\\smartscreen.exe",
                 "hash": {
                     "md5": "b9d697df9e883f0d99720b0430448cb1",
@@ -1652,7 +1646,7 @@
                         "trusted": true
                     },
                     "command_line": "svchost.exe -k DcomLaunch -p",
-                    "entity_id": "996",
+                    "entity_id": "gQarIyxiQEdqVDcHd0tRvif2k34=",
                     "executable": "c:\\windows\\system32\\svchost.exe",
                     "group_leader": {
                         "name": "services.exe",
@@ -1810,7 +1804,7 @@
                 ],
                 "args_count": 5,
                 "command_line": "powershell.exe -ExecutionPolicy AllSigned -NoProfile -NonInteractive",
-                "entity_id": "5900",
+                "entity_id": "/+/v9JucAbzdfJQ8SJGl945kH3U=",
                 "executable": "c:\\windows\\system32\\windowspowershell\\v1.0\\powershell.exe",
                 "hash": {
                     "md5": "04029e121a0cfa5991749937dd22a1d9",
@@ -1819,7 +1813,7 @@
                 },
                 "name": "powershell.exe",
                 "parent": {
-                    "entity_id": "5668",
+                    "entity_id": "1KSfp24ABmBfYa8SZ3Uh7Gsbz2g=",
                     "name": "SenseIR.exe",
                     "pid": 5668,
                     "start": "2022-11-09T19:16:54.943Z"
@@ -1959,7 +1953,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "\"MsSense.exe\"",
-                "entity_id": "4688",
+                "entity_id": "hN4NpgVQ64dPUY3AEuiF2K6Ro9I=",
                 "executable": "c:\\program files\\windows defender advanced threat protection\\mssense.exe",
                 "hash": {
                     "md5": "71fc679ef0665dde1cbb72c95cecf894",
@@ -1968,7 +1962,7 @@
                 },
                 "name": "mssense.exe",
                 "parent": {
-                    "entity_id": "688",
+                    "entity_id": "juWkgGALrAuX5yR0oRrcJfDjPrM=",
                     "name": "services.exe",
                     "pid": 688,
                     "start": "2024-05-06T11:48:52.817Z"
@@ -2111,7 +2105,7 @@
                 ],
                 "args_count": 6,
                 "command_line": "svchost.exe -k netsvcs -p -s wlidsvc",
-                "entity_id": "3176",
+                "entity_id": "bO2lNqdNHQs58kBcuKLiB2XyfiI=",
                 "executable": "c:\\windows\\system32\\svchost.exe",
                 "hash": {
                     "md5": "7469cc568ad6821fd9d925542730a7d8",
@@ -2120,7 +2114,7 @@
                 },
                 "name": "svchost.exe",
                 "parent": {
-                    "entity_id": "728",
+                    "entity_id": "V6+DQhapxQBdpcS2zVXPxBtFTd4=",
                     "name": "services.exe",
                     "pid": 728,
                     "start": "2024-06-18T16:30:41.690Z"
@@ -2260,7 +2254,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "\"MsSense.exe\"",
-                "entity_id": "3144",
+                "entity_id": "NPbxxqQQc+5NloIh6ep3UQzpw9c=",
                 "executable": "c:\\program files\\windows defender advanced threat protection\\mssense.exe",
                 "hash": {
                     "md5": "c311a5744bc0f42b2dbea2c68d1cbd06",
@@ -2269,7 +2263,7 @@
                 },
                 "name": "mssense.exe",
                 "parent": {
-                    "entity_id": "728",
+                    "entity_id": "V6+DQhapxQBdpcS2zVXPxBtFTd4=",
                     "name": "services.exe",
                     "pid": 728,
                     "start": "2024-06-18T16:30:41.690Z"
@@ -2456,7 +2450,7 @@
                 ],
                 "args_count": 17,
                 "command_line": "\"msedgewebview2.exe\" --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-US --service-sandbox-type=none --noerrdialogs --user-data-dir=\"C:\\Users\\username\\AppData\\Local\\Citrix\\SelfService\\CitrixWebControlCache\\EBWebView\" --webview-exe-name=SelfService.exe --webview-exe-version=22.3.1.22 --embedded-browser-webview=1 --embedded-browser-webview-dpi-awareness=2 --mojo-platform-channel-handle=3456 --field-trial-handle=1824,i --enable-features=msSingleSignOnOSForPrimaryAccountIsShared --disable-features=MojoIpcz /prefetch:3 /pfhostedapp:1234",
-                "entity_id": "17916",
+                "entity_id": "M3xNTxP4JeGpuol+a539MTZk3Nc=",
                 "executable": "c:\\program files (x86)\\microsoft\\edgewebview\\application\\114.0.1823.79\\msedgewebview2.exe",
                 "hash": {
                     "md5": "df9b3bee634a5578481a8c7cf4f614a3",
@@ -2465,7 +2459,7 @@
                 },
                 "name": "msedgewebview2.exe",
                 "parent": {
-                    "entity_id": "17808",
+                    "entity_id": "fgWks6E/NKS5lo/Of3mlnblLf5c=",
                     "name": "msedgewebview2.exe",
                     "pid": 17808,
                     "start": "2023-08-09T18:42:58.819Z"
@@ -2672,9 +2666,7 @@
                 "transport": "udp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -2818,9 +2810,7 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -2943,9 +2933,7 @@
                 "direction": "unknown"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -3087,9 +3075,7 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -3249,7 +3235,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "msoia.exe\" scan upload",
-                "entity_id": "65498",
+                "entity_id": "J6wezBBYXvLMk5gBEDhKWgQTkbY=",
                 "executable": "c:\\program files\\mozilla firefox\\firefox.exe",
                 "hash": {
                     "md5": "7448f851eb4e9b2fbfc46b2b49daf43f",
@@ -3258,7 +3244,7 @@
                 },
                 "name": "msoia.exe",
                 "parent": {
-                    "entity_id": "65498",
+                    "entity_id": "dc4l1VXiwcGGNxyskPKJ+eGHBYk=",
                     "name": "firefox.exe",
                     "pid": 65498,
                     "start": "2023-07-19T12:16:56.045Z"
@@ -3428,9 +3414,7 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -3590,7 +3574,7 @@
                 ],
                 "args_count": 4,
                 "command_line": "svchost.exe -k RPCSS -p",
-                "entity_id": "1772",
+                "entity_id": "AU+1jMj/Cpju4A7a2+KkQTj5Ljc=",
                 "executable": "c:\\windows\\system32\\svchost.exe",
                 "hash": {
                     "md5": "122beaba9a49e1c60bf8446668a1de3e",
@@ -3599,7 +3583,7 @@
                 },
                 "name": "svchost.exe",
                 "parent": {
-                    "entity_id": "1152",
+                    "entity_id": "gssbDCW8S2uUyOgBfrCNZYG5mZI=",
                     "name": "services.exe",
                     "pid": 1152,
                     "start": "2023-07-19T14:29:01.969Z"
@@ -3766,9 +3750,7 @@
                 "transport": "icmp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -3947,7 +3929,7 @@
                 ],
                 "args_count": 3,
                 "command_line": "/Applications/Microsoft Defender.app/Contents/MacOS/wdavdaemon_enterprise.app/Contents/Frameworks/telemetryd_v2 13",
-                "entity_id": "189",
+                "entity_id": "ewguDFdBzcQCYnU6KKt0G9OZQXM=",
                 "executable": "/applications/microsoft defender.app/contents/macos/wdavdaemon_enterprise.app/contents/frameworks/telemetryd_v2",
                 "hash": {
                     "md5": "323b1d0476181f99f76babcd87217f89",
@@ -3956,7 +3938,7 @@
                 },
                 "name": "telemetryd_v2",
                 "parent": {
-                    "entity_id": "654",
+                    "entity_id": "/HCzfWF6UeOAOHRc/7LQo2zslzM=",
                     "name": "wdavdaemon_enterprise",
                     "pid": 654,
                     "start": "2023-07-18T16:38:42.246Z"
@@ -4099,11 +4081,9 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "executable": "C:\\Program Files\\Microsoft Office\\root\\Office16\\EXCEL.EXE",
                 "name": "EXCEL.EXE",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -4226,9 +4206,7 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -4359,9 +4337,7 @@
                 "transport": "udp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -4498,9 +4474,7 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -4637,9 +4611,7 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -4801,7 +4773,7 @@
                 ],
                 "args_count": 5,
                 "command_line": "\"msedgewebview2.exe\" --type=renderer --noerrdialogs --user-data-dir=\"C:\\Users\\JANEBLOGGS\\AppData\\Local\\Microsoft\\Office\\16.0\\Wef\\webview2\\4ee9dcb0-735b-442e-945c-177c665efe6b_ADAL\\2\\EBWebView\" --webview-exe-name=MSOUTLOOK.EXE",
-                "entity_id": "5498762",
+                "entity_id": "0jd3fF7OPxHGiIbHCDc2J/ka8sM=",
                 "executable": "C:\\Program Files (x86)\\Microsoft\\EdgeWebView\\Application\\114.0.1823.79\\msedgewebview2.exe",
                 "hash": {
                     "md5": "b21b158fce974aa46125820ce6b42e9d",
@@ -4820,7 +4792,6 @@
                     ],
                     "args_count": 6,
                     "command_line": "\"msedgewebview2.exe\" --embedded-browser-webview=1 --webview-exe-name=MSOUTLOOK.EXE --webview-exe-version=16.0.15601.20706 --user-data-dir=\"C:\\Users\\USERNAME\\AppData\\Local\\Microsoft\\Office\\16.0\\Wef\\webview2\\1234dcb0-735b-442e-945c-e6c5df94062c_ADAL\\2\\EBWebView\" --noerrdialogs",
-                    "entity_id": "65485",
                     "hash": {
                         "md5": "b21b158fce974aa46125820ce6b42e9d",
                         "sha1": "271eb137d3d8519cb42e5bccd690a3b9a3059f2a",
@@ -4950,9 +4921,7 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -5170,7 +5139,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "\"MsMpEng.exe\"",
-                "entity_id": "700",
+                "entity_id": "X4STNBPcacGpvYo042PL05zdAmk=",
                 "executable": "C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18.24030.9-0\\MsMpEng.exe",
                 "group_leader": {
                     "name": "services.exe",
@@ -5184,7 +5153,7 @@
                 },
                 "name": "MsMpEng.exe",
                 "parent": {
-                    "entity_id": "688",
+                    "entity_id": "juWkgGALrAuX5yR0oRrcJfDjPrM=",
                     "name": "services.exe",
                     "pid": 688,
                     "start": "2024-05-06T11:48:52.817Z"
@@ -5312,7 +5281,7 @@
                 ],
                 "args_count": 2,
                 "command_line": "\"DllHost.exe\" /Processid:{776DBC8D-7347-478C-8D71-791E12EF49D8}",
-                "entity_id": "8140",
+                "entity_id": "yOK9aqqB65MHUYYb3+hMyl1e1b8=",
                 "executable": "c:\\windows\\syswow64\\dllhost.exe",
                 "group_leader": {
                     "name": "svchost.exe",
@@ -5326,7 +5295,7 @@
                 },
                 "name": "dllhost.exe",
                 "parent": {
-                    "entity_id": "832",
+                    "entity_id": "nL6yMvxVtwZxXuXepVdIxEomgh8=",
                     "name": "svchost.exe",
                     "pid": 832,
                     "start": "2024-05-06T11:48:52.949Z"
@@ -5455,7 +5424,7 @@
                 ],
                 "args_count": 5,
                 "command_line": "iexplore.exe /c echo -Embedding ;C:\\Users\\Public\\iexplore.exe",
-                "entity_id": "5212",
+                "entity_id": "TBRTlE4fi2A46QMwAqv5V9P3dCQ=",
                 "executable": "c:\\users\\public\\iexplore.exe",
                 "group_leader": {
                     "name": "python.exe",
@@ -5469,7 +5438,7 @@
                 },
                 "name": "iexplore.exe",
                 "parent": {
-                    "entity_id": "6968",
+                    "entity_id": "vU8x9VCFf2/Dtp2f4KLnRN9v6vg=",
                     "name": "python.exe",
                     "pid": 6968,
                     "start": "2024-05-06T19:34:34.547Z"
@@ -5619,7 +5588,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "lsass.exe",
-                "entity_id": "648",
+                "entity_id": "U66D7749OM6Tu2TxJE2BSz3IA2E=",
                 "executable": "C:\\Windows\\System32\\MRT.exe",
                 "group_leader": {
                     "name": "\\Device\\HarddiskVolume3\\Windows\\SoftwareDistribution\\Download\\Install\\Windows-KB890830-x64-V5.123.exe",
@@ -5633,7 +5602,7 @@
                 },
                 "name": "MRT.exe",
                 "parent": {
-                    "entity_id": "1860",
+                    "entity_id": "Db0Pj5t6VpCJVt5yg8RM+56Ynes=",
                     "name": "\\Device\\HarddiskVolume3\\Windows\\SoftwareDistribution\\Download\\Install\\Windows-KB890830-x64-V5.123.exe",
                     "pid": 1860,
                     "start": "2024-05-02T15:53:22.443Z"
@@ -5774,7 +5743,7 @@
                 }
             },
             "process": {
-                "entity_id": "4",
+                "entity_id": "gnL3C3NRjh13yED3tWdAReMeArE=",
                 "executable": "C:\\Windows\\System32\\ntoskrnl.exe",
                 "group_leader": {
                     "pid": 0
@@ -5786,7 +5755,6 @@
                 },
                 "name": "ntoskrnl.exe",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pe": {
@@ -5912,7 +5880,7 @@
                 ],
                 "args_count": 3,
                 "command_line": "\"InstallUtil.exe\" /u \"C:\\Program Files (x86)\\Lenovo\\System Update\\SUService.exe\"",
-                "entity_id": "4248",
+                "entity_id": "utLjuzbrOqM8u+fh65n5nL10vuE=",
                 "executable": "c:\\windows\\system32\\InstallUtil.exe",
                 "hash": {
                     "md5": "b7f884c1b74a263f746ee12a5f7c9f6a",
@@ -5921,7 +5889,7 @@
                 },
                 "name": "backgroundtaskhost.exe",
                 "parent": {
-                    "entity_id": "948",
+                    "entity_id": "NiMtqsyPROomWoEGyFit5a9MVk8=",
                     "name": "svchost.exe",
                     "pid": 948,
                     "start": "2022-11-07T16:34:27.011Z"
@@ -6160,7 +6128,7 @@
                 ],
                 "args_count": 5,
                 "command_line": "svchost.exe -k LocalService -s W32Time",
-                "entity_id": "10192",
+                "entity_id": "3Z4nXvnKXB0kfBL3ZLS7QMBG8zQ=",
                 "executable": "c:\\windows\\system32\\svchost.exe",
                 "hash": {
                     "md5": "145dcf6706eeea5b066885ee17964c09",
@@ -6169,7 +6137,7 @@
                 },
                 "name": "svchost.exe",
                 "parent": {
-                    "entity_id": "688",
+                    "entity_id": "wm9wy6tG1dDC5oUgDSjCsZSwAUo=",
                     "name": "services.exe",
                     "pid": 688,
                     "start": "2024-05-06T11:48:52.817Z"
@@ -6286,7 +6254,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "Explorer.EXE",
-                "entity_id": "1040",
+                "entity_id": "Ik9U5qQ7nW3mCTCD1HQfm8te+p4=",
                 "executable": "c:\\windows\\explorer.exe",
                 "hash": {
                     "md5": "238538d74fea273bff1e00622eccaf3a",
@@ -6295,7 +6263,7 @@
                 },
                 "name": "explorer.exe",
                 "parent": {
-                    "entity_id": "3424",
+                    "entity_id": "4COGehO+9tJyAUVAKvzqjtOwJNM=",
                     "name": "userinit.exe",
                     "pid": 3424,
                     "start": "2024-05-06T11:53:36.369Z"
@@ -6411,7 +6379,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "\"powershell.exe\" ",
-                "entity_id": "6768",
+                "entity_id": "Tx2257uaz3l+hGJPmq14mkhv5js=",
                 "executable": "c:\\windows\\system32\\windowspowershell\\v1.0\\powershell.exe",
                 "hash": {
                     "md5": "2e5a8590cf6848968fc23de3fa1e25f1",
@@ -6420,7 +6388,7 @@
                 },
                 "name": "powershell.exe",
                 "parent": {
-                    "entity_id": "6780",
+                    "entity_id": "B4273holb6ybG4ndzWWkghN6464=",
                     "name": "svchost.exe",
                     "pid": 6780,
                     "start": "2024-05-06T11:53:51.676Z"
@@ -6537,7 +6505,7 @@
                 ],
                 "args_count": 5,
                 "command_line": "\"msdt.exe\" /c echo /cab C:\\Users\\Public\\",
-                "entity_id": "10164",
+                "entity_id": "KN+krd7irczLvyW/7cATXz0iiQ8=",
                 "executable": "c:\\windows\\system32\\msdt.exe",
                 "hash": {
                     "md5": "f2c31dadb5569110e9941642728fe182",
@@ -6546,7 +6514,7 @@
                 },
                 "name": "msdt.exe",
                 "parent": {
-                    "entity_id": "4744",
+                    "entity_id": "Hu0KGLDpDrlp6rTd3Pnb6mLuysw=",
                     "name": "firefox.exe",
                     "pid": 4744,
                     "start": "2024-05-06T16:42:49.675Z"
@@ -6688,7 +6656,7 @@
                 ],
                 "args_count": 6,
                 "command_line": "svchost.exe -k netsvcs -p -s UserManager",
-                "entity_id": "2536",
+                "entity_id": "oHInmm++OgdK8BV9Yy48JZ58pnA=",
                 "executable": "C:\\Windows\\System32",
                 "hash": {
                     "md5": "8ec922c7a58a8701ab481b7be9644536",
@@ -6697,7 +6665,7 @@
                 },
                 "name": "svchost.exe",
                 "parent": {
-                    "entity_id": "1180",
+                    "entity_id": "QFYgU08Ro5Wr3c3jLBPFurir5Ww=",
                     "name": "services.exe",
                     "pid": 1180,
                     "start": "2024-06-20T18:04:49.204Z"
@@ -6829,9 +6797,7 @@
                 "transport": "icmp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0
@@ -6968,7 +6934,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "\"AppHostRegistrationVerifier.exe\"",
-                "entity_id": "1372",
+                "entity_id": "80X+iWajdkZ5PEpWtUzlN8X5ces=",
                 "executable": "c:\\windows\\system32\\apphostregistrationverifier.exe",
                 "hash": {
                     "md5": "825bbdbe835887ceda7936680b948903",
@@ -6977,7 +6943,7 @@
                 },
                 "name": "AppHostRegistrationVerifier.exe",
                 "parent": {
-                    "entity_id": "2736",
+                    "entity_id": "4mcMeH/zl/N6sCN4KvaWF4sziYg=",
                     "name": "svchost.exe",
                     "pid": 2736,
                     "start": "2024-06-20T18:12:26.339Z"
@@ -7133,7 +7099,7 @@
                 ],
                 "args_count": 2,
                 "command_line": "dashost.exe {5027b3b1-d242-4627-8963855a94ed8c77}",
-                "entity_id": "3476",
+                "entity_id": "9lwaKjuH5wnn94UNGJCOZalxnBU=",
                 "executable": "c:\\windows\\system32\\dashost.exe",
                 "hash": {
                     "md5": "1179f79ddf6d33a7191265a95a21eb68",
@@ -7142,7 +7108,7 @@
                 },
                 "name": "dasHost.exe",
                 "parent": {
-                    "entity_id": "2572",
+                    "entity_id": "aMLVjn4Tq8NNtsMsb0ssmoZsObQ=",
                     "name": "svchost.exe",
                     "pid": 2572,
                     "start": "2024-06-16T10:57:39.143Z"
@@ -7286,7 +7252,7 @@
                 ],
                 "args_count": 1,
                 "command_line": "winlogon.exe",
-                "entity_id": "1288",
+                "entity_id": "JUVRWZ8mUjmikaumt5G0180OLaw=",
                 "executable": "C:\\Windows\\System32",
                 "hash": {
                     "md5": "ee34b5513cc18a5c33158fc5750cc8ac",
@@ -7295,7 +7261,7 @@
                 },
                 "name": "winlogon.exe",
                 "parent": {
-                    "entity_id": "972",
+                    "entity_id": "DRW5KxlQFX058a3t1ftirK3CgBE=",
                     "name": "smss.exe",
                     "pid": 972,
                     "start": "2024-06-18T11:25:43.491Z"
@@ -7447,7 +7413,7 @@
                 ],
                 "args_count": 6,
                 "command_line": "svchost.exe -k LocalSystemNetworkRestricted -p -s SysMain",
-                "entity_id": "3992",
+                "entity_id": "zcGfnj9f4oI+bb9O4iXG8E4q14s=",
                 "executable": "c:\\windows\\system32\\svchost.exe",
                 "hash": {
                     "md5": "8ec922c7a58a8701ab481b7be9644536",
@@ -7456,7 +7422,7 @@
                 },
                 "name": "svchost.exe",
                 "parent": {
-                    "entity_id": "1264",
+                    "entity_id": "h/eUf6GN+ogekBHmNRS+c94kBy8=",
                     "name": "services.exe",
                     "pid": 1264,
                     "start": "2024-06-12T14:26:27.972Z"
@@ -7668,9 +7634,7 @@
                 "transport": "tcp"
             },
             "process": {
-                "entity_id": "0",
                 "parent": {
-                    "entity_id": "0",
                     "pid": 0
                 },
                 "pid": 0

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -156,13 +156,25 @@ processors:
   - set:
       field: process.entity_id
       tag: set_process_entity_id
-      value: '{{{process.pid}}}'
-      ignore_empty_value: true
+      value: '{{{process.pid}}}|{{{process.start}}}|{{{m365_defender.event.device.id}}}'
+      if: ctx.process?.pid != null && ctx.process?.start != null && ctx.m365_defender?.event?.device?.id != null
+  - fingerprint:
+      fields:
+        - process.entity_id
+      tag: fingerprint_process_entity_id
+      target_field: process.entity_id
+      ignore_missing: true
   - set:
       field: process.parent.entity_id
       tag: set_process_parent_entity_id
-      value: '{{{process.parent.pid}}}'
-      ignore_empty_value: true
+      value: '{{{process.parent.pid}}}|{{{process.parent.start}}}|{{{m365_defender.event.device.id}}}'
+      if: ctx.process?.parent?.pid != null && ctx.process?.parent?.start != null && ctx.m365_defender?.event?.device?.id != null
+  - fingerprint:
+      fields:
+        - process.parent.entity_id
+      tag: fingerprint_process_parent_entity_id
+      target_field: process.parent.entity_id
+      ignore_missing: true
   - set:
       field: process.name
       tag: set_process_name_from_executable

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -154,6 +154,7 @@ processors:
       tag: pipeline_app_and_identity
       if: ctx.m365_defender?.event?.category != null && (ctx.m365_defender.event.category.toLowerCase().contains('identity') || ctx.m365_defender.event.category.toLowerCase().contains('cloudappevents') || ctx.m365_defender.event.category.toLowerCase().contains('cloudauditevents') || ctx.m365_defender.event.category.toLowerCase().contains('cloudstorageaggregatedevents'))
   - set:
+      description: Build a joined string for fingerprinting, so it matches other data streams
       field: process.entity_id
       tag: set_process_entity_id
       value: '{{{process.pid}}}|{{{process.start}}}|{{{m365_defender.event.device.id}}}'
@@ -165,6 +166,7 @@ processors:
       target_field: process.entity_id
       ignore_missing: true
   - set:
+      description: Build a joined string for fingerprinting, so it matches other data streams
       field: process.parent.entity_id
       tag: set_process_parent_entity_id
       value: '{{{process.parent.pid}}}|{{{process.parent.start}}}|{{{m365_defender.event.device.id}}}'

--- a/packages/m365_defender/data_stream/incident/_dev/test/pipeline/test-incident.log-expected.json
+++ b/packages/m365_defender/data_stream/incident/_dev/test/pipeline/test-incident.log-expected.json
@@ -238,7 +238,7 @@
                     "\"MsSense.exe\""
                 ],
                 "entity_id": [
-                    "4780"
+                    "GdecP48p4oFdVJ7+AU6JJ5JokMc="
                 ],
                 "executable": "C:\\Program Files\\temp\\MsSense.exe",
                 "hash": {
@@ -252,7 +252,7 @@
                 "name": "MsSense.exe",
                 "parent": {
                     "entity_id": [
-                        "668"
+                        "AJts3MYV1Rb50FPjg7N4xdSt+rg="
                     ],
                     "executable": "C:\\Windows\\System32\\services.exe",
                     "pid": [
@@ -564,7 +564,7 @@
                     "\"MsSense.exe\""
                 ],
                 "entity_id": [
-                    "4780"
+                    "GdecP48p4oFdVJ7+AU6JJ5JokMc="
                 ],
                 "executable": "C:\\Program Files\\temp\\MsSense.exe",
                 "hash": {
@@ -578,7 +578,7 @@
                 "name": "MsSense.exe",
                 "parent": {
                     "entity_id": [
-                        "668"
+                        "AJts3MYV1Rb50FPjg7N4xdSt+rg="
                     ],
                     "executable": "C:\\Windows\\System32\\services.exe",
                     "pid": [

--- a/packages/m365_defender/data_stream/incident/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/incident/elasticsearch/ingest_pipeline/default.yml
@@ -2431,6 +2431,8 @@ processors:
         def fileSize = new HashSet();
         def processPid = new HashSet();
         def processParentPid = new HashSet();
+        def processEntityId = new HashSet();
+        def processParentEntityId = new HashSet();
 
         for (evidence in ctx.json.alerts.evidence) {
           maybeAddExecutable(processExecutable, evidence?.image_file);
@@ -2450,6 +2452,12 @@ processors:
             if (evidence?.parent_process?.id != null) {
               processParentPid.add(evidence.parent_process.id);
             }
+            if (evidence?.process?.id != null && evidence?.process?.creation_datetime != null && evidence?.mde_device_id != null) {
+              processEntityId.add(evidence.process.id + '|' + evidence.process.creation_datetime + '|' + evidence.mde_device_id);
+            }
+            if (evidence?.parent_process?.id != null && evidence?.parent_process?.creation_datetime != null && evidence?.mde_device_id != null) {
+              processParentEntityId.add(evidence.parent_process.id + '|' + evidence.parent_process.creation_datetime + '|' + evidence.mde_device_id);
+            }
           }
         }
 
@@ -2465,6 +2473,12 @@ processors:
         }
         if (!processParentPid.isEmpty()) {
           ctx.process.parent.pid = convertToOrderedArray(processParentPid);
+        }
+        if (!processEntityId.isEmpty()) {
+          ctx.process.entity_id = convertToOrderedArray(processEntityId);
+        }
+        if (!processParentEntityId.isEmpty()) {
+          ctx.process.parent.entity_id = convertToOrderedArray(processParentEntityId);
         }
         if (!processExecutable.isEmpty()) {
           def execList = new ArrayList(processExecutable);
@@ -2698,25 +2712,27 @@ processors:
           ctx.process.user.name = convertToOrderedArray(processUserName);
         }
   - foreach:
-      field: process.pid
-      tag: foreach_process_pid
-      if: ctx.process?.pid instanceof List
+      field: process.parent.entity_id
+      tag: foreach_fingerprint_parent_process_entity_id
+      if: ctx.process?.parent?.entity_id instanceof List
       processor:
-        append:
-          field: process.entity_id
-          tag: append_process_pid_to_entity_id
-          value: '{{{_ingest._value}}}'
-          allow_duplicates: false
+        fingerprint:
+          fields:
+            - _ingest._value
+          tag: fingerprint_parent_process_entity_id
+          target_field: _ingest._value
+          ignore_missing: true
   - foreach:
-      field: process.parent.pid
-      tag: foreach_process_parent_pid
-      if: ctx.process?.parent?.pid instanceof List
+      field: process.entity_id
+      tag: foreach_fingerprint_process_entity_id
+      if: ctx.process?.entity_id instanceof List
       processor:
-        append:
-          field: process.parent.entity_id
-          tag: append_process_parent_pid_to_entity_id
-          value: '{{{_ingest._value}}}'
-          allow_duplicates: false
+        fingerprint:
+          fields:
+            - _ingest._value
+          tag: fingerprint_process_entity_id
+          target_field: _ingest._value
+          ignore_missing: true
   - foreach:
       tag: foreach_json_alerts_evidence_0076b16f
       field: json.alerts.evidence

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: m365_defender
 title: Microsoft Defender XDR
-version: "5.13.0"
+version: "5.13.1"
 description: Collect logs from Microsoft Defender XDR with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
## Proposed commit message

```
[m365_defender] Unique `entity_id` values

Set values in `entity_id` that uniquely identify a process, rather than
using the OS PID value, which may not be unique. Since PIDs can repeat
across hosts and be reused on a single host, additional fields are
necessary to identify the process.

This change should prevent irrelevant documents being shown in the Event
Analyzer due to ID clashes.

ECS defines `process.entity_id` as:

> Unique identifier for the process.
>
> The implementation of this is specified by the data source, but some
> examples of what could be used here are a process-generated UUID,
> Sysmon Process GUIDs, or a hash of some uniquely identifying
> components of a process.
>
> Constructing a globally unique identifier is a common practice to
> mitigate PID reuse as well as to identify a specific process over
> time, across multiple monitored hosts.

Although that definition says it should identify a process globally, in
practice, other EDR integrations such as `crowdstrike` and
`sentinel_one_cloud_funnel` use globally unique IDs assigned by an
agent, not a value based on the OS PID. That means the ID for a process
won't clash with another, but may also not match the ID used for the
same process in data from a different source.

The Resolver Schemas[1] document in Kibana refers to `entity_id` but
provides no further guidance on this point.

[1]: https://github.com/elastic/kibana/blob/fb26c1c/x-pack/solutions/security/plugins/security_solution/public/resolver/documentation/schema.md
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
