### PR TITLE
[cloudflare_logpush] enhance ingestion logic with typed conversions and dissect processors

### DIFF
--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -5,7 +5,7 @@
         Replace `rename` processors with typed `convert` processors for fields whose `fields.yml` mapping is `ip`, `long`, `double`, or `boolean`. This validates incoming values against the declared mapping and prevents off-type values from being silently indexed.
         Replace grok processors with dissect for simple delimiter-based pattern matching to increase performance.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18952
 - version: "1.45.0-preview01"
   changes:
     - description: Update ECS to 9.3.0 and add new fields across multiple data streams.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,11 @@
 # newer versions go on top
+- version: "1.45.0-preview02"
+  changes:
+    - description: |
+        Replace `rename` processors with typed `convert` processors for fields whose `fields.yml` mapping is `ip`, `long`, `double`, or `boolean`. This validates incoming values against the declared mapping and prevents off-type values from being silently indexed.
+        Replace grok processors with dissect for simple delimiter-based pattern matching to increase performance.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.45.0-preview01"
   changes:
     - description: Update ECS to 9.3.0 and add new fields across multiple data streams.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: |
         Replace `rename` processors with typed `convert` processors for fields whose `fields.yml` mapping is `ip`, `long`, `double`, or `boolean`. This validates incoming values against the declared mapping and prevents off-type values from being silently indexed.
-        Replace grok processors with dissect for simple delimiter-based pattern matching to increase performance.
+        Replace grok processors with dissect for simple delimiter-based pattern.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/18952
 - version: "1.45.0-preview01"

--- a/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
@@ -92,8 +92,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.Allowed
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -148,8 +146,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.IPAddress != ''
       on_failure:
-        - remove:
-            field: json.IPAddress
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -204,8 +200,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.TemporaryAccessDuration
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
@@ -85,10 +85,18 @@ processors:
       field: event.action
       copy_from: cloudflare_logpush.access_request.action
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.Allowed
+      tag: convert_allowed_to_boolean
       target_field: cloudflare_logpush.access_request.allowed
+      type: boolean
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.Allowed
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 # Enrich event.type based on the allowed field
   - append:
       field: event.type
@@ -132,10 +140,19 @@ processors:
       field: user.email
       copy_from: cloudflare_logpush.access_request.user.email
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.IPAddress
+      tag: convert_ipaddress_to_ip
       target_field: cloudflare_logpush.access_request.client.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.IPAddress != ''
+      on_failure:
+        - remove:
+            field: json.IPAddress
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: client.ip
       copy_from: cloudflare_logpush.access_request.client.ip
@@ -180,10 +197,18 @@ processors:
       field: json.TemporaryAccessApprovers
       target_field: cloudflare_logpush.access_request.temp_access.approvers
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.TemporaryAccessDuration
+      tag: convert_temporaryaccessduration_to_long
       target_field: cloudflare_logpush.access_request.temp_access.duration
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.TemporaryAccessDuration
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.UserUID
       target_field: cloudflare_logpush.access_request.user.id

--- a/packages/cloudflare_logpush/data_stream/access_request/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/access_request/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-05-23T17:18:33.000Z",
     "agent": {
-        "ephemeral_id": "e06db4c9-f86d-4fd7-969e-b963e9a9207b",
-        "id": "7912b2c5-cf95-42a7-81e4-33a10b9e1878",
-        "name": "elastic-agent-39279",
+        "ephemeral_id": "056ec563-a195-426e-9567-24bbfabae21f",
+        "id": "b7ff516b-300e-4aa7-9b17-86fb55c9b5c3",
+        "name": "elastic-agent-10661",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -58,14 +58,14 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.access_request",
-        "namespace": "33797",
+        "namespace": "60239",
         "type": "logs"
     },
     "ecs": {
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "7912b2c5-cf95-42a7-81e4-33a10b9e1878",
+        "id": "b7ff516b-300e-4aa7-9b17-86fb55c9b5c3",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -77,7 +77,7 @@
         ],
         "dataset": "cloudflare_logpush.access_request",
         "id": "00c0ffeeabc12345",
-        "ingested": "2026-04-29T02:48:25Z",
+        "ingested": "2026-05-11T12:48:12Z",
         "kind": "event",
         "original": "{\"Action\":\"login\",\"Allowed\":true,\"AppDomain\":\"partner-zt-logs.cloudflareaccess.com/warp\",\"AppUUID\":\"123e4567-e89b-12d3-a456-426614174000\",\"Connection\":\"onetimepin\",\"Country\":\"us\",\"CreatedAt\":1684862313000000000,\"Email\":\"user@example.com\",\"IPAddress\":\"67.43.156.93\",\"PurposeJustificationPrompt\":\"Please provide your reason for accessing the application.\",\"PurposeJustificationResponse\":\"I need to access the application for work purposes.\",\"RayID\":\"00c0ffeeabc12345\",\"TemporaryAccessApprovers\":[\"approver1@example.com\",\"approver2@example.com\"],\"TemporaryAccessDuration\":7200,\"UserUID\":\"166befbb-00e3-5e20-bd6e-27245333949f\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
@@ -159,8 +159,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.PostureEvaluatedResult
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
@@ -152,10 +152,18 @@ processors:
       field: rule.category
       copy_from: cloudflare_logpush.device_posture.rule.category
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.PostureEvaluatedResult
+      tag: convert_postureevaluatedresult_to_boolean
       target_field: cloudflare_logpush.device_posture.eval.result
+      type: boolean
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.PostureEvaluatedResult
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 # Set event.outcome from cloudflare_logpush.device_posture.eval.result
   - set:
       field: event.outcome

--- a/packages/cloudflare_logpush/data_stream/device_posture/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/device_posture/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-05-17T12:00:00.000Z",
     "agent": {
-        "ephemeral_id": "f04fff25-8dd4-435f-bdcb-55e3705bb7fb",
-        "id": "39eaaafd-6328-4c81-a13b-5f82ea3def0c",
-        "name": "elastic-agent-38416",
+        "ephemeral_id": "9f68fcc3-9aab-4700-a383-a8e1a7714aaa",
+        "id": "50ffaa67-ed17-4aa2-a943-e3c704e777da",
+        "name": "elastic-agent-10003",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -50,14 +50,14 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.device_posture",
-        "namespace": "40489",
+        "namespace": "72148",
         "type": "logs"
     },
     "ecs": {
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "39eaaafd-6328-4c81-a13b-5f82ea3def0c",
+        "id": "50ffaa67-ed17-4aa2-a943-e3c704e777da",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -67,7 +67,7 @@
             "host"
         ],
         "dataset": "cloudflare_logpush.device_posture",
-        "ingested": "2026-04-29T02:51:36Z",
+        "ingested": "2026-05-11T12:49:17Z",
         "kind": "event",
         "original": "{\"ClientVersion\":\"2023.3.258\",\"DeviceID\":\"083a8354-d56c-11ed-9771-111111111\",\"DeviceManufacturer\":\"Google Compute Engine\",\"DeviceModel\":\"Google Compute Engine\",\"DeviceName\":\"zt-test-vm1\",\"DeviceSerialNumber\":\"GoogleCloud-ABCD1234567890\",\"DeviceType\":\"linux\",\"Email\":\"user@example.com\",\"OSVersion\":\"5.15.0\",\"PolicyID\":\"policy-abcdefgh\",\"PostureCheckName\":\"Ubuntu\",\"PostureCheckType\":\"os_version\",\"PostureEvaluatedResult\":true,\"PostureExpectedJSON\":{\"operator\":\"==\",\"os_distro_name\":\"ubuntu\",\"os_distro_revision\":\"20.04\",\"version\":\"5.15.0-1025-gcp\"},\"PostureReceivedJSON\":{\"operator\":\"==\",\"os_distro_name\":\"ubuntu\",\"os_distro_revision\":\"20.04\",\"version\":\"5.15.0-1025-gcp\"},\"Timestamp\":\"2023-05-17T12:00:00Z\",\"UserUID\":\"user-abcdefgh\"}",
         "outcome": "success",

--- a/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -134,10 +134,18 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
-  - rename:
+  - convert:
       field: json.ResponseCached
+      tag: convert_responsecached_to_boolean
       target_field: cloudflare_logpush.dns.response.cached
+      type: boolean
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.ResponseCached
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.ResponseCode
       target_field: cloudflare_logpush.dns.response.code

--- a/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -141,8 +141,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.ResponseCached
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/dns/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/dns/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2022-05-26T09:23:54.000Z",
     "agent": {
-        "ephemeral_id": "c9c0767e-98e7-4e83-a4a0-d716742d4b6e",
-        "id": "339c3d07-90ae-4d49-88ba-434295d3dd10",
-        "name": "elastic-agent-99087",
+        "ephemeral_id": "c957013b-877d-4f22-9ad9-944f78c98f28",
+        "id": "a8fbeca3-cf0d-4ea5-9864-6b334e3ae3f1",
+        "name": "elastic-agent-61606",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -32,7 +32,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.dns",
-        "namespace": "40068",
+        "namespace": "11830",
         "type": "logs"
     },
     "dns": {
@@ -44,7 +44,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "339c3d07-90ae-4d49-88ba-434295d3dd10",
+        "id": "a8fbeca3-cf0d-4ea5-9864-6b334e3ae3f1",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -54,7 +54,7 @@
             "network"
         ],
         "dataset": "cloudflare_logpush.dns",
-        "ingested": "2026-04-29T02:53:36Z",
+        "ingested": "2026-05-11T12:50:17Z",
         "kind": "event",
         "original": "{\"ColoCode\":\"MRS\",\"EDNSSubnet\":\"1.128.0.0\",\"EDNSSubnetLength\":0,\"QueryName\":\"example.com\",\"QueryType\":65535,\"ResponseCached\":false,\"ResponseCode\":0,\"SourceIP\":\"175.16.199.0\",\"Timestamp\":\"2022-05-26T09:23:54Z\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
@@ -86,11 +86,19 @@ processors:
       tag: set_timestamp
 
 # Handle source IP
-  - rename:
+  - convert:
       field: json.SourceIP
+      tag: convert_sourceip_to_ip
       target_field: cloudflare_logpush.dns_firewall.source.ip
+      type: ip
       ignore_missing: true
-      tag: rename_source_ip
+      if: ctx.json?.SourceIP != ''
+      on_failure:
+        - remove:
+            field: json.SourceIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.dns_firewall.source.ip
@@ -177,36 +185,79 @@ processors:
       target_field: cloudflare_logpush.dns_firewall.colo.code
       ignore_missing: true
       tag: rename_colo_code
-  - rename:
+  - convert:
       field: json.EDNSSubnet
+      tag: convert_ednssubnet_to_ip
       target_field: cloudflare_logpush.dns_firewall.edns.subnet
+      type: ip
       ignore_missing: true
-      tag: rename_edns_subnet
-  - rename:
+      if: ctx.json?.EDNSSubnet != ''
+      on_failure:
+        - remove:
+            field: json.EDNSSubnet
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.EDNSSubnetLength
+      tag: convert_ednssubnetlength_to_long
       target_field: cloudflare_logpush.dns_firewall.edns.subnet_length
+      type: long
       ignore_missing: true
-      tag: rename_edns_subnet_length
-  - rename:
+      on_failure:
+        - remove:
+            field: json.EDNSSubnetLength
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.QueryDO
+      tag: convert_querydo_to_boolean
       target_field: cloudflare_logpush.dns_firewall.question.dnssec_ok
+      type: boolean
       ignore_missing: true
-      tag: rename_question_do
-  - rename:
+      on_failure:
+        - remove:
+            field: json.QueryDO
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.QueryRD
+      tag: convert_queryrd_to_boolean
       target_field: cloudflare_logpush.dns_firewall.question.recursion_desired
+      type: boolean
       ignore_missing: true
-      tag: rename_question_recursion_desired
-  - rename:
+      on_failure:
+        - remove:
+            field: json.QueryRD
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.QuerySize
+      tag: convert_querysize_to_long
       target_field: cloudflare_logpush.dns_firewall.question.size
+      type: long
       ignore_missing: true
-      tag: rename_question_size
-  - rename:
+      on_failure:
+        - remove:
+            field: json.QuerySize
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.QueryTCP
+      tag: convert_querytcp_to_boolean
       target_field: cloudflare_logpush.dns_firewall.question.tcp
+      type: boolean
       ignore_missing: true
-      tag: rename_question_tcp
+      on_failure:
+        - remove:
+            field: json.QueryTCP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: network.transport
       value: tcp
@@ -222,31 +273,60 @@ processors:
       target_field: cloudflare_logpush.dns_firewall.question.type
       ignore_missing: true
       tag: rename_question_type
-  - rename:
+  - convert:
       field: json.ResponseCached
+      tag: convert_responsecached_to_boolean
       target_field: cloudflare_logpush.dns_firewall.response.cached
+      type: boolean
       ignore_missing: true
-      tag: rename_dns_response_cached
+      on_failure:
+        - remove:
+            field: json.ResponseCached
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.ResponseReason
       target_field: cloudflare_logpush.dns_firewall.response.reason
       ignore_missing: true
       tag: rename_dns_response_reason
-  - rename:
+  - convert:
       field: json.ResponseCachedStale
+      tag: convert_responsecachedstale_to_boolean
       target_field: cloudflare_logpush.dns_firewall.response.cached_stale
+      type: boolean
       ignore_missing: true
-      tag: rename_dns_response_cached_stale
-  - rename:
+      on_failure:
+        - remove:
+            field: json.ResponseCachedStale
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.UpstreamIP
+      tag: convert_upstreamip_to_ip
       target_field: cloudflare_logpush.dns_firewall.upstream.ip
+      type: ip
       ignore_missing: true
-      tag: rename_dns_upstream_ip
-  - rename:
+      if: ctx.json?.UpstreamIP != ''
+      on_failure:
+        - remove:
+            field: json.UpstreamIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.UpstreamResponseTimeMs
+      tag: convert_upstreamresponsetimems_to_long
       target_field: cloudflare_logpush.dns_firewall.upstream.response_time_ms
+      type: long
       ignore_missing: true
