### PR TITLE
[Elasticsearch]: Docs table and query analytics dashboard

### DIFF
--- a/packages/elasticsearch/data_stream/querylog/fields/fields.yml
+++ b/packages/elasticsearch/data_stream/querylog/fields/fields.yml
@@ -1,13 +1,13 @@
 - name: elasticsearch.querylog
   type: group
-  description: Query log events from Elasticsearch (DSL, ES|QL, SQL, EQL)
+  description: Query log events from Elasticsearch (DSL, ES&#124;QL, SQL, EQL)
   fields:
     - name: indices
       type: keyword
-      description: Indices involved (DSL, ES|QL when response present, EQL). Not emitted by SqlLogProducer.
+      description: Indices involved (DSL, ES&#124;QL when response present, EQL). Not emitted by SqlLogProducer.
     - name: query
       type: keyword
-      description: Query text (DSL JSON, ES|QL, SQL, or EQL)
+      description: Query text (DSL JSON, ES&#124;QL, SQL, or EQL)
     - name: result_count
       type: long
       description: Number of rows or hits returned (clamped to int where applicable)
@@ -58,13 +58,13 @@
       fields:
         - name: remotes
           type: keyword
-          description: Remote cluster aliases when remotes exist (DSL/ES|QL/EQL)
+          description: Remote cluster aliases when remotes exist (DSL/ES&#124;QL/EQL)
         - name: remote_count
           type: long
           description: Number of remote clusters or distinct remote aliases
         - name: total
           type: long
-          description: Total cluster entries in the map (DSL and ES|QL only; not EQL)
+          description: Total cluster entries in the map (DSL and ES&#124;QL only; not EQL)
         - name: skipped
           type: long
           description: Skipped cluster count when present in the cluster map
@@ -91,34 +91,34 @@
               fields:
                 - name: took
                   type: long
-                  description: ES|QL profile analysis phase duration in nanoseconds
+                  description: ES&#124;QL profile analysis phase duration in nanoseconds
             - name: planning
               type: group
               fields:
                 - name: took
                   type: long
-                  description: ES|QL profile planning phase duration in nanoseconds
+                  description: ES&#124;QL profile planning phase duration in nanoseconds
             - name: parsing
               type: group
               fields:
                 - name: took
                   type: long
-                  description: ES|QL profile parsing phase duration in nanoseconds
+                  description: ES&#124;QL profile parsing phase duration in nanoseconds
             - name: preanalysis
               type: group
               fields:
                 - name: took
                   type: long
-                  description: ES|QL profile preanalysis phase duration in nanoseconds
+                  description: ES&#124;QL profile preanalysis phase duration in nanoseconds
             - name: query
               type: group
               fields:
                 - name: took
                   type: long
-                  description: ES|QL profile query phase duration in nanoseconds
+                  description: ES&#124;QL profile query phase duration in nanoseconds
             - name: dependency_resolution
               type: group
               fields:
                 - name: took
                   type: long
-                  description: ES|QL profile dependency resolution phase duration in nanoseconds
+                  description: ES&#124;QL profile dependency resolution phase duration in nanoseconds

--- a/packages/elasticsearch/docs/README.md
+++ b/packages/elasticsearch/docs/README.md
@@ -299,24 +299,24 @@ Collects [query logs](https://www.elastic.co/docs/deploy-manage/monitor/logging-
 | elasticsearch.querylog.clusters.failed | Failed cluster count when present in the cluster map | long |
 | elasticsearch.querylog.clusters.partial | Partial cluster count when present in the cluster map | long |
 | elasticsearch.querylog.clusters.remote_count | Number of remote clusters or distinct remote aliases | long |
-| elasticsearch.querylog.clusters.remotes | Remote cluster aliases when remotes exist (DSL/ES|QL/EQL) | keyword |
+| elasticsearch.querylog.clusters.remotes | Remote cluster aliases when remotes exist (DSL/ES&#124;QL/EQL) | keyword |
 | elasticsearch.querylog.clusters.running | Running cluster count when present in the cluster map | long |
 | elasticsearch.querylog.clusters.skipped | Skipped cluster count when present in the cluster map | long |
 | elasticsearch.querylog.clusters.successful | Successful cluster count when present in the cluster map | long |
-| elasticsearch.querylog.clusters.total | Total cluster entries in the map (DSL and ES|QL only; not EQL) | long |
+| elasticsearch.querylog.clusters.total | Total cluster entries in the map (DSL and ES&#124;QL only; not EQL) | long |
 | elasticsearch.querylog.dsl.total_count | Total hits from TotalHits (DSL only, SearchLogProducer) | long |
 | elasticsearch.querylog.dsl.total_count_partial | True when total hit relation is not EQUAL_TO | boolean |
-| elasticsearch.querylog.esql.profile.analysis.took | ES|QL profile analysis phase duration in nanoseconds | long |
-| elasticsearch.querylog.esql.profile.dependency_resolution.took | ES|QL profile dependency resolution phase duration in nanoseconds | long |
-| elasticsearch.querylog.esql.profile.parsing.took | ES|QL profile parsing phase duration in nanoseconds | long |
-| elasticsearch.querylog.esql.profile.planning.took | ES|QL profile planning phase duration in nanoseconds | long |
-| elasticsearch.querylog.esql.profile.preanalysis.took | ES|QL profile preanalysis phase duration in nanoseconds | long |
-| elasticsearch.querylog.esql.profile.query.took | ES|QL profile query phase duration in nanoseconds | long |
+| elasticsearch.querylog.esql.profile.analysis.took | ES&#124;QL profile analysis phase duration in nanoseconds | long |
+| elasticsearch.querylog.esql.profile.dependency_resolution.took | ES&#124;QL profile dependency resolution phase duration in nanoseconds | long |
+| elasticsearch.querylog.esql.profile.parsing.took | ES&#124;QL profile parsing phase duration in nanoseconds | long |
+| elasticsearch.querylog.esql.profile.planning.took | ES&#124;QL profile planning phase duration in nanoseconds | long |
+| elasticsearch.querylog.esql.profile.preanalysis.took | ES&#124;QL profile preanalysis phase duration in nanoseconds | long |
+| elasticsearch.querylog.esql.profile.query.took | ES&#124;QL profile query phase duration in nanoseconds | long |
 | elasticsearch.querylog.has_aggregations | True if the search response has aggregations (DSL) | boolean |
-| elasticsearch.querylog.indices | Indices involved (DSL, ES|QL when response present, EQL). Not emitted by SqlLogProducer. | keyword |
+| elasticsearch.querylog.indices | Indices involved (DSL, ES&#124;QL when response present, EQL). Not emitted by SqlLogProducer. | keyword |
 | elasticsearch.querylog.is_remote | True when SearchRequest#getLocalClusterAlias() is set (DSL remote-cluster request) | boolean |
 | elasticsearch.querylog.is_system | True if all resolved indices match the system-index predicate (QueryLogger); omitted when SQL has no indices | boolean |
-| elasticsearch.querylog.query | Query text (DSL JSON, ES|QL, SQL, or EQL) | keyword |
+| elasticsearch.querylog.query | Query text (DSL JSON, ES&#124;QL, SQL, or EQL) | keyword |
 | elasticsearch.querylog.result_count | Number of rows or hits returned (clamped to int where applicable) | long |
 | elasticsearch.querylog.shards.failed | Failed shards (only emitted if count \> 0) | long |
 | elasticsearch.querylog.shards.skipped | Skipped shards (only emitted if count \> 0) | long |

--- a/packages/elasticsearch/kibana/dashboard/elasticsearch-query-analytics-dashboard.json
+++ b/packages/elasticsearch/kibana/dashboard/elasticsearch-query-analytics-dashboard.json
@@ -1519,23 +1519,7 @@
             },
             {
                 "embeddableConfig": {
-                    "description": "",
-                    "drilldowns": [],
-                    "grid": {
-                        "columns": {
-                            "elasticsearch.querylog.query": {
-                                "width": 986
-                            },
-                            "elasticsearch.querylog.took_millis": {
-                                "width": 128
-                            },
-                            "elasticsearch.querylog.type": {
-                                "width": 101
-                            }
-                        }
-                    },
-                    "selectedTabId": "fba80c37-6cd6-42c0-9348-43141bd30c12",
-                    "title": "Historical queries"
+                    "enhancements": {}
                 },
                 "gridData": {
                     "h": 20,
@@ -1545,7 +1529,9 @@
                     "y": 53
                 },
                 "panelIndex": "5d5c69be-8de4-4057-870f-d4c96e2fa37c",
-                "type": "discover_session"
+                "panelRefName": "savedObjectRef",
+                "title": "Historical queries",
+                "type": "search"
             },
             {
                 "embeddableConfig": {
@@ -1950,7 +1936,7 @@
                     "i": "1f69e963-c8cb-4b23-bc4f-010df1b82036",
                     "w": 20,
                     "x": 0,
-                    "y": 2
+                    "y": 93
                 },
                 "panelIndex": "1f69e963-c8cb-4b23-bc4f-010df1b82036",
                 "type": "vis"
@@ -2191,7 +2177,7 @@
                     "i": "49f0b222-f001-47e8-8b7e-690f68651b3c",
                     "w": 20,
                     "x": 20,
-                    "y": 2
+                    "y": 93
                 },
                 "panelIndex": "49f0b222-f001-47e8-8b7e-690f68651b3c",
                 "type": "vis"
@@ -2219,7 +2205,7 @@
                     "i": "688a8381-3905-49f4-8e58-7935d6d5e83d",
                     "w": 12,
                     "x": 0,
-                    "y": 0
+                    "y": 91
                 },
                 "panelIndex": "688a8381-3905-49f4-8e58-7935d6d5e83d",
                 "type": "options_list_control"
@@ -2247,7 +2233,7 @@
                     "i": "8bc5089f-7771-488c-b860-dc13a3884861",
                     "w": 12,
                     "x": 12,
-                    "y": 0
+                    "y": 91
                 },
                 "panelIndex": "8bc5089f-7771-488c-b860-dc13a3884861",
                 "type": "options_list_control"


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/integrations/issues/13374

Follow-up fixes for the Elasticsearch integration querylog work ([integrations#18859](https://github.com/elastic/integrations/pull/18859)):

1. **Exported fields docs** — Pipe characters in `ES|QL` broke Markdown table columns in the generated field reference.
2. **Query analytics dashboard** — After stripping newer-Kibana-only dashboard attributes for CI compatibility (`sections`, etc.), some panels kept **section-relative grid coordinates** (`y: 0` / `y: 2`) and appeared at the **top** of the dashboard instead of the bottom. The **Historical queries** panel used a **`discover_session`** embeddable tied to a Discover tab id that is **not** portable with the package, which triggered *“The Discover session tab saved with this panel no longer exists”* after install.

## Changes

### Documentation

- Replace `ES|QL` with `ES&#124;QL` in `data_stream/querylog/fields/fields.yml` descriptions (renders as ES|QL without splitting Markdown table cells).
- Regenerate `docs/README.md` via `elastic-package build`.

### Query analytics dashboard (`kibana/dashboard/elasticsearch-query-analytics-dashboard.json`)

- Replace **`discover_session`** with a **`search`** embeddable (`panelRefName`: `savedObjectRef`) so **Historical queries** uses the packaged saved search **`elasticsearch-5df8f5ab-0459-4c89-95b4-3b3d235386bd`** instead of an ephemeral Discover session id.
- Move **remote-cluster** Lens panels and **Coordinating clusters / Remote aliases** controls to **bottom** grid rows (`y` 91+ / 93+) so layout matches the intended order below the main charts.

## Testing

- `elastic-package check` (lint + package build / README render)

cc @elastic/stack-monitoring
