### PR TITLE
[Elasticsearch] bump package to 1.21.1 for querylog fixes

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.1"
+  changes:
+    - description: Bugfix for `querylog` new data stream (docs and dashboard)
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18905
 - version: "1.21.0"
   changes:
     - description: Add support for `querylog` data stream to collect Elasticsearch query logs

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.21.0
+version: 1.21.1
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
## Summary
- bump `packages/elasticsearch` package version from `1.21.0` to `1.21.1`
- add `1.21.1` changelog entry for the querylog docs/dashboard fixes that were merged in [#18905](https://github.com/elastic/integrations/pull/18905)

## Test plan
- [x] Verified diff against `main` only includes `manifest.yml` version bump + `changelog.yml` entry
- [x] Confirmed `main` currently remains at `1.21.0` and does not yet include a `1.21.1` release entry

Relates to:
- https://github.com/elastic/integrations/pull/18905
- https://github.com/elastic/integrations/pull/18859
- https://github.com/elastic/integrations/issues/13374