-      tag: rename_dns_upstream_response_time_ms
+      on_failure:
+        - remove:
+            field: json.UpstreamResponseTimeMs
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 
 # Create related fields
   - append:

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
@@ -94,8 +94,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SourceIP != ''
       on_failure:
-        - remove:
-            field: json.SourceIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -193,8 +191,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.EDNSSubnet != ''
       on_failure:
-        - remove:
-            field: json.EDNSSubnet
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -205,8 +201,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.EDNSSubnetLength
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -217,8 +211,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.QueryDO
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -229,8 +221,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.QueryRD
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -241,8 +231,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.QuerySize
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -253,8 +241,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.QueryTCP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -280,8 +266,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.ResponseCached
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -297,8 +281,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.ResponseCachedStale
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -310,8 +292,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.UpstreamIP != ''
       on_failure:
-        - remove:
-            field: json.UpstreamIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -322,8 +302,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.UpstreamResponseTimeMs
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-09-19T12:30:00.000Z",
     "agent": {
-        "ephemeral_id": "7ea51c22-048d-4d8e-9905-d10775bdd30d",
-        "id": "802f944f-a105-47e6-a799-c6dfc0045df3",
-        "name": "elastic-agent-89796",
+        "ephemeral_id": "f8b0b839-a1b3-4607-bcba-a28220449ea8",
+        "id": "9888e34b-b0c6-419d-b84a-0aae9eb1a180",
+        "name": "elastic-agent-58572",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -43,7 +43,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.dns_firewall",
-        "namespace": "83561",
+        "namespace": "65572",
         "type": "logs"
     },
     "dns": {
@@ -56,7 +56,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "802f944f-a105-47e6-a799-c6dfc0045df3",
+        "id": "9888e34b-b0c6-419d-b84a-0aae9eb1a180",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -66,7 +66,7 @@
             "network"
         ],
         "dataset": "cloudflare_logpush.dns_firewall",
-        "ingested": "2026-04-29T02:54:36Z",
+        "ingested": "2026-05-11T12:51:18Z",
         "kind": "event",
         "original": "{\"ClientResponseCode\":0,\"ClusterID\":\"CLUSTER-001\",\"ColoCode\":\"SFO\",\"EDNSSubnet\":\"67.43.156.0\",\"EDNSSubnetLength\":24,\"QueryDO\":true,\"QueryName\":\"example.com\",\"QueryRD\":true,\"QuerySize\":60,\"QueryTCP\":false,\"QueryType\":1,\"ResponseCached\":true,\"ResponseCachedStale\":false,\"SourceIP\":\"67.43.156.2\",\"Timestamp\":\"2023-09-19T12:30:00Z\",\"UpstreamIP\":\"81.2.69.144\",\"UpstreamResponseCode\":0,\"UpstreamResponseTimeMs\":30}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
@@ -231,7 +231,10 @@ processors:
       tag: dissect_client_request_protocol
       pattern: '%{network.protocol}/%{http.version}'
       ignore_missing: true
-      if: ctx.cloudflare_logpush?.firewall_event?.client?.request?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.firewall_event.client.request.protocol)
+      if: >-
+        ctx.cloudflare_logpush?.firewall_event?.client?.request?.protocol != null &&
+        ctx.cloudflare_logpush.firewall_event.client.request.protocol != 'none' &&
+        ctx.cloudflare_logpush.firewall_event.client.request.protocol != 'unknown'
       on_failure:
         - append:
             field: error.message

--- a/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
@@ -226,11 +226,11 @@ processors:
       field: json.ClientRequestProtocol
       target_field: cloudflare_logpush.firewall_event.client.request.protocol
       ignore_missing: true
-  - grok:
+  - dissect:
       field: cloudflare_logpush.firewall_event.client.request.protocol
-      patterns:
-        - "^%{DATA:network.protocol}/%{DATA:http.version}$"
-      ignore_failure: true
+      pattern: '%{network.protocol}/%{http.version}'
+      ignore_missing: true
+      if: ctx.cloudflare_logpush?.firewall_event?.client?.request?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.firewall_event.client.request.protocol)
   - lowercase:
       field: network.protocol
       ignore_missing: true

--- a/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
@@ -228,9 +228,14 @@ processors:
       ignore_missing: true
   - dissect:
       field: cloudflare_logpush.firewall_event.client.request.protocol
+      tag: dissect_client_request_protocol
       pattern: '%{network.protocol}/%{http.version}'
       ignore_missing: true
       if: ctx.cloudflare_logpush?.firewall_event?.client?.request?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.firewall_event.client.request.protocol)
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - lowercase:
       field: network.protocol
       ignore_missing: true

--- a/packages/cloudflare_logpush/data_stream/firewall_event/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2022-05-31T05:23:43.000Z",
     "agent": {
-        "ephemeral_id": "bd6ea029-172c-4b27-99c6-c3bc0424e70f",
-        "id": "acbd51de-3306-45ae-8259-cd1e337cdfe8",
-        "name": "elastic-agent-67523",
+        "ephemeral_id": "59ac2e94-d18d-446d-aaca-d5f33b2de2d7",
+        "id": "deb4d2d8-8dff-4e82-8ae3-f917de372242",
+        "name": "elastic-agent-80603",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -70,14 +70,14 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.firewall_event",
-        "namespace": "14795",
+        "namespace": "23958",
         "type": "logs"
     },
     "ecs": {
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "acbd51de-3306-45ae-8259-cd1e337cdfe8",
+        "id": "deb4d2d8-8dff-4e82-8ae3-f917de372242",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -89,7 +89,7 @@
         ],
         "dataset": "cloudflare_logpush.firewall_event",
         "id": "713d477539b55c29",
-        "ingested": "2026-04-29T02:56:36Z",
+        "ingested": "2026-05-11T12:52:16Z",
         "kind": "event",
         "original": "{\"Action\":\"block\",\"ClientASN\":15169,\"ClientASNDescription\":\"CLOUDFLARENET\",\"ClientCountry\":\"us\",\"ClientIP\":\"175.16.199.0\",\"ClientIPClass\":\"searchEngine\",\"ClientRefererHost\":\"abc.example.com\",\"ClientRefererPath\":\"/abc/checkout\",\"ClientRefererQuery\":\"?sourcerer=(default%3A(id%3A!n%2CselectedPatterns%3A!(eqldemo%2C%27logs-endpoint.*-eqldemo%27%2C%27logs-system.*-eqldemo%27%2C%27logs-windows.*-eqldemo%27%2Cmetricseqldemo)))\\u0026timerange=(global%3A(linkTo%3A!()%2Ctimerange%3A(from%3A%272022-04-05T00%3A00%3A01.199Z%27%2CfromStr%3Anow-24h%2Ckind%3Arelative%2Cto%3A%272022-04-06T00%3A00%3A01.200Z%27%2CtoStr%3Anow))%2Ctimeline%3A(linkTo%3A!()%2Ctimerange%3A(from%3A%272022-04-05T00%3A00%3A01.201Z%27%2CfromStr%3Anow-24h%2Ckind%3Arelative%2Cto%3A%272022-04-06T00%3A00%3A01.202Z%27%2CtoStr%3Anow)))\",\"ClientRefererScheme\":\"referer URL scheme\",\"ClientRequestHost\":\"xyz.example.com\",\"ClientRequestMethod\":\"GET\",\"ClientRequestPath\":\"/abc/checkout\",\"ClientRequestProtocol\":\"HTTP/1.1\",\"ClientRequestQuery\":\"?sourcerer=(default%3A(id%3A!n%2CselectedPatterns%3A!(eqldemo%2C%27logs-endpoint.*-eqldemo%27%2C%27logs-system.*-eqldemo%27%2C%27logs-windows.*-eqldemo%27%2Cmetricseqldemo)))\\u0026timerange=(global%3A(linkTo%3A!()%2Ctimerange%3A(from%3A%272022-04-05T00%3A00%3A01.199Z%27%2CfromStr%3Anow-24h%2Ckind%3Arelative%2Cto%3A%272022-04-06T00%3A00%3A01.200Z%27%2CtoStr%3Anow))%2Ctimeline%3A(linkTo%3A!()%2Ctimerange%3A(from%3A%272022-04-05T00%3A00%3A01.201Z%27%2CfromStr%3Anow-24h%2Ckind%3Arelative%2Cto%3A%272022-04-06T00%3A00%3A01.202Z%27%2CtoStr%3Anow)))\",\"ClientRequestScheme\":\"https\",\"ClientRequestUserAgent\":\"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)\",\"Datetime\":\"2022-05-31T05:23:43Z\",\"EdgeColoCode\":\"IAD\",\"EdgeResponseStatus\":403,\"Kind\":\"firewall\",\"MatchIndex\":1,\"Metadata\":{\"filter\":\"1ced07e066a34abf8b14f2a99593bc8d\",\"type\":\"customer\"},\"OriginResponseStatus\":0,\"OriginatorRayID\":\"00\",\"RayID\":\"713d477539b55c29\",\"RuleID\":\"7dc666e026974dab84884c73b3e2afe1\",\"Source\":\"firewallrules\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
@@ -109,8 +109,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.DstIP != ''
       on_failure:
-        - remove:
-            field: json.DstIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -146,8 +144,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.DstPort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -216,8 +212,6 @@ processors:
       type: ip
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.ResolvedIPs
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -233,8 +227,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SrcIP != ''
       on_failure:
-        - remove:
-            field: json.SrcIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -270,8 +262,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.SrcPort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -465,8 +455,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.QuerySize
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -529,8 +517,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.InitialResolvedIPs != ''
       on_failure:
-        - remove:
-            field: json.InitialResolvedIPs
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
@@ -101,10 +101,19 @@ processors:
       field: user.email
       copy_from: cloudflare_logpush.gateway_dns.user.email
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.DstIP
+      tag: convert_dstip_to_ip
       target_field: cloudflare_logpush.gateway_dns.destination.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.DstIP != ''
+      on_failure:
+        - remove:
+            field: json.DstIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.gateway_dns.destination.ip
@@ -130,10 +139,18 @@ processors:
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.DstPort
+      tag: convert_dstport_to_long
       target_field: cloudflare_logpush.gateway_dns.destination.port
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.DstPort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.gateway_dns.destination.port
@@ -192,18 +209,35 @@ processors:
       field: dns.answers
       copy_from: cloudflare_logpush.gateway_dns.answers
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.ResolvedIPs
+      tag: convert_resolvedips_to_ip
       target_field: cloudflare_logpush.gateway_dns.resolved_ip
+      type: ip
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.ResolvedIPs
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: dns.resolved_ip
       copy_from: cloudflare_logpush.gateway_dns.resolved_ip
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.SrcIP
+      tag: convert_srcip_to_ip
       target_field: cloudflare_logpush.gateway_dns.source.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.SrcIP != ''
+      on_failure:
+        - remove:
+            field: json.SrcIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.gateway_dns.source.ip
@@ -229,10 +263,18 @@ processors:
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.SrcPort
+      tag: convert_srcport_to_long
       target_field: cloudflare_logpush.gateway_dns.source.port
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.SrcPort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.port
       copy_from: cloudflare_logpush.gateway_dns.source.port
@@ -416,10 +458,18 @@ processors:
       field: json.QueryNameReversed
       target_field: cloudflare_logpush.gateway_dns.question.reversed
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.QuerySize
+      tag: convert_querysize_to_long
       target_field: cloudflare_logpush.gateway_dns.question.size
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.QuerySize
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.QueryType
       target_field: cloudflare_logpush.gateway_dns.question.type_id
@@ -440,15 +490,6 @@ processors:
       field: json.ResolvedIPCountryCodes
       target_field: cloudflare_logpush.gateway_dns.resolved_ip_details.country_codes
       ignore_missing: true
-  - convert:
-      field: json.ResolvedIPs
-      target_field: cloudflare_logpush.gateway_dns.resolved_ip_details.ips
-      type: ip
-      ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: '{{{_ingest.on_failure_message}}}'
   - rename:
       field: json.ResolverPolicyID
       target_field: cloudflare_logpush.gateway_dns.resolver.policy.ids
@@ -488,6 +529,8 @@ processors:
       ignore_missing: true
       if: ctx.json?.InitialResolvedIPs != ''
       on_failure:
+        - remove:
+            field: json.InitialResolvedIPs
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-05-02T22:49:53.000Z",
     "agent": {
-        "ephemeral_id": "a51869b4-aa4f-4c24-9944-37b44beffec7",
-        "id": "cebaa03a-efd5-4f50-ba1f-e70f5bcef6e6",
-        "name": "elastic-agent-10166",
+        "ephemeral_id": "d0a68378-e3d0-4ab5-b97d-747815823886",
+        "id": "06c19482-8038-4868-b1d4-088b7327fa90",
+        "name": "elastic-agent-62474",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -96,7 +96,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.gateway_dns",
-        "namespace": "24564",
+        "namespace": "26449",
         "type": "logs"
     },
     "destination": {
@@ -151,7 +151,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "cebaa03a-efd5-4f50-ba1f-e70f5bcef6e6",
+        "id": "06c19482-8038-4868-b1d4-088b7327fa90",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -161,7 +161,7 @@
             "network"
         ],
         "dataset": "cloudflare_logpush.gateway_dns",
