### PR TITLE
[CI] Add Buildkite step to run Python CI scripts unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,6 +64,7 @@ steps:
     key: "check-ci-python-scripts"
     command: ".buildkite/scripts/run_ci_python_scripts_tests.sh"
     agents:
+      # GCP VM used to match the same Python 3 version available in the steps that test packages
       provider: gcp
       image: "${IMAGE_UBUNTU_X86_64}"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,13 @@ steps:
     artifact_paths:
       - tests-report.xml
 
+  - label: ":snake: Python CI scripts unit tests"
+    key: "check-ci-python-scripts"
+    command: ".buildkite/scripts/run_ci_python_scripts_tests.sh"
+    agents:
+      provider: gcp
+      image: "${IMAGE_UBUNTU_X86_64}"
+
   - label: ":junit: Sources Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"
@@ -83,6 +90,8 @@ steps:
       UPLOAD_SAFE_LOGS: 1
     depends_on:
       - step: "check"
+        allow_failure: false
+      - step: "check-ci-python-scripts"
         allow_failure: false
 
   - wait: ~

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -900,7 +900,7 @@ teardown_test_package() {
 
 # list all directories that are packages from the root of the repository
 list_all_directories() {
-    mage -d "${WORKSPACE}" listPackages | grep "packages/elastic_package_registry"
+    mage -d "${WORKSPACE}" listPackages
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -900,7 +900,7 @@ teardown_test_package() {
 
 # list all directories that are packages from the root of the repository
 list_all_directories() {
-    mage -d "${WORKSPACE}" listPackages
+    mage -d "${WORKSPACE}" listPackages | grep "packages/elastic_package_registry"
 }
 
 check_package() {

--- a/.buildkite/scripts/requirements-ci-python-scripts.txt
+++ b/.buildkite/scripts/requirements-ci-python-scripts.txt
@@ -1,0 +1,3 @@
+# Deps for Python CI scripts (unit tests + runtime)
+requests==2.32.3
+PyYAML==6.0.2

--- a/.buildkite/scripts/run_ci_python_scripts_tests.sh
+++ b/.buildkite/scripts/run_ci_python_scripts_tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Runs Python unit tests for CI scripts in an isolated venv.
+# Intended for Buildkite (see pipeline.yml).
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VENV_DIR="${REPO_ROOT}/.buildkite/.venv-ci-python-scripts"
+REQ_FILE="${REPO_ROOT}/.buildkite/scripts/requirements-ci-python-scripts.txt"
+FIND_OLDEST_SCRIPT="${REPO_ROOT}/.buildkite/scripts/find_oldest_supported_version.py"
+
+if [[ ! -f "${VENV_DIR}/bin/activate" ]]; then
+    rm -rf "${VENV_DIR}"
+    if ! python3 -m venv "${VENV_DIR}"; then
+        if command -v apt-get >/dev/null 2>&1 && [[ "$(id -u)" -eq 0 ]]; then
+            echo "python3 -m venv unavailable; installing python3-venv"
+            DEBIAN_FRONTEND=noninteractive apt-get update -qq
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3-venv
+        fi
+        rm -rf "${VENV_DIR}"
+        python3 -m venv "${VENV_DIR}"
+    fi
+fi
+# shellcheck source=/dev/null
+source "${VENV_DIR}/bin/activate"
+pip install -q -r "${REQ_FILE}"
+python "${FIND_OLDEST_SCRIPT}" --test
+deactivate

--- a/.buildkite/scripts/run_ci_python_scripts_tests.sh
+++ b/.buildkite/scripts/run_ci_python_scripts_tests.sh
@@ -12,10 +12,10 @@ FIND_OLDEST_SCRIPT="${REPO_ROOT}/.buildkite/scripts/find_oldest_supported_versio
 if [[ ! -f "${VENV_DIR}/bin/activate" ]]; then
     rm -rf "${VENV_DIR}"
     if ! python3 -m venv "${VENV_DIR}"; then
-        if command -v apt-get >/dev/null 2>&1 && [[ "$(id -u)" -eq 0 ]]; then
+        if command -v apt-get >/dev/null 2>&1; then
             echo "python3 -m venv unavailable; installing python3-venv"
-            DEBIAN_FRONTEND=noninteractive apt-get update -qq
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3-venv
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-venv
         fi
         rm -rf "${VENV_DIR}"
         python3 -m venv "${VENV_DIR}"
@@ -23,6 +23,6 @@ if [[ ! -f "${VENV_DIR}/bin/activate" ]]; then
 fi
 # shellcheck source=/dev/null
 source "${VENV_DIR}/bin/activate"
-pip install -q -r "${REQ_FILE}"
-python "${FIND_OLDEST_SCRIPT}" --test
+python3 -m pip install -q -r "${REQ_FILE}"
+python3 "${FIND_OLDEST_SCRIPT}" --test
 deactivate

--- a/.buildkite/scripts/run_ci_python_scripts_tests.sh
+++ b/.buildkite/scripts/run_ci_python_scripts_tests.sh
@@ -12,9 +12,10 @@ FIND_OLDEST_SCRIPT="${REPO_ROOT}/.buildkite/scripts/find_oldest_supported_versio
 if [[ ! -f "${VENV_DIR}/bin/activate" ]]; then
     rm -rf "${VENV_DIR}"
     if ! python3 -m venv "${VENV_DIR}"; then
+        echo "--- Installing python3-venv"
         if command -v apt-get >/dev/null 2>&1; then
             echo "python3 -m venv unavailable; installing python3-venv"
-            sudo apt-get update
+            sudo apt-get update -q
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-venv
         fi
         rm -rf "${VENV_DIR}"
@@ -22,7 +23,10 @@ if [[ ! -f "${VENV_DIR}/bin/activate" ]]; then
     fi
 fi
 # shellcheck source=/dev/null
+echo "--- Installing dependencies"
 source "${VENV_DIR}/bin/activate"
 python3 -m pip install -q -r "${REQ_FILE}"
+echo "+++ Running tests"    
 python3 "${FIND_OLDEST_SCRIPT}" --test
+echo "--- Deactivating venv"
 deactivate

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ elastic-package
 
 # Folder created by the Sonar Scanner
 .scannerwork/
+
+# Buildkite Python CI scripts test venv
+.buildkite/.venv-ci-python-scripts/


### PR DESCRIPTION
## Proposed commit message

Add a generic Buildkite pipeline step (`check-ci-python-scripts`) that runs
unit tests for Python scripts used in CI.

**NOTE**: It is used the provider gcp in Buildkite to ensure that the same python3 version as in the integration steps is used.

**WHAT:**
- New step `:snake: Python CI scripts unit tests` in `pipeline.yml` that runs
  `run_ci_python_scripts_tests.sh` on a GCP Ubuntu agent.
- The step runs in parallel with the existing `check` (Go sources) step, keeping
  CI feedback fast.
- `test-integrations` is gated on both `check` and `check-ci-python-scripts`
  passing before triggering package tests.
- The shell script sets up an isolated Python venv, installs pinned deps from
  `requirements-ci-python-scripts.txt`, and invokes `find_oldest_supported_version.py --test`.
- `.gitignore` updated to exclude the generated venv directory.
- `list_all_directories` in `common.sh` temporarily filtered to
  `packages/elastic_package_registry` for focused testing (to be reverted).

**WHY:**
`find_oldest_supported_version.py` contains logic critical to how the CI
pipeline selects which stack versions to test against. Without a CI gate, a
regression in that script would silently affect all integration test runs.
This PR adds that safety net and lays the groundwork for testing other Python
CI scripts in the same step.


## Author's Checklist

- [x] Revert the temporary `grep` filter in `list_all_directories` (`common.sh`) before merging.
- [x] Trigger a Buildkite build on this branch and verify the new `:snake: Python CI scripts unit tests` step appears and passes.
- [x] Confirm `test-integrations` only starts after both `check` and `check-ci-python-scripts` succeed.
- [x] Run `.buildkite/scripts/run_ci_python_scripts_tests.sh` locally to verify the venv setup and tests pass.



---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).