### PR TITLE
snyk: fix audit_logs event type filter being silently ignored

### DIFF
--- a/packages/snyk/_dev/deploy/docker/files/config.yml
+++ b/packages/snyk/_dev/deploy/docker/files/config.yml
@@ -64,6 +64,60 @@ rules:
     query_params:
       version: "2024-04-29"
       sort_order: ASC
+      events: "org.project.issue.create"
+      cursor: null
+    responses:
+      - status_code: 200
+        headers:
+          X-Ratelimit-Limit: ["100, 100;w=1;name=\"per_second\", 6000;w=60;name=\"per_minute\""]
+          X-Ratelimit-Remaining: ["99"]
+          X-Ratelimit-Reset: ["60"]
+        body: |-
+          {{ minify_json `
+          {
+            "data": {
+              "items": [
+                {
+                  "content": {
+                    "action": "Returned from analysis"
+                  },
+                  "created": "2024-05-15T16:34:14.144Z",
+                  "event": "org.project.issue.create",
+                  "org_id": "0de7b2d6-c1da-46aa-887e-1886f96770d4",
+                  "project_id": "d2bf0629-84a7-4b0b-b435-f49a87f0720c"
+                },
+                {
+                  "content": {
+                    "action": "Saved to DB",
+                    "issueCounts": {
+                      "sast": {
+                        "high": 3,
+                        "low": 101,
+                        "medium": 45
+                      }
+                    }
+                  },
+                  "created": "2024-05-15T16:34:15.251Z",
+                  "event": "org.project.issue.create",
+                  "org_id": "0de7b2d6-c1da-46aa-887e-1886f96770d4",
+                  "project_id": "d2bf0629-84a7-4b0b-b435-f49a87f0720c"
+                }
+              ],
+              "type": "audit_log_search"
+            },
+            "jsonapi": {
+              "version": "1.0"
+            },
+            "links": {}
+          }
+          `}}
+  - path: /rest/orgs/0de7b2d6-c1da-46aa-887e-1886f96770d4/audit_logs/search
+    methods: ["GET"]
+    request_headers:
+      authorization: xxxxxx
+    query_params:
+      version: "2024-04-29"
+      sort_order: ASC
       cursor: null
     responses:
       - status_code: 200

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix audit_logs event type filter being silently ignored due to state key mismatch (`events_filter` vs `event_filter`).
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/18902
 - version: "3.4.2"
   changes:
     - description: Fix work list and cursor handling.

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "3.4.3"
   changes:
-    - description: Fix audit_logs event type filter being silently ignored due to state key mismatch (`events_filter` vs `event_filter`).
+    - description: Fix audit_logs event type filter being ignored due to state key mismatch.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/18902
 - version: "3.4.2"

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.3"
+  changes:
+    - description: Fix audit_logs event type filter being silently ignored due to state key mismatch (`events_filter` vs `event_filter`).
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "3.4.2"
   changes:
     - description: Fix work list and cursor handling.

--- a/packages/snyk/data_stream/audit_logs/_dev/test/system/test-event-filter-config.yml
+++ b/packages/snyk/data_stream/audit_logs/_dev/test/system/test-event-filter-config.yml
@@ -1,0 +1,17 @@
+input: cel
+service: snyk
+vars:
+  url: http://{{Hostname}}:{{Port}}/
+  api_token: xxxxxx
+  ssl:
+    verification_mode: none
+  enable_request_tracer: true
+data_stream:
+  vars:
+    preserve_original_event: true
+    audit_type: /rest/orgs/
+    audit_id: 0de7b2d6-c1da-46aa-887e-1886f96770d4
+    event:
+      - org.project.issue.create
+assert:
+  hit_count: 2

--- a/packages/snyk/data_stream/audit_logs/agent/stream/cel.yml.hbs
+++ b/packages/snyk/data_stream/audit_logs/agent/stream/cel.yml.hbs
@@ -191,7 +191,10 @@ program: |-
                 optional.of([state.project_id])
               :
                 optional.none(),
-              ?"events": state.?event_filter,
+              ?"events": has(state.event_filter) ?
+                optional.of([state.event_filter.join(",")])
+              :
+                optional.none(),
             }.format_query()
           )
         ).with(auth_header).do_request().as(resp,

--- a/packages/snyk/data_stream/audit_logs/agent/stream/cel.yml.hbs
+++ b/packages/snyk/data_stream/audit_logs/agent/stream/cel.yml.hbs
@@ -191,7 +191,7 @@ program: |-
                 optional.of([state.project_id])
               :
                 optional.none(),
-              ?"events": state.?events_filter,
+              ?"events": state.?event_filter,
             }.format_query()
           )
         ).with(auth_header).do_request().as(resp,

--- a/packages/snyk/manifest.yml
+++ b/packages/snyk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: snyk
 title: "Snyk"
-version: "3.4.2"
+version: "3.4.3"
 description: Collect logs from Snyk with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
snyk: fix audit_logs event type filter

The Handlebars template stores the user's event filter config as
state.event_filter, but the CEL program read state.events_filter
(note the extra 's'). The optional field access returned none,
so the "events" query parameter was never included in the API
request, so event filtering was silently ignored.

Additionally, format_query() on a list produces repeated keys
(events=a&events=b). The Snyk API documents the parameter as a
comma-separated list, so the fix joins the list into a single
value (events=a,b).

Snyk's OpenAPI spec names the parameter "event" (singular), but
live testing confirms the API only honours "events" (plural) —
"event" is silently ignored. The migration guide also documents
the plural form:
https://docs.snyk.io/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/search-audit-logs-group-and-org-v1-api-to-ga-rest-audit-logs-api-migration-guide

Tested against a live Snyk org endpoint with mito, confirming
the filter now correctly narrows results.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Newly added system tests (with `event` option) passes:
```
--- Test results for package: snyk - START ---
╭─────────┬─────────────┬───────────┬──────────────┬────────┬───────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME    │ RESULT │  TIME ELAPSED │
├─────────┼─────────────┼───────────┼──────────────┼────────┼───────────────┤
│ snyk    │ audit_logs  │ system    │ event-filter │ PASS   │ 46.624782375s │
╰─────────┴─────────────┴───────────┴──────────────┴────────┴───────────────╯
--- Test results for package: snyk - END   ---
Done
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes elastic/integrations#18653
- Closes #18929