-        "ingested": "2026-05-07T13:29:28Z",
+        "ingested": "2026-05-11T12:53:18Z",
         "kind": "event",
         "original": "{\"ApplicationID\":0,\"ColoCode\":\"ORD\",\"ColoID\":14,\"Datetime\":\"2023-05-02T22:49:53Z\",\"DeviceID\":\"083a8354-d56c-11ed-9771-6a842b111aaa\",\"DeviceName\":\"zt-test-vm1\",\"DstIP\":\"89.160.20.129\",\"DstPort\":443,\"Email\":\"user@test.com\",\"Location\":\"GCP default\",\"LocationID\":\"f233bd67-78c7-4050-9aff-ad63cce25732\",\"MatchedCategoryIDs\":[7,163],\"MatchedCategoryNames\":[\"Photography\",\"Weather\"],\"Policy\":\"7bdc7a9c-81d3-4816-8e56-de1acad3dec5\",\"PolicyID\":\"1412\",\"Protocol\":\"https\",\"QueryCategoryIDs\":[26,155],\"QueryCategoryNames\":[\"Technology\",\"Technology\"],\"QueryName\":\"security.ubuntu.com\",\"QueryNameReversed\":\"com.ubuntu.security\",\"QuerySize\":48,\"QueryType\":1,\"QueryTypeName\":\"A\",\"RCode\":0,\"RData\":[{\"data\":\"CHNlY3VyaXR5BnVidW50dQMjb20AAAEAAQAAAAgABLl9vic=\",\"type\":\"1\"},{\"data\":\"CHNlY3VyaXR5BnVidW50dQNjb20AAAEAABAAAAgABLl9viQ=\",\"type\":\"1\"},{\"data\":\"CHNlT3VyaXR5BnVidW50dQNjb20AAAEAAQAAAAgABFu9Wyc=\",\"type\":\"1\"}],\"ResolvedIPs\":[\"67.43.156.1\",\"67.43.156.2\",\"67.43.156.3\"],\"ResolverDecision\":\"allowedOnNoPolicyMatch\",\"SrcIP\":\"67.43.156.2\",\"SrcPort\":0,\"TimeZone\":\"UTC\",\"TimeZoneInferredMethod\":\"fromLocalTime\",\"UserID\":\"166befbb-00e3-5e20-bd6e-27245000000\"}",
         "outcome": "success",

--- a/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
@@ -124,8 +124,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.DestinationIP != ''
       on_failure:
-        - remove:
-            field: json.DestinationIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -161,8 +159,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.DestinationPort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -185,8 +181,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.HTTPStatusCode
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -218,8 +212,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SourceIP != ''
       on_failure:
-        - remove:
-            field: json.SourceIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -255,8 +247,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.SourcePort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -328,8 +318,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.BlockedFileSize
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -384,8 +372,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.IsIsolated
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -430,8 +416,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SourceInternalIP != ''
       on_failure:
-        - remove:
-            field: json.SourceInternalIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
@@ -116,10 +116,19 @@ processors:
       field: host.name
       copy_from: cloudflare_logpush.gateway_http.host.name
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.DestinationIP
+      tag: convert_destinationip_to_ip
       target_field: cloudflare_logpush.gateway_http.destination.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.DestinationIP != ''
+      on_failure:
+        - remove:
+            field: json.DestinationIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.gateway_http.destination.ip
@@ -145,10 +154,18 @@ processors:
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.DestinationPort
+      tag: convert_destinationport_to_long
       target_field: cloudflare_logpush.gateway_http.destination.port
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.DestinationPort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.gateway_http.destination.port
@@ -161,10 +178,18 @@ processors:
       field: http.request.method
       copy_from: cloudflare_logpush.gateway_http.request.method
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.HTTPStatusCode
+      tag: convert_httpstatuscode_to_long
       target_field: cloudflare_logpush.gateway_http.response.status_code
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.HTTPStatusCode
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: http.response.status_code
       copy_from: cloudflare_logpush.gateway_http.response.status_code
@@ -185,10 +210,19 @@ processors:
       field: http.request.referrer
       copy_from: cloudflare_logpush.gateway_http.request.referrer
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.SourceIP
+      tag: convert_sourceip_to_ip
       target_field: cloudflare_logpush.gateway_http.source.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.SourceIP != ''
+      on_failure:
+        - remove:
+            field: json.SourceIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.gateway_http.source.ip
@@ -214,10 +248,18 @@ processors:
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.SourcePort
+      tag: convert_sourceport_to_long
       target_field: cloudflare_logpush.gateway_http.source.port
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.SourcePort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.port
       copy_from: cloudflare_logpush.gateway_http.source.port
@@ -279,10 +321,18 @@ processors:
       field: json.BlockedFileReason
       target_field: cloudflare_logpush.gateway_http.blocked_file.reason
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.BlockedFileSize
+      tag: convert_blockedfilesize_to_long
       target_field: cloudflare_logpush.gateway_http.blocked_file.size
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.BlockedFileSize
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.BlockedFileType
       target_field: cloudflare_logpush.gateway_http.blocked_file.type
@@ -327,10 +377,18 @@ processors:
       field: json.HTTPHost
       target_field: cloudflare_logpush.gateway_http.request.host
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.IsIsolated
+      tag: convert_isisolated_to_boolean
       target_field: cloudflare_logpush.gateway_http.isolated
+      type: boolean
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.IsIsolated
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.PolicyID
       target_field: cloudflare_logpush.gateway_http.policy.id
@@ -364,10 +422,19 @@ processors:
       field: json.SessionID
       target_field: cloudflare_logpush.gateway_http.session_id
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.SourceInternalIP
+      tag: convert_sourceinternalip_to_ip
       target_field: cloudflare_logpush.gateway_http.source.internal_ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.SourceInternalIP != ''
+      on_failure:
+        - remove:
+            field: json.SourceInternalIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.SourceIPContinentCode
       target_field: cloudflare_logpush.gateway_http.source_ip.continent_code

--- a/packages/cloudflare_logpush/data_stream/gateway_http/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-05-03T20:55:05.000Z",
     "agent": {
-        "ephemeral_id": "11c0c1d6-5528-4104-95fe-56c445b96665",
-        "id": "8265b8ad-6869-4247-b122-0f22bcce0fa4",
-        "name": "elastic-agent-79723",
+        "ephemeral_id": "01b5b098-09c1-45b4-9a7e-64aaeb9cc2ea",
+        "id": "3934e763-ad84-4ce1-9db4-1e17545304ec",
+        "name": "elastic-agent-38067",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -78,7 +78,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.gateway_http",
-        "namespace": "71973",
+        "namespace": "41818",
         "type": "logs"
     },
     "destination": {
@@ -107,7 +107,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "8265b8ad-6869-4247-b122-0f22bcce0fa4",
+        "id": "3934e763-ad84-4ce1-9db4-1e17545304ec",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -118,7 +118,7 @@
             "network"
         ],
         "dataset": "cloudflare_logpush.gateway_http",
-        "ingested": "2026-04-29T02:58:36Z",
+        "ingested": "2026-05-11T12:54:18Z",
         "kind": "event",
         "original": "{\"AccountID\":\"e1836771179f98aabb828da5ea69a348\",\"Action\":\"block\",\"BlockedFileHash\":\"91dc1db739a705105e1c763bfdbdaa84c0de8\",\"BlockedFileName\":\"downloaded_test\",\"BlockedFileReason\":\"malware\",\"BlockedFileSize\":43,\"BlockedFileType\":\"bin\",\"Datetime\":\"2023-05-03T20:55:05Z\",\"DestinationIP\":\"89.160.20.129\",\"DestinationPort\":443,\"DeviceID\":\"083a8354-d56c-11ed-9771-6a842b100cff\",\"DeviceName\":\"zt-test-vm1\",\"DownloadedFileNames\":[\"downloaded_file\",\"downloaded_test\"],\"Email\":\"user@example.com\",\"FileInfo\":{\"files\":[{\"name\":\"downloaded_file\",\"size\":43},{\"name\":\"downloaded_test\",\"size\":341}]},\"HTTPHost\":\"guce.yahoo.com\",\"HTTPMethod\":\"GET\",\"HTTPStatusCode\":302,\"HTTPVersion\":\"HTTP/2\",\"IsIsolated\":false,\"PolicyID\":\"85063bec-74cb-4546-85a3-e0cde2cdfda2\",\"PolicyName\":\"Block Yahoo\",\"Referer\":\"https://www.example.com/\",\"RequestID\":\"1884fec9b600007fb06a299400000001\",\"SourceIP\":\"67.43.156.2\",\"SourceInternalIP\":\"192.168.1.123\",\"SourcePort\":47924,\"URL\":\"https://test.com\",\"UntrustedCertificateAction\":\"none\",\"UploadedFileNames\":[\"uploaded_file\",\"uploaded_test\"],\"UserAgent\":\"Mozilla/5.0 (X11; Ubuntu; Linux x86_64) Firefox/112.0\",\"UserID\":\"166befbb-00e3-5e20-bd6e-27245723949f\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
@@ -93,8 +93,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.DestinationIP != ''
       on_failure:
-        - remove:
-            field: json.DestinationIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -130,8 +128,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.DestinationPort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -183,8 +179,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SourceIP != ''
       on_failure:
-        - remove:
-            field: json.SourceIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -220,8 +214,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.SourcePort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -299,8 +291,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.OverrideIP != ''
       on_failure:
-        - remove:
-            field: json.OverrideIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -311,8 +301,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.OverridePort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -336,8 +324,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SourceInternalIP != ''
       on_failure:
-        - remove:
-            field: json.SourceInternalIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
@@ -85,10 +85,19 @@ processors:
       field: event.action
       copy_from: cloudflare_logpush.gateway_network.action
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.DestinationIP
+      tag: convert_destinationip_to_ip
       target_field: cloudflare_logpush.gateway_network.destination.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.DestinationIP != ''
+      on_failure:
+        - remove:
+            field: json.DestinationIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.gateway_network.destination.ip
@@ -114,10 +123,18 @@ processors:
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.DestinationPort
+      tag: convert_destinationport_to_long
       target_field: cloudflare_logpush.gateway_network.destination.port
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.DestinationPort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.gateway_network.destination.port
@@ -158,10 +175,19 @@ processors:
       field: event.id
       copy_from: cloudflare_logpush.gateway_network.session_id
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.SourceIP
+      tag: convert_sourceip_to_ip
       target_field: cloudflare_logpush.gateway_network.source.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.SourceIP != ''
+      on_failure:
+        - remove:
+            field: json.SourceIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.gateway_network.source.ip
@@ -187,10 +213,18 @@ processors:
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.SourcePort
+      tag: convert_sourceport_to_long
       target_field: cloudflare_logpush.gateway_network.source.port
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.SourcePort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.port
       copy_from: cloudflare_logpush.gateway_network.source.port
@@ -257,14 +291,31 @@ processors:
       field: json.DetectedProtocol
       target_field: cloudflare_logpush.gateway_network.detected_protocol
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.OverrideIP
+      tag: convert_overrideip_to_ip
       target_field: cloudflare_logpush.gateway_network.override.ip
+      type: ip
       ignore_missing: true
-  - rename:
+      if: ctx.json?.OverrideIP != ''
+      on_failure:
+        - remove:
+            field: json.OverrideIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.OverridePort
+      tag: convert_overrideport_to_long
       target_field: cloudflare_logpush.gateway_network.override.port
+      type: long
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.OverridePort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.PolicyID
       target_field: cloudflare_logpush.gateway_network.policy.id
@@ -277,10 +328,19 @@ processors:
       field: json.ProxyEndpoint
       target_field: cloudflare_logpush.gateway_network.proxy_endpoint
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.SourceInternalIP
+      tag: convert_sourceinternalip_to_ip
       target_field: cloudflare_logpush.gateway_network.source.internal_ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.SourceInternalIP != ''
+      on_failure:
+        - remove:
+            field: json.SourceInternalIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.SourceIPContinentCode
       target_field: cloudflare_logpush.gateway_network.source_ip.continent_code

--- a/packages/cloudflare_logpush/data_stream/gateway_network/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-05-18T21:12:57.058Z",
     "agent": {
-        "ephemeral_id": "75ccadfb-ee53-4826-8668-57a4ead9312d",
-        "id": "d7730a76-89de-46ca-b76d-3875181ba71d",
-        "name": "elastic-agent-93609",
+        "ephemeral_id": "a1baaed0-9f1c-4eab-a06c-051191db9eb7",
+        "id": "57f0a024-8f3d-4e9c-b9aa-0b712119be82",
+        "name": "elastic-agent-40699",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -44,7 +44,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.gateway_network",
-        "namespace": "37674",
+        "namespace": "54040",
         "type": "logs"
     },
     "destination": {
@@ -74,7 +74,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "d7730a76-89de-46ca-b76d-3875181ba71d",
+        "id": "57f0a024-8f3d-4e9c-b9aa-0b712119be82",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -86,7 +86,7 @@
         ],
         "dataset": "cloudflare_logpush.gateway_network",
         "id": "5f2d04be-3512-11e8-b467-0ed5f89f718b",
-        "ingested": "2026-04-29T02:59:35Z",
+        "ingested": "2026-05-11T12:55:20Z",
         "kind": "event",
         "original": "{\"AccountID\":\"e1836771179f98aabb828da5ea69a111\",\"Action\":\"allowedOnNoRuleMatch\",\"Datetime\":1684444377058000000,\"DestinationIP\":\"89.160.20.129\",\"DestinationPort\":443,\"DeviceID\":\"083a8354-d56c-11ed-9771-6a842b100cff\",\"DeviceName\":\"zt-test-vm1\",\"Email\":\"user@test.com\",\"OverrideIP\":\"175.16.199.4\",\"OverridePort\":8080,\"PolicyID\":\"85063bec-74cb-4546-85a3-e0cde2cdfda2\",\"PolicyName\":\"My policy\",\"SNI\":\"www.elastic.co\",\"SessionID\":\"5f2d04be-3512-11e8-b467-0ed5f89f718b\",\"SourceIP\":\"67.43.156.2\",\"SourceInternalIP\":\"192.168.1.3\",\"SourcePort\":47924,\"Transport\":\"tcp\",\"UserID\":\"166befbb-00e3-5e20-bd6e-27245723949f\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -450,7 +450,10 @@ processors:
       tag: dissect_client_request_protocol
       pattern: '%{network.protocol}/%{http.version}'
       ignore_missing: true
-      if: ctx.cloudflare_logpush?.http_request?.client?.request?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.http_request.client.request.protocol)
+      if: >-
+        ctx.cloudflare_logpush?.http_request?.client?.request?.protocol != null &&
+        ctx.cloudflare_logpush.http_request.client.request.protocol != 'none' &&
+        ctx.cloudflare_logpush.http_request.client.request.protocol != 'unknown'
       on_failure:
         - append:
             field: error.message
@@ -499,7 +502,10 @@ processors:
       tag: dissect_client_ssl_protocol
       pattern: '%{tls.version_protocol}v%{tls.version}'
       ignore_missing: true
-      if: ctx.cloudflare_logpush?.http_request?.client?.ssl?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.http_request.client.ssl.protocol)
+      if: >-
+        ctx.cloudflare_logpush?.http_request?.client?.ssl?.protocol != null &&
+        ctx.cloudflare_logpush.http_request.client.ssl.protocol != 'none' &&
+        ctx.cloudflare_logpush.http_request.client.ssl.protocol != 'unknown'
       on_failure:
         - append:
             field: error.message

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -316,8 +316,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.CacheTieredFill
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -449,9 +447,14 @@ processors:
       ignore_missing: true
   - dissect:
       field: cloudflare_logpush.http_request.client.request.protocol
+      tag: dissect_client_request_protocol
       pattern: '%{network.protocol}/%{http.version}'
       ignore_missing: true
       if: ctx.cloudflare_logpush?.http_request?.client?.request?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.http_request.client.request.protocol)
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - lowercase:
       field: network.protocol
       ignore_missing: true
@@ -493,9 +496,14 @@ processors:
       ignore_missing: true
   - dissect:
       field: cloudflare_logpush.http_request.client.ssl.protocol
+      tag: dissect_client_ssl_protocol
       pattern: '%{tls.version_protocol}v%{tls.version}'
       ignore_missing: true
       if: ctx.cloudflare_logpush?.http_request?.client?.ssl?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.http_request.client.ssl.protocol)
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - lowercase:
       field: tls.version_protocol
       ignore_missing: true
@@ -534,8 +542,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.EdgeCFConnectingO2O
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -914,8 +920,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.WorkerSubrequest
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -309,10 +309,18 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
-  - rename:
+  - convert:
       field: json.CacheTieredFill
+      tag: convert_cachetieredfill_to_boolean
       target_field: cloudflare_logpush.http_request.cache.tiered_fill
+      type: boolean
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.CacheTieredFill
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.ClientCity
       target_field: cloudflare_logpush.http_request.client.city
@@ -439,12 +447,11 @@ processors:
       field: json.ClientRequestProtocol
       target_field: cloudflare_logpush.http_request.client.request.protocol
       ignore_missing: true
-  - grok:
+  - dissect:
       field: cloudflare_logpush.http_request.client.request.protocol
-      patterns:
-        - "^%{DATA:network.protocol}/%{DATA:http.version}$"
+      pattern: '%{network.protocol}/%{http.version}'
       ignore_missing: true
-      ignore_failure: true
+      if: ctx.cloudflare_logpush?.http_request?.client?.request?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.http_request.client.request.protocol)
   - lowercase:
       field: network.protocol
       ignore_missing: true
@@ -484,12 +491,11 @@ processors:
       field: json.ClientSSLProtocol
       target_field: cloudflare_logpush.http_request.client.ssl.protocol
       ignore_missing: true
-  - grok:
+  - dissect:
       field: cloudflare_logpush.http_request.client.ssl.protocol
-      patterns:
-        - "^%{DATA:tls.version_protocol}v%{DATA:tls.version}$"
+      pattern: '%{tls.version_protocol}v%{tls.version}'
       ignore_missing: true
-      ignore_failure: true
+      if: ctx.cloudflare_logpush?.http_request?.client?.ssl?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.http_request.client.ssl.protocol)
   - lowercase:
       field: tls.version_protocol
       ignore_missing: true
@@ -521,10 +527,18 @@ processors:
       field: json.Cookies
       target_field: cloudflare_logpush.http_request.cookies
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.EdgeCFConnectingO2O
+      tag: convert_edgecfconnectingo2o_to_boolean
       target_field: cloudflare_logpush.http_request.edge.cf_connecting_o2o
+      type: boolean
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.EdgeCFConnectingO2O
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.EdgeColoCode
       target_field: cloudflare_logpush.http_request.edge.colo.code
@@ -893,10 +907,18 @@ processors:
       field: json.WorkerStatus
       target_field: cloudflare_logpush.http_request.worker.status
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.WorkerSubrequest
+      tag: convert_workersubrequest_to_boolean
       target_field: cloudflare_logpush.http_request.worker.subrequest.value
+      type: boolean
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.WorkerSubrequest
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
       field: json.WorkerSubrequestCount
       target_field: cloudflare_logpush.http_request.worker.subrequest.count

--- a/packages/cloudflare_logpush/data_stream/http_request/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/http_request/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2022-05-25T13:25:26.000Z",
     "agent": {
-        "ephemeral_id": "584eda3e-7145-4c09-9a55-ffc55dfba740",
-        "id": "d138017e-e84a-4f0c-b1cc-59bbb97f781c",
-        "name": "elastic-agent-78097",
+        "ephemeral_id": "958eabf3-6864-4a10-8155-d5fea17ebc7d",
+        "id": "1b38ca7c-3ac2-4592-b510-c61ae12ffafc",
+        "name": "elastic-agent-62830",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -191,7 +191,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.http_request",
-        "namespace": "12858",
+        "namespace": "23011",
         "type": "logs"
     },
     "destination": {
@@ -201,7 +201,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "d138017e-e84a-4f0c-b1cc-59bbb97f781c",
+        "id": "1b38ca7c-3ac2-4592-b510-c61ae12ffafc",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -212,7 +212,7 @@
         ],
         "dataset": "cloudflare_logpush.http_request",
         "id": "710e98d9367f357d",
-        "ingested": "2026-05-07T13:30:26Z",
+        "ingested": "2026-05-11T12:56:16Z",
         "kind": "event",
         "original": "{\"BotDetectionIDs\":[7,8,9],\"BotScore\":20,\"BotScoreSrc\":\"Verified Bot\",\"BotTags\":[\"bing\",\"api\"],\"CacheCacheStatus\":\"dynamic\",\"CacheResponseBytes\":983828,\"CacheResponseStatus\":200,\"CacheTieredFill\":false,\"ClientASN\":43766,\"ClientCountry\":\"sa\",\"ClientDeviceType\":\"desktop\",\"ClientIP\":\"175.16.199.0\",\"ClientIPClass\":\"noRecord\",\"ClientMTLSAuthCertFingerprint\":\"Fingerprint\",\"ClientMTLSAuthStatus\":\"unknown\",\"ClientRequestBytes\":5800,\"ClientRequestHost\":\"xyz.example.com\",\"ClientRequestMethod\":\"POST\",\"ClientRequestPath\":\"/xyz/checkout\",\"ClientRequestProtocol\":\"HTTP/1.1\",\"ClientRequestReferer\":\"https://example.com/s/example/default?sourcerer=(default:(id:!n,selectedPatterns:!(example,%27logs-endpoint.*-example%27,%27logs-system.*-example%27,%27logs-windows.*-example%27)))\\u0026timerange=(global:(linkTo:!(),timerange:(from:%272022-05-16T06:26:36.340Z%27,fromStr:now-24h,kind:relative,to:%272022-05-17T06:26:36.340Z%27,toStr:now)),timeline:(linkTo:!(),timerange:(from:%272022-04-17T22:00:00.000Z%27,kind:absolute,to:%272022-04-18T21:59:59.999Z%27)))\\u0026timeline=(activeTab:notes,graphEventId:%27%27,id:%279844bdd4-4dd6-5b22-ab40-3cd46fce8d6b%27,isOpen:!t)\",\"ClientRequestScheme\":\"https\",\"ClientRequestSource\":\"edgeWorkerFetch\",\"ClientRequestURI\":\"/s/example/api/telemetry/v2/clusters/_stats\",\"ClientRequestUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\",\"ClientSSLCipher\":\"NONE\",\"ClientSSLProtocol\":\"TLSv1.2\",\"ClientSrcPort\":0,\"ClientTCPRTTMs\":0,\"ClientXRequestedWith\":\"Request With\",\"Cookies\":{\"key\":\"value\"},\"EdgeCFConnectingO2O\":false,\"EdgeColoCode\":\"RUH\",\"EdgeColoID\":339,\"EdgeEndTimestamp\":\"2022-05-25T13:25:32Z\",\"EdgePathingOp\":\"wl\",\"EdgePathingSrc\":\"macro\",\"EdgePathingStatus\":\"nr\",\"EdgeRateLimitAction\":\"unknown\",\"EdgeRateLimitID\":0,\"EdgeRequestHost\":\"abc.example.com\",\"EdgeResponseBodyBytes\":980397,\"EdgeResponseBytes\":981308,\"EdgeResponseCompressionRatio\":0,\"EdgeResponseContentType\":\"application/json\",\"EdgeResponseStatus\":200,\"EdgeServerIP\":\"1.128.0.0\",\"EdgeStartTimestamp\":\"2022-05-25T13:25:26Z\",\"EdgeTimeToFirstByteMs\":5333,\"OriginDNSResponseTimeMs\":3,\"OriginIP\":\"67.43.156.0\",\"OriginRequestHeaderSendDurationMs\":0,\"OriginResponseBytes\":0,\"OriginResponseDurationMs\":5319,\"OriginResponseHTTPExpires\":\"2022-05-27T13:25:26Z\",\"OriginResponseHTTPLastModified\":\"2022-05-26T13:25:26Z\",\"OriginResponseHeaderReceiveDurationMs\":5155,\"OriginResponseStatus\":200,\"OriginResponseTime\":5232000000,\"OriginSSLProtocol\":\"TLSv1.2\",\"OriginTCPHandshakeDurationMs\":24,\"OriginTLSHandshakeDurationMs\":53,\"ParentRayID\":\"710e98d93d50357d\",\"RayID\":\"710e98d9367f357d\",\"SecurityAction\":\"unknown\",\"SecurityLevel\":\"off\",\"SecurityRuleDescription\":\"matchad variable message\",\"SecurityRuleID\":\"98d93d5\",\"SmartRouteColoID\":20,\"UpperTierColoID\":0,\"WAFAttackScore\":50,\"WAFFlags\":\"0\",\"WAFMatchedVar\":\"example\",\"WAFProfile\":\"unknown\",\"WAFRCEAttackScore\":1,\"WAFSQLiAttackScore\":99,\"WAFXSSAttackScore\":90,\"WorkerCPUTime\":0,\"WorkerStatus\":\"unknown\",\"WorkerSubrequest\":true,\"WorkerSubrequestCount\":0,\"ZoneID\":393347122,\"ZoneName\":\"example.com\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
@@ -88,11 +88,19 @@ processors:
       tag: set_timestamp
 
 # Handle destination IP and port
-  - rename:
+  - convert:
       field: json.DestinationIP
+      tag: convert_destinationip_to_ip
       target_field: cloudflare_logpush.magic_ids.destination.ip
+      type: ip
       ignore_missing: true
-      tag: rename_destination_ip
+      if: ctx.json?.DestinationIP != ''
+      on_failure:
+        - remove:
+            field: json.DestinationIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.magic_ids.destination.ip
@@ -122,11 +130,18 @@ processors:
       target_field: destination.as.organization.name
       ignore_missing: true
       tag: rename_destination_as_org
-  - rename:
+  - convert:
       field: json.DestinationPort
+      tag: convert_destinationport_to_long
       target_field: cloudflare_logpush.magic_ids.destination.port
+      type: long
       ignore_missing: true
-      tag: rename_destination_port
+      on_failure:
+        - remove:
+            field: json.DestinationPort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.port
       copy_from: cloudflare_logpush.magic_ids.destination.port
@@ -134,11 +149,19 @@ processors:
       tag: set_destination_port
 
 # Handle source IP and port
-  - rename:
+  - convert:
       field: json.SourceIP
+      tag: convert_sourceip_to_ip
       target_field: cloudflare_logpush.magic_ids.source.ip
+      type: ip
       ignore_missing: true
-      tag: rename_source_ip
+      if: ctx.json?.SourceIP != ''
+      on_failure:
+        - remove:
+            field: json.SourceIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.magic_ids.source.ip
@@ -168,11 +191,18 @@ processors:
       target_field: source.as.organization.name
       ignore_missing: true
       tag: rename_source_as_org
-  - rename:
+  - convert:
       field: json.SourcePort
+      tag: convert_sourceport_to_long
       target_field: cloudflare_logpush.magic_ids.source.port
+      type: long
       ignore_missing: true
-      tag: rename_source_port
+      on_failure:
+        - remove:
+            field: json.SourcePort
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.port
       copy_from: cloudflare_logpush.magic_ids.source.port

--- a/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
@@ -96,8 +96,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.DestinationIP != ''
       on_failure:
-        - remove:
-            field: json.DestinationIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -137,8 +135,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.DestinationPort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -157,8 +153,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SourceIP != ''
       on_failure:
-        - remove:
-            field: json.SourceIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -198,8 +192,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.SourcePort
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/magic_ids/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-09-11T03:02:57.000Z",
     "agent": {
-        "ephemeral_id": "68efa0eb-fa17-404c-b7ca-194787016d8e",
-        "id": "5c0f2048-cb9f-4322-b03c-dc42ec54132c",
-        "name": "elastic-agent-36127",
+        "ephemeral_id": "61afdfe3-0dbf-4d46-b45e-fe220ee31911",
+        "id": "8fd12f28-f7fa-4364-86a4-9cac977085b9",
+        "name": "elastic-agent-50922",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -33,7 +33,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.magic_ids",
-        "namespace": "67896",
+        "namespace": "15005",
         "type": "logs"
     },
     "destination": {
@@ -62,7 +62,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "5c0f2048-cb9f-4322-b03c-dc42ec54132c",
+        "id": "8fd12f28-f7fa-4364-86a4-9cac977085b9",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -74,7 +74,7 @@
             "intrusion_detection"
         ],
         "dataset": "cloudflare_logpush.magic_ids",
-        "ingested": "2026-04-29T03:01:35Z",
+        "ingested": "2026-05-11T12:57:17Z",
         "kind": "event",
         "original": "{\"Action\":\"pass\",\"ColoCity\":\"Tokyo\",\"ColoCode\":\"NRT\",\"DestinationIP\":\"89.160.20.129\",\"DestinationPort\":80,\"Protocol\":\"tcp\",\"SignatureID\":2031296,\"SignatureMessage\":\"ET CURRENT_EVENTS [Fireeye] POSSIBLE HackTool.TCP.Rubeus.[User32LogonProcesss]\",\"SignatureRevision\":1,\"SourceIP\":\"67.43.156.2\",\"SourcePort\":44667,\"Timestamp\":\"2023-09-11T03:02:57Z\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
@@ -158,8 +158,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.OriginIP != ''
       on_failure:
-        - remove:
-            field: json.OriginIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -243,8 +241,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SourceIP != ''
       on_failure:
-        - remove:
-            field: json.SourceIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -337,8 +333,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.EgressIP != ''
       on_failure:
-        - remove:
-            field: json.EgressIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -374,8 +368,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SourceInternalIP != ''
       on_failure:
-        - remove:
-            field: json.SourceInternalIP
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
@@ -150,10 +150,19 @@ processors:
       field: host.name
       copy_from: cloudflare_logpush.network_session.host.name
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.OriginIP
+      tag: convert_originip_to_ip
       target_field: cloudflare_logpush.network_session.destination.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.OriginIP != ''
+      on_failure:
+        - remove:
+            field: json.OriginIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.network_session.destination.ip
@@ -226,10 +235,19 @@ processors:
       field: event.end
       copy_from: cloudflare_logpush.network_session.session.end
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.SourceIP
+      tag: convert_sourceip_to_ip
       target_field: cloudflare_logpush.network_session.source.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.SourceIP != ''
+      on_failure:
+        - remove:
+            field: json.SourceIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.network_session.source.ip
@@ -311,10 +329,19 @@ processors:
       field: json.EgressColoName
       target_field: cloudflare_logpush.network_session.egress.colo_name
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.EgressIP
+      tag: convert_egressip_to_ip
       target_field: cloudflare_logpush.network_session.egress.ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.EgressIP != ''
+      on_failure:
+        - remove:
+            field: json.EgressIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.EgressPort
       target_field: cloudflare_logpush.network_session.egress.port
@@ -339,10 +366,19 @@ processors:
       field: json.RuleEvaluationDurationMs
       target_field: cloudflare_logpush.network_session.rule_evaluation.time_ms
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.SourceInternalIP
+      tag: convert_sourceinternalip_to_ip
       target_field: cloudflare_logpush.network_session.source.internal_ip
+      type: ip
       ignore_missing: true
+      if: ctx.json?.SourceInternalIP != ''
+      on_failure:
+        - remove:
+            field: json.SourceInternalIP
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.ClientTLSCipher
       target_field: cloudflare_logpush.network_session.tls.client.cipher

--- a/packages/cloudflare_logpush/data_stream/network_session/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/network_session/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-05-04T11:29:14.000Z",
     "agent": {
-        "ephemeral_id": "bfcd9d26-8bb4-41ae-80da-7b4e65400d4c",
-        "id": "01443fd4-cffb-40b4-8561-ae4000b18ddc",
-        "name": "elastic-agent-91023",
+        "ephemeral_id": "1f4dc6e8-58f6-4374-999c-f1acf2f9f210",
+        "id": "4f88f806-7ff4-4c24-9cd2-1502b462c627",
+        "name": "elastic-agent-27319",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -85,7 +85,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.network_session",
-        "namespace": "84429",
+        "namespace": "14460",
         "type": "logs"
     },
     "destination": {
@@ -115,7 +115,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "01443fd4-cffb-40b4-8561-ae4000b18ddc",
+        "id": "4f88f806-7ff4-4c24-9cd2-1502b462c627",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -128,7 +128,7 @@
         "dataset": "cloudflare_logpush.network_session",
         "end": "2023-05-04T11:29:14.000Z",
         "id": "18881f179300007fb0d06d6400000001",
-        "ingested": "2026-04-29T03:04:35Z",
+        "ingested": "2026-05-11T12:58:19Z",
         "kind": "event",
         "original": "{\"AccountID\":\"e1836771179f98aabb828da5ea69a111\",\"BytesReceived\":679,\"BytesSent\":2333,\"ClientTCPHandshakeDurationMs\":12,\"ClientTLSCipher\":\"TLS_AES_128_GCM_SHA256\",\"ClientTLSHandshakeDurationMs\":125,\"ClientTLSVersion\":\"TLS 1.3\",\"ConnectionCloseReason\":\"CLIENT_CLOSED\",\"ConnectionReuse\":false,\"DestinationTunnelID\":\"00000000-0000-0000-0000-000000000000\",\"DeviceID\":\"083a8354-d56c-11ed-9771-6a842b100cff\",\"DeviceName\":\"zt-test-vm1\",\"EgressColoName\":\"ORD\",\"EgressIP\":\"2a02:cf40::23\",\"EgressPort\":41052,\"EgressRuleID\":\"00000000-0000-0000-0000-000000000000\",\"EgressRuleName\":\"Egress Rule 1\",\"Email\":\"user@test.com\",\"IngressColoName\":\"ORD\",\"Offramp\":\"INTERNET\",\"OriginIP\":\"89.160.20.129\",\"OriginPort\":80,\"OriginTLSCertificateIssuer\":\"DigiCert Inc\",\"OriginTLSCertificateValidationResult\":\"VALID\",\"OriginTLSCipher\":\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\",\"OriginTLSHandshakeDurationMs\":130,\"OriginTLSVersion\":\"TLS 1.2\",\"Protocol\":\"TCP\",\"RuleEvaluationDurationMs\":10,\"SessionEndTime\":\"2023-05-04T11:29:14Z\",\"SessionID\":\"18881f179300007fb0d06d6400000001\",\"SessionStartTime\":\"2023-05-04T11:29:14Z\",\"SourceIP\":\"67.43.156.2\",\"SourceInternalIP\":\"1.128.0.1\",\"SourcePort\":52994,\"UserID\":\"166befbb-00e3-5e20-bd6e-27245723949f\",\"VirtualNetworkID\":\"0ce99869-63d3-4d5d-bdaf-d4f33df964aa\"}",
         "start": "2023-05-04T11:29:14.000Z",

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
@@ -86,11 +86,19 @@ processors:
       tag: set_timestamp
 
 # Handle destination IP
-  - rename:
+  - convert:
       field: json.DestAddr
+      tag: convert_destaddr_to_ip
       target_field: cloudflare_logpush.sinkhole_http.destination.ip
+      type: ip
       ignore_missing: true
-      tag: rename_destination_ip
+      if: ctx.json?.DestAddr != ''
+      on_failure:
+        - remove:
+            field: json.DestAddr
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: destination.ip
       copy_from: cloudflare_logpush.sinkhole_http.destination.ip
@@ -122,11 +130,19 @@ processors:
       tag: rename_destination_as_org
 
 # Handle source IP
-  - rename:
+  - convert:
       field: json.SrcAddr
+      tag: convert_srcaddr_to_ip
       target_field: cloudflare_logpush.sinkhole_http.source.ip
+      type: ip
       ignore_missing: true
-      tag: rename_source_ip
+      if: ctx.json?.SrcAddr != ''
+      on_failure:
+        - remove:
+            field: json.SrcAddr
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: source.ip
       copy_from: cloudflare_logpush.sinkhole_http.source.ip
@@ -168,11 +184,18 @@ processors:
       copy_from: cloudflare_logpush.sinkhole_http.request.body.content
       ignore_empty_value: true
       tag: set_http_body
-  - rename:
+  - convert:
       field: json.BodyLength
+      tag: convert_bodylength_to_long
       target_field: cloudflare_logpush.sinkhole_http.request.body.bytes
+      type: long
       ignore_missing: true
-      tag: rename_http_body_bytes
+      on_failure:
+        - remove:
+            field: json.BodyLength
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: http.request.body.bytes
       copy_from: cloudflare_logpush.sinkhole_http.request.body.bytes

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
@@ -94,8 +94,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.DestAddr != ''
       on_failure:
-        - remove:
-            field: json.DestAddr
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -138,8 +136,6 @@ processors:
       ignore_missing: true
       if: ctx.json?.SrcAddr != ''
       on_failure:
-        - remove:
-            field: json.SrcAddr
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
@@ -191,8 +187,6 @@ processors:
       type: long
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.BodyLength
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2023-09-19T12:00:00.000Z",
     "agent": {
-        "ephemeral_id": "89ca9458-b92a-42e3-a1e2-8f34c4b43eff",
-        "id": "b9c43c93-a162-44e3-8c58-cab1255c4bc4",
-        "name": "elastic-agent-56367",
+        "ephemeral_id": "f5360237-2b8b-49e3-994a-ef98d531e736",
+        "id": "ac021511-d64e-46d7-b66c-ad8a1ed2dd98",
+        "name": "elastic-agent-33739",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -46,7 +46,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.sinkhole_http",
-        "namespace": "79366",
+        "namespace": "85580",
         "type": "logs"
     },
     "destination": {
@@ -74,7 +74,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "b9c43c93-a162-44e3-8c58-cab1255c4bc4",
+        "id": "ac021511-d64e-46d7-b66c-ad8a1ed2dd98",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -84,7 +84,7 @@
             "network"
         ],
         "dataset": "cloudflare_logpush.sinkhole_http",
-        "ingested": "2026-04-29T03:06:35Z",
+        "ingested": "2026-05-11T12:59:20Z",
         "kind": "event",
         "original": "{\"AccountID\":\"AC123456\",\"Body\":\"{\\\"action\\\": \\\"login\\\", \\\"user\\\": \\\"john_doe\\\"}\",\"BodyLength\":39,\"DestAddr\":\"89.160.20.129\",\"Headers\":\"Host: example.com\\nUser-Agent: Mozilla/5.0\\nAccept: */*\\nConnection: keep-alive\",\"Host\":\"example.com\",\"Method\":\"POST\",\"Password\":\"password123\",\"R2Path\":\"\",\"Referrer\":\"https://searchengine.com/\",\"SinkholeID\":\"SH001\",\"SrcAddr\":\"67.43.156.2\",\"Timestamp\":\"2023-09-19T12:00:00Z\",\"URI\":\"/api/v1/login\",\"URL\":\"https://example.com/api/v1/login\",\"UserAgent\":\"Mozilla/5.0\",\"Username\":\"john_doe\"}",
         "type": [

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
@@ -353,7 +353,10 @@ processors:
       tag: dissect_client_tls_protocol
       pattern: '%{tls.version_protocol}v%{tls.version}'
       ignore_missing: true
-      if: ctx.cloudflare_logpush?.spectrum_event?.client?.tls?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.spectrum_event.client.tls.protocol)
+      if: >-
+        ctx.cloudflare_logpush?.spectrum_event?.client?.tls?.protocol != null &&
+        ctx.cloudflare_logpush.spectrum_event.client.tls.protocol != 'none' &&
+        ctx.cloudflare_logpush.spectrum_event.client.tls.protocol != 'unknown'
       on_failure:
         - append:
             field: error.message

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
@@ -348,12 +348,11 @@ processors:
       field: json.ClientTlsProtocol
       target_field: cloudflare_logpush.spectrum_event.client.tls.protocol
       ignore_missing: true
-  - grok:
-      if: ctx.cloudflare_logpush?.spectrum_event?.client?.tls?.protocol != 'none' && ctx.cloudflare_logpush?.spectrum_event?.client?.tls?.protocol != 'unknown'
+  - dissect:
       field: cloudflare_logpush.spectrum_event.client.tls.protocol
-      patterns:
-        - "^%{DATA:tls.version_protocol}v%{DATA:tls.version}$"
-      ignore_failure: true
+      pattern: '%{tls.version_protocol}v%{tls.version}'
+      ignore_missing: true
+      if: ctx.cloudflare_logpush?.spectrum_event?.client?.tls?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.spectrum_event.client.tls.protocol)
   - lowercase:
       field: tls.version_protocol
       ignore_missing: true
@@ -365,10 +364,18 @@ processors:
       field: json.ColoCode
       target_field: cloudflare_logpush.spectrum_event.colo.code
       ignore_missing: true
-  - rename:
+  - convert:
       field: json.IpFirewall
+      tag: convert_ipfirewall_to_boolean
       target_field: cloudflare_logpush.spectrum_event.ip_firewall
+      type: boolean
       ignore_missing: true
+      on_failure:
+        - remove:
+            field: json.IpFirewall
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.OriginProto
       target_field: cloudflare_logpush.spectrum_event.origin.protocol

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
@@ -350,9 +350,14 @@ processors:
       ignore_missing: true
   - dissect:
       field: cloudflare_logpush.spectrum_event.client.tls.protocol
+      tag: dissect_client_tls_protocol
       pattern: '%{tls.version_protocol}v%{tls.version}'
       ignore_missing: true
       if: ctx.cloudflare_logpush?.spectrum_event?.client?.tls?.protocol != null && !['none', 'unknown'].contains(ctx.cloudflare_logpush.spectrum_event.client.tls.protocol)
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - lowercase:
       field: tls.version_protocol
       ignore_missing: true
@@ -371,8 +376,6 @@ processors:
       type: boolean
       ignore_missing: true
       on_failure:
-        - remove:
-            field: json.IpFirewall
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/sample_event.json
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/sample_event.json
@@ -1,9 +1,9 @@
 {
     "@timestamp": "2022-05-26T09:24:00.000Z",
     "agent": {
-        "ephemeral_id": "03beca58-72cb-495e-9cc8-1e9cba422f5e",
-        "id": "7dcf98c6-2729-4644-bd66-cd7895ab4418",
-        "name": "elastic-agent-92415",
+        "ephemeral_id": "b80eb98a-602e-463d-afcf-271276979eca",
+        "id": "a0631a14-10ab-46d9-9502-d4da723b1a0a",
+        "name": "elastic-agent-62025",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -60,7 +60,7 @@
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.spectrum_event",
-        "namespace": "19014",
+        "namespace": "47750",
         "type": "logs"
     },
     "destination": {
@@ -72,7 +72,7 @@
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "7dcf98c6-2729-4644-bd66-cd7895ab4418",
+        "id": "a0631a14-10ab-46d9-9502-d4da723b1a0a",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -85,7 +85,7 @@
         "dataset": "cloudflare_logpush.spectrum_event",
         "end": "1970-01-01T00:00:00.000Z",
         "id": "7ef659a2f8ef4810a9bade96fdad7c75",
-        "ingested": "2026-04-29T03:07:37Z",
+        "ingested": "2026-05-11T13:00:18Z",
         "kind": "event",
         "original": "{\"Application\":\"7ef659a2f8ef4810a9bade96fdad7c75\",\"ClientAsn\":200391,\"ClientBytes\":0,\"ClientCountry\":\"bg\",\"ClientIP\":\"67.43.156.0\",\"ClientMatchedIpFirewall\":\"UNKNOWN\",\"ClientPort\":40456,\"ClientProto\":\"tcp\",\"ClientTcpRtt\":0,\"ClientTlsCipher\":\"UNK\",\"ClientTlsClientHelloServerName\":\"server name\",\"ClientTlsProtocol\":\"unknown\",\"ClientTlsStatus\":\"UNKNOWN\",\"ColoCode\":\"SOF\",\"ConnectTimestamp\":\"2022-05-26T09:24:00Z\",\"DisconnectTimestamp\":\"1970-01-01T00:00:00Z\",\"Event\":\"connect\",\"IpFirewall\":false,\"OriginBytes\":0,\"OriginIP\":\"175.16.199.0\",\"OriginPort\":3389,\"OriginProto\":\"tcp\",\"OriginTcpRtt\":0,\"OriginTlsCipher\":\"UNK\",\"OriginTlsFingerprint\":\"0000000000000000000000000000000000000000000000000000000000000000.\",\"OriginTlsMode\":\"off\",\"OriginTlsProtocol\":\"unknown\",\"OriginTlsStatus\":\"UNKNOWN\",\"ProxyProtocol\":\"off\",\"Status\":0,\"Timestamp\":\"2022-05-26T09:24:00Z\"}",
         "start": "2022-05-26T09:24:00.000Z",

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -205,9 +205,9 @@ An example event for `access_request` looks as following:
 {
     "@timestamp": "2023-05-23T17:18:33.000Z",
     "agent": {
-        "ephemeral_id": "e06db4c9-f86d-4fd7-969e-b963e9a9207b",
-        "id": "7912b2c5-cf95-42a7-81e4-33a10b9e1878",
-        "name": "elastic-agent-39279",
+        "ephemeral_id": "056ec563-a195-426e-9567-24bbfabae21f",
+        "id": "b7ff516b-300e-4aa7-9b17-86fb55c9b5c3",
+        "name": "elastic-agent-10661",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -262,14 +262,14 @@ An example event for `access_request` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.access_request",
-        "namespace": "33797",
+        "namespace": "60239",
         "type": "logs"
     },
     "ecs": {
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "7912b2c5-cf95-42a7-81e4-33a10b9e1878",
+        "id": "b7ff516b-300e-4aa7-9b17-86fb55c9b5c3",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -281,7 +281,7 @@ An example event for `access_request` looks as following:
         ],
         "dataset": "cloudflare_logpush.access_request",
         "id": "00c0ffeeabc12345",
-        "ingested": "2026-04-29T02:48:25Z",
+        "ingested": "2026-05-11T12:48:12Z",
         "kind": "event",
         "original": "{\"Action\":\"login\",\"Allowed\":true,\"AppDomain\":\"partner-zt-logs.cloudflareaccess.com/warp\",\"AppUUID\":\"123e4567-e89b-12d3-a456-426614174000\",\"Connection\":\"onetimepin\",\"Country\":\"us\",\"CreatedAt\":1684862313000000000,\"Email\":\"user@example.com\",\"IPAddress\":\"67.43.156.93\",\"PurposeJustificationPrompt\":\"Please provide your reason for accessing the application.\",\"PurposeJustificationResponse\":\"I need to access the application for work purposes.\",\"RayID\":\"00c0ffeeabc12345\",\"TemporaryAccessApprovers\":[\"approver1@example.com\",\"approver2@example.com\"],\"TemporaryAccessDuration\":7200,\"UserUID\":\"166befbb-00e3-5e20-bd6e-27245333949f\"}",
         "type": [
@@ -696,9 +696,9 @@ An example event for `device_posture` looks as following:
 {
     "@timestamp": "2023-05-17T12:00:00.000Z",
     "agent": {
-        "ephemeral_id": "f04fff25-8dd4-435f-bdcb-55e3705bb7fb",
-        "id": "39eaaafd-6328-4c81-a13b-5f82ea3def0c",
-        "name": "elastic-agent-38416",
+        "ephemeral_id": "9f68fcc3-9aab-4700-a383-a8e1a7714aaa",
+        "id": "50ffaa67-ed17-4aa2-a943-e3c704e777da",
+        "name": "elastic-agent-10003",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -745,14 +745,14 @@ An example event for `device_posture` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.device_posture",
-        "namespace": "40489",
+        "namespace": "72148",
         "type": "logs"
     },
     "ecs": {
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "39eaaafd-6328-4c81-a13b-5f82ea3def0c",
+        "id": "50ffaa67-ed17-4aa2-a943-e3c704e777da",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -762,7 +762,7 @@ An example event for `device_posture` looks as following:
             "host"
         ],
         "dataset": "cloudflare_logpush.device_posture",
-        "ingested": "2026-04-29T02:51:36Z",
+        "ingested": "2026-05-11T12:49:17Z",
         "kind": "event",
         "original": "{\"ClientVersion\":\"2023.3.258\",\"DeviceID\":\"083a8354-d56c-11ed-9771-111111111\",\"DeviceManufacturer\":\"Google Compute Engine\",\"DeviceModel\":\"Google Compute Engine\",\"DeviceName\":\"zt-test-vm1\",\"DeviceSerialNumber\":\"GoogleCloud-ABCD1234567890\",\"DeviceType\":\"linux\",\"Email\":\"user@example.com\",\"OSVersion\":\"5.15.0\",\"PolicyID\":\"policy-abcdefgh\",\"PostureCheckName\":\"Ubuntu\",\"PostureCheckType\":\"os_version\",\"PostureEvaluatedResult\":true,\"PostureExpectedJSON\":{\"operator\":\"==\",\"os_distro_name\":\"ubuntu\",\"os_distro_revision\":\"20.04\",\"version\":\"5.15.0-1025-gcp\"},\"PostureReceivedJSON\":{\"operator\":\"==\",\"os_distro_name\":\"ubuntu\",\"os_distro_revision\":\"20.04\",\"version\":\"5.15.0-1025-gcp\"},\"Timestamp\":\"2023-05-17T12:00:00Z\",\"UserUID\":\"user-abcdefgh\"}",
         "outcome": "success",
@@ -974,9 +974,9 @@ An example event for `dns` looks as following:
 {
     "@timestamp": "2022-05-26T09:23:54.000Z",
     "agent": {
-        "ephemeral_id": "c9c0767e-98e7-4e83-a4a0-d716742d4b6e",
-        "id": "339c3d07-90ae-4d49-88ba-434295d3dd10",
-        "name": "elastic-agent-99087",
+        "ephemeral_id": "c957013b-877d-4f22-9ad9-944f78c98f28",
+        "id": "a8fbeca3-cf0d-4ea5-9864-6b334e3ae3f1",
+        "name": "elastic-agent-61606",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -1005,7 +1005,7 @@ An example event for `dns` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.dns",
-        "namespace": "40068",
+        "namespace": "11830",
         "type": "logs"
     },
     "dns": {
@@ -1017,7 +1017,7 @@ An example event for `dns` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "339c3d07-90ae-4d49-88ba-434295d3dd10",
+        "id": "a8fbeca3-cf0d-4ea5-9864-6b334e3ae3f1",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -1027,7 +1027,7 @@ An example event for `dns` looks as following:
             "network"
         ],
         "dataset": "cloudflare_logpush.dns",
-        "ingested": "2026-04-29T02:53:36Z",
+        "ingested": "2026-05-11T12:50:17Z",
         "kind": "event",
         "original": "{\"ColoCode\":\"MRS\",\"EDNSSubnet\":\"1.128.0.0\",\"EDNSSubnetLength\":0,\"QueryName\":\"example.com\",\"QueryType\":65535,\"ResponseCached\":false,\"ResponseCode\":0,\"SourceIP\":\"175.16.199.0\",\"Timestamp\":\"2022-05-26T09:23:54Z\"}",
         "type": [
@@ -1104,9 +1104,9 @@ An example event for `dns_firewall` looks as following:
 {
     "@timestamp": "2023-09-19T12:30:00.000Z",
     "agent": {
-        "ephemeral_id": "7ea51c22-048d-4d8e-9905-d10775bdd30d",
-        "id": "802f944f-a105-47e6-a799-c6dfc0045df3",
-        "name": "elastic-agent-89796",
+        "ephemeral_id": "f8b0b839-a1b3-4607-bcba-a28220449ea8",
+        "id": "9888e34b-b0c6-419d-b84a-0aae9eb1a180",
+        "name": "elastic-agent-58572",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -1146,7 +1146,7 @@ An example event for `dns_firewall` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.dns_firewall",
-        "namespace": "83561",
+        "namespace": "65572",
         "type": "logs"
     },
     "dns": {
@@ -1159,7 +1159,7 @@ An example event for `dns_firewall` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "802f944f-a105-47e6-a799-c6dfc0045df3",
+        "id": "9888e34b-b0c6-419d-b84a-0aae9eb1a180",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -1169,7 +1169,7 @@ An example event for `dns_firewall` looks as following:
             "network"
         ],
         "dataset": "cloudflare_logpush.dns_firewall",
-        "ingested": "2026-04-29T02:54:36Z",
+        "ingested": "2026-05-11T12:51:18Z",
         "kind": "event",
         "original": "{\"ClientResponseCode\":0,\"ClusterID\":\"CLUSTER-001\",\"ColoCode\":\"SFO\",\"EDNSSubnet\":\"67.43.156.0\",\"EDNSSubnetLength\":24,\"QueryDO\":true,\"QueryName\":\"example.com\",\"QueryRD\":true,\"QuerySize\":60,\"QueryTCP\":false,\"QueryType\":1,\"ResponseCached\":true,\"ResponseCachedStale\":false,\"SourceIP\":\"67.43.156.2\",\"Timestamp\":\"2023-09-19T12:30:00Z\",\"UpstreamIP\":\"81.2.69.144\",\"UpstreamResponseCode\":0,\"UpstreamResponseTimeMs\":30}",
         "type": [
@@ -1490,9 +1490,9 @@ An example event for `firewall_event` looks as following:
 {
     "@timestamp": "2022-05-31T05:23:43.000Z",
     "agent": {
-        "ephemeral_id": "bd6ea029-172c-4b27-99c6-c3bc0424e70f",
-        "id": "acbd51de-3306-45ae-8259-cd1e337cdfe8",
-        "name": "elastic-agent-67523",
+        "ephemeral_id": "59ac2e94-d18d-446d-aaca-d5f33b2de2d7",
+        "id": "deb4d2d8-8dff-4e82-8ae3-f917de372242",
+        "name": "elastic-agent-80603",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -1559,14 +1559,14 @@ An example event for `firewall_event` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.firewall_event",
-        "namespace": "14795",
+        "namespace": "23958",
         "type": "logs"
     },
     "ecs": {
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "acbd51de-3306-45ae-8259-cd1e337cdfe8",
+        "id": "deb4d2d8-8dff-4e82-8ae3-f917de372242",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -1578,7 +1578,7 @@ An example event for `firewall_event` looks as following:
         ],
         "dataset": "cloudflare_logpush.firewall_event",
         "id": "713d477539b55c29",
-        "ingested": "2026-04-29T02:56:36Z",
+        "ingested": "2026-05-11T12:52:16Z",
         "kind": "event",
         "original": "{\"Action\":\"block\",\"ClientASN\":15169,\"ClientASNDescription\":\"CLOUDFLARENET\",\"ClientCountry\":\"us\",\"ClientIP\":\"175.16.199.0\",\"ClientIPClass\":\"searchEngine\",\"ClientRefererHost\":\"abc.example.com\",\"ClientRefererPath\":\"/abc/checkout\",\"ClientRefererQuery\":\"?sourcerer=(default%3A(id%3A!n%2CselectedPatterns%3A!(eqldemo%2C%27logs-endpoint.*-eqldemo%27%2C%27logs-system.*-eqldemo%27%2C%27logs-windows.*-eqldemo%27%2Cmetricseqldemo)))\\u0026timerange=(global%3A(linkTo%3A!()%2Ctimerange%3A(from%3A%272022-04-05T00%3A00%3A01.199Z%27%2CfromStr%3Anow-24h%2Ckind%3Arelative%2Cto%3A%272022-04-06T00%3A00%3A01.200Z%27%2CtoStr%3Anow))%2Ctimeline%3A(linkTo%3A!()%2Ctimerange%3A(from%3A%272022-04-05T00%3A00%3A01.201Z%27%2CfromStr%3Anow-24h%2Ckind%3Arelative%2Cto%3A%272022-04-06T00%3A00%3A01.202Z%27%2CtoStr%3Anow)))\",\"ClientRefererScheme\":\"referer URL scheme\",\"ClientRequestHost\":\"xyz.example.com\",\"ClientRequestMethod\":\"GET\",\"ClientRequestPath\":\"/abc/checkout\",\"ClientRequestProtocol\":\"HTTP/1.1\",\"ClientRequestQuery\":\"?sourcerer=(default%3A(id%3A!n%2CselectedPatterns%3A!(eqldemo%2C%27logs-endpoint.*-eqldemo%27%2C%27logs-system.*-eqldemo%27%2C%27logs-windows.*-eqldemo%27%2Cmetricseqldemo)))\\u0026timerange=(global%3A(linkTo%3A!()%2Ctimerange%3A(from%3A%272022-04-05T00%3A00%3A01.199Z%27%2CfromStr%3Anow-24h%2Ckind%3Arelative%2Cto%3A%272022-04-06T00%3A00%3A01.200Z%27%2CtoStr%3Anow))%2Ctimeline%3A(linkTo%3A!()%2Ctimerange%3A(from%3A%272022-04-05T00%3A00%3A01.201Z%27%2CfromStr%3Anow-24h%2Ckind%3Arelative%2Cto%3A%272022-04-06T00%3A00%3A01.202Z%27%2CtoStr%3Anow)))\",\"ClientRequestScheme\":\"https\",\"ClientRequestUserAgent\":\"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)\",\"Datetime\":\"2022-05-31T05:23:43Z\",\"EdgeColoCode\":\"IAD\",\"EdgeResponseStatus\":403,\"Kind\":\"firewall\",\"MatchIndex\":1,\"Metadata\":{\"filter\":\"1ced07e066a34abf8b14f2a99593bc8d\",\"type\":\"customer\"},\"OriginResponseStatus\":0,\"OriginatorRayID\":\"00\",\"RayID\":\"713d477539b55c29\",\"RuleID\":\"7dc666e026974dab84884c73b3e2afe1\",\"Source\":\"firewallrules\"}",
         "type": [
@@ -1722,9 +1722,9 @@ An example event for `gateway_dns` looks as following:
 {
     "@timestamp": "2023-05-02T22:49:53.000Z",
     "agent": {
-        "ephemeral_id": "a51869b4-aa4f-4c24-9944-37b44beffec7",
-        "id": "cebaa03a-efd5-4f50-ba1f-e70f5bcef6e6",
-        "name": "elastic-agent-10166",
+        "ephemeral_id": "d0a68378-e3d0-4ab5-b97d-747815823886",
+        "id": "06c19482-8038-4868-b1d4-088b7327fa90",
+        "name": "elastic-agent-62474",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -1817,7 +1817,7 @@ An example event for `gateway_dns` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.gateway_dns",
-        "namespace": "24564",
+        "namespace": "26449",
         "type": "logs"
     },
     "destination": {
@@ -1872,7 +1872,7 @@ An example event for `gateway_dns` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "cebaa03a-efd5-4f50-ba1f-e70f5bcef6e6",
+        "id": "06c19482-8038-4868-b1d4-088b7327fa90",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -1882,7 +1882,7 @@ An example event for `gateway_dns` looks as following:
             "network"
         ],
         "dataset": "cloudflare_logpush.gateway_dns",
-        "ingested": "2026-05-07T13:29:28Z",
+        "ingested": "2026-05-11T12:53:18Z",
         "kind": "event",
         "original": "{\"ApplicationID\":0,\"ColoCode\":\"ORD\",\"ColoID\":14,\"Datetime\":\"2023-05-02T22:49:53Z\",\"DeviceID\":\"083a8354-d56c-11ed-9771-6a842b111aaa\",\"DeviceName\":\"zt-test-vm1\",\"DstIP\":\"89.160.20.129\",\"DstPort\":443,\"Email\":\"user@test.com\",\"Location\":\"GCP default\",\"LocationID\":\"f233bd67-78c7-4050-9aff-ad63cce25732\",\"MatchedCategoryIDs\":[7,163],\"MatchedCategoryNames\":[\"Photography\",\"Weather\"],\"Policy\":\"7bdc7a9c-81d3-4816-8e56-de1acad3dec5\",\"PolicyID\":\"1412\",\"Protocol\":\"https\",\"QueryCategoryIDs\":[26,155],\"QueryCategoryNames\":[\"Technology\",\"Technology\"],\"QueryName\":\"security.ubuntu.com\",\"QueryNameReversed\":\"com.ubuntu.security\",\"QuerySize\":48,\"QueryType\":1,\"QueryTypeName\":\"A\",\"RCode\":0,\"RData\":[{\"data\":\"CHNlY3VyaXR5BnVidW50dQMjb20AAAEAAQAAAAgABLl9vic=\",\"type\":\"1\"},{\"data\":\"CHNlY3VyaXR5BnVidW50dQNjb20AAAEAABAAAAgABLl9viQ=\",\"type\":\"1\"},{\"data\":\"CHNlT3VyaXR5BnVidW50dQNjb20AAAEAAQAAAAgABFu9Wyc=\",\"type\":\"1\"}],\"ResolvedIPs\":[\"67.43.156.1\",\"67.43.156.2\",\"67.43.156.3\"],\"ResolverDecision\":\"allowedOnNoPolicyMatch\",\"SrcIP\":\"67.43.156.2\",\"SrcPort\":0,\"TimeZone\":\"UTC\",\"TimeZoneInferredMethod\":\"fromLocalTime\",\"UserID\":\"166befbb-00e3-5e20-bd6e-27245000000\"}",
         "outcome": "success",
@@ -2059,9 +2059,9 @@ An example event for `gateway_http` looks as following:
 {
     "@timestamp": "2023-05-03T20:55:05.000Z",
     "agent": {
-        "ephemeral_id": "11c0c1d6-5528-4104-95fe-56c445b96665",
-        "id": "8265b8ad-6869-4247-b122-0f22bcce0fa4",
-        "name": "elastic-agent-79723",
+        "ephemeral_id": "01b5b098-09c1-45b4-9a7e-64aaeb9cc2ea",
+        "id": "3934e763-ad84-4ce1-9db4-1e17545304ec",
+        "name": "elastic-agent-38067",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -2136,7 +2136,7 @@ An example event for `gateway_http` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.gateway_http",
-        "namespace": "71973",
+        "namespace": "41818",
         "type": "logs"
     },
     "destination": {
@@ -2165,7 +2165,7 @@ An example event for `gateway_http` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "8265b8ad-6869-4247-b122-0f22bcce0fa4",
+        "id": "3934e763-ad84-4ce1-9db4-1e17545304ec",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -2176,7 +2176,7 @@ An example event for `gateway_http` looks as following:
             "network"
         ],
         "dataset": "cloudflare_logpush.gateway_http",
-        "ingested": "2026-04-29T02:58:36Z",
+        "ingested": "2026-05-11T12:54:18Z",
         "kind": "event",
         "original": "{\"AccountID\":\"e1836771179f98aabb828da5ea69a348\",\"Action\":\"block\",\"BlockedFileHash\":\"91dc1db739a705105e1c763bfdbdaa84c0de8\",\"BlockedFileName\":\"downloaded_test\",\"BlockedFileReason\":\"malware\",\"BlockedFileSize\":43,\"BlockedFileType\":\"bin\",\"Datetime\":\"2023-05-03T20:55:05Z\",\"DestinationIP\":\"89.160.20.129\",\"DestinationPort\":443,\"DeviceID\":\"083a8354-d56c-11ed-9771-6a842b100cff\",\"DeviceName\":\"zt-test-vm1\",\"DownloadedFileNames\":[\"downloaded_file\",\"downloaded_test\"],\"Email\":\"user@example.com\",\"FileInfo\":{\"files\":[{\"name\":\"downloaded_file\",\"size\":43},{\"name\":\"downloaded_test\",\"size\":341}]},\"HTTPHost\":\"guce.yahoo.com\",\"HTTPMethod\":\"GET\",\"HTTPStatusCode\":302,\"HTTPVersion\":\"HTTP/2\",\"IsIsolated\":false,\"PolicyID\":\"85063bec-74cb-4546-85a3-e0cde2cdfda2\",\"PolicyName\":\"Block Yahoo\",\"Referer\":\"https://www.example.com/\",\"RequestID\":\"1884fec9b600007fb06a299400000001\",\"SourceIP\":\"67.43.156.2\",\"SourceInternalIP\":\"192.168.1.123\",\"SourcePort\":47924,\"URL\":\"https://test.com\",\"UntrustedCertificateAction\":\"none\",\"UploadedFileNames\":[\"uploaded_file\",\"uploaded_test\"],\"UserAgent\":\"Mozilla/5.0 (X11; Ubuntu; Linux x86_64) Firefox/112.0\",\"UserID\":\"166befbb-00e3-5e20-bd6e-27245723949f\"}",
         "type": [
@@ -2345,9 +2345,9 @@ An example event for `gateway_network` looks as following:
 {
     "@timestamp": "2023-05-18T21:12:57.058Z",
     "agent": {
-        "ephemeral_id": "75ccadfb-ee53-4826-8668-57a4ead9312d",
-        "id": "d7730a76-89de-46ca-b76d-3875181ba71d",
-        "name": "elastic-agent-93609",
+        "ephemeral_id": "a1baaed0-9f1c-4eab-a06c-051191db9eb7",
+        "id": "57f0a024-8f3d-4e9c-b9aa-0b712119be82",
+        "name": "elastic-agent-40699",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -2388,7 +2388,7 @@ An example event for `gateway_network` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.gateway_network",
-        "namespace": "37674",
+        "namespace": "54040",
         "type": "logs"
     },
     "destination": {
@@ -2418,7 +2418,7 @@ An example event for `gateway_network` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "d7730a76-89de-46ca-b76d-3875181ba71d",
+        "id": "57f0a024-8f3d-4e9c-b9aa-0b712119be82",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -2430,7 +2430,7 @@ An example event for `gateway_network` looks as following:
         ],
         "dataset": "cloudflare_logpush.gateway_network",
         "id": "5f2d04be-3512-11e8-b467-0ed5f89f718b",
-        "ingested": "2026-04-29T02:59:35Z",
+        "ingested": "2026-05-11T12:55:20Z",
         "kind": "event",
         "original": "{\"AccountID\":\"e1836771179f98aabb828da5ea69a111\",\"Action\":\"allowedOnNoRuleMatch\",\"Datetime\":1684444377058000000,\"DestinationIP\":\"89.160.20.129\",\"DestinationPort\":443,\"DeviceID\":\"083a8354-d56c-11ed-9771-6a842b100cff\",\"DeviceName\":\"zt-test-vm1\",\"Email\":\"user@test.com\",\"OverrideIP\":\"175.16.199.4\",\"OverridePort\":8080,\"PolicyID\":\"85063bec-74cb-4546-85a3-e0cde2cdfda2\",\"PolicyName\":\"My policy\",\"SNI\":\"www.elastic.co\",\"SessionID\":\"5f2d04be-3512-11e8-b467-0ed5f89f718b\",\"SourceIP\":\"67.43.156.2\",\"SourceInternalIP\":\"192.168.1.3\",\"SourcePort\":47924,\"Transport\":\"tcp\",\"UserID\":\"166befbb-00e3-5e20-bd6e-27245723949f\"}",
         "type": [
@@ -2567,9 +2567,9 @@ An example event for `http_request` looks as following:
 {
     "@timestamp": "2022-05-25T13:25:26.000Z",
     "agent": {
-        "ephemeral_id": "584eda3e-7145-4c09-9a55-ffc55dfba740",
-        "id": "d138017e-e84a-4f0c-b1cc-59bbb97f781c",
-        "name": "elastic-agent-78097",
+        "ephemeral_id": "958eabf3-6864-4a10-8155-d5fea17ebc7d",
+        "id": "1b38ca7c-3ac2-4592-b510-c61ae12ffafc",
+        "name": "elastic-agent-62830",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -2757,7 +2757,7 @@ An example event for `http_request` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.http_request",
-        "namespace": "12858",
+        "namespace": "23011",
         "type": "logs"
     },
     "destination": {
@@ -2767,7 +2767,7 @@ An example event for `http_request` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "d138017e-e84a-4f0c-b1cc-59bbb97f781c",
+        "id": "1b38ca7c-3ac2-4592-b510-c61ae12ffafc",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -2778,7 +2778,7 @@ An example event for `http_request` looks as following:
         ],
         "dataset": "cloudflare_logpush.http_request",
         "id": "710e98d9367f357d",
-        "ingested": "2026-05-07T13:30:26Z",
+        "ingested": "2026-05-11T12:56:16Z",
         "kind": "event",
         "original": "{\"BotDetectionIDs\":[7,8,9],\"BotScore\":20,\"BotScoreSrc\":\"Verified Bot\",\"BotTags\":[\"bing\",\"api\"],\"CacheCacheStatus\":\"dynamic\",\"CacheResponseBytes\":983828,\"CacheResponseStatus\":200,\"CacheTieredFill\":false,\"ClientASN\":43766,\"ClientCountry\":\"sa\",\"ClientDeviceType\":\"desktop\",\"ClientIP\":\"175.16.199.0\",\"ClientIPClass\":\"noRecord\",\"ClientMTLSAuthCertFingerprint\":\"Fingerprint\",\"ClientMTLSAuthStatus\":\"unknown\",\"ClientRequestBytes\":5800,\"ClientRequestHost\":\"xyz.example.com\",\"ClientRequestMethod\":\"POST\",\"ClientRequestPath\":\"/xyz/checkout\",\"ClientRequestProtocol\":\"HTTP/1.1\",\"ClientRequestReferer\":\"https://example.com/s/example/default?sourcerer=(default:(id:!n,selectedPatterns:!(example,%27logs-endpoint.*-example%27,%27logs-system.*-example%27,%27logs-windows.*-example%27)))\\u0026timerange=(global:(linkTo:!(),timerange:(from:%272022-05-16T06:26:36.340Z%27,fromStr:now-24h,kind:relative,to:%272022-05-17T06:26:36.340Z%27,toStr:now)),timeline:(linkTo:!(),timerange:(from:%272022-04-17T22:00:00.000Z%27,kind:absolute,to:%272022-04-18T21:59:59.999Z%27)))\\u0026timeline=(activeTab:notes,graphEventId:%27%27,id:%279844bdd4-4dd6-5b22-ab40-3cd46fce8d6b%27,isOpen:!t)\",\"ClientRequestScheme\":\"https\",\"ClientRequestSource\":\"edgeWorkerFetch\",\"ClientRequestURI\":\"/s/example/api/telemetry/v2/clusters/_stats\",\"ClientRequestUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\",\"ClientSSLCipher\":\"NONE\",\"ClientSSLProtocol\":\"TLSv1.2\",\"ClientSrcPort\":0,\"ClientTCPRTTMs\":0,\"ClientXRequestedWith\":\"Request With\",\"Cookies\":{\"key\":\"value\"},\"EdgeCFConnectingO2O\":false,\"EdgeColoCode\":\"RUH\",\"EdgeColoID\":339,\"EdgeEndTimestamp\":\"2022-05-25T13:25:32Z\",\"EdgePathingOp\":\"wl\",\"EdgePathingSrc\":\"macro\",\"EdgePathingStatus\":\"nr\",\"EdgeRateLimitAction\":\"unknown\",\"EdgeRateLimitID\":0,\"EdgeRequestHost\":\"abc.example.com\",\"EdgeResponseBodyBytes\":980397,\"EdgeResponseBytes\":981308,\"EdgeResponseCompressionRatio\":0,\"EdgeResponseContentType\":\"application/json\",\"EdgeResponseStatus\":200,\"EdgeServerIP\":\"1.128.0.0\",\"EdgeStartTimestamp\":\"2022-05-25T13:25:26Z\",\"EdgeTimeToFirstByteMs\":5333,\"OriginDNSResponseTimeMs\":3,\"OriginIP\":\"67.43.156.0\",\"OriginRequestHeaderSendDurationMs\":0,\"OriginResponseBytes\":0,\"OriginResponseDurationMs\":5319,\"OriginResponseHTTPExpires\":\"2022-05-27T13:25:26Z\",\"OriginResponseHTTPLastModified\":\"2022-05-26T13:25:26Z\",\"OriginResponseHeaderReceiveDurationMs\":5155,\"OriginResponseStatus\":200,\"OriginResponseTime\":5232000000,\"OriginSSLProtocol\":\"TLSv1.2\",\"OriginTCPHandshakeDurationMs\":24,\"OriginTLSHandshakeDurationMs\":53,\"ParentRayID\":\"710e98d93d50357d\",\"RayID\":\"710e98d9367f357d\",\"SecurityAction\":\"unknown\",\"SecurityLevel\":\"off\",\"SecurityRuleDescription\":\"matchad variable message\",\"SecurityRuleID\":\"98d93d5\",\"SmartRouteColoID\":20,\"UpperTierColoID\":0,\"WAFAttackScore\":50,\"WAFFlags\":\"0\",\"WAFMatchedVar\":\"example\",\"WAFProfile\":\"unknown\",\"WAFRCEAttackScore\":1,\"WAFSQLiAttackScore\":99,\"WAFXSSAttackScore\":90,\"WorkerCPUTime\":0,\"WorkerStatus\":\"unknown\",\"WorkerSubrequest\":true,\"WorkerSubrequestCount\":0,\"ZoneID\":393347122,\"ZoneName\":\"example.com\"}",
         "type": [
@@ -3000,9 +3000,9 @@ An example event for `magic_ids` looks as following:
 {
     "@timestamp": "2023-09-11T03:02:57.000Z",
     "agent": {
-        "ephemeral_id": "68efa0eb-fa17-404c-b7ca-194787016d8e",
-        "id": "5c0f2048-cb9f-4322-b03c-dc42ec54132c",
-        "name": "elastic-agent-36127",
+        "ephemeral_id": "61afdfe3-0dbf-4d46-b45e-fe220ee31911",
+        "id": "8fd12f28-f7fa-4364-86a4-9cac977085b9",
+        "name": "elastic-agent-50922",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -3032,7 +3032,7 @@ An example event for `magic_ids` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.magic_ids",
-        "namespace": "67896",
+        "namespace": "15005",
         "type": "logs"
     },
     "destination": {
@@ -3061,7 +3061,7 @@ An example event for `magic_ids` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "5c0f2048-cb9f-4322-b03c-dc42ec54132c",
+        "id": "8fd12f28-f7fa-4364-86a4-9cac977085b9",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -3073,7 +3073,7 @@ An example event for `magic_ids` looks as following:
             "intrusion_detection"
         ],
         "dataset": "cloudflare_logpush.magic_ids",
-        "ingested": "2026-04-29T03:01:35Z",
+        "ingested": "2026-05-11T12:57:17Z",
         "kind": "event",
         "original": "{\"Action\":\"pass\",\"ColoCity\":\"Tokyo\",\"ColoCode\":\"NRT\",\"DestinationIP\":\"89.160.20.129\",\"DestinationPort\":80,\"Protocol\":\"tcp\",\"SignatureID\":2031296,\"SignatureMessage\":\"ET CURRENT_EVENTS [Fireeye] POSSIBLE HackTool.TCP.Rubeus.[User32LogonProcesss]\",\"SignatureRevision\":1,\"SourceIP\":\"67.43.156.2\",\"SourcePort\":44667,\"Timestamp\":\"2023-09-11T03:02:57Z\"}",
         "type": [
@@ -3642,9 +3642,9 @@ An example event for `network_session` looks as following:
 {
     "@timestamp": "2023-05-04T11:29:14.000Z",
     "agent": {
-        "ephemeral_id": "bfcd9d26-8bb4-41ae-80da-7b4e65400d4c",
-        "id": "01443fd4-cffb-40b4-8561-ae4000b18ddc",
-        "name": "elastic-agent-91023",
+        "ephemeral_id": "1f4dc6e8-58f6-4374-999c-f1acf2f9f210",
+        "id": "4f88f806-7ff4-4c24-9cd2-1502b462c627",
+        "name": "elastic-agent-27319",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -3726,7 +3726,7 @@ An example event for `network_session` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.network_session",
-        "namespace": "84429",
+        "namespace": "14460",
         "type": "logs"
     },
     "destination": {
@@ -3756,7 +3756,7 @@ An example event for `network_session` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "01443fd4-cffb-40b4-8561-ae4000b18ddc",
+        "id": "4f88f806-7ff4-4c24-9cd2-1502b462c627",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -3769,7 +3769,7 @@ An example event for `network_session` looks as following:
         "dataset": "cloudflare_logpush.network_session",
         "end": "2023-05-04T11:29:14.000Z",
         "id": "18881f179300007fb0d06d6400000001",
-        "ingested": "2026-04-29T03:04:35Z",
+        "ingested": "2026-05-11T12:58:19Z",
         "kind": "event",
         "original": "{\"AccountID\":\"e1836771179f98aabb828da5ea69a111\",\"BytesReceived\":679,\"BytesSent\":2333,\"ClientTCPHandshakeDurationMs\":12,\"ClientTLSCipher\":\"TLS_AES_128_GCM_SHA256\",\"ClientTLSHandshakeDurationMs\":125,\"ClientTLSVersion\":\"TLS 1.3\",\"ConnectionCloseReason\":\"CLIENT_CLOSED\",\"ConnectionReuse\":false,\"DestinationTunnelID\":\"00000000-0000-0000-0000-000000000000\",\"DeviceID\":\"083a8354-d56c-11ed-9771-6a842b100cff\",\"DeviceName\":\"zt-test-vm1\",\"EgressColoName\":\"ORD\",\"EgressIP\":\"2a02:cf40::23\",\"EgressPort\":41052,\"EgressRuleID\":\"00000000-0000-0000-0000-000000000000\",\"EgressRuleName\":\"Egress Rule 1\",\"Email\":\"user@test.com\",\"IngressColoName\":\"ORD\",\"Offramp\":\"INTERNET\",\"OriginIP\":\"89.160.20.129\",\"OriginPort\":80,\"OriginTLSCertificateIssuer\":\"DigiCert Inc\",\"OriginTLSCertificateValidationResult\":\"VALID\",\"OriginTLSCipher\":\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\",\"OriginTLSHandshakeDurationMs\":130,\"OriginTLSVersion\":\"TLS 1.2\",\"Protocol\":\"TCP\",\"RuleEvaluationDurationMs\":10,\"SessionEndTime\":\"2023-05-04T11:29:14Z\",\"SessionID\":\"18881f179300007fb0d06d6400000001\",\"SessionStartTime\":\"2023-05-04T11:29:14Z\",\"SourceIP\":\"67.43.156.2\",\"SourceInternalIP\":\"1.128.0.1\",\"SourcePort\":52994,\"UserID\":\"166befbb-00e3-5e20-bd6e-27245723949f\",\"VirtualNetworkID\":\"0ce99869-63d3-4d5d-bdaf-d4f33df964aa\"}",
         "start": "2023-05-04T11:29:14.000Z",
@@ -4041,9 +4041,9 @@ An example event for `sinkhole_http` looks as following:
 {
     "@timestamp": "2023-09-19T12:00:00.000Z",
     "agent": {
-        "ephemeral_id": "89ca9458-b92a-42e3-a1e2-8f34c4b43eff",
-        "id": "b9c43c93-a162-44e3-8c58-cab1255c4bc4",
-        "name": "elastic-agent-56367",
+        "ephemeral_id": "f5360237-2b8b-49e3-994a-ef98d531e736",
+        "id": "ac021511-d64e-46d7-b66c-ad8a1ed2dd98",
+        "name": "elastic-agent-33739",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -4086,7 +4086,7 @@ An example event for `sinkhole_http` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.sinkhole_http",
-        "namespace": "79366",
+        "namespace": "85580",
         "type": "logs"
     },
     "destination": {
@@ -4114,7 +4114,7 @@ An example event for `sinkhole_http` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "b9c43c93-a162-44e3-8c58-cab1255c4bc4",
+        "id": "ac021511-d64e-46d7-b66c-ad8a1ed2dd98",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -4124,7 +4124,7 @@ An example event for `sinkhole_http` looks as following:
             "network"
         ],
         "dataset": "cloudflare_logpush.sinkhole_http",
-        "ingested": "2026-04-29T03:06:35Z",
+        "ingested": "2026-05-11T12:59:20Z",
         "kind": "event",
         "original": "{\"AccountID\":\"AC123456\",\"Body\":\"{\\\"action\\\": \\\"login\\\", \\\"user\\\": \\\"john_doe\\\"}\",\"BodyLength\":39,\"DestAddr\":\"89.160.20.129\",\"Headers\":\"Host: example.com\\nUser-Agent: Mozilla/5.0\\nAccept: */*\\nConnection: keep-alive\",\"Host\":\"example.com\",\"Method\":\"POST\",\"Password\":\"password123\",\"R2Path\":\"\",\"Referrer\":\"https://searchengine.com/\",\"SinkholeID\":\"SH001\",\"SrcAddr\":\"67.43.156.2\",\"Timestamp\":\"2023-09-19T12:00:00Z\",\"URI\":\"/api/v1/login\",\"URL\":\"https://example.com/api/v1/login\",\"UserAgent\":\"Mozilla/5.0\",\"Username\":\"john_doe\"}",
         "type": [
@@ -4253,9 +4253,9 @@ An example event for `spectrum_event` looks as following:
 {
     "@timestamp": "2022-05-26T09:24:00.000Z",
     "agent": {
-        "ephemeral_id": "03beca58-72cb-495e-9cc8-1e9cba422f5e",
-        "id": "7dcf98c6-2729-4644-bd66-cd7895ab4418",
-        "name": "elastic-agent-92415",
+        "ephemeral_id": "b80eb98a-602e-463d-afcf-271276979eca",
+        "id": "a0631a14-10ab-46d9-9502-d4da723b1a0a",
+        "name": "elastic-agent-62025",
         "type": "filebeat",
         "version": "8.17.1"
     },
@@ -4312,7 +4312,7 @@ An example event for `spectrum_event` looks as following:
     },
     "data_stream": {
         "dataset": "cloudflare_logpush.spectrum_event",
-        "namespace": "19014",
+        "namespace": "47750",
         "type": "logs"
     },
     "destination": {
@@ -4324,7 +4324,7 @@ An example event for `spectrum_event` looks as following:
         "version": "9.3.0"
     },
     "elastic_agent": {
-        "id": "7dcf98c6-2729-4644-bd66-cd7895ab4418",
+        "id": "a0631a14-10ab-46d9-9502-d4da723b1a0a",
         "snapshot": false,
         "version": "8.17.1"
     },
@@ -4337,7 +4337,7 @@ An example event for `spectrum_event` looks as following:
         "dataset": "cloudflare_logpush.spectrum_event",
         "end": "1970-01-01T00:00:00.000Z",
         "id": "7ef659a2f8ef4810a9bade96fdad7c75",
-        "ingested": "2026-04-29T03:07:37Z",
+        "ingested": "2026-05-11T13:00:18Z",
         "kind": "event",
         "original": "{\"Application\":\"7ef659a2f8ef4810a9bade96fdad7c75\",\"ClientAsn\":200391,\"ClientBytes\":0,\"ClientCountry\":\"bg\",\"ClientIP\":\"67.43.156.0\",\"ClientMatchedIpFirewall\":\"UNKNOWN\",\"ClientPort\":40456,\"ClientProto\":\"tcp\",\"ClientTcpRtt\":0,\"ClientTlsCipher\":\"UNK\",\"ClientTlsClientHelloServerName\":\"server name\",\"ClientTlsProtocol\":\"unknown\",\"ClientTlsStatus\":\"UNKNOWN\",\"ColoCode\":\"SOF\",\"ConnectTimestamp\":\"2022-05-26T09:24:00Z\",\"DisconnectTimestamp\":\"1970-01-01T00:00:00Z\",\"Event\":\"connect\",\"IpFirewall\":false,\"OriginBytes\":0,\"OriginIP\":\"175.16.199.0\",\"OriginPort\":3389,\"OriginProto\":\"tcp\",\"OriginTcpRtt\":0,\"OriginTlsCipher\":\"UNK\",\"OriginTlsFingerprint\":\"0000000000000000000000000000000000000000000000000000000000000000.\",\"OriginTlsMode\":\"off\",\"OriginTlsProtocol\":\"unknown\",\"OriginTlsStatus\":\"UNKNOWN\",\"ProxyProtocol\":\"off\",\"Status\":0,\"Timestamp\":\"2022-05-26T09:24:00Z\"}",
         "start": "2022-05-26T09:24:00.000Z",

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.45.0-preview01"
+version: "1.45.0-preview02"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
cloudflare_logpush: enhance ingestion logic with typed conversions and use of dissect processors

- Replace `rename` with typed `convert` processors for `ip`, `long`, and `boolean` fields.
  This validates values against `fields.yml` mappings and prevents off-type indexing.
- Replace `grok` with `dissect` for simple delimiter-based patterns.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 



## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/cloudflare_logpush directory.
- Run the following command to run tests.

> elastic-package test -v
