### PR TITLE
[cloudflare_logpush] add a tag key to each processor

### DIFF
--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.45.0-preview03"
+  changes:
+    - description: Add `tag` key to each processor in the ingest pipelines.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.45.0-preview01"
   changes:
     - description: Update ECS to 9.3.0 and add new fields across multiple data streams.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `tag` key to each processor in the ingest pipelines.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18953
 - version: "1.45.0-preview01"
   changes:
     - description: Update ECS to 9.3.0 and add new fields across multiple data streams.

--- a/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Access Request logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,20 +19,24 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_type_24c7243c
       field: event.type
       value: [access]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -40,7 +45,7 @@ processors:
         must be removed.
       if: ctx._conf?.enable_deduplication == false && ctx.input?.type == 'aws-s3'
       ignore_missing: true
-# ECS fields
+  # ECS fields
   - script:
       lang: painless
       tag: painless_created_at_to_milli
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_CreatedAt_71066ccc
       field: json.CreatedAt
       if: ctx.json?.CreatedAt != null && ctx.json.CreatedAt != ''
       formats:
@@ -72,79 +78,98 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_d9aeb333
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_access_request_timestamp_7b8f00af
       field: cloudflare_logpush.access_request.timestamp
       copy_from: "@timestamp"
   - rename:
+      tag: rename_json_Action_to_cloudflare_logpush_access_request_action_cd9b83c4
       field: json.Action
       target_field: cloudflare_logpush.access_request.action
       ignore_missing: true
   - set:
+      tag: set_event_action_3b69f4cf
       field: event.action
       copy_from: cloudflare_logpush.access_request.action
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Allowed_to_cloudflare_logpush_access_request_allowed_333c5906
       field: json.Allowed
       target_field: cloudflare_logpush.access_request.allowed
       ignore_missing: true
-# Enrich event.type based on the allowed field
+  # Enrich event.type based on the allowed field
   - append:
+      tag: append_event_type_88337741
       field: event.type
       value: allowed
       allow_duplicates: false
       if: ctx.cloudflare_logpush?.access_request?.allowed != null && ctx.cloudflare_logpush?.access_request?.allowed == true
   - append:
+      tag: append_event_type_078c13d5
       field: event.type
       value: denied
       allow_duplicates: false
       if: ctx.cloudflare_logpush?.access_request?.allowed != null && ctx.cloudflare_logpush?.access_request?.allowed == false
   - rename:
+      tag: rename_json_AppDomain_to_cloudflare_logpush_access_request_app_domain_1f56d686
       field: json.AppDomain
       target_field: cloudflare_logpush.access_request.app.domain
       ignore_missing: true
   - set:
+      tag: set_url_domain_7cb52535
       field: url.domain
       copy_from: cloudflare_logpush.access_request.app.domain
       ignore_empty_value: true
   - rename:
+      tag: rename_json_AppUUID_to_cloudflare_logpush_access_request_app_uuid_d39a6a6e
       field: json.AppUUID
       target_field: cloudflare_logpush.access_request.app.uuid
       ignore_missing: true
   - rename:
+      tag: rename_json_Connection_to_cloudflare_logpush_access_request_connection_c6197c9c
       field: json.Connection
       target_field: cloudflare_logpush.access_request.connection
       ignore_missing: true
   - rename:
+      tag: rename_json_Country_to_cloudflare_logpush_access_request_country_4a1942ee
       field: json.Country
       target_field: cloudflare_logpush.access_request.country
       ignore_missing: true
   - set:
+      tag: set_client_geo_country_name_cc252be1
       field: client.geo.country_name
       copy_from: cloudflare_logpush.access_request.country
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Email_to_cloudflare_logpush_access_request_user_email_8368fd05
       field: json.Email
       target_field: cloudflare_logpush.access_request.user.email
       ignore_missing: true
   - set:
+      tag: set_user_email_777a8c8b
       field: user.email
       copy_from: cloudflare_logpush.access_request.user.email
       ignore_empty_value: true
   - rename:
+      tag: rename_json_IPAddress_to_cloudflare_logpush_access_request_client_ip_37faff3b
       field: json.IPAddress
       target_field: cloudflare_logpush.access_request.client.ip
       ignore_missing: true
   - set:
+      tag: set_client_ip_fea56e55
       field: client.ip
       copy_from: cloudflare_logpush.access_request.client.ip
       ignore_empty_value: true
-# Geo enrichment
+  # Geo enrichment
   - geoip:
+      tag: geoip_client_ip_to_client_geo_92da0c99
       field: client.ip
       target_field: client.geo
   - geoip:
+      tag: geoip_client_ip_to_client_as_f17fb2b3
       database_file: GeoLite2-ASN.mmdb
       field: client.ip
       target_field: client.as
@@ -153,62 +178,76 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_client_as_asn_to_client_as_number_a6e30d01
       field: client.as.asn
       target_field: client.as.number
       ignore_missing: true
   - rename:
+      tag: rename_client_as_organization_name_to_client_as_organization_name_817a526f
       field: client.as.organization_name
       target_field: client.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_PurposeJustificationPrompt_to_cloudflare_logpush_access_request_request_prompt_4c2a8f1f
       field: json.PurposeJustificationPrompt
       target_field: cloudflare_logpush.access_request.request.prompt
       ignore_missing: true
   - rename:
+      tag: rename_json_PurposeJustificationResponse_to_cloudflare_logpush_access_request_request_response_634724ab
       field: json.PurposeJustificationResponse
       target_field: cloudflare_logpush.access_request.request.response
       ignore_missing: true
   - rename:
+      tag: rename_json_RayID_to_cloudflare_logpush_access_request_ray_id_c5de5bdc
       field: json.RayID
       target_field: cloudflare_logpush.access_request.ray.id
       ignore_missing: true
   - set:
+      tag: set_event_id_dcd710c3
       field: event.id
       copy_from: cloudflare_logpush.access_request.ray.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_TemporaryAccessApprovers_to_cloudflare_logpush_access_request_temp_access_approvers_018ad516
       field: json.TemporaryAccessApprovers
       target_field: cloudflare_logpush.access_request.temp_access.approvers
       ignore_missing: true
   - rename:
+      tag: rename_json_TemporaryAccessDuration_to_cloudflare_logpush_access_request_temp_access_duration_f8473a8a
       field: json.TemporaryAccessDuration
       target_field: cloudflare_logpush.access_request.temp_access.duration
       ignore_missing: true
   - rename:
+      tag: rename_json_UserUID_to_cloudflare_logpush_access_request_user_id_dde20323
       field: json.UserUID
       target_field: cloudflare_logpush.access_request.user.id
       ignore_missing: true
   - set:
+      tag: set_user_id_1cba3d65
       field: user.id
       copy_from: cloudflare_logpush.access_request.user.id
       ignore_empty_value: true
-# Create related fields
+  # Create related fields
   - append:
+      tag: append_related_ip_3726c45d
       field: related.ip
       value: "{{{client.ip}}}"
       if: ctx.client?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_7f407fef
       field: related.user
       value: "{{{user.id}}}"
       if: ctx.user?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_34fcf415
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_cloudflare_logpush_access_request_temp_access_approvers_eb3fbf32
       field: cloudflare_logpush.access_request.temp_access.approvers
       processor:
         append:
@@ -223,6 +262,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_66238882
       field:
         - cloudflare_logpush.access_request.timestamp
         - cloudflare_logpush.access_request.action
@@ -237,6 +277,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |

--- a/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
@@ -103,9 +103,10 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9532bc98
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-# Enrich event.type based on the allowed field
+  # Enrich event.type based on the allowed field
   - append:
       tag: append_event_type_88337741
       field: event.type
@@ -167,6 +168,7 @@ processors:
       if: ctx.json?.IPAddress != ''
       on_failure:
         - append:
+            tag: append_error_message_64a77b32
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -231,6 +233,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a2b0f5ef
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:

--- a/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -35,9 +35,9 @@ processors:
       tag: set_event_category
       field: event.category
       value: [authentication]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -78,6 +78,7 @@ processors:
       timezone: UTC
       on_failure:
         - append:
+            tag: append_error_message_cf54c4b8
             field: error.message
             value: "{{{_ingest.on_failure_message}}}"
   - set:
@@ -143,6 +144,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_dee045ad
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:

--- a/packages/cloudflare_logpush/data_stream/casb/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare CASB Findings logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,20 +19,24 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_type_24c7243c
       field: event.type
       value: [access]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -62,6 +67,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_DetectedTimestamp_ea878f55
       field: json.DetectedTimestamp
       if: ctx.json?.DetectedTimestamp != null && ctx.json.DetectedTimestamp != ''
       formats:
@@ -71,81 +77,100 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_60a0a2fe
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_casb_timestamp_e42a92e8
       field: cloudflare_logpush.casb.timestamp
       copy_from: "@timestamp"
   - rename:
+      tag: rename_json_AssetDisplayName_to_cloudflare_logpush_casb_asset_name_63f9ef91
       field: json.AssetDisplayName
       target_field: cloudflare_logpush.casb.asset.name
       ignore_missing: true
   - rename:
+      tag: rename_json_AssetExternalID_to_cloudflare_logpush_casb_asset_id_efa6dd3c
       field: json.AssetExternalID
       target_field: cloudflare_logpush.casb.asset.id
       ignore_missing: true
   - rename:
+      tag: rename_json_AssetLink_to_cloudflare_logpush_casb_asset_url_cf671294
       field: json.AssetLink
       target_field: cloudflare_logpush.casb.asset.url
       ignore_missing: true
   - uri_parts:
+      tag: uri_parts_cloudflare_logpush_casb_asset_url_to_url_38a3e7b3
       field: cloudflare_logpush.casb.asset.url
       target_field: url
       if: ctx.cloudflare_logpush?.casb?.asset?.url != null
   - rename:
+      tag: rename_json_AssetMetadata_to_cloudflare_logpush_casb_asset_metadata_b65bc3fd
       field: json.AssetMetadata
       target_field: cloudflare_logpush.casb.asset.metadata
       ignore_missing: true
   - rename:
+      tag: rename_json_FindingTypeDisplayName_to_cloudflare_logpush_casb_finding_type_name_5434146f
       field: json.FindingTypeDisplayName
       target_field: cloudflare_logpush.casb.finding.type.name
       ignore_missing: true
   - rename:
+      tag: rename_json_FindingTypeID_to_cloudflare_logpush_casb_finding_type_id_1de37d4d
       field: json.FindingTypeID
       target_field: cloudflare_logpush.casb.finding.type.id
       ignore_missing: true
   - rename:
+      tag: rename_json_FindingTypeSeverity_to_cloudflare_logpush_casb_finding_type_severity_94779089
       field: json.FindingTypeSeverity
       target_field: cloudflare_logpush.casb.finding.type.severity
       ignore_missing: true
-# Set event.severity based on the incoming severity value ("low", "medium", "high", "critical")
+  # Set event.severity based on the incoming severity value ("low", "medium", "high", "critical")
   - set:
+      tag: set_event_severity_114ed469
       field: event.severity
       value: 1
       if: ctx.cloudflare_logpush?.casb?.finding?.type?.severity == "Low"
   - set:
+      tag: set_event_severity_a8bcf8b1
       field: event.severity
       value: 2
       if: ctx.cloudflare_logpush?.casb?.finding?.type?.severity == "Medium"
   - set:
+      tag: set_event_severity_49e96e4b
       field: event.severity
       value: 3
       if: ctx.cloudflare_logpush?.casb?.finding?.type?.severity == "High"
   - set:
+      tag: set_event_severity_8f2d0035
       field: event.severity
       value: 4
       if: ctx.cloudflare_logpush?.casb?.finding?.type?.severity == "Critical"
   - rename:
+      tag: rename_json_InstanceID_to_cloudflare_logpush_casb_finding_id_ecd3a70b
       field: json.InstanceID
       target_field: cloudflare_logpush.casb.finding.id
       ignore_missing: true
   - set:
+      tag: set_event_id_e9188c13
       field: event.id
       copy_from: cloudflare_logpush.casb.finding.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_IntegrationDisplayName_to_cloudflare_logpush_casb_integration_name_ad60962d
       field: json.IntegrationDisplayName
       target_field: cloudflare_logpush.casb.integration.name
       ignore_missing: true
   - rename:
+      tag: rename_json_IntegrationID_to_cloudflare_logpush_casb_integration_id_4913e059
       field: json.IntegrationID
       target_field: cloudflare_logpush.casb.integration.id
       ignore_missing: true
   - rename:
+      tag: rename_json_IntegrationPolicyVendor_to_cloudflare_logpush_casb_integration_policy_vendor_48bcfb2c
       field: json.IntegrationPolicyVendor
       target_field: cloudflare_logpush.casb.integration.policy_vendor
       ignore_missing: true
-# Clean event
+  # Clean event
   - remove:
       tag: remove_json_conf
       field:
@@ -153,6 +178,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_08601542
       field:
         - cloudflare_logpush.casb.timestamp
         - cloudflare_logpush.casb.asset.url
@@ -162,6 +188,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |

--- a/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
@@ -187,9 +187,10 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_dfd5c25a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-# Set event.outcome from cloudflare_logpush.device_posture.eval.result
+  # Set event.outcome from cloudflare_logpush.device_posture.eval.result
   - set:
       tag: set_event_outcome_1d222747
       field: event.outcome

--- a/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Device Posture Results logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,20 +19,24 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_event_category_ba9b1d84
       field: event.category
       value: [host]
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -62,6 +67,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Timestamp_772fbe7f
       field: json.Timestamp
       if: ctx.json?.Timestamp != null && ctx.json.Timestamp != ''
       formats:
@@ -71,145 +77,180 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_2e342a9c
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_device_posture_timestamp_058b7d14
       field: cloudflare_logpush.device_posture.timestamp
       copy_from: "@timestamp"
   - rename:
+      tag: rename_json_ClientVersion_to_cloudflare_logpush_device_posture_version_cd931ae0
       field: json.ClientVersion
       target_field: cloudflare_logpush.device_posture.version
       ignore_missing: true
   - set:
+      tag: set_user_agent_version_0039ca63
       field: user_agent.version
       copy_from: cloudflare_logpush.device_posture.version
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceID_to_cloudflare_logpush_device_posture_host_id_3ce2738f
       field: json.DeviceID
       target_field: cloudflare_logpush.device_posture.host.id
       ignore_missing: true
   - set:
+      tag: set_host_id_e7544a66
       field: host.id
       copy_from: cloudflare_logpush.device_posture.host.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceManufacturer_to_cloudflare_logpush_device_posture_host_manufacturer_043abe93
       field: json.DeviceManufacturer
       target_field: cloudflare_logpush.device_posture.host.manufacturer
       ignore_missing: true
   - rename:
+      tag: rename_json_DeviceModel_to_cloudflare_logpush_device_posture_host_model_265ecd11
       field: json.DeviceModel
       target_field: cloudflare_logpush.device_posture.host.model
       ignore_missing: true
   - rename:
+      tag: rename_json_DeviceName_to_cloudflare_logpush_device_posture_host_name_707832af
       field: json.DeviceName
       target_field: cloudflare_logpush.device_posture.host.name
       ignore_missing: true
   - set:
+      tag: set_host_name_6d640aee
       field: host.name
       copy_from: cloudflare_logpush.device_posture.host.name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceSerialNumber_to_cloudflare_logpush_device_posture_host_serial_b4965794
       field: json.DeviceSerialNumber
       target_field: cloudflare_logpush.device_posture.host.serial
       ignore_missing: true
   - rename:
+      tag: rename_json_DeviceType_to_cloudflare_logpush_device_posture_host_os_family_44e10223
       field: json.DeviceType
       target_field: cloudflare_logpush.device_posture.host.os.family
       ignore_missing: true
   - set:
+      tag: set_host_os_family_d17288fa
       field: host.os.family
       copy_from: cloudflare_logpush.device_posture.host.os.family
       ignore_empty_value: true
   - rename:
+      tag: rename_json_OSVersion_to_cloudflare_logpush_device_posture_host_os_version_07952967
       field: json.OSVersion
       target_field: cloudflare_logpush.device_posture.host.os.version
       ignore_missing: true
   - set:
+      tag: set_host_os_version_0207737e
       field: host.os.version
       copy_from: cloudflare_logpush.device_posture.host.os.version
       ignore_empty_value: true
   - rename:
+      tag: rename_json_PolicyID_to_cloudflare_logpush_device_posture_rule_id_49b576e7
       field: json.PolicyID
       target_field: cloudflare_logpush.device_posture.rule.id
       ignore_missing: true
   - set:
+      tag: set_rule_id_c7dba46e
       field: rule.id
       copy_from: cloudflare_logpush.device_posture.rule.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_PostureCheckName_to_cloudflare_logpush_device_posture_rule_name_7da2cd15
       field: json.PostureCheckName
       target_field: cloudflare_logpush.device_posture.rule.name
       ignore_missing: true
   - set:
+      tag: set_rule_name_74bd3f32
       field: rule.name
       copy_from: cloudflare_logpush.device_posture.rule.name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_PostureCheckType_to_cloudflare_logpush_device_posture_rule_category_cee57ee7
       field: json.PostureCheckType
       target_field: cloudflare_logpush.device_posture.rule.category
       ignore_missing: true
   - set:
+      tag: set_rule_category_96fa1c5a
       field: rule.category
       copy_from: cloudflare_logpush.device_posture.rule.category
       ignore_empty_value: true
   - rename:
+      tag: rename_json_PostureEvaluatedResult_to_cloudflare_logpush_device_posture_eval_result_8b2e584c
       field: json.PostureEvaluatedResult
       target_field: cloudflare_logpush.device_posture.eval.result
       ignore_missing: true
-# Set event.outcome from cloudflare_logpush.device_posture.eval.result
+  # Set event.outcome from cloudflare_logpush.device_posture.eval.result
   - set:
+      tag: set_event_outcome_1d222747
       field: event.outcome
       value: success
       if: ctx.cloudflare_logpush?.device_posture?.eval?.result != null && ctx.cloudflare_logpush?.device_posture?.eval?.result == true
   - set:
+      tag: set_event_outcome_47177ebb
       field: event.outcome
       value: failure
       if: ctx.cloudflare_logpush?.device_posture?.eval?.result != null && ctx.cloudflare_logpush?.device_posture?.eval?.result == false
   - rename:
+      tag: rename_json_PostureExpectedJSON_to_cloudflare_logpush_device_posture_eval_expected_624f00fb
       field: json.PostureExpectedJSON
       target_field: cloudflare_logpush.device_posture.eval.expected
       ignore_missing: true
   - rename:
+      tag: rename_json_PostureReceivedJSON_to_cloudflare_logpush_device_posture_eval_received_c94d95bd
       field: json.PostureReceivedJSON
       target_field: cloudflare_logpush.device_posture.eval.received
       ignore_missing: true
   - rename:
+      tag: rename_json_RegistrationID_to_cloudflare_logpush_device_posture_registration_id_aecfd64a
       field: json.RegistrationID
       target_field: cloudflare_logpush.device_posture.registration_id
       ignore_missing: true
   - rename:
+      tag: rename_json_UserUID_to_cloudflare_logpush_device_posture_user_id_b055e3c0
       field: json.UserUID
       target_field: cloudflare_logpush.device_posture.user.id
       ignore_missing: true
   - set:
+      tag: set_user_id_9ab83028
       field: user.id
       copy_from: cloudflare_logpush.device_posture.user.id
       if: ctx.cloudflare_logpush?.device_posture?.user?.id != null && ctx.cloudflare_logpush?.device_posture?.user?.id != ""
   - rename:
+      tag: rename_json_Email_to_cloudflare_logpush_device_posture_user_email_70ea23e4
       field: json.Email
       target_field: cloudflare_logpush.device_posture.user.email
       ignore_missing: true
   - set:
+      tag: set_user_email_839e5d58
       field: user.email
       copy_from: cloudflare_logpush.device_posture.user.email
       if: ctx.cloudflare_logpush?.device_posture?.user?.email != null && ctx.cloudflare_logpush?.device_posture?.user?.email != ""
-# Create related fields
+  # Create related fields
   - append:
+      tag: append_related_hosts_d1851e05
       field: related.hosts
       value: "{{{host.id}}}"
       if: ctx.host?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_452ef445
       field: related.hosts
       value: "{{{host.name}}}"
       if: ctx.host?.name != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_7f407fef
       field: related.user
       value: "{{{user.id}}}"
       if: ctx.user?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_34fcf415
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
@@ -221,6 +262,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_f9fe5077
       field:
         - cloudflare_logpush.device_posture.timestamp
         - cloudflare_logpush.device_posture.version
@@ -237,6 +279,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |

--- a/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare DLP Forensic Copies logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Datetime_7d886bee
       field: json.Datetime
       if: ctx.json?.Datetime != null && ctx.json.Datetime != ''
       formats:
@@ -72,44 +78,54 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_29e9e999
           field: error.message
           value: >-
             Processor '{{{ _ingest.on_failure_processor_type }}}'
             {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
             {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
+      tag: set_cloudflare_logpush_dlp_forensic_copies_datetime_94563ee8
       field: cloudflare_logpush.dlp_forensic_copies.datetime
       copy_from: '@timestamp'
       ignore_empty_value: true
   - rename:
+      tag: rename_json_AccountID_to_cloudflare_logpush_dlp_forensic_copies_account_id_7a9b9bc3
       field: json.AccountID
       target_field: cloudflare_logpush.dlp_forensic_copies.account_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ForensicCopyID_to_cloudflare_logpush_dlp_forensic_copies_forensic_copy_id_837e04d6
       field: json.ForensicCopyID
       target_field: cloudflare_logpush.dlp_forensic_copies.forensic_copy_id
       ignore_missing: true
   - rename:
+      tag: rename_json_GatewayRequestID_to_cloudflare_logpush_dlp_forensic_copies_gateway_request_id_6dd30812
       field: json.GatewayRequestID
       target_field: cloudflare_logpush.dlp_forensic_copies.gateway_request_id
       ignore_missing: true
   - rename:
+      tag: rename_json_Headers_to_cloudflare_logpush_dlp_forensic_copies_headers_6c33bc32
       field: json.Headers
       target_field: cloudflare_logpush.dlp_forensic_copies.headers
       ignore_missing: true
   - rename:
+      tag: rename_json_Payload_to_cloudflare_logpush_dlp_forensic_copies_payload_78daacc6
       field: json.Payload
       target_field: cloudflare_logpush.dlp_forensic_copies.payload
       ignore_missing: true
   - rename:
+      tag: rename_json_Phase_to_cloudflare_logpush_dlp_forensic_copies_phase_153ee19a
       field: json.Phase
       target_field: cloudflare_logpush.dlp_forensic_copies.phase
       ignore_missing: true
   - rename:
+      tag: rename_json_TriggeredRuleID_to_cloudflare_logpush_dlp_forensic_copies_triggered_rule_id_3e1335d4
       field: json.TriggeredRuleID
       target_field: cloudflare_logpush.dlp_forensic_copies.triggered_rule_id
       ignore_missing: true
   - set:
+      tag: set_rule_id_f2c7e8a4
       field: rule.id
       copy_from: cloudflare_logpush.dlp_forensic_copies.triggered_rule_id
       ignore_empty_value: true
@@ -120,6 +136,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_bd294ab1
       field:
         - cloudflare_logpush.dlp_forensic_copies.action
         - cloudflare_logpush.dlp_forensic_copies.host
@@ -129,6 +146,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |
@@ -151,6 +169,7 @@ processors:
       tag: set_pipeline_error_into_event_kind
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -162,6 +162,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_eddf0012
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:

--- a/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare DNS logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Timestamp_772fbe7f
       field: json.Timestamp
       if: ctx.json?.Timestamp != null && ctx.json.Timestamp != ''
       formats:
@@ -72,13 +78,16 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_2e342a9c
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_dns_timestamp_9e5e1fac
       field: cloudflare_logpush.dns.timestamp
       copy_from: '@timestamp'
       ignore_empty_value: true
   - convert:
+      tag: convert_json_SourceIP_to_cloudflare_logpush_dns_source_ip_75350b07
       field: json.SourceIP
       target_field: cloudflare_logpush.dns.source.ip
       if: ctx.json?.SourceIP != ''
@@ -86,21 +95,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3471a5da
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_ip_a6b54f72
       field: source.ip
       copy_from: cloudflare_logpush.dns.source.ip
       ignore_empty_value: true
   - rename:
+      tag: rename_json_QueryName_to_cloudflare_logpush_dns_query_name_c1af2645
       field: json.QueryName
       target_field: cloudflare_logpush.dns.query.name
       ignore_missing: true
   - set:
+      tag: set_dns_question_name_2b839091
       field: dns.question.name
       copy_from: cloudflare_logpush.dns.query.name
       ignore_empty_value: true
   - convert:
+      tag: convert_json_QueryType_to_cloudflare_logpush_dns_query_type_338b0b66
       field: json.QueryType
       target_field: cloudflare_logpush.dns.query.type
       if: ctx.json?.QueryType != ''
@@ -108,13 +122,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bf7aa4b9
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ColoCode_to_cloudflare_logpush_dns_colo_code_81807dd5
       field: json.ColoCode
       target_field: cloudflare_logpush.dns.colo.code
       ignore_missing: true
   - convert:
+      tag: convert_json_EDNSSubnet_to_cloudflare_logpush_dns_edns_subnet_64443394
       field: json.EDNSSubnet
       target_field: cloudflare_logpush.dns.edns.subnet
       if: ctx.json?.EDNSSubnet != ''
@@ -122,9 +139,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7eabd1ad
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_EDNSSubnetLength_to_cloudflare_logpush_dns_edns_subnet_length_30aeafd8
       field: json.EDNSSubnetLength
       target_field: cloudflare_logpush.dns.edns.subnet_length
       if: ctx.json?.EDNSSubnetLength != ''
@@ -132,13 +151,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_77bbf26b
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ResponseCached_to_cloudflare_logpush_dns_response_cached_65a351a9
       field: json.ResponseCached
       target_field: cloudflare_logpush.dns.response.cached
       ignore_missing: true
   - convert:
+      tag: convert_json_ResponseCode_to_cloudflare_logpush_dns_response_code_0e3a9a64
       field: json.ResponseCode
       target_field: cloudflare_logpush.dns.response.code
       if: ctx.json?.ResponseCode != ''
@@ -146,21 +168,25 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_708e10f1
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_hosts_d7e930d8
       field: related.hosts
       value: '{{{cloudflare_logpush.dns.query.name}}}'
       if: ctx.cloudflare_logpush?.dns?.query?.name != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_30d15214
       field: related.ip
       value: '{{{source.ip}}}'
       if: ctx.source?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_c1edff72
       field: related.ip
       value: '{{{cloudflare_logpush.dns.edns.subnet}}}'
       if: ctx.cloudflare_logpush?.dns?.edns?.subnet != null
@@ -173,6 +199,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_8d04016b
       field:
         - cloudflare_logpush.dns.timestamp
         - cloudflare_logpush.dns.query.name
@@ -181,6 +208,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
@@ -86,7 +86,7 @@ processors:
       copy_from: "@timestamp"
       tag: set_timestamp
 
-# Handle source IP
+  # Handle source IP
   - convert:
       field: json.SourceIP
       tag: convert_sourceip_to_ip
@@ -96,6 +96,7 @@ processors:
       if: ctx.json?.SourceIP != ''
       on_failure:
         - append:
+            tag: append_error_message_83a22c97
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -195,6 +196,7 @@ processors:
       if: ctx.json?.EDNSSubnet != ''
       on_failure:
         - append:
+            tag: append_error_message_01372df7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -205,6 +207,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_84fd5472
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -215,6 +218,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_406f267d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -225,6 +229,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8c6a76fb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -235,6 +240,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b8dd0db1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -245,6 +251,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_13cd5a09
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -270,6 +277,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d63cfe79
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -285,6 +293,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0ce63313
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -296,6 +305,7 @@ processors:
       if: ctx.json?.UpstreamIP != ''
       on_failure:
         - append:
+            tag: append_error_message_a33c06b7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -306,6 +316,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f9eca425
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
@@ -34,9 +34,9 @@ processors:
       field: event.type
       value: [info]
       tag: set_event_type
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -45,7 +45,7 @@ processors:
         must be removed.
       if: ctx._conf?.enable_deduplication == false && ctx.input?.type == 'aws-s3'
       ignore_missing: true
-# Timestamp
+  # Timestamp
   - script:
       lang: painless
       tag: painless_timestamp_to_milli
@@ -78,6 +78,7 @@ processors:
       tag: date_event_timestamp
       on_failure:
       - append:
+          tag: append_error_message_38394fec
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
@@ -85,7 +86,7 @@ processors:
       copy_from: "@timestamp"
       tag: set_timestamp
 
-# Handle source IP
+  # Handle source IP
   - rename:
       field: json.SourceIP
       target_field: cloudflare_logpush.dns_firewall.source.ip
@@ -96,7 +97,7 @@ processors:
       copy_from: cloudflare_logpush.dns_firewall.source.ip
       ignore_empty_value: true
       tag: set_source_ip
-# Geo enrichment (source IP)
+  # Geo enrichment (source IP)
   - geoip:
       field: source.ip
       target_field: source.geo
@@ -121,7 +122,7 @@ processors:
       ignore_missing: true
       tag: rename_source_as_org
 
-# DNS ECS fields
+  # DNS ECS fields
   - rename:
       field: json.QueryName
       target_field: cloudflare_logpush.dns_firewall.question.name
@@ -142,6 +143,7 @@ processors:
       tag: convert_dns_response_code
       on_failure:
         - append:
+            tag: append_error_message_d8ae6c3a
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
@@ -153,6 +155,7 @@ processors:
       tag: convert_dns_upstream_response_code
       on_failure:
         - append:
+            tag: append_error_message_510a49ca
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
@@ -166,7 +169,7 @@ processors:
       if: ctx.cloudflare_logpush?.dns_firewall?.response?.code == null && ctx.cloudflare_logpush?.dns_firewall?.upstream?.response_code != null
       tag: set_dns_upstream_response_code
 
-# Custom fields
+  # Custom fields
   - rename:
       field: json.ClusterID
       target_field: cloudflare_logpush.dns_firewall.cluster_id
@@ -248,7 +251,7 @@ processors:
       ignore_missing: true
       tag: rename_dns_upstream_response_time_ms
 
-# Create related fields
+  # Create related fields
   - append:
       field: related.ip
       value: '{{{source.ip}}}'
@@ -268,7 +271,7 @@ processors:
       allow_duplicates: false
       tag: append_related_upstream_ip
 
-# Clean resulting event
+  # Clean resulting event
   - remove:
       tag: remove_json_conf
       field:

--- a/packages/cloudflare_logpush/data_stream/email_security_alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/email_security_alerts/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Email Security Alerts logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_52cf4ba2
       field: event.category
-      value: [email,network]
+      value: [email, network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Timestamp_a965763d
       field: json.Timestamp
       if: ctx.json?.Timestamp != null && ctx.json.Timestamp != ''
       formats:
@@ -72,80 +78,99 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_458edc7c
           field: error.message
           value: >-
             Processor '{{{ _ingest.on_failure_processor_type }}}'
             {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
             {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
+      tag: set_cloudflare_logpush_email_security_alerts_timestamp_c2f86b60
       field: cloudflare_logpush.email_security_alerts.timestamp
       copy_from: '@timestamp'
       ignore_empty_value: true
   - rename:
+      tag: rename_json_AlertID_to_cloudflare_logpush_email_security_alerts_alert_id_97d97274
       field: json.AlertID
       target_field: cloudflare_logpush.email_security_alerts.alert_id
       ignore_missing: true
   - rename:
+      tag: rename_json_AlertReasons_to_cloudflare_logpush_email_security_alerts_alert_reasons_2fb8abf0
       field: json.AlertReasons
       target_field: cloudflare_logpush.email_security_alerts.alert_reasons
       ignore_missing: true
   - rename:
+      tag: rename_json_Attachments_to_cloudflare_logpush_email_security_alerts_attachments_8e776cc3
       field: json.Attachments
       target_field: cloudflare_logpush.email_security_alerts.attachments
       ignore_missing: true
   - rename:
+      tag: rename_json_CC_to_cloudflare_logpush_email_security_alerts_cc_57428a37
       field: json.CC
       target_field: cloudflare_logpush.email_security_alerts.cc
       ignore_missing: true
   - rename:
+      tag: rename_json_CCName_to_cloudflare_logpush_email_security_alerts_cc_name_4557bc82
       field: json.CCName
       target_field: cloudflare_logpush.email_security_alerts.cc_name
       ignore_missing: true
   - rename:
+      tag: rename_json_FinalDisposition_to_cloudflare_logpush_email_security_alerts_final_disposition_395b5850
       field: json.FinalDisposition
       target_field: cloudflare_logpush.email_security_alerts.final_disposition
       ignore_missing: true
   - rename:
+      tag: rename_json_From_to_cloudflare_logpush_email_security_alerts_from_fb9cca97
       field: json.From
       target_field: cloudflare_logpush.email_security_alerts.from
       ignore_missing: true
   - rename:
+      tag: rename_json_FromName_to_cloudflare_logpush_email_security_alerts_from_name_ec6c39de
       field: json.FromName
       target_field: cloudflare_logpush.email_security_alerts.from_name
       ignore_missing: true
   - rename:
+      tag: rename_json_Links_to_cloudflare_logpush_email_security_alerts_links_c0d5311f
       field: json.Links
       target_field: cloudflare_logpush.email_security_alerts.links
       ignore_missing: true
   - rename:
+      tag: rename_json_MessageDeliveryMode_to_cloudflare_logpush_email_security_alerts_message_delivery_mode_bdce12b1
       field: json.MessageDeliveryMode
       target_field: cloudflare_logpush.email_security_alerts.message_delivery_mode
       ignore_missing: true
   - rename:
+      tag: rename_json_MessageID_to_cloudflare_logpush_email_security_alerts_message_id_db845350
       field: json.MessageID
       target_field: cloudflare_logpush.email_security_alerts.message_id
       ignore_missing: true
   - rename:
+      tag: rename_json_Origin_to_cloudflare_logpush_email_security_alerts_origin_0d91ddaf
       field: json.Origin
       target_field: cloudflare_logpush.email_security_alerts.origin
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginalSender_to_cloudflare_logpush_email_security_alerts_original_sender_c6da8814
       field: json.OriginalSender
       target_field: cloudflare_logpush.email_security_alerts.original_sender
       ignore_missing: true
   - rename:
+      tag: rename_json_ReplyTo_to_cloudflare_logpush_email_security_alerts_reply_to_0912c860
       field: json.ReplyTo
       target_field: cloudflare_logpush.email_security_alerts.reply_to
       ignore_missing: true
   - rename:
+      tag: rename_json_ReplyToName_to_cloudflare_logpush_email_security_alerts_reply_to_name_67e356fb
       field: json.ReplyToName
       target_field: cloudflare_logpush.email_security_alerts.reply_to_name
       ignore_missing: true
   - rename:
+      tag: rename_json_SMTPEnvelopeFrom_to_cloudflare_logpush_email_security_alerts_smtp_envelope_from_3d667d21
       field: json.SMTPEnvelopeFrom
       target_field: cloudflare_logpush.email_security_alerts.smtp_envelope_from
       ignore_missing: true
   - rename:
+      tag: rename_json_SMTPEnvelopeTo_to_cloudflare_logpush_email_security_alerts_smtp_envelope_to_78d640cb
       field: json.SMTPEnvelopeTo
       target_field: cloudflare_logpush.email_security_alerts.smtp_envelope_to
       ignore_missing: true
@@ -157,63 +182,77 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_42dddf15
             field: error.message
             value: >-
               Processor '{{{ _ingest.on_failure_processor_type }}}'
               {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
               {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - rename:
+      tag: rename_json_SMTPHeloServerIPAsName_to_cloudflare_logpush_email_security_alerts_smtp_helo_server_ip_as_name_b961a980
       field: json.SMTPHeloServerIPAsName
       target_field: cloudflare_logpush.email_security_alerts.smtp_helo_server_ip_as_name
       ignore_missing: true
   - rename:
+      tag: rename_json_SMTPHeloServerIPAsNumber_to_cloudflare_logpush_email_security_alerts_smtp_helo_server_ip_as_number_65e39794
       field: json.SMTPHeloServerIPAsNumber
       target_field: cloudflare_logpush.email_security_alerts.smtp_helo_server_ip_as_number
       ignore_missing: true
   - rename:
+      tag: rename_json_SMTPHeloServerIPGeo_to_cloudflare_logpush_email_security_alerts_smtp_helo_server_ip_geo_ec006311
       field: json.SMTPHeloServerIPGeo
       target_field: cloudflare_logpush.email_security_alerts.smtp_helo_server_ip_geo
       ignore_missing: true
   - rename:
+      tag: rename_json_SMTPHeloServerName_to_cloudflare_logpush_email_security_alerts_smtp_helo_server_name_9f512ad6
       field: json.SMTPHeloServerName
       target_field: cloudflare_logpush.email_security_alerts.smtp_helo_server_name
       ignore_missing: true
   - rename:
+      tag: rename_json_Subject_to_cloudflare_logpush_email_security_alerts_subject_5da0dbf7
       field: json.Subject
       target_field: cloudflare_logpush.email_security_alerts.subject
       ignore_missing: true
   - rename:
+      tag: rename_json_ThreatCategories_to_cloudflare_logpush_email_security_alerts_threat_categories_c839555e
       field: json.ThreatCategories
       target_field: cloudflare_logpush.email_security_alerts.threat_categories
       ignore_missing: true
   - rename:
+      tag: rename_json_To_to_cloudflare_logpush_email_security_alerts_to_4cac6e15
       field: json.To
       target_field: cloudflare_logpush.email_security_alerts.to
       ignore_missing: true
   - rename:
+      tag: rename_json_ToName_to_cloudflare_logpush_email_security_alerts_to_name_4d463964
       field: json.ToName
       target_field: cloudflare_logpush.email_security_alerts.to_name
       ignore_missing: true
   - set:
+      tag: set_event_kind_ca27f3f7
       field: event.kind
       value: alert
       if: ctx.cloudflare_logpush?.email_security_alerts?.final_disposition != null && ctx.cloudflare_logpush.email_security_alerts.final_disposition != 'unset'
   - append:
+      tag: append_related_user_fcaf8dbe
       field: related.user
       value: '{{{cloudflare_logpush.email_security_alerts.from}}}'
       if: ctx.cloudflare_logpush?.email_security_alerts?.from != null && ctx.cloudflare_logpush.email_security_alerts.from != ''
       allow_duplicates: false
   - append:
+      tag: append_related_user_0c233780
       field: related.user
       value: '{{{cloudflare_logpush.email_security_alerts.from_name}}}'
       if: ctx.cloudflare_logpush?.email_security_alerts?.from_name != null && ctx.cloudflare_logpush.email_security_alerts.from_name != ''
       allow_duplicates: false
   - append:
+      tag: append_related_user_eb8b29e0
       field: related.user
       value: '{{{cloudflare_logpush.email_security_alerts.smtp_envelope_from}}}'
       if: ctx.cloudflare_logpush?.email_security_alerts?.smtp_envelope_from != null && ctx.cloudflare_logpush.email_security_alerts.smtp_envelope_from != ''
       allow_duplicates: false
   - foreach:
+      tag: foreach_cloudflare_logpush_email_security_alerts_to_968c1ea6
       field: cloudflare_logpush.email_security_alerts.to
       if: ctx.cloudflare_logpush?.email_security_alerts?.to instanceof List
       processor:
@@ -222,6 +261,7 @@ processors:
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_cloudflare_logpush_email_security_alerts_smtp_envelope_to_47da8216
       field: cloudflare_logpush.email_security_alerts.smtp_envelope_to
       if: ctx.cloudflare_logpush?.email_security_alerts?.smtp_envelope_to instanceof List
       processor:
@@ -230,6 +270,7 @@ processors:
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_cloudflare_logpush_email_security_alerts_to_name_e4b51f52
       field: cloudflare_logpush.email_security_alerts.to_name
       if: ctx.cloudflare_logpush?.email_security_alerts?.to_name instanceof List
       processor:
@@ -238,6 +279,7 @@ processors:
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_cloudflare_logpush_email_security_alerts_cc_4f4644fc
       field: cloudflare_logpush.email_security_alerts.cc
       if: ctx.cloudflare_logpush?.email_security_alerts?.cc instanceof List
       processor:
@@ -246,6 +288,7 @@ processors:
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_cloudflare_logpush_email_security_alerts_cc_name_dcbdbc3e
       field: cloudflare_logpush.email_security_alerts.cc_name
       if: ctx.cloudflare_logpush?.email_security_alerts?.cc_name instanceof List
       processor:
@@ -254,6 +297,7 @@ processors:
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - set:
+      tag: set_server_address_b86252fa
       field: server.address
       copy_from: cloudflare_logpush.email_security_alerts.smtp_helo_server_name
       ignore_empty_value: true
@@ -265,14 +309,17 @@ processors:
       ignore_missing: true
       on_failure:
         - set:
+            tag: set_server_domain_d9956d45
             field: server.domain
             copy_from: server.address
             ignore_empty_value: true
   - set:
+      tag: set__tmp_links_65cfc504
       field: _tmp.links
       copy_from: cloudflare_logpush.email_security_alerts.links
       ignore_empty_value: true
   - foreach:
+      tag: foreach__tmp_links_33149570
       field: _tmp.links
       if: ctx._tmp?.links instanceof List
       processor:
@@ -289,6 +336,7 @@ processors:
                   {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
                   {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - foreach:
+      tag: foreach__tmp_links_94875667
       field: _tmp.links
       if: ctx._tmp?.links instanceof List
       processor:
@@ -297,6 +345,7 @@ processors:
           value: '{{{_ingest._value.domain}}}'
           allow_duplicates: false
   - script:
+      tag: script_45dae815
       lang: painless
       if: ctx.related?.user instanceof List || (ctx.server?.domain != null)
       source: |-
@@ -323,18 +372,22 @@ processors:
         }
         ctx.related.hosts = domains;
   - set:
+      tag: set_server_ip_2b83be7f
       field: server.ip
       copy_from: cloudflare_logpush.email_security_alerts.smtp_helo_server_ip
       ignore_empty_value: true
   - append:
+      tag: append_related_ip_c3acf835
       field: related.ip
       value: '{{{server.ip}}}'
       if: ctx.server?.ip != null
       allow_duplicates: false
   - geoip:
+      tag: geoip_server_ip_to_server_geo_bc3fd9f9
       field: server.ip
       target_field: server.geo
   - geoip:
+      tag: geoip_server_ip_to_server_as_ed2798db
       database_file: GeoLite2-ASN.mmdb
       field: server.ip
       target_field: server.as
@@ -343,14 +396,17 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_server_as_asn_to_server_as_number_f46ba339
       field: server.as.asn
       target_field: server.as.number
       ignore_missing: true
   - rename:
+      tag: rename_server_as_organization_name_to_server_as_organization_name_a7e512d7
       field: server.as.organization_name
       target_field: server.as.organization.name
       ignore_missing: true
   - script:
+      tag: script_218079c2
       lang: painless
       if: ctx.cloudflare_logpush?.email_security_alerts?.attachments instanceof List
       source: |-
@@ -403,6 +459,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_9637410d
       field:
         - cloudflare_logpush.email_security_alerts.timestamp
         - cloudflare_logpush.email_security_alerts.smtp_helo_server_ip
@@ -410,6 +467,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |
@@ -432,6 +490,7 @@ processors:
       tag: set_pipeline_error_into_event_kind
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
@@ -280,6 +280,7 @@ processors:
         ctx.cloudflare_logpush.firewall_event.client.request.protocol != 'unknown'
       on_failure:
         - append:
+            tag: append_error_message_52a55c75
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - lowercase:

--- a/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Firewall Event logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Datetime_5886cebc
       field: json.Datetime
       if: ctx.json?.Datetime != null && ctx.json.Datetime != ''
       formats:
@@ -72,49 +78,61 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_da98a171
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_firewall_event_timestamp_98eb2c1e
       field: cloudflare_logpush.firewall_event.timestamp
       copy_from: '@timestamp'
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Action_to_cloudflare_logpush_firewall_event_action_143ea91b
       field: json.Action
       target_field: cloudflare_logpush.firewall_event.action
       ignore_missing: true
   - set:
+      tag: set_event_action_e4c1757e
       field: event.action
       copy_from: cloudflare_logpush.firewall_event.action
       ignore_empty_value: true
   - lowercase:
+      tag: lowercase_event_action_9334b869
       field: event.action
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestMethod_to_cloudflare_logpush_firewall_event_client_request_method_5f681fbf
       field: json.ClientRequestMethod
       target_field: cloudflare_logpush.firewall_event.client.request.method
       ignore_missing: true
   - rename:
+      tag: rename_json_ContentScanObjResults_to_cloudflare_logpush_firewall_event_content_scan_results_da351a8b
       field: json.ContentScanObjResults
       target_field: cloudflare_logpush.firewall_event.content_scan.results
       ignore_missing: true
   - convert:
+      tag: convert_json_ContentScanObjSizes_to_cloudflare_logpush_firewall_event_content_scan_sizes_97df0491
       field: json.ContentScanObjSizes
       target_field: cloudflare_logpush.firewall_event.content_scan.sizes
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2d1d4b5e
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ContentScanObjTypes_to_cloudflare_logpush_firewall_event_content_scan_types_55800203
       field: json.ContentScanObjTypes
       target_field: cloudflare_logpush.firewall_event.content_scan.types
       ignore_missing: true
   - set:
+      tag: set_http_request_method_9615ebe7
       field: http.request.method
       copy_from: cloudflare_logpush.firewall_event.client.request.method
       ignore_empty_value: true
   - convert:
+      tag: convert_json_EdgeResponseStatus_to_cloudflare_logpush_firewall_event_edge_response_status_346dde9e
       field: json.EdgeResponseStatus
       target_field: cloudflare_logpush.firewall_event.edge.response.status
       if: ctx.json?.EdgeResponseStatus != ''
@@ -122,29 +140,36 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e8ed0a0f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_http_response_status_code_80e2f001
       field: http.response.status_code
       copy_from: cloudflare_logpush.firewall_event.edge.response.status
       ignore_empty_value: true
   - rename:
+      tag: rename_json_RuleID_to_cloudflare_logpush_firewall_event_rule_id_c313f3c5
       field: json.RuleID
       target_field: cloudflare_logpush.firewall_event.rule.id
       ignore_missing: true
   - set:
+      tag: set_rule_id_df8c5850
       field: rule.id
       copy_from: cloudflare_logpush.firewall_event.rule.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Description_to_cloudflare_logpush_firewall_event_rule_description_0ce0fc91
       field: json.Description
       target_field: cloudflare_logpush.firewall_event.rule.description
       ignore_missing: true
   - set:
+      tag: set_rule_description_f88f8340
       field: rule.description
       copy_from: cloudflare_logpush.firewall_event.rule.description
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientASN_to_cloudflare_logpush_firewall_event_client_asn_value_90a6e434
       field: json.ClientASN
       target_field: cloudflare_logpush.firewall_event.client.asn.value
       if: ctx.json?.ClientASN != ''
@@ -152,21 +177,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0422f6d1
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_as_number_3e029828
       field: source.as.number
       copy_from: cloudflare_logpush.firewall_event.client.asn.value
       ignore_empty_value: true
   - rename:
+      tag: rename_json_ClientCountry_to_cloudflare_logpush_firewall_event_client_country_c56768f5
       field: json.ClientCountry
       target_field: cloudflare_logpush.firewall_event.client.country
       ignore_missing: true
   - set:
+      tag: set_source_geo_country_iso_code_e3426c91
       field: source.geo.country_iso_code
       copy_from: cloudflare_logpush.firewall_event.client.country
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientIP_to_cloudflare_logpush_firewall_event_client_ip_534d6853
       field: json.ClientIP
       target_field: cloudflare_logpush.firewall_event.client.ip
       if: ctx.json?.ClientIP != ''
@@ -174,110 +204,136 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0497e684
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_ip_134d8e5a
       field: source.ip
       copy_from: cloudflare_logpush.firewall_event.client.ip
       ignore_empty_value: true
   - rename:
+      tag: rename_json_ClientASNDescription_to_cloudflare_logpush_firewall_event_client_asn_description_55ba93ab
       field: json.ClientASNDescription
       target_field: cloudflare_logpush.firewall_event.client.asn.description
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientIPClass_to_cloudflare_logpush_firewall_event_client_ip_class_f46c33fa
       field: json.ClientIPClass
       target_field: cloudflare_logpush.firewall_event.client.ip_class
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRefererHost_to_cloudflare_logpush_firewall_event_client_referer_host_bf194225
       field: json.ClientRefererHost
       target_field: cloudflare_logpush.firewall_event.client.referer.host
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRefererPath_to_cloudflare_logpush_firewall_event_client_referer_path_63db6fdb
       field: json.ClientRefererPath
       target_field: cloudflare_logpush.firewall_event.client.referer.path
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRefererQuery_to_cloudflare_logpush_firewall_event_client_referer_query_1dcfdcdd
       field: json.ClientRefererQuery
       target_field: cloudflare_logpush.firewall_event.client.referer.query
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRefererScheme_to_cloudflare_logpush_firewall_event_client_referer_scheme_704ecab7
       field: json.ClientRefererScheme
       target_field: cloudflare_logpush.firewall_event.client.referer.scheme
       ignore_missing: true
   - set:
+      tag: set_url_domain_72a6f745
       field: url.domain
       copy_from: json.ClientRequestHost
       ignore_empty_value: true
       if: ctx.url?.domain == null
   - rename:
+      tag: rename_json_ClientRequestHost_to_cloudflare_logpush_firewall_event_client_request_host_8cf01305
       field: json.ClientRequestHost
       target_field: cloudflare_logpush.firewall_event.client.request.host
       ignore_missing: true
   - set:
+      tag: set_url_path_b062c440
       field: url.path
       copy_from: json.ClientRequestPath
       ignore_empty_value: true
       if: ctx.url?.path == null
   - rename:
+      tag: rename_json_ClientRequestPath_to_cloudflare_logpush_firewall_event_client_request_path_87996df7
       field: json.ClientRequestPath
       target_field: cloudflare_logpush.firewall_event.client.request.path
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestProtocol_to_cloudflare_logpush_firewall_event_client_request_protocol_99f3ee29
       field: json.ClientRequestProtocol
       target_field: cloudflare_logpush.firewall_event.client.request.protocol
       ignore_missing: true
   - grok:
+      tag: grok_cloudflare_logpush_firewall_event_client_request_protocol_3ee431a4
       field: cloudflare_logpush.firewall_event.client.request.protocol
       patterns:
         - "^%{DATA:network.protocol}/%{DATA:http.version}$"
       ignore_failure: true
   - lowercase:
+      tag: lowercase_network_protocol_49872259
       field: network.protocol
       ignore_missing: true
   - set:
+      tag: set_url_query_a659fb29
       field: url.query
       copy_from: json.ClientRequestQuery
       ignore_empty_value: true
       if: ctx.url?.query == null
   - script:
+        tag: script_4acec607
         description: Trim leading '?' in query if it exists.
         lang: painless
         source: |
           ctx.url.query = ctx.url.query.substring(1);
         if: ctx.url?.query instanceof String && ctx.url.query.startsWith('?')
   - rename:
+      tag: rename_json_ClientRequestQuery_to_cloudflare_logpush_firewall_event_client_request_query_c26d538d
       field: json.ClientRequestQuery
       target_field: cloudflare_logpush.firewall_event.client.request.query
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestScheme_to_cloudflare_logpush_firewall_event_client_request_scheme_0adf8f33
       field: json.ClientRequestScheme
       target_field: cloudflare_logpush.firewall_event.client.request.scheme
       ignore_missing: true
   - set:
+      tag: set_url_scheme_4a92982f
       field: url.scheme
       copy_from: cloudflare_logpush.firewall_event.client.request.scheme
       ignore_empty_value: true
   - user_agent:
+      tag: user_agent_json_ClientRequestUserAgent_a0e18c70
       field: json.ClientRequestUserAgent
       if: ctx.json?.ClientRequestUserAgent != ''
       ignore_failure: true
   - rename:
+      tag: rename_json_ClientRequestUserAgent_to_cloudflare_logpush_firewall_event_client_request_user_agent_f438ab23
       field: json.ClientRequestUserAgent
       target_field: cloudflare_logpush.firewall_event.client.request.user.agent
       ignore_missing: true
   - rename:
+      tag: rename_json_EdgeColoCode_to_cloudflare_logpush_firewall_event_edge_colo_code_8d5606b1
       field: json.EdgeColoCode
       target_field: cloudflare_logpush.firewall_event.edge.colo.code
       ignore_missing: true
   - rename:
+      tag: rename_json_Kind_to_cloudflare_logpush_firewall_event_kind_7b726d4b
       field: json.Kind
       target_field: cloudflare_logpush.firewall_event.kind
       ignore_missing: true
   - rename:
+      tag: rename_json_LeakedCredentialCheckResult_to_cloudflare_logpush_firewall_event_leaked_credential_check_1e3c7db0
       field: json.LeakedCredentialCheckResult
       target_field: cloudflare_logpush.firewall_event.leaked_credential_check
       ignore_missing: true
   - convert:
+      tag: convert_json_MatchIndex_to_cloudflare_logpush_firewall_event_match_index_23dc3fca
       field: json.MatchIndex
       target_field: cloudflare_logpush.firewall_event.match_index
       if: ctx.json?.MatchIndex != ''
@@ -285,13 +341,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_477c63dd
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Metadata_to_cloudflare_logpush_firewall_event_meta_data_2ca55072
       field: json.Metadata
       target_field: cloudflare_logpush.firewall_event.meta_data
       ignore_missing: true
   - convert:
+      tag: convert_json_OriginResponseStatus_to_cloudflare_logpush_firewall_event_origin_response_status_da198427
       field: json.OriginResponseStatus
       target_field: cloudflare_logpush.firewall_event.origin.response.status
       if: ctx.json?.OriginResponseStatus != ''
@@ -299,54 +358,66 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_94532f32
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_OriginatorRayID_to_cloudflare_logpush_firewall_event_origin_ray_id_5be4f8a5
       field: json.OriginatorRayID
       target_field: cloudflare_logpush.firewall_event.origin.ray.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Ref_to_cloudflare_logpush_firewall_event_ref_59cbb419
       field: json.Ref
       target_field: cloudflare_logpush.firewall_event.ref
       ignore_missing: true
   - rename:
+      tag: rename_json_RayID_to_cloudflare_logpush_firewall_event_ray_id_ce479357
       field: json.RayID
       target_field: cloudflare_logpush.firewall_event.ray.id
       ignore_missing: true
   - set:
+      tag: set_event_id_24bc1dca
       field: event.id
       copy_from: cloudflare_logpush.firewall_event.ray.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Source_to_cloudflare_logpush_firewall_event_source_24749817
       field: json.Source
       target_field: cloudflare_logpush.firewall_event.source
       ignore_missing: true
   - rename:
+      tag: rename_json_ZoneName_to_cloudflare_logpush_firewall_event_zone_name_641ba6e1
       field: json.ZoneName
       target_field: cloudflare_logpush.firewall_event.zone.name
       ignore_missing: true
   - rename:
+      tag: rename_json_FraudUserID_to_cloudflare_logpush_firewall_event_fraud_user_id_20fee20c
       field: json.FraudUserID
       target_field: cloudflare_logpush.firewall_event.fraud.user_id
       ignore_missing: true
   - append:
+      tag: append_related_user_4ab7e6c3
       field: related.user
       value: '{{{cloudflare_logpush.firewall_event.fraud.user_id}}}'
       if: ctx.cloudflare_logpush?.firewall_event?.fraud?.user_id != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_30d15214
       field: related.ip
       value: '{{{source.ip}}}'
       if: ctx.source?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_hosts_bab13cab
       field: related.hosts
       value: '{{{cloudflare_logpush.firewall_event.client.referer.host}}}'
       if: ctx.cloudflare_logpush?.firewall_event?.client?.referer?.host != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_hosts_0a281fcb
       field: related.hosts
       value: '{{{cloudflare_logpush.firewall_event.client.request.host}}}'
       if: ctx.cloudflare_logpush?.firewall_event?.client?.request?.host != null
@@ -359,6 +430,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_5f4df7d3
       field:
         - cloudflare_logpush.firewall_event.timestamp
         - cloudflare_logpush.firewall_event.action
@@ -373,6 +445,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
@@ -124,6 +124,7 @@ processors:
       if: ctx.json?.DstIP != ''
       on_failure:
         - append:
+            tag: append_error_message_1c988cc4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -164,6 +165,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_92121ec1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -246,6 +248,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_32506aaa
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -262,6 +265,7 @@ processors:
       if: ctx.json?.SrcIP != ''
       on_failure:
         - append:
+            tag: append_error_message_dcbe79e0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -302,6 +306,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a116148c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -540,6 +545,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_91f42de3
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Gateway DNS logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,20 +19,24 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -40,7 +45,7 @@ processors:
         must be removed.
       if: ctx._conf?.enable_deduplication == false && ctx.input?.type == 'aws-s3'
       ignore_missing: true
-# ECS fields
+  # ECS fields
   - script:
       lang: painless
       tag: painless_datetime_to_milli
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Datetime_5886cebc
       field: json.Datetime
       if: ctx.json?.Datetime != null && ctx.json.Datetime != ''
       formats:
@@ -72,49 +78,61 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_da98a171
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_gateway_dns_timestamp_69c587e3
       field: cloudflare_logpush.gateway_dns.timestamp
       copy_from: "@timestamp"
   - rename:
+      tag: rename_json_DeviceID_to_cloudflare_logpush_gateway_dns_host_id_0913a274
       field: json.DeviceID
       target_field: cloudflare_logpush.gateway_dns.host.id
       ignore_missing: true
   - set:
+      tag: set_host_id_a0ae6001
       field: host.id
       copy_from: cloudflare_logpush.gateway_dns.host.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceName_to_cloudflare_logpush_gateway_dns_host_name_f807b974
       field: json.DeviceName
       target_field: cloudflare_logpush.gateway_dns.host.name
       ignore_missing: true
   - set:
+      tag: set_host_name_569f7319
       field: host.name
       copy_from: cloudflare_logpush.gateway_dns.host.name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Email_to_cloudflare_logpush_gateway_dns_user_email_4b03f587
       field: json.Email
       target_field: cloudflare_logpush.gateway_dns.user.email
       ignore_missing: true
   - set:
+      tag: set_user_email_1716d357
       field: user.email
       copy_from: cloudflare_logpush.gateway_dns.user.email
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DstIP_to_cloudflare_logpush_gateway_dns_destination_ip_0e585b73
       field: json.DstIP
       target_field: cloudflare_logpush.gateway_dns.destination.ip
       ignore_missing: true
   - set:
+      tag: set_destination_ip_7bf16b8b
       field: destination.ip
       copy_from: cloudflare_logpush.gateway_dns.destination.ip
       ignore_empty_value: true
-# Geo enrichment (destination IP)
+  # Geo enrichment (destination IP)
   - geoip:
+      tag: geoip_destination_ip_to_destination_geo_ab5e2968
       field: destination.ip
       target_field: destination.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_destination_ip_to_destination_as_8a007787
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
       target_field: destination.as
@@ -123,55 +141,68 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_asn_to_destination_as_number_3b459fcd
       field: destination.as.asn
       target_field: destination.as.number
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_organization_name_to_destination_as_organization_name_814bd459
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_DstPort_to_cloudflare_logpush_gateway_dns_destination_port_2632841b
       field: json.DstPort
       target_field: cloudflare_logpush.gateway_dns.destination.port
       ignore_missing: true
   - set:
+      tag: set_destination_port_31b4e3b7
       field: destination.port
       copy_from: cloudflare_logpush.gateway_dns.destination.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Protocol_to_cloudflare_logpush_gateway_dns_protocol_57d684da
       field: json.Protocol
       target_field: cloudflare_logpush.gateway_dns.protocol
       ignore_missing: true
   - set:
+      tag: set_network_protocol_f955c405
       field: network.protocol
       copy_from: cloudflare_logpush.gateway_dns.protocol
       ignore_empty_value: true
   - rename:
+      tag: rename_json_QueryName_to_cloudflare_logpush_gateway_dns_question_name_34684116
       field: json.QueryName
       target_field: cloudflare_logpush.gateway_dns.question.name
       ignore_missing: true
   - set:
+      tag: set_dns_question_name_172294a2
       field: dns.question.name
       copy_from: cloudflare_logpush.gateway_dns.question.name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_QueryTypeName_to_cloudflare_logpush_gateway_dns_question_type_016cf433
       field: json.QueryTypeName
       target_field: cloudflare_logpush.gateway_dns.question.type
       ignore_missing: true
   - set:
+      tag: set_dns_question_type_68d1ca0e
       field: dns.question.type
       copy_from: cloudflare_logpush.gateway_dns.question.type
       ignore_empty_value: true
-# Set event.outcome based on the response code
+  # Set event.outcome based on the response code
   - set:
+      tag: set_event_outcome_73b064e5
       field: event.outcome
       value: success
       if: ctx.json?.RCode != null && ctx.json?.RCode == 0
   - set:
+      tag: set_event_outcome_a3475405
       field: event.outcome
       value: failure
       if: ctx.json?.RCode != null && ctx.json?.RCode > 0
   - convert:
+      tag: convert_json_RCode_to_cloudflare_logpush_gateway_dns_response_code_a0eb5c53
       field: json.RCode
       target_field: cloudflare_logpush.gateway_dns.response_code
       if: ctx.json?.RCode != ''
@@ -179,41 +210,51 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ee256292
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_dns_response_code_3de8fbb6
       field: dns.response_code
       copy_from: cloudflare_logpush.gateway_dns.response_code
   - rename:
+      tag: rename_json_RData_to_cloudflare_logpush_gateway_dns_answers_9bdd6d3f
       field: json.RData
       target_field: cloudflare_logpush.gateway_dns.answers
       ignore_missing: true
   - set:
+      tag: set_dns_answers_ab8b7c56
       field: dns.answers
       copy_from: cloudflare_logpush.gateway_dns.answers
       ignore_empty_value: true
   - rename:
+      tag: rename_json_ResolvedIPs_to_cloudflare_logpush_gateway_dns_resolved_ip_df29f9ea
       field: json.ResolvedIPs
       target_field: cloudflare_logpush.gateway_dns.resolved_ip
       ignore_missing: true
   - set:
+      tag: set_dns_resolved_ip_20ae27a6
       field: dns.resolved_ip
       copy_from: cloudflare_logpush.gateway_dns.resolved_ip
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SrcIP_to_cloudflare_logpush_gateway_dns_source_ip_f4e899b1
       field: json.SrcIP
       target_field: cloudflare_logpush.gateway_dns.source.ip
       ignore_missing: true
   - set:
+      tag: set_source_ip_bb6bfb91
       field: source.ip
       copy_from: cloudflare_logpush.gateway_dns.source.ip
       ignore_empty_value: true
-# Geo enrichment (source IP)
+  # Geo enrichment (source IP)
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -222,266 +263,331 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_SrcPort_to_cloudflare_logpush_gateway_dns_source_port_a7f4998d
       field: json.SrcPort
       target_field: cloudflare_logpush.gateway_dns.source.port
       ignore_missing: true
   - set:
+      tag: set_source_port_1a426ae9
       field: source.port
       copy_from: cloudflare_logpush.gateway_dns.source.port
   - rename:
+      tag: rename_json_TimeZone_to_cloudflare_logpush_gateway_dns_timezone_665792ac
       field: json.TimeZone
       target_field: cloudflare_logpush.gateway_dns.timezone
       ignore_missing: true
   - set:
+      tag: set_event_timezone_960e95b1
       field: event.timezone
       copy_from: cloudflare_logpush.gateway_dns.timezone
   - rename:
+      tag: rename_json_UserID_to_cloudflare_logpush_gateway_dns_user_id_c4e5da4a
       field: json.UserID
       target_field: cloudflare_logpush.gateway_dns.user.id
       ignore_missing: true
   - set:
+      tag: set_user_id_0d9672f9
       field: user.id
       copy_from: cloudflare_logpush.gateway_dns.user.id
-# Custom fields
+  # Custom fields
   - rename:
+      tag: rename_json_ColoCode_to_cloudflare_logpush_gateway_dns_colo_code_9e8b055e
       field: json.ColoCode
       target_field: cloudflare_logpush.gateway_dns.colo.code
       ignore_missing: true
   - rename:
+      tag: rename_json_ColoID_to_cloudflare_logpush_gateway_dns_colo_id_f4a69bc2
       field: json.ColoID
       target_field: cloudflare_logpush.gateway_dns.colo.id
       ignore_missing: true
   - rename:
+      tag: rename_json_AccountID_to_cloudflare_logpush_gateway_dns_account_id_6d1ff20d
       field: json.AccountID
       target_field: cloudflare_logpush.gateway_dns.account_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ApplicationID_to_cloudflare_logpush_gateway_dns_application_id_e0d58a41
       field: json.ApplicationID
       target_field: cloudflare_logpush.gateway_dns.application_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ApplicationName_to_cloudflare_logpush_gateway_dns_application_name_ba9cfc41
       field: json.ApplicationName
       target_field: cloudflare_logpush.gateway_dns.application_name
       ignore_missing: true
   - convert:
+      tag: convert_json_AuthoritativeNameServerIPs_to_cloudflare_logpush_gateway_dns_authoritative_name_server_ip_11d7c24b
       field: json.AuthoritativeNameServerIPs
       target_field: cloudflare_logpush.gateway_dns.authoritative_name_server_ip
       type: ip
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_82741c48
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_CNAMECategoryIDs_to_cloudflare_logpush_gateway_dns_cname_category_ids_2f184c33
       field: json.CNAMECategoryIDs
       target_field: cloudflare_logpush.gateway_dns.cname_category.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_CNAMECategoryNames_to_cloudflare_logpush_gateway_dns_cname_category_names_7a0914db
       field: json.CNAMECategoryNames
       target_field: cloudflare_logpush.gateway_dns.cname_category.names
       ignore_missing: true
   - rename:
+      tag: rename_json_CNAMEs_to_cloudflare_logpush_gateway_dns_cname_68bb9d35
       field: json.CNAMEs
       target_field: cloudflare_logpush.gateway_dns.cname
       ignore_missing: true
   - rename:
+      tag: rename_json_CNAMEsReversed_to_cloudflare_logpush_gateway_dns_cname_reversed_a3bb7c08
       field: json.CNAMEsReversed
       target_field: cloudflare_logpush.gateway_dns.cname_reversed
       ignore_missing: true
   - convert:
+      tag: convert_json_CustomResolveDurationMs_to_cloudflare_logpush_gateway_dns_custom_resolver_duration_milli_7f0fc4e1
       field: json.CustomResolveDurationMs
       target_field: cloudflare_logpush.gateway_dns.custom_resolver.duration_milli
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6ddf5c48
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_CustomResolverAddress_to_cloudflare_logpush_gateway_dns_custom_resolver_address_25998f09
       field: json.CustomResolverAddress
       target_field: cloudflare_logpush.gateway_dns.custom_resolver.address
       ignore_missing: true
   - rename:
+      tag: rename_json_CustomResolverPolicyID_to_cloudflare_logpush_gateway_dns_custom_resolver_policy_ids_51fbe982
       field: json.CustomResolverPolicyID
       target_field: cloudflare_logpush.gateway_dns.custom_resolver.policy.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_CustomResolverPolicyName_to_cloudflare_logpush_gateway_dns_custom_resolver_policy_names_fd7d6c8a
       field: json.CustomResolverPolicyName
       target_field: cloudflare_logpush.gateway_dns.custom_resolver.policy.names
       ignore_missing: true
   - rename:
+      tag: rename_json_CustomResolverResponse_to_cloudflare_logpush_gateway_dns_custom_resolver_response_6c1c4d8d
       field: json.CustomResolverResponse
       target_field: cloudflare_logpush.gateway_dns.custom_resolver.response
       ignore_missing: true
   - rename:
+      tag: rename_json_DoHSubdomain_to_cloudflare_logpush_gateway_dns_doh_subdomain_0ad0b205
       field: json.DoHSubdomain
       target_field: cloudflare_logpush.gateway_dns.doh_subdomain
       ignore_missing: true
   - rename:
+      tag: rename_json_DoTSubdomain_to_cloudflare_logpush_gateway_dns_dot_subdomain_e962eec5
       field: json.DoTSubdomain
       target_field: cloudflare_logpush.gateway_dns.dot_subdomain
       ignore_missing: true
   - rename:
+      tag: rename_json_EDEErrors_to_cloudflare_logpush_gateway_dns_extended_dns_error_codes_7d863bd0
       field: json.EDEErrors
       target_field: cloudflare_logpush.gateway_dns.extended_dns_error_codes
       ignore_missing: true
   - rename:
+      tag: rename_json_InitialCategoryIDs_to_cloudflare_logpush_gateway_dns_initial_category_ids_3d17e85f
       field: json.InitialCategoryIDs
       target_field: cloudflare_logpush.gateway_dns.initial_category.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_InitialCategoryNames_to_cloudflare_logpush_gateway_dns_initial_category_names_cfbbf7ff
       field: json.InitialCategoryNames
       target_field: cloudflare_logpush.gateway_dns.initial_category.names
       ignore_missing: true
   - convert:
+      tag: convert_json_IsResponseCached_to_cloudflare_logpush_gateway_dns_is_response_cached_8430241a
       field: json.IsResponseCached
       target_field: cloudflare_logpush.gateway_dns.is_response_cached
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ca83d42f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Location_to_cloudflare_logpush_gateway_dns_location_name_eccbdcc3
       field: json.Location
       target_field: cloudflare_logpush.gateway_dns.location.name
       ignore_missing: true
   - rename:
+      tag: rename_json_LocationID_to_cloudflare_logpush_gateway_dns_location_id_2bba31fa
       field: json.LocationID
       target_field: cloudflare_logpush.gateway_dns.location.id
       ignore_missing: true
   - rename:
+      tag: rename_json_MatchedCategoryIDs_to_cloudflare_logpush_gateway_dns_matched_category_ids_41228506
       field: json.MatchedCategoryIDs
       target_field: cloudflare_logpush.gateway_dns.matched.category.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_MatchedCategoryNames_to_cloudflare_logpush_gateway_dns_matched_category_names_6ebe505e
       field: json.MatchedCategoryNames
       target_field: cloudflare_logpush.gateway_dns.matched.category.names
       ignore_missing: true
   - rename:
+      tag: rename_json_MatchedIndicatorFeedIDs_to_cloudflare_logpush_gateway_dns_matched_indicator_feed_ids_a39e3c95
       field: json.MatchedIndicatorFeedIDs
       target_field: cloudflare_logpush.gateway_dns.matched.indicator_feed.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_MatchedIndicatorFeedNames_to_cloudflare_logpush_gateway_dns_matched_indicator_feed_names_deac207d
       field: json.MatchedIndicatorFeedNames
       target_field: cloudflare_logpush.gateway_dns.matched.indicator_feed.names
       ignore_missing: true
   - rename:
+      tag: rename_json_PolicyID_to_cloudflare_logpush_gateway_dns_policy_id_d10336d0
       field: json.PolicyID
       target_field: cloudflare_logpush.gateway_dns.policy.id
       ignore_missing: true
   - rename:
+      tag: rename_json_PolicyName_to_cloudflare_logpush_gateway_dns_policy_name_5c572998
       field: json.PolicyName
       target_field: cloudflare_logpush.gateway_dns.policy.name
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_gateway_dns_policy_name_2036581b
       field: cloudflare_logpush.gateway_dns.policy.name
       value: '{{{json.Policy}}}'
       if: ctx.cloudflare_logpush?.gateway_dns?.policy?.name != null && ctx.json?.Policy != null && ctx.json.Policy != '' && ctx.json.Policy != ctx.cloudflare_logpush?.gateway_dns?.policy?.name
       allow_duplicates: false
   - rename:
+      tag: rename_json_Policy_to_cloudflare_logpush_gateway_dns_policy_name_de9b6002
       field: json.Policy
       target_field: cloudflare_logpush.gateway_dns.policy.name
       if: ctx.cloudflare_logpush?.gateway_dns?.policy?.name == null
       ignore_missing: true
   - rename:
+      tag: rename_json_QueryCategoryIDs_to_cloudflare_logpush_gateway_dns_question_category_ids_cbae315e
       field: json.QueryCategoryIDs
       target_field: cloudflare_logpush.gateway_dns.question.category.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_QueryID_to_cloudflare_logpush_gateway_dns_question_id_2f8c08b6
       field: json.QueryID
       target_field: cloudflare_logpush.gateway_dns.question.id
       ignore_missing: true
   - rename:
+      tag: rename_json_QueryIndicatorFeedIDs_to_cloudflare_logpush_gateway_dns_question_indicator_feed_ids_b5a1274b
       field: json.QueryIndicatorFeedIDs
       target_field: cloudflare_logpush.gateway_dns.question.indicator_feed.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_QueryIndicatorFeedNames_to_cloudflare_logpush_gateway_dns_question_indicator_feed_names_8336b1f3
       field: json.QueryIndicatorFeedNames
       target_field: cloudflare_logpush.gateway_dns.question.indicator_feed.names
       ignore_missing: true
   - rename:
+      tag: rename_json_QueryCategoryNames_to_cloudflare_logpush_gateway_dns_question_category_names_e7ffd8d2
       field: json.QueryCategoryNames
       target_field: cloudflare_logpush.gateway_dns.question.category.names
       ignore_missing: true
   - rename:
+      tag: rename_json_QueryNameReversed_to_cloudflare_logpush_gateway_dns_question_reversed_4f968253
       field: json.QueryNameReversed
       target_field: cloudflare_logpush.gateway_dns.question.reversed
       ignore_missing: true
   - rename:
+      tag: rename_json_QuerySize_to_cloudflare_logpush_gateway_dns_question_size_7fde6fe6
       field: json.QuerySize
       target_field: cloudflare_logpush.gateway_dns.question.size
       ignore_missing: true
   - rename:
+      tag: rename_json_QueryType_to_cloudflare_logpush_gateway_dns_question_type_id_76943c0a
       field: json.QueryType
       target_field: cloudflare_logpush.gateway_dns.question.type_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ResolvedIPCategoryIDs_to_cloudflare_logpush_gateway_dns_resolved_ip_details_category_ids_f020c922
       field: json.ResolvedIPCategoryIDs
       target_field: cloudflare_logpush.gateway_dns.resolved_ip_details.category.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_ResolvedIPCategoryNames_to_cloudflare_logpush_gateway_dns_resolved_ip_details_category_names_158080c6
       field: json.ResolvedIPCategoryNames
       target_field: cloudflare_logpush.gateway_dns.resolved_ip_details.category.names
       ignore_missing: true
   - rename:
+      tag: rename_json_ResolvedIPContinentCodes_to_cloudflare_logpush_gateway_dns_resolved_ip_details_continent_codes_c77efd69
       field: json.ResolvedIPContinentCodes
       target_field: cloudflare_logpush.gateway_dns.resolved_ip_details.continent_codes
       ignore_missing: true
   - rename:
+      tag: rename_json_ResolvedIPCountryCodes_to_cloudflare_logpush_gateway_dns_resolved_ip_details_country_codes_5019bd29
       field: json.ResolvedIPCountryCodes
       target_field: cloudflare_logpush.gateway_dns.resolved_ip_details.country_codes
       ignore_missing: true
   - convert:
+      tag: convert_json_ResolvedIPs_to_cloudflare_logpush_gateway_dns_resolved_ip_details_ips_726a7934
       field: json.ResolvedIPs
       target_field: cloudflare_logpush.gateway_dns.resolved_ip_details.ips
       type: ip
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_13ef8b4f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ResolverPolicyID_to_cloudflare_logpush_gateway_dns_resolver_policy_ids_f7d8c48b
       field: json.ResolverPolicyID
       target_field: cloudflare_logpush.gateway_dns.resolver.policy.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_ResolverPolicyName_to_cloudflare_logpush_gateway_dns_resolver_policy_names_033b4dc3
       field: json.ResolverPolicyName
       target_field: cloudflare_logpush.gateway_dns.resolver.policy.names
       ignore_missing: true
   - rename:
+      tag: rename_json_ResolverDecision_to_cloudflare_logpush_gateway_dns_resolver_decision_911c662d
       field: json.ResolverDecision
       target_field: cloudflare_logpush.gateway_dns.resolver_decision
       ignore_missing: true
   - rename:
+      tag: rename_json_ResourceRecords_to_cloudflare_logpush_gateway_dns_resource_records_object_43f55d40
       field: json.ResourceRecords
       target_field: cloudflare_logpush.gateway_dns.resource_records.object
       ignore_missing: true
   - rename:
+      tag: rename_json_ResourceRecordsJSON_to_cloudflare_logpush_gateway_dns_resource_records_json_47fc6b61
       field: json.ResourceRecordsJSON
       target_field: cloudflare_logpush.gateway_dns.resource_records.json
       ignore_missing: true
   - rename:
+      tag: rename_json_SrcIPContinentCode_to_cloudflare_logpush_gateway_dns_source_id_continent_code_c0059dd3
       field: json.SrcIPContinentCode
       target_field: cloudflare_logpush.gateway_dns.source_id.continent_code
       ignore_missing: true
   - rename:
+      tag: rename_json_SrcIPCountryCode_to_cloudflare_logpush_gateway_dns_source_id_country_code_8a74743f
       field: json.SrcIPCountryCode
       target_field: cloudflare_logpush.gateway_dns.source_id.country_code
       ignore_missing: true
   - rename:
+      tag: rename_json_TimeZoneInferredMethod_to_cloudflare_logpush_gateway_dns_timezone_inferred_method_7bdd7c84
       field: json.TimeZoneInferredMethod
       target_field: cloudflare_logpush.gateway_dns.timezone_inferred_method
       ignore_missing: true
   - convert:
+      tag: convert_json_InitialResolvedIPs_to_cloudflare_logpush_gateway_dns_initial_resolved_ips_b54d142d
       field: json.InitialResolvedIPs
       target_field: cloudflare_logpush.gateway_dns.initial_resolved_ips
       type: ip
@@ -489,96 +595,117 @@ processors:
       if: ctx.json?.InitialResolvedIPs != ''
       on_failure:
         - append:
+            tag: append_error_message_7b30fdfb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_InternalDNSDurationMs_to_cloudflare_logpush_gateway_dns_internal_dns_duration_ms_5cf064a7
       field: json.InternalDNSDurationMs
       target_field: cloudflare_logpush.gateway_dns.internal_dns.duration_ms
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5ebffd81
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_InternalDNSFallbackStrategy_to_cloudflare_logpush_gateway_dns_internal_dns_fallback_strategy_520cff78
       field: json.InternalDNSFallbackStrategy
       target_field: cloudflare_logpush.gateway_dns.internal_dns.fallback_strategy
       ignore_missing: true
   - convert:
+      tag: convert_json_InternalDNSRCode_to_cloudflare_logpush_gateway_dns_internal_dns_rcode_e0a7366e
       field: json.InternalDNSRCode
       target_field: cloudflare_logpush.gateway_dns.internal_dns.rcode
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e22099b8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_InternalDNSViewID_to_cloudflare_logpush_gateway_dns_internal_dns_view_id_fa155a94
       field: json.InternalDNSViewID
       target_field: cloudflare_logpush.gateway_dns.internal_dns.view_id
       ignore_missing: true
   - rename:
+      tag: rename_json_InternalDNSZoneID_to_cloudflare_logpush_gateway_dns_internal_dns_zone_id_f43b780c
       field: json.InternalDNSZoneID
       target_field: cloudflare_logpush.gateway_dns.internal_dns.zone_id
       ignore_missing: true
   - convert:
+      tag: convert_json_QueryApplicationIDs_to_cloudflare_logpush_gateway_dns_question_application_ids_0e1c13ec
       field: json.QueryApplicationIDs
       target_field: cloudflare_logpush.gateway_dns.question.application.ids
       type: string
       ignore_missing: true
   - rename:
+      tag: rename_json_QueryApplicationNames_to_cloudflare_logpush_gateway_dns_question_application_names_11808228
       field: json.QueryApplicationNames
       target_field: cloudflare_logpush.gateway_dns.question.application.names
       ignore_missing: true
   - rename:
+      tag: rename_json_RedirectTargetURI_to_cloudflare_logpush_gateway_dns_redirect_target_uri_8da36c04
       field: json.RedirectTargetURI
       target_field: cloudflare_logpush.gateway_dns.redirect_target_uri
       ignore_missing: true
   - rename:
+      tag: rename_json_RegistrationID_to_cloudflare_logpush_gateway_dns_registration_id_c2a72a3b
       field: json.RegistrationID
       target_field: cloudflare_logpush.gateway_dns.registration_id
       ignore_missing: true
   - convert:
+      tag: convert_json_RequestContextCategoryIDs_to_cloudflare_logpush_gateway_dns_request_context_category_ids_198a6fcc
       field: json.RequestContextCategoryIDs
       target_field: cloudflare_logpush.gateway_dns.request_context_category.ids
       type: string
       ignore_missing: true
   - rename:
+      tag: rename_json_RequestContextCategoryNames_to_cloudflare_logpush_gateway_dns_request_context_category_names_e9b6b904
       field: json.RequestContextCategoryNames
       target_field: cloudflare_logpush.gateway_dns.request_context_category.names
       ignore_missing: true
-# Create related fields
+  # Create related fields
   - append:
+      tag: append_related_ip_8121c591
       field: related.ip
       value: '{{{source.ip}}}'
       if: ctx.source?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_c1a6356b
       field: related.ip
       value: '{{{destination.ip}}}'
       if: ctx.destination?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_d1851e05
       field: related.hosts
       value: "{{{host.id}}}"
       if: ctx.host?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_452ef445
       field: related.hosts
       value: "{{{host.name}}}"
       if: ctx.host?.name != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_7f407fef
       field: related.user
       value: '{{{user.id}}}'
       if: ctx.user?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_34fcf415
       field: related.user
       value: '{{{user.email}}}'
       if: ctx.user?.email != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_cloudflare_logpush_gateway_dns_initial_resolved_ips_1a8b4c4e
       field: cloudflare_logpush.gateway_dns.initial_resolved_ips
       if: ctx.cloudflare_logpush?.gateway_dns?.initial_resolved_ips instanceof List
       processor:
@@ -586,7 +713,7 @@ processors:
           field: related.ip
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
-# Clean resulting event
+  # Clean resulting event
   - remove:
       tag: remove_json_conf
       field:
@@ -594,6 +721,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_79fb7088
       field:
         - cloudflare_logpush.gateway_dns.timestamp
         - cloudflare_logpush.gateway_dns.host.id
@@ -615,6 +743,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |

--- a/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
@@ -142,6 +142,7 @@ processors:
       if: ctx.json?.DestinationIP != ''
       on_failure:
         - append:
+            tag: append_error_message_75e1c9c2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -182,6 +183,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_685049c4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -207,6 +209,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_13830a66
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -243,6 +246,7 @@ processors:
       if: ctx.json?.SourceIP != ''
       on_failure:
         - append:
+            tag: append_error_message_2345f176
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -283,6 +287,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_aa939c7d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -369,6 +374,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2976e983
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -434,6 +440,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c90d95ae
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -486,6 +493,7 @@ processors:
       if: ctx.json?.SourceInternalIP != ''
       on_failure:
         - append:
+            tag: append_error_message_bbf87ecb
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:

--- a/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Gateway HTTP logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,35 +19,42 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
   - append:
+      tag: append_event_type_f178ce9b
       field: event.type
       value: allowed
       allow_duplicates: false
       if: ctx.json?.Action != '' && ctx.json?.Action == 'allow'
   - append:
+      tag: append_event_type_0e4bad26
       field: event.type
       value: allowed
       allow_duplicates: false
       if: ctx.json?.Action != '' && ctx.json?.Action == 'bypass'
   - append:
+      tag: append_event_type_267507e8
       field: event.type
       value: denied
       allow_duplicates: false
       if: ctx.json?.Action != '' && ctx.json?.Action == 'block'
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -55,7 +63,7 @@ processors:
         must be removed.
       if: ctx._conf?.enable_deduplication == false && ctx.input?.type == 'aws-s3'
       ignore_missing: true
-# ECS fields
+  # ECS fields
   - script:
       lang: painless
       tag: painless_datetime_to_milli
@@ -78,6 +86,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Datetime_5886cebc
       field: json.Datetime
       if: ctx.json?.Datetime != null && ctx.json.Datetime != ''
       formats:
@@ -87,49 +96,61 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_da98a171
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_gateway_http_timestamp_81b84a1e
       field: cloudflare_logpush.gateway_http.timestamp
       copy_from: "@timestamp"
   - rename:
+      tag: rename_json_Action_to_cloudflare_logpush_gateway_http_action_e2c0d6b7
       field: json.Action
       target_field: cloudflare_logpush.gateway_http.action
       ignore_missing: true
   - set:
+      tag: set_event_action_d51e882e
       field: event.action
       copy_from: cloudflare_logpush.gateway_http.action
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceID_to_cloudflare_logpush_gateway_http_host_id_65ac8bc9
       field: json.DeviceID
       target_field: cloudflare_logpush.gateway_http.host.id
       ignore_missing: true
   - set:
+      tag: set_host_id_99855bb0
       field: host.id
       copy_from: cloudflare_logpush.gateway_http.host.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceName_to_cloudflare_logpush_gateway_http_host_name_84c5dcb9
       field: json.DeviceName
       target_field: cloudflare_logpush.gateway_http.host.name
       ignore_missing: true
   - set:
+      tag: set_host_name_dd86bf58
       field: host.name
       copy_from: cloudflare_logpush.gateway_http.host.name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DestinationIP_to_cloudflare_logpush_gateway_http_destination_ip_0b9cc7a3
       field: json.DestinationIP
       target_field: cloudflare_logpush.gateway_http.destination.ip
       ignore_missing: true
   - set:
+      tag: set_destination_ip_837c9892
       field: destination.ip
       copy_from: cloudflare_logpush.gateway_http.destination.ip
       ignore_empty_value: true
-# Geo enrichment (destination IP)
+  # Geo enrichment (destination IP)
   - geoip:
+      tag: geoip_destination_ip_to_destination_geo_ab5e2968
       field: destination.ip
       target_field: destination.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_destination_ip_to_destination_as_8a007787
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
       target_field: destination.as
@@ -138,67 +159,83 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_asn_to_destination_as_number_3b459fcd
       field: destination.as.asn
       target_field: destination.as.number
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_organization_name_to_destination_as_organization_name_814bd459
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationPort_to_cloudflare_logpush_gateway_http_destination_port_e4f72c27
       field: json.DestinationPort
       target_field: cloudflare_logpush.gateway_http.destination.port
       ignore_missing: true
   - set:
+      tag: set_destination_port_f3bb2b4e
       field: destination.port
       copy_from: cloudflare_logpush.gateway_http.destination.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_HTTPMethod_to_cloudflare_logpush_gateway_http_request_method_6172f61c
       field: json.HTTPMethod
       target_field: cloudflare_logpush.gateway_http.request.method
       ignore_missing: true
   - set:
+      tag: set_http_request_method_69168ea6
       field: http.request.method
       copy_from: cloudflare_logpush.gateway_http.request.method
       ignore_empty_value: true
   - rename:
+      tag: rename_json_HTTPStatusCode_to_cloudflare_logpush_gateway_http_response_status_code_534c51bf
       field: json.HTTPStatusCode
       target_field: cloudflare_logpush.gateway_http.response.status_code
       ignore_missing: true
   - set:
+      tag: set_http_response_status_code_63af1e22
       field: http.response.status_code
       copy_from: cloudflare_logpush.gateway_http.response.status_code
       ignore_empty_value: true
   - rename:
+      tag: rename_json_HTTPVersion_to_cloudflare_logpush_gateway_http_request_version_c7ca5f2e
       field: json.HTTPVersion
       target_field: cloudflare_logpush.gateway_http.request.version
       ignore_missing: true
   - set:
+      tag: set_http_version_2a76bccd
       field: http.version
       copy_from: cloudflare_logpush.gateway_http.request.version
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Referer_to_cloudflare_logpush_gateway_http_request_referrer_9148694c
       field: json.Referer
       target_field: cloudflare_logpush.gateway_http.request.referrer
       ignore_missing: true
   - set:
+      tag: set_http_request_referrer_e0995d6e
       field: http.request.referrer
       copy_from: cloudflare_logpush.gateway_http.request.referrer
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SourceIP_to_cloudflare_logpush_gateway_http_source_ip_00bbb849
       field: json.SourceIP
       target_field: cloudflare_logpush.gateway_http.source.ip
       ignore_missing: true
   - set:
+      tag: set_source_ip_2da8b268
       field: source.ip
       copy_from: cloudflare_logpush.gateway_http.source.ip
       ignore_empty_value: true
-# Geo enrichment (source IP)
+  # Geo enrichment (source IP)
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -207,247 +244,306 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_SourcePort_to_cloudflare_logpush_gateway_http_source_port_28aa0759
       field: json.SourcePort
       target_field: cloudflare_logpush.gateway_http.source.port
       ignore_missing: true
   - set:
+      tag: set_source_port_0321a1a0
       field: source.port
       copy_from: cloudflare_logpush.gateway_http.source.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_URL_to_cloudflare_logpush_gateway_http_url_6b9de1e1
       field: json.URL
       target_field: cloudflare_logpush.gateway_http.url
       ignore_missing: true
   - uri_parts:
+      tag: uri_parts_cloudflare_logpush_gateway_http_url_to_url_a1cdd978
       field: cloudflare_logpush.gateway_http.url
       target_field: url
       if: ctx.cloudflare_logpush?.gateway_http?.url != null
   - rename:
+      tag: rename_json_UserAgent_to_cloudflare_logpush_gateway_http_user_agent_a8bd2af6
       field: json.UserAgent
       target_field: cloudflare_logpush.gateway_http.user_agent
       ignore_missing: true
   - set:
+      tag: set_user_agent_original_55a5449d
       field: user_agent.original
       copy_from: cloudflare_logpush.gateway_http.user_agent
       ignore_empty_value: true
   - rename:
+      tag: rename_json_UserID_to_cloudflare_logpush_gateway_http_user_id_651716a9
       field: json.UserID
       target_field: cloudflare_logpush.gateway_http.user.id
       ignore_missing: true
   - set:
+      tag: set_user_id_b987eb50
       field: user.id
       copy_from: cloudflare_logpush.gateway_http.user.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Email_to_cloudflare_logpush_gateway_http_user_email_75bd2046
       field: json.Email
       target_field: cloudflare_logpush.gateway_http.user.email
       ignore_missing: true
   - set:
+      tag: set_user_email_515524fe
       field: user.email
       copy_from: cloudflare_logpush.gateway_http.user.email
       ignore_empty_value: true
-# Custom fields
+  # Custom fields
   - rename:
+      tag: rename_json_AccountID_to_cloudflare_logpush_gateway_http_account_id_96473be8
       field: json.AccountID
       target_field: cloudflare_logpush.gateway_http.account_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ApplicationIDs_to_cloudflare_logpush_gateway_http_application_ids_436f1ac3
       field: json.ApplicationIDs
       target_field: cloudflare_logpush.gateway_http.application.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_ApplicationNames_to_cloudflare_logpush_gateway_http_application_names_f73b8713
       field: json.ApplicationNames
       target_field: cloudflare_logpush.gateway_http.application.names
       ignore_missing: true
   - rename:
+      tag: rename_json_BlockedFileHash_to_cloudflare_logpush_gateway_http_blocked_file_hash_10149780
       field: json.BlockedFileHash
       target_field: cloudflare_logpush.gateway_http.blocked_file.hash
       ignore_missing: true
   - rename:
+      tag: rename_json_BlockedFileName_to_cloudflare_logpush_gateway_http_blocked_file_name_92a883de
       field: json.BlockedFileName
       target_field: cloudflare_logpush.gateway_http.blocked_file.name
       ignore_missing: true
   - rename:
+      tag: rename_json_BlockedFileReason_to_cloudflare_logpush_gateway_http_blocked_file_reason_d2532038
       field: json.BlockedFileReason
       target_field: cloudflare_logpush.gateway_http.blocked_file.reason
       ignore_missing: true
   - rename:
+      tag: rename_json_BlockedFileSize_to_cloudflare_logpush_gateway_http_blocked_file_size_cc2cc2ca
       field: json.BlockedFileSize
       target_field: cloudflare_logpush.gateway_http.blocked_file.size
       ignore_missing: true
   - rename:
+      tag: rename_json_BlockedFileType_to_cloudflare_logpush_gateway_http_blocked_file_type_813e4450
       field: json.BlockedFileType
       target_field: cloudflare_logpush.gateway_http.blocked_file.type
       ignore_missing: true
   - rename:
+      tag: rename_json_CategoryIDs_to_cloudflare_logpush_gateway_http_category_ids_3d6fd593
       field: json.CategoryIDs
       target_field: cloudflare_logpush.gateway_http.category.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_CategoryNames_to_cloudflare_logpush_gateway_http_category_names_40f1817b
       field: json.CategoryNames
       target_field: cloudflare_logpush.gateway_http.category.names
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationIPContinentCode_to_cloudflare_logpush_gateway_http_destination_ip_continent_code_9fdde7b1
       field: json.DestinationIPContinentCode
       target_field: cloudflare_logpush.gateway_http.destination_ip.continent_code
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationIPCountryCode_to_cloudflare_logpush_gateway_http_destination_ip_country_code_4de8d4c5
       field: json.DestinationIPCountryCode
       target_field: cloudflare_logpush.gateway_http.destination_ip.country_code
       ignore_missing: true
   - rename:
+      tag: rename_json_DownloadedFileNames_to_cloudflare_logpush_gateway_http_downloaded_files_0a00963d
       field: json.DownloadedFileNames
       target_field: cloudflare_logpush.gateway_http.downloaded_files
       ignore_missing: true
   - rename:
+      tag: rename_json_DownloadMatchedDlpProfileEntries_to_cloudflare_logpush_gateway_http_download_matched_dlp_profile_entries_849ef096
       field: json.DownloadMatchedDlpProfileEntries
       target_field: cloudflare_logpush.gateway_http.download_matched_dlp.profile_entries
       ignore_missing: true
   - rename:
+      tag: rename_json_DownloadMatchedDlpProfiles_to_cloudflare_logpush_gateway_http_download_matched_dlp_profiles_634a15d7
       field: json.DownloadMatchedDlpProfiles
       target_field: cloudflare_logpush.gateway_http.download_matched_dlp.profiles
       ignore_missing: true
   - rename:
+      tag: rename_json_FileInfo_to_cloudflare_logpush_gateway_http_file_info_0862bd42
       field: json.FileInfo
       target_field: cloudflare_logpush.gateway_http.file_info
       ignore_missing: true
   - rename:
+      tag: rename_json_ForensicCopyStatus_to_cloudflare_logpush_gateway_http_forensic_copy_status_346706cb
       field: json.ForensicCopyStatus
       target_field: cloudflare_logpush.gateway_http.forensic_copy_status
       ignore_missing: true
   - rename:
+      tag: rename_json_HTTPHost_to_cloudflare_logpush_gateway_http_request_host_bc8a245c
       field: json.HTTPHost
       target_field: cloudflare_logpush.gateway_http.request.host
       ignore_missing: true
   - rename:
+      tag: rename_json_IsIsolated_to_cloudflare_logpush_gateway_http_isolated_74fad537
       field: json.IsIsolated
       target_field: cloudflare_logpush.gateway_http.isolated
       ignore_missing: true
   - rename:
+      tag: rename_json_PolicyID_to_cloudflare_logpush_gateway_http_policy_id_24ccffdd
       field: json.PolicyID
       target_field: cloudflare_logpush.gateway_http.policy.id
       ignore_missing: true
   - rename:
+      tag: rename_json_PolicyName_to_cloudflare_logpush_gateway_http_policy_name_16ffb46d
       field: json.PolicyName
       target_field: cloudflare_logpush.gateway_http.policy.name
       ignore_missing: true
   - rename:
+      tag: rename_json_PrivateAppAUD_to_cloudflare_logpush_gateway_http_private_app_aud_4b5ea161
       field: json.PrivateAppAUD
       target_field: cloudflare_logpush.gateway_http.private_app_aud
       ignore_missing: true
   - rename:
+      tag: rename_json_ProxyEndpoint_to_cloudflare_logpush_gateway_http_proxy_endpoint_5f4e91b6
       field: json.ProxyEndpoint
       target_field: cloudflare_logpush.gateway_http.proxy_endpoint
       ignore_missing: true
   - convert:
+      tag: convert_json_Quarantined_to_cloudflare_logpush_gateway_http_quarantined_f31dfd9b
       field: json.Quarantined
       target_field: cloudflare_logpush.gateway_http.quarantined
       type: boolean
       ignore_missing: true
       on_failure:
       - append:
+          tag: append_error_message_9338ef24
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - rename:
+      tag: rename_json_RequestID_to_cloudflare_logpush_gateway_http_request_id_ad9f8c34
       field: json.RequestID
       target_field: cloudflare_logpush.gateway_http.request_id
       ignore_missing: true
   - rename:
+      tag: rename_json_SessionID_to_cloudflare_logpush_gateway_http_session_id_ed7f705a
       field: json.SessionID
       target_field: cloudflare_logpush.gateway_http.session_id
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceInternalIP_to_cloudflare_logpush_gateway_http_source_internal_ip_4e2dfdec
       field: json.SourceInternalIP
       target_field: cloudflare_logpush.gateway_http.source.internal_ip
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceIPContinentCode_to_cloudflare_logpush_gateway_http_source_ip_continent_code_28450e67
       field: json.SourceIPContinentCode
       target_field: cloudflare_logpush.gateway_http.source_ip.continent_code
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceIPCountryCode_to_cloudflare_logpush_gateway_http_source_ip_country_code_548be907
       field: json.SourceIPCountryCode
       target_field: cloudflare_logpush.gateway_http.source_ip.country_code
       ignore_missing: true
   - rename:
+      tag: rename_json_UntrustedCertificateAction_to_cloudflare_logpush_gateway_http_untrusted_certificate_action_717d6185
       field: json.UntrustedCertificateAction
       target_field: cloudflare_logpush.gateway_http.untrusted_certificate_action
       ignore_missing: true
   - rename:
+      tag: rename_json_UploadMatchedDlpProfileEntries_to_cloudflare_logpush_gateway_http_upload_matched_dlp_profile_entries_24d0b066
       field: json.UploadMatchedDlpProfileEntries
       target_field: cloudflare_logpush.gateway_http.upload_matched_dlp.profile_entries
       ignore_missing: true
   - rename:
+      tag: rename_json_UploadMatchedDlpProfiles_to_cloudflare_logpush_gateway_http_upload_matched_dlp_profiles_eefa4a53
       field: json.UploadMatchedDlpProfiles
       target_field: cloudflare_logpush.gateway_http.upload_matched_dlp.profiles
       ignore_missing: true
   - rename:
+      tag: rename_json_UploadedFileNames_to_cloudflare_logpush_gateway_http_uploaded_files_7e0bf6c3
       field: json.UploadedFileNames
       target_field: cloudflare_logpush.gateway_http.uploaded_files
       ignore_missing: true
   - rename:
+      tag: rename_json_VirtualNetworkID_to_cloudflare_logpush_gateway_http_virtual_network_id_3d61e73a
       field: json.VirtualNetworkID
       target_field: cloudflare_logpush.gateway_http.virtual_network.id
       ignore_missing: true
   - rename:
+      tag: rename_json_VirtualNetworkName_to_cloudflare_logpush_gateway_http_virtual_network_name_b9ac8c6e
       field: json.VirtualNetworkName
       target_field: cloudflare_logpush.gateway_http.virtual_network.name
       ignore_missing: true
   - rename:
+      tag: rename_json_AppControlInfo_to_cloudflare_logpush_gateway_http_app_control_info_63f61099
       field: json.AppControlInfo
       target_field: cloudflare_logpush.gateway_http.app_control_info
       ignore_missing: true
   - rename:
+      tag: rename_json_ApplicationStatuses_to_cloudflare_logpush_gateway_http_application_statuses_336d5293
       field: json.ApplicationStatuses
       target_field: cloudflare_logpush.gateway_http.application.statuses
       ignore_missing: true
   - rename:
+      tag: rename_json_RedirectTargetURI_to_cloudflare_logpush_gateway_http_redirect_target_uri_0db7ee2d
       field: json.RedirectTargetURI
       target_field: cloudflare_logpush.gateway_http.redirect_target_uri
       ignore_missing: true
   - rename:
+      tag: rename_json_RegistrationID_to_cloudflare_logpush_gateway_http_registration_id_ec6607ec
       field: json.RegistrationID
       target_field: cloudflare_logpush.gateway_http.registration_id
       ignore_missing: true
-# Create related fields
+  # Create related fields
   - append:
+      tag: append_related_ip_8121c591
       field: related.ip
       value: "{{{source.ip}}}"
       if: ctx.source?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_c1a6356b
       field: related.ip
       value: "{{{destination.ip}}}"
       if: ctx.destination?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_850e9c49
       field: related.ip
       value: "{{{cloudflare_logpush.gateway_http.source.internal_ip}}}"
       if: ctx.cloudflare_logpush?.gateway_http?.source?.internal_ip != null && ctx.cloudflare_logpush.gateway_http.source.internal_ip != ''
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_d1851e05
       field: related.hosts
       value: "{{{host.id}}}"
       if: ctx.host?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_452ef445
       field: related.hosts
       value: "{{{host.name}}}"
       if: ctx.host?.name != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_7f407fef
       field: related.user
       value: "{{{user.id}}}"
       if: ctx.user?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_34fcf415
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
@@ -459,6 +555,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_3a16012a
       field:
         - cloudflare_logpush.gateway_http.timestamp
         - cloudflare_logpush.gateway_http.action
@@ -480,6 +577,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |

--- a/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
@@ -104,6 +104,7 @@ processors:
       if: ctx.json?.DestinationIP != ''
       on_failure:
         - append:
+            tag: append_error_message_4a3961f8
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -144,6 +145,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_137fbb14
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -205,6 +207,7 @@ processors:
       if: ctx.json?.SourceIP != ''
       on_failure:
         - append:
+            tag: append_error_message_1d82882e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -245,6 +248,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_772449f5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -338,6 +342,7 @@ processors:
       if: ctx.json?.OverrideIP != ''
       on_failure:
         - append:
+            tag: append_error_message_acc703b0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -348,6 +353,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_163e7972
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -374,6 +380,7 @@ processors:
       if: ctx.json?.SourceInternalIP != ''
       on_failure:
         - append:
+            tag: append_error_message_aeea9379
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:

--- a/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Gateway Network logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,20 +19,24 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -40,7 +45,7 @@ processors:
         must be removed.
       if: ctx._conf?.enable_deduplication == false && ctx.input?.type == 'aws-s3'
       ignore_missing: true
-# ECS fields
+  # ECS fields
   - script:
       lang: painless
       tag: painless_datetime_to_milli
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Datetime_5886cebc
       field: json.Datetime
       if: ctx.json?.Datetime != null && ctx.json.Datetime != ''
       formats:
@@ -72,33 +78,41 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_da98a171
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_gateway_network_timestamp_f08081fc
       field: cloudflare_logpush.gateway_network.timestamp
       copy_from: "@timestamp"
   - rename:
+      tag: rename_json_Action_to_cloudflare_logpush_gateway_network_action_f9131c6f
       field: json.Action
       target_field: cloudflare_logpush.gateway_network.action
       ignore_missing: true
   - set:
+      tag: set_event_action_1c1356b0
       field: event.action
       copy_from: cloudflare_logpush.gateway_network.action
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DestinationIP_to_cloudflare_logpush_gateway_network_destination_ip_df1e1da5
       field: json.DestinationIP
       target_field: cloudflare_logpush.gateway_network.destination.ip
       ignore_missing: true
   - set:
+      tag: set_destination_ip_fc548a68
       field: destination.ip
       copy_from: cloudflare_logpush.gateway_network.destination.ip
       ignore_empty_value: true
-# Geo enrichment (destination IP)
+  # Geo enrichment (destination IP)
   - geoip:
+      tag: geoip_destination_ip_to_destination_geo_ab5e2968
       field: destination.ip
       target_field: destination.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_destination_ip_to_destination_as_8a007787
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
       target_field: destination.as
@@ -107,71 +121,88 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_asn_to_destination_as_number_3b459fcd
       field: destination.as.asn
       target_field: destination.as.number
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_organization_name_to_destination_as_organization_name_814bd459
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationPort_to_cloudflare_logpush_gateway_network_destination_port_089577c1
       field: json.DestinationPort
       target_field: cloudflare_logpush.gateway_network.destination.port
       ignore_missing: true
   - set:
+      tag: set_destination_port_b39fa4bc
       field: destination.port
       copy_from: cloudflare_logpush.gateway_network.destination.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceID_to_cloudflare_logpush_gateway_network_host_id_23bb4a67
       field: json.DeviceID
       target_field: cloudflare_logpush.gateway_network.host.id
       ignore_missing: true
   - set:
+      tag: set_host_id_0fad592e
       field: host.id
       copy_from: cloudflare_logpush.gateway_network.host.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceName_to_cloudflare_logpush_gateway_network_host_name_bfa47a8b
       field: json.DeviceName
       target_field: cloudflare_logpush.gateway_network.host.name
       ignore_missing: true
   - set:
+      tag: set_host_name_a1136376
       field: host.name
       copy_from: cloudflare_logpush.gateway_network.host.name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SNI_to_cloudflare_logpush_gateway_network_sni_5dfb7cb7
       field: json.SNI
       target_field: cloudflare_logpush.gateway_network.sni
       ignore_missing: true
   - set:
+      tag: set_tls_client_server_name_43b005ff
       field: tls.client.server_name
       copy_from: cloudflare_logpush.gateway_network.sni
       ignore_empty_value: true
   - set:
+      tag: set_destination_domain_7150388e
       field: destination.domain
       copy_from: tls.client.server_name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SessionID_to_cloudflare_logpush_gateway_network_session_id_0f621aa8
       field: json.SessionID
       target_field: cloudflare_logpush.gateway_network.session_id
       ignore_missing: true
   - set:
+      tag: set_event_id_eab92dbf
       field: event.id
       copy_from: cloudflare_logpush.gateway_network.session_id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SourceIP_to_cloudflare_logpush_gateway_network_source_ip_e1a5f1b9
       field: json.SourceIP
       target_field: cloudflare_logpush.gateway_network.source.ip
       ignore_missing: true
   - set:
+      tag: set_source_ip_a7eaf136
       field: source.ip
       copy_from: cloudflare_logpush.gateway_network.source.ip
       ignore_empty_value: true
-# Geo enrichment (source IP)
+  # Geo enrichment (source IP)
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -180,169 +211,208 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_SourcePort_to_cloudflare_logpush_gateway_network_source_port_44973c01
       field: json.SourcePort
       target_field: cloudflare_logpush.gateway_network.source.port
       ignore_missing: true
   - set:
+      tag: set_source_port_f2cb7e4e
       field: source.port
       copy_from: cloudflare_logpush.gateway_network.source.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_TransportProtocol_to_cloudflare_logpush_gateway_network_transport_9ad64d3b
       field: json.TransportProtocol
       target_field: cloudflare_logpush.gateway_network.transport
       ignore_missing: true
   - rename:
+      tag: rename_json_Transport_to_cloudflare_logpush_gateway_network_transport_b090eb6c
       field: json.Transport
       target_field: cloudflare_logpush.gateway_network.transport
       if: ctx.cloudflare_logpush?.gateway_network?.transport == null
       ignore_missing: true
   - set:
+      tag: set_network_transport_6112981a
       field: network.transport
       copy_from: cloudflare_logpush.gateway_network.transport
       ignore_empty_value: true
   - rename:
+      tag: rename_json_UserID_to_cloudflare_logpush_gateway_network_user_id_50554b81
       field: json.UserID
       target_field: cloudflare_logpush.gateway_network.user.id
       ignore_missing: true
   - set:
+      tag: set_user_id_3ad0ce7e
       field: user.id
       copy_from: cloudflare_logpush.gateway_network.user.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Email_to_cloudflare_logpush_gateway_network_user_email_960d254e
       field: json.Email
       target_field: cloudflare_logpush.gateway_network.user.email
       ignore_missing: true
   - set:
+      tag: set_user_email_a33e851c
       field: user.email
       copy_from: cloudflare_logpush.gateway_network.user.email
       ignore_empty_value: true
-# Custom fields
+  # Custom fields
   - rename:
+      tag: rename_json_AccountID_to_cloudflare_logpush_gateway_network_account_id_c6306708
       field: json.AccountID
       target_field: cloudflare_logpush.gateway_network.account_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ApplicationIDs_to_cloudflare_logpush_gateway_network_application_ids_d33347b3
       field: json.ApplicationIDs
       target_field: cloudflare_logpush.gateway_network.application.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_ApplicationNames_to_cloudflare_logpush_gateway_network_application_names_5b43358b
       field: json.ApplicationNames
       target_field: cloudflare_logpush.gateway_network.application.names
       ignore_missing: true
   - rename:
+      tag: rename_json_CategoryIDs_to_cloudflare_logpush_gateway_network_category_ids_37347273
       field: json.CategoryIDs
       target_field: cloudflare_logpush.gateway_network.category.ids
       ignore_missing: true
   - rename:
+      tag: rename_json_CategoryNames_to_cloudflare_logpush_gateway_network_category_names_ca527583
       field: json.CategoryNames
       target_field: cloudflare_logpush.gateway_network.category.names
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationIPContinentCode_to_cloudflare_logpush_gateway_network_destination_ip_continent_code_1cec9049
       field: json.DestinationIPContinentCode
       target_field: cloudflare_logpush.gateway_network.destination_ip.continent_code
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationIPCountryCode_to_cloudflare_logpush_gateway_network_destination_ip_country_code_c7588d55
       field: json.DestinationIPCountryCode
       target_field: cloudflare_logpush.gateway_network.destination_ip.country_code
       ignore_missing: true
   - rename:
+      tag: rename_json_DetectedProtocol_to_cloudflare_logpush_gateway_network_detected_protocol_53051a82
       field: json.DetectedProtocol
       target_field: cloudflare_logpush.gateway_network.detected_protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_OverrideIP_to_cloudflare_logpush_gateway_network_override_ip_e9c561f3
       field: json.OverrideIP
       target_field: cloudflare_logpush.gateway_network.override.ip
       ignore_missing: true
   - rename:
+      tag: rename_json_OverridePort_to_cloudflare_logpush_gateway_network_override_port_3b00cb43
       field: json.OverridePort
       target_field: cloudflare_logpush.gateway_network.override.port
       ignore_missing: true
   - rename:
+      tag: rename_json_PolicyID_to_cloudflare_logpush_gateway_network_policy_id_70acd37b
       field: json.PolicyID
       target_field: cloudflare_logpush.gateway_network.policy.id
       ignore_missing: true
   - rename:
+      tag: rename_json_PolicyName_to_cloudflare_logpush_gateway_network_policy_name_2532643f
       field: json.PolicyName
       target_field: cloudflare_logpush.gateway_network.policy.name
       ignore_missing: true
   - rename:
+      tag: rename_json_ProxyEndpoint_to_cloudflare_logpush_gateway_network_proxy_endpoint_5182661c
       field: json.ProxyEndpoint
       target_field: cloudflare_logpush.gateway_network.proxy_endpoint
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceInternalIP_to_cloudflare_logpush_gateway_network_source_internal_ip_c3362976
       field: json.SourceInternalIP
       target_field: cloudflare_logpush.gateway_network.source.internal_ip
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceIPContinentCode_to_cloudflare_logpush_gateway_network_source_ip_continent_code_fddc275d
       field: json.SourceIPContinentCode
       target_field: cloudflare_logpush.gateway_network.source_ip.continent_code
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceIPCountryCode_to_cloudflare_logpush_gateway_network_source_ip_country_code_a48881b1
       field: json.SourceIPCountryCode
       target_field: cloudflare_logpush.gateway_network.source_ip.country_code
       ignore_missing: true
   - rename:
+      tag: rename_json_VirtualNetworkID_to_cloudflare_logpush_gateway_network_virtual_network_id_1e540812
       field: json.VirtualNetworkID
       target_field: cloudflare_logpush.gateway_network.virtual_network.id
       ignore_missing: true
   - rename:
+      tag: rename_json_VirtualNetworkName_to_cloudflare_logpush_gateway_network_virtual_network_name_f490f5ce
       field: json.VirtualNetworkName
       target_field: cloudflare_logpush.gateway_network.virtual_network.name
       ignore_missing: true
   - rename:
+      tag: rename_json_RegistrationID_to_cloudflare_logpush_gateway_network_registration_id_f5c57cfc
       field: json.RegistrationID
       target_field: cloudflare_logpush.gateway_network.registration_id
       ignore_missing: true
-# Create related fields
+  # Create related fields
   - append:
+      tag: append_related_ip_8121c591
       field: related.ip
       value: "{{{source.ip}}}"
       if: ctx.source?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_c1a6356b
       field: related.ip
       value: "{{{destination.ip}}}"
       if: ctx.destination?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_ed97380d
       field: related.ip
       value: "{{{cloudflare_logpush.gateway_network.override.ip}}}"
       if: ctx.cloudflare_logpush?.gateway_network?.override?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_969fdcf5
       field: related.ip
       value: "{{{cloudflare_logpush.gateway_network.source.internal_ip}}}"
       if: ctx.cloudflare_logpush?.gateway_network?.source?.internal_ip != null && ctx.cloudflare_logpush.gateway_network.source.internal_ip != ''
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_b0d7ba0b
       field: related.hosts
       value: "{{{destination.domain}}}"
       if: ctx.destination?.domain != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_d1851e05
       field: related.hosts
       value: "{{{host.id}}}"
       if: ctx.host?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_452ef445
       field: related.hosts
       value: "{{{host.name}}}"
       if: ctx.host?.name != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_7f407fef
       field: related.user
       value: "{{{user.id}}}"
       if: ctx.user?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_34fcf415
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
@@ -354,6 +424,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_77a523d4
       field:
         - cloudflare_logpush.gateway_network.timestamp
         - cloudflare_logpush.gateway_network.action
@@ -372,6 +443,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -360,6 +360,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4d555959
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -521,6 +522,7 @@ processors:
         ctx.cloudflare_logpush.http_request.client.request.protocol != 'unknown'
       on_failure:
         - append:
+            tag: append_error_message_b7321807
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - lowercase:
@@ -583,6 +585,7 @@ processors:
         ctx.cloudflare_logpush.http_request.client.ssl.protocol != 'unknown'
       on_failure:
         - append:
+            tag: append_error_message_e0710c4a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - lowercase:
@@ -631,6 +634,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4c2889bc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -1083,6 +1087,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d9b9ba2a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare HTTP Request logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_EdgeStartTimestamp_to_cloudflare_logpush_http_request_edge_start_time_e2106ccb
       field: json.EdgeStartTimestamp
       if: ctx.json?.EdgeStartTimestamp != null && ctx.json.EdgeStartTimestamp != ''
       formats:
@@ -73,9 +79,11 @@ processors:
       target_field: cloudflare_logpush.http_request.edge.start_time
       on_failure:
       - append:
+          tag: append_error_message_172be258
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - date:
+      tag: date_json_Datetime_to_cloudflare_logpush_http_request_datetime_aa973639
       field: json.Datetime
       if: ctx.json?.Datetime != null && ctx.json.Datetime != ''
       formats:
@@ -86,13 +94,16 @@ processors:
       target_field: cloudflare_logpush.http_request.datetime
       on_failure:
       - append:
+          tag: append_error_message_08b2e7e8
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_timestamp_b2955a8a
       field: '@timestamp'
       copy_from: cloudflare_logpush.http_request.datetime
       ignore_empty_value: true
   - set:
+      tag: set_timestamp_f04385f0
       field: '@timestamp'
       copy_from: cloudflare_logpush.http_request.edge.start_time
       ignore_empty_value: true
@@ -118,6 +129,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_EdgeEndTimestamp_to_cloudflare_logpush_http_request_edge_end_time_a93397bd
       field: json.EdgeEndTimestamp
       if: ctx.json?.EdgeEndTimestamp != null && ctx.json.EdgeEndTimestamp != ''
       formats:
@@ -128,9 +140,11 @@ processors:
       target_field: cloudflare_logpush.http_request.edge.end_time
       on_failure:
         - append:
+            tag: append_error_message_98b3b972
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_OriginResponseHTTPExpires_to_cloudflare_logpush_http_request_origin_response_http_expires_5fcc3d5b
       field: json.OriginResponseHTTPExpires
       if: ctx.json?.OriginResponseHTTPExpires != null && ctx.json.OriginResponseHTTPExpires != ''
       formats:
@@ -145,9 +159,11 @@ processors:
       target_field: cloudflare_logpush.http_request.origin.response.http.expires
       on_failure:
         - append:
+            tag: append_error_message_bcdbbe26
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_OriginResponseHTTPLastModified_to_cloudflare_logpush_http_request_origin_response_http_last_modified_bd80d19e
       field: json.OriginResponseHTTPLastModified
       if: ctx.json?.OriginResponseHTTPLastModified != null && ctx.json.OriginResponseHTTPLastModified != ''
       timezone: UTC
@@ -162,9 +178,11 @@ processors:
       target_field: cloudflare_logpush.http_request.origin.response.http.last_modified
       on_failure:
         - append:
+            tag: append_error_message_06185e39
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_OriginIP_to_cloudflare_logpush_http_request_origin_ip_191f66a5
       field: json.OriginIP
       target_field: cloudflare_logpush.http_request.origin.ip
       if: ctx.json?.OriginIP != ''
@@ -172,29 +190,36 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2d6d9dae
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_destination_ip_76755d6d
       field: destination.ip
       copy_from: cloudflare_logpush.http_request.origin.ip
       ignore_empty_value: true
   - rename:
+      tag: rename_json_ClientRequestMethod_to_cloudflare_logpush_http_request_client_request_method_f40864a4
       field: json.ClientRequestMethod
       target_field: cloudflare_logpush.http_request.client.request.method
       ignore_missing: true
   - set:
+      tag: set_http_request_method_08f4da24
       field: http.request.method
       copy_from: cloudflare_logpush.http_request.client.request.method
       ignore_empty_value: true
   - rename:
+      tag: rename_json_EdgeResponseContentType_to_cloudflare_logpush_http_request_edge_response_content_type_5fd766bf
       field: json.EdgeResponseContentType
       target_field: cloudflare_logpush.http_request.edge.response.content_type
       ignore_missing: true
   - set:
+      tag: set_http_response_mime_type_1f0cd015
       field: http.response.mime_type
       copy_from: cloudflare_logpush.http_request.edge.response.content_type
       ignore_empty_value: true
   - convert:
+      tag: convert_json_EdgeResponseStatus_to_cloudflare_logpush_http_request_edge_response_status_168bfabf
       field: json.EdgeResponseStatus
       target_field: cloudflare_logpush.http_request.edge.response.status
       if: ctx.json?.EdgeResponseStatus != ''
@@ -202,13 +227,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_17d75dfe
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_http_response_status_code_ae85d3c4
       field: http.response.status_code
       copy_from: cloudflare_logpush.http_request.edge.response.status
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientASN_to_cloudflare_logpush_http_request_client_asn_82a23ec8
       field: json.ClientASN
       target_field: cloudflare_logpush.http_request.client.asn
       if: ctx.json?.ClientASN != ''
@@ -216,21 +244,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6d8b09b1
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_as_number_bff92218
       field: source.as.number
       copy_from: cloudflare_logpush.http_request.client.asn
       ignore_empty_value: true
   - rename:
+      tag: rename_json_ClientCountry_to_cloudflare_logpush_http_request_client_country_f44be20c
       field: json.ClientCountry
       target_field: cloudflare_logpush.http_request.client.country
       ignore_missing: true
   - set:
+      tag: set_source_geo_country_iso_code_1764ada0
       field: source.geo.country_iso_code
       copy_from: cloudflare_logpush.http_request.client.country
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientIP_to_cloudflare_logpush_http_request_client_ip_3d9346d4
       field: json.ClientIP
       target_field: cloudflare_logpush.http_request.client.ip
       if: ctx.json?.ClientIP != ''
@@ -238,9 +271,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fd8e3f53
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_ip_a2ad6d49
       field: source.ip
       copy_from: cloudflare_logpush.http_request.client.ip
       ignore_empty_value: true
@@ -263,6 +298,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0c9a001e
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
@@ -276,10 +312,12 @@ processors:
       tag: rename_bot_tags
       ignore_missing: true
   - rename:
+      tag: rename_json_CacheCacheStatus_to_cloudflare_logpush_http_request_cache_status_1744173a
       field: json.CacheCacheStatus
       target_field: cloudflare_logpush.http_request.cache.status
       ignore_missing: true
   - convert:
+      tag: convert_json_CacheReserveUsed_to_cloudflare_logpush_http_request_cache_reserve_used_f36316b4
       field: json.CacheReserveUsed
       target_field: cloudflare_logpush.http_request.cache.reserve_used
       if: ctx.json?.CacheReserveUsed != null && ctx.json.CacheReserveUsed != ''
@@ -287,9 +325,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_84cdcb4d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_CacheResponseBytes_to_cloudflare_logpush_http_request_cache_response_bytes_af455bfb
       field: json.CacheResponseBytes
       target_field: cloudflare_logpush.http_request.cache.response.bytes
       if: ctx.json?.CacheResponseBytes != null && ctx.json.CacheResponseBytes != ''
@@ -297,9 +337,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e620d244
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_CacheResponseStatus_to_cloudflare_logpush_http_request_cache_response_status_18a55e44
       field: json.CacheResponseStatus
       target_field: cloudflare_logpush.http_request.cache.response.status
       if: ctx.json?.CacheResponseStatus != ''
@@ -307,45 +349,56 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3f9d719f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_CacheTieredFill_to_cloudflare_logpush_http_request_cache_tiered_fill_4d84627f
       field: json.CacheTieredFill
       target_field: cloudflare_logpush.http_request.cache.tiered_fill
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientCity_to_cloudflare_logpush_http_request_client_city_c3f90d8e
       field: json.ClientCity
       target_field: cloudflare_logpush.http_request.client.city
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientDeviceType_to_cloudflare_logpush_http_request_client_device_type_1a6d51fa
       field: json.ClientDeviceType
       target_field: cloudflare_logpush.http_request.client.device.type
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientIPClass_to_cloudflare_logpush_http_request_client_ip_class_5adb6839
       field: json.ClientIPClass
       target_field: cloudflare_logpush.http_request.client.ip_class
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientLatitude_to_cloudflare_logpush_http_request_client_latitude_06f27c28
       field: json.ClientLatitude
       target_field: cloudflare_logpush.http_request.client.latitude
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientLongitude_to_cloudflare_logpush_http_request_client_longitude_b4f7387c
       field: json.ClientLongitude
       target_field: cloudflare_logpush.http_request.client.longitude
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientMTLSAuthCertFingerprint_to_cloudflare_logpush_http_request_client_mtls_auth_fingerprint_735ba6be
       field: json.ClientMTLSAuthCertFingerprint
       target_field: cloudflare_logpush.http_request.client.mtls.auth.fingerprint
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientMTLSAuthStatus_to_cloudflare_logpush_http_request_client_mtls_auth_status_b0179374
       field: json.ClientMTLSAuthStatus
       target_field: cloudflare_logpush.http_request.client.mtls.auth.status
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRegionCode_to_cloudflare_logpush_http_request_client_region_code_01e279bb
       field: json.ClientRegionCode
       target_field: cloudflare_logpush.http_request.client.region_code
       ignore_missing: true
   - convert:
+      tag: convert_json_ClientRequestBytes_to_cloudflare_logpush_http_request_client_request_bytes_7aa1b76a
       field: json.ClientRequestBytes
       target_field: cloudflare_logpush.http_request.client.request.bytes
       if: ctx.json?.ClientRequestBytes != ''
@@ -353,55 +406,67 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_55ff3d97
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ContentScanObjResults_to_cloudflare_logpush_http_request_content_scan_results_9bec8ee2
       field: json.ContentScanObjResults
       target_field: cloudflare_logpush.http_request.content_scan.results
       ignore_missing: true
   - convert:
+      tag: convert_json_ContentScanObjSizes_to_cloudflare_logpush_http_request_content_scan_sizes_8c19d2c4
       field: json.ContentScanObjSizes
       target_field: cloudflare_logpush.http_request.content_scan.sizes
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f3c9ca8f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ContentScanObjTypes_to_cloudflare_logpush_http_request_content_scan_types_a06b8342
       field: json.ContentScanObjTypes
       target_field: cloudflare_logpush.http_request.content_scan.types
       ignore_missing: true
   - rename:
+      tag: rename_json_LeakedCredentialCheckResult_to_cloudflare_logpush_http_request_leaked_credential_check_d4d0d473
       field: json.LeakedCredentialCheckResult
       target_field: cloudflare_logpush.http_request.leaked_credential_check
       ignore_missing: true
   - set:
+      tag: set_url_scheme_212f97c8
       field: url.scheme
       copy_from: json.ClientRequestScheme
       ignore_empty_value: true
       if: ctx.url?.scheme == null
   - set:
+      tag: set_url_scheme_5a754785
       field: url.scheme
       value: https
       ignore_empty_value: true
       if: ctx.url?.scheme == null && ctx.json?.ClientSSLProtocol != null
   - set:
+      tag: set_url_scheme_cb50bce2
       field: url.scheme
       value: http
       ignore_empty_value: true
       if: ctx.url?.scheme == null
   - set:
+      tag: set_url_domain_72a6f745
       field: url.domain
       copy_from: json.ClientRequestHost
       ignore_empty_value: true
       if: ctx.url?.domain == null
   - set:
+      tag: set_url_path_b062c440
       field: url.path
       copy_from: json.ClientRequestPath
       ignore_empty_value: true
       if: ctx.url?.path == null
   - set:
+      tag: set_url_query_a659fb29
       field: url.query
       copy_from: json.ClientRequestQuery
       ignore_empty_value: true
@@ -410,10 +475,7 @@ processors:
       field: tmp.constructed_uri
       tag: set_tmp_constructed_uri
       value: '{{{url.scheme}}}://{{{url.domain}}}{{{json.ClientRequestURI}}}'
-      if: ctx.json?.ClientRequestURI != null 
-          && ctx.url?.scheme != null 
-          && ctx.url?.domain != null
-          && ctx.json.ClientRequestURI.startsWith('/')
+      if: ctx.json?.ClientRequestURI != null && ctx.url?.scheme != null && ctx.url?.domain != null && ctx.json.ClientRequestURI.startsWith('/')
   - set:
       field: tmp.constructed_uri
       tag: set_tmp_constructed_uri_from_ClientRequestURI
@@ -425,75 +487,93 @@ processors:
       ignore_failure: true
       if: ctx.tmp?.constructed_uri != null
   - remove:
+      tag: remove_tmp_constructed_uri_9f65bf9e
       field: tmp.constructed_uri
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestHost_to_cloudflare_logpush_http_request_client_request_host_d4498d5e
       field: json.ClientRequestHost
       target_field: cloudflare_logpush.http_request.client.request.host
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestPath_to_cloudflare_logpush_http_request_client_request_path_f5f75878
       field: json.ClientRequestPath
       target_field: cloudflare_logpush.http_request.client.request.path
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestProtocol_to_cloudflare_logpush_http_request_client_request_protocol_07c944a2
       field: json.ClientRequestProtocol
       target_field: cloudflare_logpush.http_request.client.request.protocol
       ignore_missing: true
   - grok:
+      tag: grok_cloudflare_logpush_http_request_client_request_protocol_5275bfc4
       field: cloudflare_logpush.http_request.client.request.protocol
       patterns:
         - "^%{DATA:network.protocol}/%{DATA:http.version}$"
       ignore_missing: true
       ignore_failure: true
   - lowercase:
+      tag: lowercase_network_protocol_49872259
       field: network.protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestReferer_to_cloudflare_logpush_http_request_client_request_referer_e413e594
       field: json.ClientRequestReferer
       target_field: cloudflare_logpush.http_request.client.request.referer
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestScheme_to_cloudflare_logpush_http_request_client_request_scheme_349d1500
       field: json.ClientRequestScheme
       target_field: cloudflare_logpush.http_request.client.request.scheme
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestSource_to_cloudflare_logpush_http_request_client_request_source_1b28f824
       field: json.ClientRequestSource
       target_field: cloudflare_logpush.http_request.client.request.source
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientRequestURI_to_cloudflare_logpush_http_request_client_request_uri_9f914974
       field: json.ClientRequestURI
       target_field: cloudflare_logpush.http_request.client.request.uri
       ignore_missing: true
   - user_agent:
+      tag: user_agent_json_ClientRequestUserAgent_a0e18c70
       field: json.ClientRequestUserAgent
       if: ctx.json?.ClientRequestUserAgent != ''
       ignore_failure: true
   - rename:
+      tag: rename_json_ClientRequestUserAgent_to_cloudflare_logpush_http_request_client_request_user_agent_712bf2d0
       field: json.ClientRequestUserAgent
       target_field: cloudflare_logpush.http_request.client.request.user.agent
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientSSLCipher_to_cloudflare_logpush_http_request_client_ssl_cipher_91147e80
       field: json.ClientSSLCipher
       target_field: cloudflare_logpush.http_request.client.ssl.cipher
       ignore_missing: true
   - set:
+      tag: set_tls_cipher_d8c6958f
       field: tls.cipher
       copy_from: cloudflare_logpush.http_request.client.ssl.cipher
       ignore_empty_value: true
   - rename:
+      tag: rename_json_ClientSSLProtocol_to_cloudflare_logpush_http_request_client_ssl_protocol_146b34d6
       field: json.ClientSSLProtocol
       target_field: cloudflare_logpush.http_request.client.ssl.protocol
       ignore_missing: true
   - grok:
+      tag: grok_cloudflare_logpush_http_request_client_ssl_protocol_b064e6b1
       field: cloudflare_logpush.http_request.client.ssl.protocol
       patterns:
         - "^%{DATA:tls.version_protocol}v%{DATA:tls.version}$"
       ignore_missing: true
       ignore_failure: true
   - lowercase:
+      tag: lowercase_tls_version_protocol_b840a1f9
       field: tls.version_protocol
       ignore_missing: true
   - convert:
+      tag: convert_json_ClientSrcPort_to_cloudflare_logpush_http_request_client_src_port_1a19cb99
       field: json.ClientSrcPort
       target_field: cloudflare_logpush.http_request.client.src.port
       if: ctx.json?.ClientSrcPort != ''
@@ -501,9 +581,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9dc529f2
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_ClientTCPRTTMs_to_cloudflare_logpush_http_request_client_tcp_rtt_ms_d65b4e12
       field: json.ClientTCPRTTMs
       target_field: cloudflare_logpush.http_request.client.tcp_rtt.ms
       if: ctx.json?.ClientTCPRTTMs != ''
@@ -511,25 +593,31 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9c5dc0bd
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ClientXRequestedWith_to_cloudflare_logpush_http_request_client_xrequested_with_4fbd479f
       field: json.ClientXRequestedWith
       target_field: cloudflare_logpush.http_request.client.xrequested_with
       ignore_missing: true
   - rename:
+      tag: rename_json_Cookies_to_cloudflare_logpush_http_request_cookies_1ddf2546
       field: json.Cookies
       target_field: cloudflare_logpush.http_request.cookies
       ignore_missing: true
   - rename:
+      tag: rename_json_EdgeCFConnectingO2O_to_cloudflare_logpush_http_request_edge_cf_connecting_o2o_91472862
       field: json.EdgeCFConnectingO2O
       target_field: cloudflare_logpush.http_request.edge.cf_connecting_o2o
       ignore_missing: true
   - rename:
+      tag: rename_json_EdgeColoCode_to_cloudflare_logpush_http_request_edge_colo_code_78f5d638
       field: json.EdgeColoCode
       target_field: cloudflare_logpush.http_request.edge.colo.code
       ignore_missing: true
   - convert:
+      tag: convert_json_EdgeColoID_to_cloudflare_logpush_http_request_edge_colo_id_329b38d6
       field: json.EdgeColoID
       target_field: cloudflare_logpush.http_request.edge.colo.id
       if: ctx.json?.EdgeColoID != ''
@@ -537,25 +625,31 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3c76de3f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_EdgePathingOp_to_cloudflare_logpush_http_request_edge_pathing_op_d3b079a8
       field: json.EdgePathingOp
       target_field: cloudflare_logpush.http_request.edge.pathing.op
       ignore_missing: true
   - rename:
+      tag: rename_json_EdgePathingSrc_to_cloudflare_logpush_http_request_edge_pathing_src_247c1a48
       field: json.EdgePathingSrc
       target_field: cloudflare_logpush.http_request.edge.pathing.src
       ignore_missing: true
   - rename:
+      tag: rename_json_EdgePathingStatus_to_cloudflare_logpush_http_request_edge_pathing_status_efbc6d66
       field: json.EdgePathingStatus
       target_field: cloudflare_logpush.http_request.edge.pathing.status
       ignore_missing: true
   - rename:
+      tag: rename_json_EdgeRateLimitAction_to_cloudflare_logpush_http_request_edge_rate_limit_action_ee838a82
       field: json.EdgeRateLimitAction
       target_field: cloudflare_logpush.http_request.edge.rate.limit.action
       ignore_missing: true
   - convert:
+      tag: convert_json_EdgeRateLimitID_to_cloudflare_logpush_http_request_edge_rate_limit_id_6b98f73a
       field: json.EdgeRateLimitID
       target_field: cloudflare_logpush.http_request.edge.rate.limit.id
       if: ctx.json?.EdgeRateLimitID != ''
@@ -563,13 +657,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d5a2e35f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_EdgeRequestHost_to_cloudflare_logpush_http_request_edge_request_host_92a86166
       field: json.EdgeRequestHost
       target_field: cloudflare_logpush.http_request.edge.request.host
       ignore_missing: true
   - convert:
+      tag: convert_json_EdgeResponseBodyBytes_to_cloudflare_logpush_http_request_edge_response_body_bytes_a3f683b9
       field: json.EdgeResponseBodyBytes
       target_field: cloudflare_logpush.http_request.edge.response.body_bytes
       if: ctx.json?.EdgeResponseBodyBytes != ''
@@ -577,9 +674,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_21b4d334
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_EdgeResponseBytes_to_cloudflare_logpush_http_request_edge_response_bytes_ae183152
       field: json.EdgeResponseBytes
       target_field: cloudflare_logpush.http_request.edge.response.bytes
       if: ctx.json?.EdgeResponseBytes != ''
@@ -587,9 +686,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_cce99f2d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_EdgeResponseCompressionRatio_to_cloudflare_logpush_http_request_edge_response_compression_ratio_14ec9748
       field: json.EdgeResponseCompressionRatio
       target_field: cloudflare_logpush.http_request.edge.response.compression_ratio
       if: ctx.json?.EdgeResponseCompressionRatio != ''
@@ -597,9 +698,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6516a7eb
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_EdgeServerIP_to_cloudflare_logpush_http_request_edge_server_ip_4aaf36d3
       field: json.EdgeServerIP
       target_field: cloudflare_logpush.http_request.edge.server.ip
       if: ctx.json?.EdgeServerIP != ''
@@ -607,9 +710,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d4cb4b16
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_EdgeTimeToFirstByteMs_to_cloudflare_logpush_http_request_edge_time_to_first_byte_ms_c11ce527
       field: json.EdgeTimeToFirstByteMs
       target_field: cloudflare_logpush.http_request.edge.time_to_first_byte.ms
       if: ctx.json?.EdgeTimeToFirstByteMs != ''
@@ -617,48 +722,59 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2a65a986
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_SecurityActions_to_cloudflare_logpush_http_request_firewall_matches_action_5da10512
       field: json.SecurityActions
       target_field: cloudflare_logpush.http_request.firewall.matches.action
       ignore_missing: true
   - rename:
+      tag: rename_json_FirewallMatchesActions_to_cloudflare_logpush_http_request_firewall_matches_action_d95e64b7
       field: json.FirewallMatchesActions
       target_field: cloudflare_logpush.http_request.firewall.matches.action
       ignore_missing: true
       if: ctx.cloudflare_logpush?.http_request?.firewall?.matches?.action == null
   - rename:
+      tag: rename_json_SecurityRuleIDs_to_cloudflare_logpush_http_request_firewall_matches_rule_id_a6a1429b
       field: json.SecurityRuleIDs
       target_field: cloudflare_logpush.http_request.firewall.matches.rule_id
       ignore_missing: true
   - rename:
+      tag: rename_json_FirewallMatchesRuleIDs_to_cloudflare_logpush_http_request_firewall_matches_rule_id_e5128330
       field: json.FirewallMatchesRuleIDs
       target_field: cloudflare_logpush.http_request.firewall.matches.rule_id
       ignore_missing: true
       if: ctx.cloudflare_logpush?.http_request?.firewall?.matches?.rule_id == null
   - rename:
+      tag: rename_json_SecuritySources_to_cloudflare_logpush_http_request_firewall_matches_sources_3be8a2a9
       field: json.SecuritySources
       target_field: cloudflare_logpush.http_request.firewall.matches.sources
       ignore_missing: true
   - rename:
+      tag: rename_json_FirewallMatchesSources_to_cloudflare_logpush_http_request_firewall_matches_sources_4c6b7d3e
       field: json.FirewallMatchesSources
       target_field: cloudflare_logpush.http_request.firewall.matches.sources
       ignore_missing: true
       if: ctx.cloudflare_logpush?.http_request?.firewall?.matches?.sources == null
   - rename:
+      tag: rename_json_JA3Hash_to_cloudflare_logpush_http_request_ja3_hash_e226d5df
       field: json.JA3Hash
       target_field: cloudflare_logpush.http_request.ja3_hash
       ignore_missing: true
   - rename:
+      tag: rename_json_JA4_to_cloudflare_logpush_http_request_ja4_59bce106
       field: json.JA4
       target_field: cloudflare_logpush.http_request.ja4
       ignore_missing: true
   - rename:
+      tag: rename_json_JA4Signals_to_cloudflare_logpush_http_request_ja4_signals_d95118dd
       field: json.JA4Signals
       target_field: cloudflare_logpush.http_request.ja4_signals
       ignore_missing: true
   - convert:
+      tag: convert_json_OriginDNSResponseTimeMs_to_cloudflare_logpush_http_request_origin_dns_response_time_ms_d0100f64
       field: json.OriginDNSResponseTimeMs
       target_field: cloudflare_logpush.http_request.origin.dns_response_time.ms
       if: ctx.json?.OriginDNSResponseTimeMs != ''
@@ -666,9 +782,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2d0723c3
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_OriginRequestHeaderSendDurationMs_to_cloudflare_logpush_http_request_origin_request_header_send_duration_ms_b5c4844e
       field: json.OriginRequestHeaderSendDurationMs
       target_field: cloudflare_logpush.http_request.origin.request_header_send_duration.ms
       if: ctx.json?.OriginRequestHeaderSendDurationMs != ''
@@ -676,9 +794,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1555f28f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_OriginResponseBytes_to_cloudflare_logpush_http_request_origin_response_bytes_4252af5f
       field: json.OriginResponseBytes
       target_field: cloudflare_logpush.http_request.origin.response.bytes
       if: ctx.json?.OriginResponseBytes != ''
@@ -686,9 +806,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_54b816c8
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_OriginResponseDurationMs_to_cloudflare_logpush_http_request_origin_response_duration_ms_50a340a2
       field: json.OriginResponseDurationMs
       target_field: cloudflare_logpush.http_request.origin.response.duration.ms
       if: ctx.json?.OriginResponseDurationMs != ''
@@ -696,9 +818,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_360a085d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_OriginResponseHeaderReceiveDurationMs_to_cloudflare_logpush_http_request_origin_response_header_receive_duration_ms_10d61fbe
       field: json.OriginResponseHeaderReceiveDurationMs
       target_field: cloudflare_logpush.http_request.origin.response.header_receive_duration.ms
       if: ctx.json?.OriginResponseHeaderReceiveDurationMs != ''
@@ -706,9 +830,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e9a3c87f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_OriginResponseStatus_to_cloudflare_logpush_http_request_origin_response_status_ef757c92
       field: json.OriginResponseStatus
       target_field: cloudflare_logpush.http_request.origin.response.status
       if: ctx.json?.OriginResponseStatus != ''
@@ -716,9 +842,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1b820ed7
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_OriginResponseTime_to_cloudflare_logpush_http_request_origin_response_time_e009296b
       field: json.OriginResponseTime
       target_field: cloudflare_logpush.http_request.origin.response.time
       if: ctx.json?.OriginResponseTime != ''
@@ -726,13 +854,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_882e9482
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_OriginSSLProtocol_to_cloudflare_logpush_http_request_origin_ssl_protocol_beee50a5
       field: json.OriginSSLProtocol
       target_field: cloudflare_logpush.http_request.origin.ssl_protocol
       ignore_missing: true
   - convert:
+      tag: convert_json_OriginTCPHandshakeDurationMs_to_cloudflare_logpush_http_request_origin_tcp_handshake_duration_ms_03155549
       field: json.OriginTCPHandshakeDurationMs
       target_field: cloudflare_logpush.http_request.origin.tcp_handshake_duration.ms
       if: ctx.json?.OriginTCPHandshakeDurationMs != ''
@@ -740,9 +871,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b2114d08
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_OriginTLSHandshakeDurationMs_to_cloudflare_logpush_http_request_origin_tls_handshake_duration_ms_8519a42f
       field: json.OriginTLSHandshakeDurationMs
       target_field: cloudflare_logpush.http_request.origin.tls_handshake_duration.ms
       if: ctx.json?.OriginTLSHandshakeDurationMs != ''
@@ -750,33 +883,41 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_733eda06
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ParentRayID_to_cloudflare_logpush_http_request_parent_ray_id_f27e6a53
       field: json.ParentRayID
       target_field: cloudflare_logpush.http_request.parent_ray.id
       ignore_missing: true
   - rename:
+      tag: rename_json_RayID_to_cloudflare_logpush_http_request_ray_id_5aae985a
       field: json.RayID
       target_field: cloudflare_logpush.http_request.ray.id
       ignore_missing: true
   - set:
+      tag: set_event_id_a8495d8d
       field: event.id
       copy_from: cloudflare_logpush.http_request.ray.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_RequestHeaders_to_cloudflare_logpush_http_request_request_header_88514ca5
       field: json.RequestHeaders
       target_field: cloudflare_logpush.http_request.request.header
       ignore_missing: true
   - rename:
+      tag: rename_json_ResponseHeaders_to_cloudflare_logpush_http_request_response_header_a8900b0d
       field: json.ResponseHeaders
       target_field: cloudflare_logpush.http_request.response.header
       ignore_missing: true
   - rename:
+      tag: rename_json_SecurityLevel_to_cloudflare_logpush_http_request_security_level_b8abdf6d
       field: json.SecurityLevel
       target_field: cloudflare_logpush.http_request.security_level
       ignore_missing: true
   - convert:
+      tag: convert_json_SmartRouteColoID_to_cloudflare_logpush_http_request_smart_route_colo_id_9738fe1a
       field: json.SmartRouteColoID
       target_field: cloudflare_logpush.http_request.smart_route.colo.id
       if: ctx.json?.SmartRouteColoID != ''
@@ -784,9 +925,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_cf201011
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_UpperTierColoID_to_cloudflare_logpush_http_request_upper_tier_colo_id_72c67384
       field: json.UpperTierColoID
       target_field: cloudflare_logpush.http_request.upper_tier.colo.id
       if: ctx.json?.UpperTierColoID != ''
@@ -794,43 +937,53 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b0b5cabd
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_SecurityAction_to_cloudflare_logpush_http_request_waf_action_5e276a4c
       field: json.SecurityAction
       target_field: cloudflare_logpush.http_request.waf.action
       ignore_missing: true
   - rename:
+      tag: rename_json_WAFAction_to_cloudflare_logpush_http_request_waf_action_d16779f0
       field: json.WAFAction
       target_field: cloudflare_logpush.http_request.waf.action
       ignore_missing: true
       if: ctx.cloudflare_logpush?.http_request?.waf?.action == null
   - rename:
+      tag: rename_json_WAFFlags_to_cloudflare_logpush_http_request_waf_flag_f6f072ab
       field: json.WAFFlags
       target_field: cloudflare_logpush.http_request.waf.flag
       ignore_missing: true
   - rename:
+      tag: rename_json_WAFMatchedVar_to_cloudflare_logpush_http_request_waf_matched_var_d988df35
       field: json.WAFMatchedVar
       target_field: cloudflare_logpush.http_request.waf.matched_var
       ignore_missing: true
   - rename:
+      tag: rename_json_WAFProfile_to_cloudflare_logpush_http_request_waf_profile_2fd3fefe
       field: json.WAFProfile
       target_field: cloudflare_logpush.http_request.waf.profile
       ignore_missing: true
   - rename:
+      tag: rename_json_SecurityRuleID_to_cloudflare_logpush_http_request_waf_rule_id_a0ada520
       field: json.SecurityRuleID
       target_field: cloudflare_logpush.http_request.waf.rule.id
       ignore_missing: true
   - rename:
+      tag: rename_json_WAFRuleID_to_cloudflare_logpush_http_request_waf_rule_id_e3b580fa
       field: json.WAFRuleID
       target_field: cloudflare_logpush.http_request.waf.rule.id
       ignore_missing: true
       if: ctx.cloudflare_logpush?.http_request?.waf?.rule?.id == null
   - rename:
+      tag: rename_json_SecurityRuleDescription_to_cloudflare_logpush_http_request_waf_rule_message_8ceb7d17
       field: json.SecurityRuleDescription
       target_field: cloudflare_logpush.http_request.waf.rule.message
       ignore_missing: true
   - rename:
+      tag: rename_json_WAFRuleMessage_to_cloudflare_logpush_http_request_waf_rule_message_dbbafec4
       field: json.WAFRuleMessage
       target_field: cloudflare_logpush.http_request.waf.rule.message
       ignore_missing: true
@@ -844,6 +997,7 @@ processors:
       tag: convert_waf_score_global
       on_failure:
         - append:
+            tag: append_error_message_2be3f4ae
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
@@ -855,6 +1009,7 @@ processors:
       tag: convert_waf_score_rce
       on_failure:
         - append:
+            tag: append_error_message_a3dc0f30
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
@@ -866,6 +1021,7 @@ processors:
       tag: convert_waf_score_sqli
       on_failure:
         - append:
+            tag: append_error_message_f1147aa6
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
@@ -877,9 +1033,11 @@ processors:
       tag: convert_waf_score_xss
       on_failure:
         - append:
+            tag: append_error_message_f75c83a0
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_WorkerCPUTime_to_cloudflare_logpush_http_request_worker_cpu_time_8e836d9d
       field: json.WorkerCPUTime
       target_field: cloudflare_logpush.http_request.worker.cpu_time
       if: ctx.json?.WorkerCPUTime != ''
@@ -887,17 +1045,21 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_308a4c7e
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_WorkerStatus_to_cloudflare_logpush_http_request_worker_status_a56133c4
       field: json.WorkerStatus
       target_field: cloudflare_logpush.http_request.worker.status
       ignore_missing: true
   - rename:
+      tag: rename_json_WorkerSubrequest_to_cloudflare_logpush_http_request_worker_subrequest_value_d96f1113
       field: json.WorkerSubrequest
       target_field: cloudflare_logpush.http_request.worker.subrequest.value
       ignore_missing: true
   - convert:
+      tag: convert_json_WorkerSubrequestCount_to_cloudflare_logpush_http_request_worker_subrequest_count_108a2873
       field: json.WorkerSubrequestCount
       target_field: cloudflare_logpush.http_request.worker.subrequest.count
       if: ctx.json?.WorkerSubrequestCount != ''
@@ -905,9 +1067,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9393f194
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_WorkerWallTimeUs_to_cloudflare_logpush_http_request_worker_wall_time_us_ecfb12d0
       field: json.WorkerWallTimeUs
       target_field: cloudflare_logpush.http_request.worker.wall_time_us
       if: ctx.json?.WorkerWallTimeUs != ''
@@ -915,9 +1079,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b64b2c07
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_ZoneID_to_cloudflare_logpush_http_request_zone_id_b1a75554
       field: json.ZoneID
       target_field: cloudflare_logpush.http_request.zone.id
       if: ctx.json?.ZoneID != ''
@@ -925,75 +1091,92 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7728d8d3
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ZoneName_to_cloudflare_logpush_http_request_zone_name_21fed8d2
       field: json.ZoneName
       target_field: cloudflare_logpush.http_request.zone.name
       ignore_missing: true
   - rename:
+      tag: rename_json_FraudAttack_to_cloudflare_logpush_http_request_fraud_attack_8a45d67a
       field: json.FraudAttack
       target_field: cloudflare_logpush.http_request.fraud.attack
       ignore_missing: true
   - convert:
+      tag: convert_json_FraudDetectionIDs_to_cloudflare_logpush_http_request_fraud_detection_ids_fdb8be67
       field: json.FraudDetectionIDs
       target_field: cloudflare_logpush.http_request.fraud.detection_ids
       type: string
       ignore_missing: true
   - rename:
+      tag: rename_json_FraudDetectionTags_to_cloudflare_logpush_http_request_fraud_detection_tags_2dcf7c41
       field: json.FraudDetectionTags
       target_field: cloudflare_logpush.http_request.fraud.detection_tags
       ignore_missing: true
   - rename:
+      tag: rename_json_FraudEmailRisk_to_cloudflare_logpush_http_request_fraud_email_risk_1caf224b
       field: json.FraudEmailRisk
       target_field: cloudflare_logpush.http_request.fraud.email_risk
       ignore_missing: true
   - rename:
+      tag: rename_json_FraudUserID_to_cloudflare_logpush_http_request_fraud_user_id_eb218e7f
       field: json.FraudUserID
       target_field: cloudflare_logpush.http_request.fraud.user_id
       ignore_missing: true
   - rename:
+      tag: rename_json_JSDetectionPassed_to_cloudflare_logpush_http_request_js_detection_passed_09fbbdc6
       field: json.JSDetectionPassed
       target_field: cloudflare_logpush.http_request.js_detection_passed
       ignore_missing: true
   - rename:
+      tag: rename_json_PayPerCrawlStatus_to_cloudflare_logpush_http_request_pay_per_crawl_status_962677d5
       field: json.PayPerCrawlStatus
       target_field: cloudflare_logpush.http_request.pay_per_crawl_status
       ignore_missing: true
   - rename:
+      tag: rename_json_VerifiedBotCategory_to_cloudflare_logpush_http_request_verified_bot_category_286debc8
       field: json.VerifiedBotCategory
       target_field: cloudflare_logpush.http_request.verified_bot_category
       ignore_missing: true
   - rename:
+      tag: rename_json_WebAssetsLabelsManaged_to_cloudflare_logpush_http_request_web_assets_labels_managed_681f6654
       field: json.WebAssetsLabelsManaged
       target_field: cloudflare_logpush.http_request.web_assets.labels_managed
       ignore_missing: true
   - rename:
+      tag: rename_json_WebAssetsOperationID_to_cloudflare_logpush_http_request_web_assets_operation_id_d3e3500e
       field: json.WebAssetsOperationID
       target_field: cloudflare_logpush.http_request.web_assets.operation_id
       ignore_missing: true
   - rename:
+      tag: rename_json_WorkerScriptName_to_cloudflare_logpush_http_request_worker_script_name_a6f79051
       field: json.WorkerScriptName
       target_field: cloudflare_logpush.http_request.worker.script_name
       ignore_missing: true
   - append:
+      tag: append_related_user_7ed39041
       field: related.user
       value: '{{{cloudflare_logpush.http_request.fraud.user_id}}}'
       if: ctx.cloudflare_logpush?.http_request?.fraud?.user_id != null
       allow_duplicates: false
   - append:
+      tag: append_related_hash_f60c2bde
       field: related.hash
       value: '{{{cloudflare_logpush.http_request.ja3_hash}}}'
       if: ctx.cloudflare_logpush?.http_request?.ja3_hash != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_30d15214
       field: related.ip
       value: '{{{source.ip}}}'
       if: ctx.source?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_51dd17d0
       field: related.ip
       value: '{{{destination.ip}}}'
       if: ctx.destination?.ip != null
@@ -1006,6 +1189,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_05224ab7
       field:
         - cloudflare_logpush.http_request.origin.ip
         - cloudflare_logpush.http_request.client.request.method
@@ -1020,6 +1204,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |

--- a/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
@@ -88,7 +88,7 @@ processors:
       copy_from: "@timestamp"
       tag: set_timestamp
 
-# Handle destination IP and port
+  # Handle destination IP and port
   - convert:
       field: json.DestinationIP
       tag: convert_destinationip_to_ip
@@ -98,6 +98,7 @@ processors:
       if: ctx.json?.DestinationIP != ''
       on_failure:
         - append:
+            tag: append_error_message_263745d1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -137,6 +138,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_cb8ac72d
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -145,7 +147,7 @@ processors:
       ignore_empty_value: true
       tag: set_destination_port
 
-# Handle source IP and port
+  # Handle source IP and port
   - convert:
       field: json.SourceIP
       tag: convert_sourceip_to_ip
@@ -155,6 +157,7 @@ processors:
       if: ctx.json?.SourceIP != ''
       on_failure:
         - append:
+            tag: append_error_message_f9692ba1
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -194,6 +197,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b05d4b82
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:

--- a/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
@@ -28,7 +28,7 @@ processors:
       tag: set_event_kind
   - set:
       field: event.category
-      value: 
+      value:
          - network
          - intrusion_detection
       tag: set_event_category
@@ -36,9 +36,9 @@ processors:
       field: event.type
       value: [info]
       tag: set_event_type
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -47,7 +47,7 @@ processors:
         must be removed.
       if: ctx._conf?.enable_deduplication == false && ctx.input?.type == 'aws-s3'
       ignore_missing: true
-# Timestamp
+  # Timestamp
   - script:
       lang: painless
       tag: painless_timestamp_to_milli
@@ -80,6 +80,7 @@ processors:
       tag: date_event_timestamp
       on_failure:
       - append:
+          tag: append_error_message_38394fec
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
@@ -87,7 +88,7 @@ processors:
       copy_from: "@timestamp"
       tag: set_timestamp
 
-# Handle destination IP and port
+  # Handle destination IP and port
   - rename:
       field: json.DestinationIP
       target_field: cloudflare_logpush.magic_ids.destination.ip
@@ -98,7 +99,7 @@ processors:
       copy_from: cloudflare_logpush.magic_ids.destination.ip
       ignore_empty_value: true
       tag: set_destination_ip
-# Geo enrichment (destination IP)
+  # Geo enrichment (destination IP)
   - geoip:
       field: destination.ip
       target_field: destination.geo
@@ -133,7 +134,7 @@ processors:
       ignore_empty_value: true
       tag: set_destination_port
 
-# Handle source IP and port
+  # Handle source IP and port
   - rename:
       field: json.SourceIP
       target_field: cloudflare_logpush.magic_ids.source.ip
@@ -144,7 +145,7 @@ processors:
       copy_from: cloudflare_logpush.magic_ids.source.ip
       ignore_empty_value: true
       tag: set_source_ip
-# Geo enrichment (source IP)
+  # Geo enrichment (source IP)
   - geoip:
       field: source.ip
       target_field: source.geo
@@ -213,7 +214,7 @@ processors:
        if: ctx.event?.action == 'block'
        tag: append_event_type_block
 
-# Custom fields
+  # Custom fields
   - rename:
       field: json.ColoCode
       target_field: cloudflare_logpush.magic_ids.colo.code
@@ -240,7 +241,7 @@ processors:
       ignore_missing: true
       tag: rename_signature_revision
 
-# Create related fields
+  # Create related fields
   - append:
       field: related.ip
       value: '{{{destination.ip}}}'
@@ -254,7 +255,7 @@ processors:
       allow_duplicates: false
       tag: append_related_source_ip
 
-# Clean resulting event
+  # Clean resulting event
   - remove:
       tag: remove_json_conf
       field:

--- a/packages/cloudflare_logpush/data_stream/nel_report/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare NEL Report logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Timestamp_772fbe7f
       field: json.Timestamp
       if: ctx.json?.Timestamp != null && ctx.json.Timestamp != ''
       formats:
@@ -72,21 +78,26 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_2e342a9c
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_nel_report_timestamp_26266fd5
       field: cloudflare_logpush.nel_report.timestamp
       copy_from: '@timestamp'
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Type_to_cloudflare_logpush_nel_report_error_type_7eb310ae
       field: json.Type
       target_field: cloudflare_logpush.nel_report.error.type
       ignore_missing: true
   - set:
+      tag: set_error_type_147e9bbb
       field: error.type
       copy_from: cloudflare_logpush.nel_report.error.type
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientIPASN_to_cloudflare_logpush_nel_report_client_ip_asn_value_300a6be2
       field: json.ClientIPASN
       target_field: cloudflare_logpush.nel_report.client.ip.asn.value
       if: ctx.json?.ClientIPASN != ''
@@ -94,21 +105,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bdef4019
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ClientIPASNDescription_to_cloudflare_logpush_nel_report_client_ip_asn_description_263da4c2
       field: json.ClientIPASNDescription
       target_field: cloudflare_logpush.nel_report.client.ip.asn.description
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientIPCountry_to_cloudflare_logpush_nel_report_client_ip_country_6c2f728a
       field: json.ClientIPCountry
       target_field: cloudflare_logpush.nel_report.client.ip.country
       ignore_missing: true
   - rename:
+      tag: rename_json_LastKnownGoodColoCode_to_cloudflare_logpush_nel_report_last_known_good_colo_code_5bab09a8
       field: json.LastKnownGoodColoCode
       target_field: cloudflare_logpush.nel_report.last_known_good.colo.code
       ignore_missing: true
   - rename:
+      tag: rename_json_Phase_to_cloudflare_logpush_nel_report_phase_5a53d486
       field: json.Phase
       target_field: cloudflare_logpush.nel_report.phase
       ignore_missing: true
@@ -119,6 +135,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_2bb47153
       field:
         - cloudflare_logpush.nel_report.timestamp
         - cloudflare_logpush.nel_report.error.type
@@ -126,6 +143,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |

--- a/packages/cloudflare_logpush/data_stream/network_analytics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Network Analytics logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Datetime_5886cebc
       field: json.Datetime
       if: ctx.json?.Datetime != null && ctx.json.Datetime != ''
       formats:
@@ -72,21 +78,26 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_da98a171
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_network_analytics_timestamp_5d354fd6
       field: cloudflare_logpush.network_analytics.timestamp
       copy_from: '@timestamp'
       ignore_empty_value: true
   - set:
+      tag: set_cloudflare_logpush_network_analytics_outcome_4476b418
       field: cloudflare_logpush.network_analytics.outcome
       value: success
       if: ctx.json?.Outcome == 'pass'
   - set:
+      tag: set_cloudflare_logpush_network_analytics_outcome_cfd333fb
       field: cloudflare_logpush.network_analytics.outcome
       value: failure
       if: ctx.json?.Outcome == 'drop'
   - set:
+      tag: set_event_outcome_61f32c56
       field: event.outcome
       copy_from: cloudflare_logpush.network_analytics.outcome
       ignore_empty_value: true
@@ -99,10 +110,12 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6fed3df1
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_destination_as_number_d9408f17
       field: destination.as.number
       copy_from: cloudflare_logpush.network_analytics.destination.asn
       ignore_empty_value: true
@@ -115,10 +128,12 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b07c157a
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_destination_ip_84cf708a
       field: destination.ip
       copy_from: cloudflare_logpush.network_analytics.destination.ip
       ignore_empty_value: true
@@ -131,30 +146,37 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7a6d8e95
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_destination_port_3c5d6b46
       field: destination.port
       copy_from: cloudflare_logpush.network_analytics.destination.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Direction_to_cloudflare_logpush_network_analytics_direction_cbfd61b5
       field: json.Direction
       target_field: cloudflare_logpush.network_analytics.direction
       ignore_missing: true
   - set:
+      tag: set_network_direction_21150cc8
       field: network.direction
       copy_from: cloudflare_logpush.network_analytics.direction
       ignore_empty_value: true
   - rename:
+      tag: rename_json_IPProtocolName_to_cloudflare_logpush_network_analytics_ip_protocol_name_1e143b25
       field: json.IPProtocolName
       target_field: cloudflare_logpush.network_analytics.ip.protocol.name
       ignore_missing: true
   - set:
+      tag: set_network_transport_90b70a4d
       field: network.transport
       copy_from: cloudflare_logpush.network_analytics.ip.protocol.name
       ignore_empty_value: true
   - lowercase:
+      tag: lowercase_network_transport_bc8c1c12
       field: network.transport
       ignore_missing: true
   - convert:
@@ -166,10 +188,12 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_25034cae
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_source_ip_a7297980
       field: source.ip
       copy_from: cloudflare_logpush.network_analytics.source.ip
       ignore_empty_value: true
@@ -182,10 +206,12 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2dfdb20b
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_source_as_number_3022b95d
       field: source.as.number
       copy_from: cloudflare_logpush.network_analytics.source.asn
       ignore_empty_value: true
@@ -198,50 +224,62 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a9852f97
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - set:
+      tag: set_source_port_7623a0b8
       field: source.port
       copy_from: cloudflare_logpush.network_analytics.source.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_RuleID_to_cloudflare_logpush_network_analytics_rule_id_2b8c6abd
       field: json.RuleID
       target_field: cloudflare_logpush.network_analytics.rule.id
       ignore_missing: true
   - set:
+      tag: set_rule_id_5728b9d8
       field: rule.id
       copy_from: cloudflare_logpush.network_analytics.rule.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_AttackCampaignID_to_cloudflare_logpush_network_analytics_attack_campaign_id_472be873
       field: json.AttackCampaignID
       target_field: cloudflare_logpush.network_analytics.attack.campaign.id
       ignore_missing: true
   - rename:
+      tag: rename_json_AttackID_to_cloudflare_logpush_network_analytics_attack_id_3d175e85
       field: json.AttackID
       target_field: cloudflare_logpush.network_analytics.attack.id
       ignore_missing: true
   - rename:
+      tag: rename_json_AttackVector_to_cloudflare_logpush_network_analytics_attack_vector_ee323f41
       field: json.AttackVector
       target_field: cloudflare_logpush.network_analytics.attack.vector
       ignore_missing: true
   - rename:
+      tag: rename_json_ColoCity_to_cloudflare_logpush_network_analytics_colo_city_a53dc7a7
       field: json.ColoCity
       target_field: cloudflare_logpush.network_analytics.colo.city
       ignore_missing: true
   - rename:
+      tag: rename_json_ColoCode_to_cloudflare_logpush_network_analytics_colo_code_c7a63d3b
       field: json.ColoCode
       target_field: cloudflare_logpush.network_analytics.colo.code
       ignore_missing: true
   - rename:
+      tag: rename_json_ColoCountry_to_cloudflare_logpush_network_analytics_colo_country_d6750495
       field: json.ColoCountry
       target_field: cloudflare_logpush.network_analytics.colo.country
       ignore_missing: true
   - rename:
+      tag: rename_json_ColoGeoHash_to_cloudflare_logpush_network_analytics_colo_geo_hash_f884fb06
       field: json.ColoGeoHash
       target_field: cloudflare_logpush.network_analytics.colo.geo_hash
       ignore_missing: true
   - set:
+      tag: set_cloudflare_logpush_network_analytics_colo_geo_location_6969330e
       field: cloudflare_logpush.network_analytics.colo.geo_location
       copy_from: cloudflare_logpush.network_analytics.colo.geo_hash
       ignore_empty_value: true
@@ -254,30 +292,37 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_56fee3b7
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_ColoName_to_cloudflare_logpush_network_analytics_colo_name_4eba22ef
       field: json.ColoName
       target_field: cloudflare_logpush.network_analytics.colo.name
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationASNDescription_to_cloudflare_logpush_network_analytics_destination_as_number_description_6c53e992
       field: json.DestinationASNDescription
       target_field: cloudflare_logpush.network_analytics.destination.as.number.description
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationASNName_to_cloudflare_logpush_network_analytics_destination_as_number_name_f0a751ba
       field: json.DestinationASNName
       target_field: cloudflare_logpush.network_analytics.destination.as.number.name
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationCountry_to_cloudflare_logpush_network_analytics_destination_country_41b25d39
       field: json.DestinationCountry
       target_field: cloudflare_logpush.network_analytics.destination.country
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationGeoHash_to_cloudflare_logpush_network_analytics_destination_geo_hash_3760770c
       field: json.DestinationGeoHash
       target_field: cloudflare_logpush.network_analytics.destination.geo_hash
       ignore_missing: true
   - set:
+      tag: set_cloudflare_logpush_network_analytics_destination_geo_location_7feda026
       field: cloudflare_logpush.network_analytics.destination.geo_location
       copy_from: cloudflare_logpush.network_analytics.destination.geo_hash
       ignore_empty_value: true
@@ -290,6 +335,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b8840269
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -302,6 +348,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_20f5cc9d
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -314,6 +361,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_94caddbd
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -326,6 +374,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f9e7fa1c
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -338,6 +387,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5e3f94f4
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -350,6 +400,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_56ff7487
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -362,6 +413,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e8bfc131
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -374,6 +426,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8d15e17f
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -386,6 +439,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_67269d93
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -398,10 +452,12 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0fc0a20b
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPDestinationSubnet_to_cloudflare_logpush_network_analytics_ip_destination_subnet_82888579
       field: json.IPDestinationSubnet
       target_field: cloudflare_logpush.network_analytics.ip.destination.subnet
       ignore_missing: true
@@ -414,6 +470,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1e290dd6
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -426,6 +483,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2a3696da
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -438,6 +496,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d3f7abb8
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -450,10 +509,12 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_da0b2506
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPSourceSubnet_to_cloudflare_logpush_network_analytics_ip_source_subnet_a13f22f5
       field: json.IPSourceSubnet
       target_field: cloudflare_logpush.network_analytics.ip.source.subnet
       ignore_missing: true
@@ -466,6 +527,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b0b3717f
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -478,20 +540,24 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ad6b2e89
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPTTL_to_cloudflare_logpush_network_analytics_ip_ttl_value_a7e5501d
       field: json.IPTTL
       target_field: cloudflare_logpush.network_analytics.ip.ttl.value
       if: ctx.json?.IPTTL != null && ctx.json.IPTTL != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_ip_ttl_value_118eaadb
       field: cloudflare_logpush.network_analytics.ip.ttl.value
       value: '{{{json.IPTtl}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.ip?.ttl?.value != null && ctx.json?.IPTtl != null && ctx.json.IPTtl != '' && ctx.json.IPTtl != ctx.cloudflare_logpush.network_analytics.ip.ttl.value
       allow_duplicates: false
   - rename:
+      tag: rename_json_IPTtl_to_cloudflare_logpush_network_analytics_ip_ttl_value_5661224a
       field: json.IPTtl
       target_field: cloudflare_logpush.network_analytics.ip.ttl.value
       if: ctx.cloudflare_logpush?.network_analytics?.ip?.ttl?.value == null && ctx.json?.IPTtl != null && ctx.json.IPTtl != ''
@@ -504,20 +570,24 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_23f4280c
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPTTLBuckets_to_cloudflare_logpush_network_analytics_ip_ttl_buckets_a9999f1a
       field: json.IPTTLBuckets
       target_field: cloudflare_logpush.network_analytics.ip.ttl.buckets
       if: ctx.json?.IPTTLBuckets != null && ctx.json.IPTTLBuckets != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_ip_ttl_buckets_36d32073
       field: cloudflare_logpush.network_analytics.ip.ttl.buckets
       value: '{{{json.IPTtlBuckets}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.ip?.ttl?.buckets != null && ctx.json?.IPTtlBuckets != null && ctx.json.IPTtlBuckets != '' && ctx.json.IPTtlBuckets != ctx.cloudflare_logpush.network_analytics.ip.ttl.buckets
       allow_duplicates: false
   - rename:
+      tag: rename_json_IPTtlBuckets_to_cloudflare_logpush_network_analytics_ip_ttl_buckets_1321b5b5
       field: json.IPTtlBuckets
       target_field: cloudflare_logpush.network_analytics.ip.ttl.buckets
       if: ctx.cloudflare_logpush?.network_analytics?.ip?.ttl?.buckets == null && ctx.json?.IPTtlBuckets != null && ctx.json.IPTtlBuckets != ''
@@ -530,6 +600,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6ac74af4
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -542,6 +613,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fc7a5e0b
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -554,20 +626,24 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e48616c3
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPv4DSCP_to_cloudflare_logpush_network_analytics_ipv4_dscp_d9a537ca
       field: json.IPv4DSCP
       target_field: cloudflare_logpush.network_analytics.ipv4.dscp
       if: ctx.json?.IPv4DSCP != null && ctx.json.IPv4DSCP != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_ipv4_dscp_f86dedeb
       field: cloudflare_logpush.network_analytics.ipv4.dscp
       value: '{{{json.IPv4Dscp}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.ipv4?.dscp != null && ctx.json?.IPv4Dscp != null && ctx.json.IPv4Dscp != '' && ctx.json.IPv4Dscp != ctx.cloudflare_logpush.network_analytics.ipv4.dscp
       allow_duplicates: false
   - rename:
+      tag: rename_json_IPv4Dscp_to_cloudflare_logpush_network_analytics_ipv4_dscp_59bdb9b1
       field: json.IPv4Dscp
       target_field: cloudflare_logpush.network_analytics.ipv4.dscp
       if: ctx.cloudflare_logpush?.network_analytics?.ipv4?.dscp == null && ctx.json?.IPv4Dscp != null && ctx.json.IPv4Dscp != ''
@@ -580,20 +656,24 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7f3f5fce
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPv4ECN_to_cloudflare_logpush_network_analytics_ipv4_ecn_f6376678
       field: json.IPv4ECN
       target_field: cloudflare_logpush.network_analytics.ipv4.ecn
       if: ctx.json?.IPv4ECN != null && ctx.json.IPv4ECN != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_ipv4_ecn_e639006d
       field: cloudflare_logpush.network_analytics.ipv4.ecn
       value: '{{{json.IPv4Ecn}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.ipv4?.ecn != null && ctx.json?.IPv4Ecn != null && ctx.json.IPv4Ecn != '' && ctx.json.IPv4Ecn != ctx.cloudflare_logpush.network_analytics.ipv4.ecn
       allow_duplicates: false
   - rename:
+      tag: rename_json_IPv4Ecn_to_cloudflare_logpush_network_analytics_ipv4_ecn_e9c2129f
       field: json.IPv4Ecn
       target_field: cloudflare_logpush.network_analytics.ipv4.ecn
       if: ctx.cloudflare_logpush?.network_analytics?.ipv4?.ecn == null && ctx.json?.IPv4Ecn != null && ctx.json.IPv4Ecn != ''
@@ -606,6 +686,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fa047d46
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -618,6 +699,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c63f0b6f
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -630,20 +712,24 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e6dbb0e3
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPv6DSCP_to_cloudflare_logpush_network_analytics_ipv6_dscp_29df8bce
       field: json.IPv6DSCP
       target_field: cloudflare_logpush.network_analytics.ipv6.dscp
       if: ctx.json?.IPv6DSCP != null && ctx.json.IPv6DSCP != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_ipv6_dscp_c6b9d3f9
       field: cloudflare_logpush.network_analytics.ipv6.dscp
       value: '{{{json.IPv6Dscp}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.ipv6?.dscp != null && ctx.json?.IPv6Dscp != null && ctx.json.IPv6Dscp != '' && ctx.json.IPv6Dscp != ctx.cloudflare_logpush.network_analytics.ipv6.dscp
       allow_duplicates: false
   - rename:
+      tag: rename_json_IPv6Dscp_to_cloudflare_logpush_network_analytics_ipv6_dscp_9377b07f
       field: json.IPv6Dscp
       target_field: cloudflare_logpush.network_analytics.ipv6.dscp
       if: ctx.cloudflare_logpush?.network_analytics?.ipv6?.dscp == null && ctx.json?.IPv6Dscp != null && ctx.json.IPv6Dscp != ''
@@ -656,20 +742,24 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e7390c1a
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPv6ECN_to_cloudflare_logpush_network_analytics_ipv6_ecn_7091f9d8
       field: json.IPv6ECN
       target_field: cloudflare_logpush.network_analytics.ipv6.ecn
       if: ctx.json?.IPv6ECN != null && ctx.json.IPv6ECN != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_ipv6_ecn_8abd78a3
       field: cloudflare_logpush.network_analytics.ipv6.ecn
       value: '{{{json.IPv6Ecn}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.ipv6?.ecn != null && ctx.json?.IPv6Ecn != null && ctx.json.IPv6Ecn != '' && ctx.json.IPv6Ecn != ctx.cloudflare_logpush.network_analytics.ipv6.ecn
       allow_duplicates: false
   - rename:
+      tag: rename_json_IPv6Ecn_to_cloudflare_logpush_network_analytics_ipv6_ecn_7256fda5
       field: json.IPv6Ecn
       target_field: cloudflare_logpush.network_analytics.ipv6.ecn
       if: ctx.cloudflare_logpush?.network_analytics?.ipv6?.ecn == null && ctx.json?.IPv6Ecn != null && ctx.json.IPv6Ecn != ''
@@ -682,10 +772,12 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d4c6526e
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_IPv6ExtensionHeaders_to_cloudflare_logpush_network_analytics_ipv6_extension_headers_cdd8e128
       field: json.IPv6ExtensionHeaders
       target_field: cloudflare_logpush.network_analytics.ipv6.extension_headers
       ignore_missing: true
@@ -698,6 +790,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5836c8e3
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -710,34 +803,42 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_252080b3
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_MitigationReason_to_cloudflare_logpush_network_analytics_mitigation_reason_59208f9b
       field: json.MitigationReason
       target_field: cloudflare_logpush.network_analytics.mitigation.reason
       ignore_missing: true
   - rename:
+      tag: rename_json_MitigationScope_to_cloudflare_logpush_network_analytics_mitigation_scope_6d29f385
       field: json.MitigationScope
       target_field: cloudflare_logpush.network_analytics.mitigation.scope
       ignore_missing: true
   - rename:
+      tag: rename_json_MitigationSystem_to_cloudflare_logpush_network_analytics_mitigation_system_0ac311db
       field: json.MitigationSystem
       target_field: cloudflare_logpush.network_analytics.mitigation.system
       ignore_missing: true
   - rename:
+      tag: rename_json_ProtocolState_to_cloudflare_logpush_network_analytics_protocol_state_1e631304
       field: json.ProtocolState
       target_field: cloudflare_logpush.network_analytics.protocol_state
       ignore_missing: true
   - rename:
+      tag: rename_json_RuleName_to_cloudflare_logpush_network_analytics_rule_name_4d8b0585
       field: json.RuleName
       target_field: cloudflare_logpush.network_analytics.rule.name
       ignore_missing: true
   - rename:
+      tag: rename_json_RulesetID_to_cloudflare_logpush_network_analytics_rule_set_id_ce25cb79
       field: json.RulesetID
       target_field: cloudflare_logpush.network_analytics.rule.set.id
       ignore_missing: true
   - rename:
+      tag: rename_json_RulesetOverrideID_to_cloudflare_logpush_network_analytics_rule_set_override_id_eee4e7fb
       field: json.RulesetOverrideID
       target_field: cloudflare_logpush.network_analytics.rule.set.override.id
       ignore_missing: true
@@ -750,26 +851,32 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a7f59d86
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_SourceASNName_to_cloudflare_logpush_network_analytics_source_as_number_name_b995e894
       field: json.SourceASNName
       target_field: cloudflare_logpush.network_analytics.source.as.number.name
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceASNDescription_to_cloudflare_logpush_network_analytics_source_as_number_description_b4edf388
       field: json.SourceASNDescription
       target_field: cloudflare_logpush.network_analytics.source.as.number.description
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceCountry_to_cloudflare_logpush_network_analytics_source_country_ffe895c9
       field: json.SourceCountry
       target_field: cloudflare_logpush.network_analytics.source.country
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceGeoHash_to_cloudflare_logpush_network_analytics_source_geo_hash_1f37e21e
       field: json.SourceGeoHash
       target_field: cloudflare_logpush.network_analytics.source.geo_hash
       ignore_missing: true
   - set:
+      tag: set_cloudflare_logpush_network_analytics_source_geo_location_d48297d2
       field: cloudflare_logpush.network_analytics.source.geo_location
       copy_from: cloudflare_logpush.network_analytics.source.geo_hash
       ignore_empty_value: true
@@ -782,6 +889,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_40337db1
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -794,6 +902,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b7f3ee91
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -806,6 +915,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bdbbdf96
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -818,24 +928,29 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_66f99dac
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_TCPFlagsString_to_cloudflare_logpush_network_analytics_tcp_flags_string_df4680fd
       field: json.TCPFlagsString
       target_field: cloudflare_logpush.network_analytics.tcp.flags.string
       ignore_missing: true
   - rename:
+      tag: rename_json_TCPMSS_to_cloudflare_logpush_network_analytics_tcp_mss_f53c9bd6
       field: json.TCPMSS
       target_field: cloudflare_logpush.network_analytics.tcp.mss
       if: ctx.json?.TCPMSS != null && ctx.json.TCPMSS != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_tcp_mss_33576750
       field: cloudflare_logpush.network_analytics.tcp.mss
       value: '{{{json.TCPMss}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.tcp?.mss != null && ctx.json?.TCPMss != null && ctx.json.TCPMss != '' && ctx.json.TCPMss != ctx.cloudflare_logpush.network_analytics.tcp.mss
       allow_duplicates: false
   - rename:
+      tag: rename_json_TCPMss_to_cloudflare_logpush_network_analytics_tcp_mss_2b90b11c
       field: json.TCPMss
       target_field: cloudflare_logpush.network_analytics.tcp.mss
       if: ctx.cloudflare_logpush?.network_analytics?.tcp?.mss == null && ctx.json?.TCPMss != null && ctx.json.TCPMss != ''
@@ -848,18 +963,22 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e4a4fc5e
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_TCPOptions_to_cloudflare_logpush_network_analytics_tcp_options_0cd59237
       field: json.TCPOptions
       target_field: cloudflare_logpush.network_analytics.tcp.options
       ignore_missing: true
   - split:
+      tag: split_json_TCPSACKBlocks_e086a612
       field: json.TCPSACKBlocks
       separator: ', *'
       if: ctx.json?.TCPSACKBlocks instanceof String && ctx.json.TCPSACKBlocks != ''
   - split:
+      tag: split_json_TCPSackBlocks_42519872
       field: json.TCPSackBlocks
       separator: ', *'
       if: ctx.json?.TCPSackBlocks instanceof String && ctx.json.TCPSackBlocks != ''
@@ -874,9 +993,11 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_3b61f5c9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_TCPSACKBlocks_to_cloudflare_logpush_network_analytics_tcp_sack_blocks_fce9ee1d
       field: json.TCPSACKBlocks
       target_field: cloudflare_logpush.network_analytics.tcp.sack.blocks
       ignore_missing: true
@@ -897,20 +1018,24 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_889a83e6
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_TCPSACKPermitted_to_cloudflare_logpush_network_analytics_tcp_sack_permitted_324342d0
       field: json.TCPSACKPermitted
       target_field: cloudflare_logpush.network_analytics.tcp.sack.permitted
       if: ctx.json?.TCPSACKPermitted != null && ctx.json.TCPSACKPermitted != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_tcp_sack_permitted_b734c4b6
       field: cloudflare_logpush.network_analytics.tcp.sack.permitted
       value: '{{{json.TCPSacksPermitted}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.tcp?.sack?.permitted != null && ctx.json?.TCPSacksPermitted != null && ctx.json.TCPSacksPermitted != '' && ctx.json.TCPSacksPermitted != ctx.cloudflare_logpush.network_analytics.tcp.sack.permitted
       allow_duplicates: false
   - rename:
+      tag: rename_json_TCPSacksPermitted_to_cloudflare_logpush_network_analytics_tcp_sack_permitted_b2646965
       field: json.TCPSacksPermitted
       target_field: cloudflare_logpush.network_analytics.tcp.sack.permitted
       if: ctx.cloudflare_logpush?.network_analytics?.tcp?.sack?.permitted == null && ctx.json?.TCPSacksPermitted != null && ctx.json.TCPSacksPermitted != ''
@@ -923,6 +1048,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0492955a
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -935,20 +1061,24 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0b4a34e5
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_TCPTimestampECR_to_cloudflare_logpush_network_analytics_tcp_timestamp_ecr_b92c89a2
       field: json.TCPTimestampECR
       target_field: cloudflare_logpush.network_analytics.tcp.timestamp.ecr
       if: ctx.json?.TCPTimestampECR != null && ctx.json.TCPTimestampECR != ''
       ignore_missing: true
   - append:
+      tag: append_cloudflare_logpush_network_analytics_tcp_timestamp_ecr_e0048eae
       field: cloudflare_logpush.network_analytics.tcp.timestamp.ecr
       value: '{{{json.TCPTimestampEcr}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.tcp?.timestamp?.ecr != null && ctx.json?.TCPTimestampEcr != null && ctx.json.TCPTimestampEcr != '' && ctx.json.TCPTimestampEcr != ctx.cloudflare_logpush.network_analytics.tcp.timestamp.ecr
       allow_duplicates: false
   - rename:
+      tag: rename_json_TCPTimestampEcr_to_cloudflare_logpush_network_analytics_tcp_timestamp_ecr_7cf8e2a0
       field: json.TCPTimestampEcr
       target_field: cloudflare_logpush.network_analytics.tcp.timestamp.ecr
       if: ctx.cloudflare_logpush?.network_analytics?.tcp?.timestamp?.ecr == null && ctx.json?.TCPTimestampEcr != null && ctx.json.TCPTimestampEcr != ''
@@ -961,6 +1091,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1e5ad762
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -973,6 +1104,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1b4d9258
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -985,6 +1117,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_765ad76b
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -997,6 +1130,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_51371744
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -1009,6 +1143,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ff56e1f2
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -1021,6 +1156,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d6313995
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -1033,70 +1169,84 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_708a2da3
             field: error.message
             value: |-
               Processor "{{{ _ingest.on_failure_processor_type }}}" with tag {{{_ingest.on_failure_processor_tag}}} in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
   - rename:
+      tag: rename_json_Verdict_to_cloudflare_logpush_network_analytics_verdict_78867681
       field: json.Verdict
       target_field: cloudflare_logpush.network_analytics.verdict
       ignore_missing: true
   - rename:
+      tag: rename_json_DNSQueryName_to_cloudflare_logpush_network_analytics_dns_query_name_edc75b81
       field: json.DNSQueryName
       target_field: cloudflare_logpush.network_analytics.dns.query.name
       ignore_missing: true
   - set:
+      tag: set_dns_question_name_7a289c62
       field: dns.question.name
       copy_from: cloudflare_logpush.network_analytics.dns.query.name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DNSQueryType_to_cloudflare_logpush_network_analytics_dns_query_type_37315fd3
       field: json.DNSQueryType
       target_field: cloudflare_logpush.network_analytics.dns.query.type
       ignore_missing: true
   - set:
+      tag: set_dns_question_type_83f01ece
       field: dns.question.type
       copy_from: cloudflare_logpush.network_analytics.dns.query.type
       ignore_empty_value: true
   - convert:
+      tag: convert_json_PFPCustomTag_to_cloudflare_logpush_network_analytics_pfp_custom_tag_f32b77ed
       field: json.PFPCustomTag
       target_field: cloudflare_logpush.network_analytics.pfp_custom_tag
       type: string
       ignore_missing: true
   - append:
+      tag: append_related_hosts_87ec35de
       field: related.hosts
       value: '{{{cloudflare_logpush.network_analytics.dns.query.name}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.dns?.query?.name != null
       allow_duplicates: false
   - append:
+      tag: append_related_hash_5d1e3fe7
       field: related.hash
       value: '{{{cloudflare_logpush.network_analytics.source.geo_hash}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.source?.geo_hash != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_hash_2b7befbd
       field: related.hash
       value: '{{{cloudflare_logpush.network_analytics.destination.geo_hash}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.destination?.geo_hash != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_hash_4269df8f
       field: related.hash
       value: '{{{cloudflare_logpush.network_analytics.colo.geo_hash}}}'
       if: ctx.cloudflare_logpush?.network_analytics?.colo?.geo_hash != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_30d15214
       field: related.ip
       value: '{{{source.ip}}}'
       if: ctx.source?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_51dd17d0
       field: related.ip
       value: '{{{destination.ip}}}'
       if: ctx.destination?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - community_id:
+      tag: community_id_d2308e7a
       target_field: network.community_id
       ignore_failure: true
   - remove:
@@ -1106,6 +1256,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_488fb31a
       field:
         - cloudflare_logpush.network_analytics.timestamp
         - cloudflare_logpush.network_analytics.outcome
@@ -1124,6 +1275,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |

--- a/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
@@ -179,6 +179,7 @@ processors:
       if: ctx.json?.OriginIP != ''
       on_failure:
         - append:
+            tag: append_error_message_394f4054
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -279,6 +280,7 @@ processors:
       if: ctx.json?.SourceIP != ''
       on_failure:
         - append:
+            tag: append_error_message_1ee8a1ac
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -390,6 +392,7 @@ processors:
       if: ctx.json?.EgressIP != ''
       on_failure:
         - append:
+            tag: append_error_message_0b129a2c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -431,6 +434,7 @@ processors:
       if: ctx.json?.SourceInternalIP != ''
       on_failure:
         - append:
+            tag: append_error_message_3a73acf7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:

--- a/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Zero Trust Network Session logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,20 +19,24 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_event_category_ed69613e
       field: event.category
       value: [network, session]
   - set:
+      tag: set_event_type_8fd37e4e
       field: event.type
       value: [connection]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -40,7 +45,7 @@ processors:
         must be removed.
       if: ctx._conf?.enable_deduplication == false && ctx.input?.type == 'aws-s3'
       ignore_missing: true
-# ECS fields
+  # ECS fields
   - script:
       lang: painless
       tag: painless_session_start_time_to_milli
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_SessionStartTime_4f338910
       field: json.SessionStartTime
       if: ctx.json?.SessionStartTime != null && ctx.json.SessionStartTime != ''
       formats:
@@ -72,9 +78,11 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_dddd6385
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_json_SessionStartTime_3f0f0e5a
       field: json.SessionStartTime
       copy_from: "@timestamp"
   - script:
@@ -99,6 +107,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_SessionEndTime_to_json_SessionEndTime_d82a46a9
       field: json.SessionEndTime
       target_field: json.SessionEndTime
       if: ctx.json?.SessionEndTime != null && ctx.json.SessionEndTime != ''
@@ -109,60 +118,75 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_91e96f26
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_network_session_timestamp_7ec4f502
       field: cloudflare_logpush.network_session.timestamp
       copy_from: "@timestamp"
   - rename:
+      tag: rename_json_BytesReceived_to_cloudflare_logpush_network_session_destination_bytes_088c6ffa
       field: json.BytesReceived
       target_field: cloudflare_logpush.network_session.destination.bytes
       ignore_missing: true
   - set:
+      tag: set_destination_bytes_e38f3e4c
       field: destination.bytes
       copy_from: cloudflare_logpush.network_session.destination.bytes
       ignore_empty_value: true
   - rename:
+      tag: rename_json_BytesSent_to_cloudflare_logpush_network_session_source_bytes_e3654c9a
       field: json.BytesSent
       target_field: cloudflare_logpush.network_session.source.bytes
       ignore_missing: true
   - set:
+      tag: set_source_bytes_1d92f200
       field: source.bytes
       copy_from: cloudflare_logpush.network_session.source.bytes
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DetectedProtocol_to_cloudflare_logpush_network_session_detected_protocol_1c65f314
       field: json.DetectedProtocol
       target_field: cloudflare_logpush.network_session.detected_protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_DeviceID_to_cloudflare_logpush_network_session_host_id_26f4a4bd
       field: json.DeviceID
       target_field: cloudflare_logpush.network_session.host.id
       ignore_missing: true
   - set:
+      tag: set_host_id_8ded5f2c
       field: host.id
       copy_from: cloudflare_logpush.network_session.host.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_DeviceName_to_cloudflare_logpush_network_session_host_name_145bb719
       field: json.DeviceName
       target_field: cloudflare_logpush.network_session.host.name
       ignore_missing: true
   - set:
+      tag: set_host_name_840dd844
       field: host.name
       copy_from: cloudflare_logpush.network_session.host.name
       ignore_empty_value: true
   - rename:
+      tag: rename_json_OriginIP_to_cloudflare_logpush_network_session_destination_ip_a78373a3
       field: json.OriginIP
       target_field: cloudflare_logpush.network_session.destination.ip
       ignore_missing: true
   - set:
+      tag: set_destination_ip_94459dee
       field: destination.ip
       copy_from: cloudflare_logpush.network_session.destination.ip
       ignore_empty_value: true
-# Geo enrichment (destination IP)
+  # Geo enrichment (destination IP)
   - geoip:
+      tag: geoip_destination_ip_to_destination_geo_394bcdb5
       field: destination.ip
       target_field: destination.geo
   - geoip:
+      tag: geoip_destination_ip_to_destination_as_8a007787
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
       target_field: destination.as
@@ -171,74 +195,92 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_asn_to_destination_as_number_3b459fcd
       field: destination.as.asn
       target_field: destination.as.number
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_organization_name_to_destination_as_organization_name_814bd459
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginPort_to_cloudflare_logpush_network_session_destination_port_c7f218d3
       field: json.OriginPort
       target_field: cloudflare_logpush.network_session.destination.port
       ignore_missing: true
   - set:
+      tag: set_destination_port_5f15990a
       field: destination.port
       copy_from: cloudflare_logpush.network_session.destination.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_OriginTLSCertificateIssuer_to_cloudflare_logpush_network_session_tls_server_certificate_issuer_94eda834
       field: json.OriginTLSCertificateIssuer
       target_field: cloudflare_logpush.network_session.tls.server.certificate.issuer
       ignore_missing: true
   - set:
+      tag: set_tls_server_issuer_84dfe341
       field: tls.server.issuer
       copy_from: cloudflare_logpush.network_session.tls.server.certificate.issuer
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Protocol_to_cloudflare_logpush_network_session_transport_932973e8
       field: json.Protocol
       target_field: cloudflare_logpush.network_session.transport
       ignore_missing: true
   - set:
+      tag: set_network_transport_3f402e30
       field: network.transport
       copy_from: cloudflare_logpush.network_session.transport
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SessionID_to_cloudflare_logpush_network_session_session_id_d026538b
       field: json.SessionID
       target_field: cloudflare_logpush.network_session.session.id
       ignore_missing: true
   - set:
+      tag: set_event_id_9ca1813e
       field: event.id
       copy_from: cloudflare_logpush.network_session.session.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SessionStartTime_to_cloudflare_logpush_network_session_session_start_a635411e
       field: json.SessionStartTime
       target_field: cloudflare_logpush.network_session.session.start
       ignore_missing: true
   - set:
+      tag: set_event_start_6e95ec84
       field: event.start
       copy_from: cloudflare_logpush.network_session.session.start
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SessionEndTime_to_cloudflare_logpush_network_session_session_end_3279df7a
       field: json.SessionEndTime
       target_field: cloudflare_logpush.network_session.session.end
       ignore_missing: true
   - set:
+      tag: set_event_end_d2325484
       field: event.end
       copy_from: cloudflare_logpush.network_session.session.end
       ignore_empty_value: true
   - rename:
+      tag: rename_json_SourceIP_to_cloudflare_logpush_network_session_source_ip_95a53637
       field: json.SourceIP
       target_field: cloudflare_logpush.network_session.source.ip
       ignore_missing: true
   - set:
+      tag: set_source_ip_60b5c944
       field: source.ip
       copy_from: cloudflare_logpush.network_session.source.ip
       ignore_empty_value: true
-# Geo enrichment (source IP)
+  # Geo enrichment (source IP)
   - geoip:
+      tag: geoip_source_ip_to_source_geo_0494c6b1
       field: source.ip
       target_field: source.geo
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -247,131 +289,163 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_json_SourcePort_to_cloudflare_logpush_network_session_source_port_3cd518f3
       field: json.SourcePort
       target_field: cloudflare_logpush.network_session.source.port
       ignore_missing: true
   - set:
+      tag: set_source_port_14399d1c
       field: source.port
       copy_from: cloudflare_logpush.network_session.source.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_UserID_to_cloudflare_logpush_network_session_user_id_48a9a5b3
       field: json.UserID
       target_field: cloudflare_logpush.network_session.user.id
       ignore_missing: true
   - set:
+      tag: set_user_id_d4461d6c
       field: user.id
       copy_from: cloudflare_logpush.network_session.user.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Email_to_cloudflare_logpush_network_session_user_email_1f12a13c
       field: json.Email
       target_field: cloudflare_logpush.network_session.user.email
       ignore_missing: true
   - set:
+      tag: set_user_email_a8fe96ba
       field: user.email
       copy_from: cloudflare_logpush.network_session.user.email
       ignore_empty_value: true
   - rename:
+      tag: rename_json_VirtualNetworkID_to_cloudflare_logpush_network_session_vlan_id_0d1d80e9
       field: json.VirtualNetworkID
       target_field: cloudflare_logpush.network_session.vlan.id
       ignore_missing: true
   - set:
+      tag: set_network_vlan_id_ee700abc
       field: network.vlan.id
       copy_from: cloudflare_logpush.network_session.vlan.id
       ignore_empty_value: true
-# Custom fields
+  # Custom fields
   - rename:
+      tag: rename_json_AccountID_to_cloudflare_logpush_network_session_account_id_10bbb2fa
       field: json.AccountID
       target_field: cloudflare_logpush.network_session.account_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientTCPHandshakeDurationMs_to_cloudflare_logpush_network_session_tcp_client_handshake_time_ms_c9b170b8
       field: json.ClientTCPHandshakeDurationMs
       target_field: cloudflare_logpush.network_session.tcp.client.handshake_time_ms
       ignore_missing: true
   - rename:
+      tag: rename_json_ConnectionCloseReason_to_cloudflare_logpush_network_session_tcp_connection_close_reason_75e8a337
       field: json.ConnectionCloseReason
       target_field: cloudflare_logpush.network_session.tcp.connection.close_reason
       ignore_missing: true
   - rename:
+      tag: rename_json_ConnectionReuse_to_cloudflare_logpush_network_session_tcp_connection_reuse_7a99cc64
       field: json.ConnectionReuse
       target_field: cloudflare_logpush.network_session.tcp.connection.reuse
       ignore_missing: true
   - rename:
+      tag: rename_json_DestinationTunnelID_to_cloudflare_logpush_network_session_destination_tunnel_id_34922a94
       field: json.DestinationTunnelID
       target_field: cloudflare_logpush.network_session.destination.tunnel_id
       ignore_missing: true
   - rename:
+      tag: rename_json_EgressColoName_to_cloudflare_logpush_network_session_egress_colo_name_469fcc54
       field: json.EgressColoName
       target_field: cloudflare_logpush.network_session.egress.colo_name
       ignore_missing: true
   - rename:
+      tag: rename_json_EgressIP_to_cloudflare_logpush_network_session_egress_ip_cabda593
       field: json.EgressIP
       target_field: cloudflare_logpush.network_session.egress.ip
       ignore_missing: true
   - rename:
+      tag: rename_json_EgressPort_to_cloudflare_logpush_network_session_egress_port_7422959f
       field: json.EgressPort
       target_field: cloudflare_logpush.network_session.egress.port
       ignore_missing: true
   - rename:
+      tag: rename_json_EgressRuleID_to_cloudflare_logpush_network_session_egress_rule_id_88aeb3b5
       field: json.EgressRuleID
       target_field: cloudflare_logpush.network_session.egress.rule.id
       ignore_missing: true
   - rename:
+      tag: rename_json_EgressRuleName_to_cloudflare_logpush_network_session_egress_rule_name_930f5f11
       field: json.EgressRuleName
       target_field: cloudflare_logpush.network_session.egress.rule.name
       ignore_missing: true
   - rename:
+      tag: rename_json_IngressColoName_to_cloudflare_logpush_network_session_ingress_colo_name_c5ed9816
       field: json.IngressColoName
       target_field: cloudflare_logpush.network_session.ingress.colo_name
       ignore_missing: true
   - rename:
+      tag: rename_json_Offramp_to_cloudflare_logpush_network_session_offramp_7546864d
       field: json.Offramp
       target_field: cloudflare_logpush.network_session.offramp
       ignore_missing: true
   - rename:
+      tag: rename_json_RuleEvaluationDurationMs_to_cloudflare_logpush_network_session_rule_evaluation_time_ms_f41b18e8
       field: json.RuleEvaluationDurationMs
       target_field: cloudflare_logpush.network_session.rule_evaluation.time_ms
       ignore_missing: true
   - rename:
+      tag: rename_json_SourceInternalIP_to_cloudflare_logpush_network_session_source_internal_ip_ba89460c
       field: json.SourceInternalIP
       target_field: cloudflare_logpush.network_session.source.internal_ip
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientTLSCipher_to_cloudflare_logpush_network_session_tls_client_cipher_4f9c2371
       field: json.ClientTLSCipher
       target_field: cloudflare_logpush.network_session.tls.client.cipher
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientTLSHandshakeDurationMs_to_cloudflare_logpush_network_session_tls_client_handshake_time_ms_e9250db4
       field: json.ClientTLSHandshakeDurationMs
       target_field: cloudflare_logpush.network_session.tls.client.handshake_time_ms
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientTLSVersion_to_cloudflare_logpush_network_session_tls_client_version_ed81718d
       field: json.ClientTLSVersion
       target_field: cloudflare_logpush.network_session.tls.client.version
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginTLSCertificateValidationResult_to_cloudflare_logpush_network_session_tls_server_certificate_validation_result_8626f7e1
       field: json.OriginTLSCertificateValidationResult
       target_field: cloudflare_logpush.network_session.tls.server.certificate.validation_result
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginTLSCipher_to_cloudflare_logpush_network_session_tls_server_cipher_4039a3d8
       field: json.OriginTLSCipher
       target_field: cloudflare_logpush.network_session.tls.server.cipher
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginTLSHandshakeDurationMs_to_cloudflare_logpush_network_session_tls_server_handshake_time_ms_ac775769
       field: json.OriginTLSHandshakeDurationMs
       target_field: cloudflare_logpush.network_session.tls.server.handshake_time_ms
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginTLSVersion_to_cloudflare_logpush_network_session_tls_server_version_6509c1f8
       field: json.OriginTLSVersion
       target_field: cloudflare_logpush.network_session.tls.server.version
       ignore_missing: true
   - convert:
+      tag: convert_json_InitialOriginIP_to_cloudflare_logpush_network_session_initial_origin_ip_45718b53
       field: json.InitialOriginIP
       target_field: cloudflare_logpush.network_session.initial_origin_ip
       type: ip
@@ -379,71 +453,86 @@ processors:
       if: ctx.json?.InitialOriginIP != ''
       on_failure:
         - append:
+            tag: append_error_message_34d648d9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_RegistrationID_to_cloudflare_logpush_network_session_registration_id_5daa239a
       field: json.RegistrationID
       target_field: cloudflare_logpush.network_session.registration_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ResolvedFQDN_to_cloudflare_logpush_network_session_resolved_fqdn_f2d2e5e4
       field: json.ResolvedFQDN
       target_field: cloudflare_logpush.network_session.resolved_fqdn
       ignore_missing: true
   - rename:
+      tag: rename_json_SNI_to_cloudflare_logpush_network_session_sni_ed6abd1d
       field: json.SNI
       target_field: cloudflare_logpush.network_session.sni
       ignore_missing: true
   - set:
+      tag: set_tls_client_server_name_c3f65e85
       field: tls.client.server_name
       copy_from: cloudflare_logpush.network_session.sni
       ignore_empty_value: true
-# Create related fields
+  # Create related fields
   - append:
+      tag: append_related_ip_8121c591
       field: related.ip
       value: "{{{source.ip}}}"
       if: ctx.source?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_c1a6356b
       field: related.ip
       value: "{{{destination.ip}}}"
       if: ctx.destination?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_e5930da7
       field: related.ip
       value: "{{{cloudflare_logpush.network_session.egress.ip}}}"
       if: ctx.cloudflare_logpush?.network_session?.egress?.ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_d1851e05
       field: related.hosts
       value: "{{{host.id}}}"
       if: ctx.host?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_452ef445
       field: related.hosts
       value: "{{{host.name}}}"
       if: ctx.host?.name != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_7f407fef
       field: related.user
       value: "{{{user.id}}}"
       if: ctx.user?.id != null
       allow_duplicates: false
   - append:
+      tag: append_related_user_34fcf415
       field: related.user
       value: "{{{user.email}}}"
       if: ctx.user?.email != null
       allow_duplicates: false
   - append:
+      tag: append_related_ip_c98bd3f4
       field: related.ip
       value: '{{{cloudflare_logpush.network_session.initial_origin_ip}}}'
       if: ctx.cloudflare_logpush?.network_session?.initial_origin_ip != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_857bdfa8
       field: related.hosts
       value: '{{{cloudflare_logpush.network_session.resolved_fqdn}}}'
       if: ctx.cloudflare_logpush?.network_session?.resolved_fqdn != null
       allow_duplicates: false
   - append:
+      tag: append_related_hosts_09a22ef4
       field: related.hosts
       value: '{{{cloudflare_logpush.network_session.sni}}}'
       if: ctx.cloudflare_logpush?.network_session?.sni != null
@@ -455,6 +544,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_e2e9c790
       field:
         - cloudflare_logpush.network_session.timestamp
         - cloudflare_logpush.network_session.destination.bytes
@@ -478,6 +568,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |

--- a/packages/cloudflare_logpush/data_stream/page_shield_events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/page_shield_events/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Page Shield Event logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Timestamp_a965763d
       field: json.Timestamp
       if: ctx.json?.Timestamp != null && ctx.json.Timestamp != ''
       formats:
@@ -72,48 +78,59 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_458edc7c
           field: error.message
           value: >-
             Processor '{{{ _ingest.on_failure_processor_type }}}'
             {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
             {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
+      tag: set_cloudflare_logpush_page_shield_events_timestamp_15ff66de
       field: cloudflare_logpush.page_shield_events.timestamp
       copy_from: '@timestamp'
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Action_to_cloudflare_logpush_page_shield_events_action_249c1317
       field: json.Action
       target_field: cloudflare_logpush.page_shield_events.action
       ignore_missing: true
   - set:
+      tag: set_event_action_b99711ae
       field: event.action
       copy_from: cloudflare_logpush.page_shield_events.action
       ignore_empty_value: true
   - lowercase:
+      tag: lowercase_event_action_9334b869
       field: event.action
       ignore_missing: true
   - rename:
+      tag: rename_json_CSPDirective_to_cloudflare_logpush_page_shield_events_csp_directive_ec50c63e
       field: json.CSPDirective
       target_field: cloudflare_logpush.page_shield_events.csp_directive
       ignore_missing: true
   - rename:
+      tag: rename_json_Host_to_cloudflare_logpush_page_shield_events_host_664c8787
       field: json.Host
       target_field: cloudflare_logpush.page_shield_events.host
       ignore_missing: true
   - set:
+      tag: set_host_name_122ed077
       field: host.name
       copy_from: cloudflare_logpush.page_shield_events.host
       ignore_empty_value: true
   - append:
+      tag: append_related_hosts_555b812b
       field: related.hosts
       value: '{{{host.name}}}'
       if: ctx.host?.name != null && ctx.host.name != ''
       allow_duplicates: false
   - rename:
+      tag: rename_json_PageURL_to_cloudflare_logpush_page_shield_events_page_url_529399de
       field: json.PageURL
       target_field: cloudflare_logpush.page_shield_events.page_url
       ignore_missing: true
   - rename:
+      tag: rename_json_URL_to_cloudflare_logpush_page_shield_events_url_32905bc9
       field: json.URL
       target_field: cloudflare_logpush.page_shield_events.url
       ignore_missing: true
@@ -124,16 +141,19 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b6e9755f
             field: error.message
             value: >-
               Processor '{{{ _ingest.on_failure_processor_type }}}'
               {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
               {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - rename:
+      tag: rename_json_PolicyID_to_cloudflare_logpush_page_shield_events_policy_id_8eed8fc8
       field: json.PolicyID
       target_field: cloudflare_logpush.page_shield_events.policy_id
       ignore_missing: true
   - rename:
+      tag: rename_json_ResourceType_to_cloudflare_logpush_page_shield_events_resource_type_085e4bce
       field: json.ResourceType
       target_field: cloudflare_logpush.page_shield_events.resource_type
       ignore_missing: true
@@ -145,16 +165,19 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_888a80d6
             field: error.message
             value: >-
               Processor '{{{ _ingest.on_failure_processor_type }}}'
               {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
               {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
   - rename:
+      tag: rename_json_URLHost_to_cloudflare_logpush_page_shield_events_url_host_ed944944
       field: json.URLHost
       target_field: cloudflare_logpush.page_shield_events.url_host
       ignore_missing: true
   - set:
+      tag: set_url_domain_086e7313
       field: url.domain
       copy_from: cloudflare_logpush.page_shield_events.url_host
       ignore_empty_value: true
@@ -165,6 +188,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_4c693a8d
       field:
         - cloudflare_logpush.page_shield_events.action
         - cloudflare_logpush.page_shield_events.host
@@ -174,6 +198,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |
@@ -196,6 +221,7 @@ processors:
       tag: set_pipeline_error_into_event_kind
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
@@ -34,9 +34,9 @@ processors:
       field: event.type
       value: [info]
       tag: set_event_type
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -45,7 +45,7 @@ processors:
         must be removed.
       if: ctx._conf?.enable_deduplication == false && ctx.input?.type == 'aws-s3'
       ignore_missing: true
-# Timestamp
+  # Timestamp
   - script:
       lang: painless
       tag: painless_timestamp_to_milli
@@ -78,6 +78,7 @@ processors:
       tag: date_event_timestamp
       on_failure:
       - append:
+          tag: append_error_message_38394fec
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
@@ -85,7 +86,7 @@ processors:
       copy_from: "@timestamp"
       tag: set_timestamp
 
-# Handle destination IP
+  # Handle destination IP
   - rename:
       field: json.DestAddr
       target_field: cloudflare_logpush.sinkhole_http.destination.ip
@@ -96,7 +97,7 @@ processors:
       copy_from: cloudflare_logpush.sinkhole_http.destination.ip
       ignore_empty_value: true
       tag: set_destination_ip
-# Geo enrichment (destination IP)
+  # Geo enrichment (destination IP)
   - geoip:
       field: destination.ip
       target_field: destination.geo
@@ -121,7 +122,7 @@ processors:
       ignore_missing: true
       tag: rename_destination_as_org
 
-# Handle source IP
+  # Handle source IP
   - rename:
       field: json.SrcAddr
       target_field: cloudflare_logpush.sinkhole_http.source.ip
@@ -132,7 +133,7 @@ processors:
       copy_from: cloudflare_logpush.sinkhole_http.source.ip
       ignore_empty_value: true
       tag: set_source_ip
-# Geo enrichment (source IP)
+  # Geo enrichment (source IP)
   - geoip:
       field: source.ip
       target_field: source.geo
@@ -157,7 +158,7 @@ processors:
       ignore_missing: true
       tag: rename_source_as_org
 
-# HTTP fields
+  # HTTP fields
   - rename:
       field: json.Body
       target_field: cloudflare_logpush.sinkhole_http.request.body.content
@@ -210,14 +211,17 @@ processors:
       ignore_empty_value: true
       tag: set_http_host
   - rename:
+      tag: rename_json_URI_to_cloudflare_logpush_sinkhole_http_request_uri_fcb3a925
       field: json.URI
       target_field: cloudflare_logpush.sinkhole_http.request.uri
       ignore_missing: true
   - rename:
+      tag: rename_json_URL_to_cloudflare_logpush_sinkhole_http_request_url_44a29715
       field: json.URL
       target_field: cloudflare_logpush.sinkhole_http.request.url
       ignore_missing: true
   - uri_parts:
+      tag: uri_parts_cloudflare_logpush_sinkhole_http_request_url_to_url_4d919288
       field: cloudflare_logpush.sinkhole_http.request.url
       target_field: url
       if: ctx.cloudflare_logpush?.sinkhole_http?.request?.url != null && ctx.cloudflare_logpush.sinkhole_http.request.url != ''
@@ -227,6 +231,7 @@ processors:
       ignore_missing: true
       tag: rename_user_agent
   - user_agent:
+      tag: user_agent_cloudflare_logpush_sinkhole_http_user_agent_3af01702
       field: cloudflare_logpush.sinkhole_http.user_agent
       ignore_missing: true
   - rename:
@@ -240,7 +245,7 @@ processors:
       ignore_empty_value: true
       tag: set_username
 
-# Custom fields
+  # Custom fields
   - rename:
       field: json.AccountID
       target_field: cloudflare_logpush.sinkhole_http.account_id
@@ -272,7 +277,7 @@ processors:
       ignore_missing: true
       tag: rename_sinkhole_id
 
-# Create related fields
+  # Create related fields
   - append:
       field: related.ip
       value: '{{{destination.ip}}}'
@@ -298,7 +303,7 @@ processors:
       allow_duplicates: false
       tag: append_related_user
 
-# Clean resulting event
+  # Clean resulting event
   - remove:
       tag: remove_json_conf
       field:

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
@@ -86,7 +86,7 @@ processors:
       copy_from: "@timestamp"
       tag: set_timestamp
 
-# Handle destination IP
+  # Handle destination IP
   - convert:
       field: json.DestAddr
       tag: convert_destaddr_to_ip
@@ -96,6 +96,7 @@ processors:
       if: ctx.json?.DestAddr != ''
       on_failure:
         - append:
+            tag: append_error_message_9c5ae997
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -128,7 +129,7 @@ processors:
       ignore_missing: true
       tag: rename_destination_as_org
 
-# Handle source IP
+  # Handle source IP
   - convert:
       field: json.SrcAddr
       tag: convert_srcaddr_to_ip
@@ -138,6 +139,7 @@ processors:
       if: ctx.json?.SrcAddr != ''
       on_failure:
         - append:
+            tag: append_error_message_f9c3eb86
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -189,6 +191,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_cdc179d0
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for parsing Cloudflare Spectrum Event logs.
 processors:
   - set:
+      tag: set_ecs_version_b777da29
       field: ecs.version
       value: '9.3.0'
   - rename:
@@ -18,21 +19,25 @@ processors:
       description: The `message` field is no longer required if the document has an `event.original` field.
       if: ctx.event?.original != null
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -63,6 +68,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_Timestamp_772fbe7f
       field: json.Timestamp
       if: ctx.json?.Timestamp != null && ctx.json.Timestamp != ''
       formats:
@@ -72,9 +78,11 @@ processors:
       timezone: UTC
       on_failure:
       - append:
+          tag: append_error_message_2e342a9c
           field: error.message
           value: "{{{_ingest.on_failure_message}}}"
   - set:
+      tag: set_cloudflare_logpush_spectrum_event_timestamp_eb12da0f
       field: cloudflare_logpush.spectrum_event.timestamp
       copy_from: '@timestamp'
       ignore_empty_value: true
@@ -106,6 +114,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_ConnectTimestamp_to_cloudflare_logpush_spectrum_event_connect_time_2d3e71a3
       field: json.ConnectTimestamp
       if: ctx.json?.ConnectTimestamp != null
       formats:
@@ -119,9 +128,11 @@ processors:
       target_field: cloudflare_logpush.spectrum_event.connect.time
       on_failure:
         - append:
+            tag: append_error_message_3ef54342
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_event_start_0859f146
       field: event.start
       copy_from: cloudflare_logpush.spectrum_event.connect.time
       ignore_empty_value: true
@@ -153,6 +164,7 @@ processors:
         }
         catch (Exception e) {}
   - date:
+      tag: date_json_DisconnectTimestamp_to_cloudflare_logpush_spectrum_event_disconnect_time_73e74811
       field: json.DisconnectTimestamp
       if: ctx.json?.DisconnectTimestamp != null
       formats:
@@ -166,24 +178,30 @@ processors:
       target_field: cloudflare_logpush.spectrum_event.disconnect.time
       on_failure:
         - append:
+            tag: append_error_message_94c41526
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_event_end_74af7957
       field: event.end
       copy_from: cloudflare_logpush.spectrum_event.disconnect.time
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Event_to_cloudflare_logpush_spectrum_event_action_a1437c14
       field: json.Event
       target_field: cloudflare_logpush.spectrum_event.action
       ignore_missing: true
   - set:
+      tag: set_event_action_f87e3943
       field: event.action
       copy_from: cloudflare_logpush.spectrum_event.action
       ignore_empty_value: true
   - lowercase:
+      tag: lowercase_event_action_9334b869
       field: event.action
       ignore_missing: true
   - convert:
+      tag: convert_json_OriginBytes_to_cloudflare_logpush_spectrum_event_origin_bytes_6396e1ea
       field: json.OriginBytes
       target_field: cloudflare_logpush.spectrum_event.origin.bytes
       if: ctx.json?.OriginBytes != ''
@@ -191,13 +209,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4afed647
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_destination_bytes_37d6657d
       field: destination.bytes
       copy_from: cloudflare_logpush.spectrum_event.origin.bytes
       ignore_empty_value: true
   - convert:
+      tag: convert_json_OriginIP_to_cloudflare_logpush_spectrum_event_origin_ip_b269aecb
       field: json.OriginIP
       target_field: cloudflare_logpush.spectrum_event.origin.ip
       if: ctx.json?.OriginIP != ''
@@ -205,13 +226,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_732a4df0
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_destination_ip_cbefb767
       field: destination.ip
       copy_from: cloudflare_logpush.spectrum_event.origin.ip
       ignore_empty_value: true
   - convert:
+      tag: convert_json_OriginPort_to_cloudflare_logpush_spectrum_event_origin_port_1a731398
       field: json.OriginPort
       target_field: cloudflare_logpush.spectrum_event.origin.port
       if: ctx.json?.OriginPort != ''
@@ -219,21 +243,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_df6bcf1b
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_destination_port_078de763
       field: destination.port
       copy_from: cloudflare_logpush.spectrum_event.origin.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Application_to_cloudflare_logpush_spectrum_event_application_4a0e3d0e
       field: json.Application
       target_field: cloudflare_logpush.spectrum_event.application
       ignore_missing: true
   - set:
+      tag: set_event_id_fe813204
       field: event.id
       copy_from: cloudflare_logpush.spectrum_event.application
       ignore_empty_value: true
   - convert:
+      tag: convert_json_Status_to_cloudflare_logpush_spectrum_event_status_82e7a265
       field: json.Status
       target_field: cloudflare_logpush.spectrum_event.status
       if: ctx.json?.Status != ''
@@ -241,13 +270,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_86e36d6c
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_http_response_status_code_8eb3b996
       field: http.response.status_code
       copy_from: cloudflare_logpush.spectrum_event.status
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientAsn_to_cloudflare_logpush_spectrum_event_client_asn_00481746
       field: json.ClientAsn
       target_field: cloudflare_logpush.spectrum_event.client.asn
       if: ctx.json?.ClientAsn != ''
@@ -255,13 +287,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_47348373
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_as_number_43c84eca
       field: source.as.number
       copy_from: cloudflare_logpush.spectrum_event.client.asn
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientBytes_to_cloudflare_logpush_spectrum_event_client_bytes_d6f6bef3
       field: json.ClientBytes
       target_field: cloudflare_logpush.spectrum_event.client.bytes
       if: ctx.json?.ClientBytes != ''
@@ -269,21 +304,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_dedd5a0a
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_bytes_61e86c9f
       field: source.bytes
       copy_from: cloudflare_logpush.spectrum_event.client.bytes
       ignore_empty_value: true
   - rename:
+      tag: rename_json_ClientCountry_to_cloudflare_logpush_spectrum_event_client_country_7e53c63a
       field: json.ClientCountry
       target_field: cloudflare_logpush.spectrum_event.client.country
       ignore_missing: true
   - set:
+      tag: set_source_geo_country_iso_code_a5c289a6
       field: source.geo.country_iso_code
       copy_from: cloudflare_logpush.spectrum_event.client.country
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientIP_to_cloudflare_logpush_spectrum_event_client_ip_8e63b9ca
       field: json.ClientIP
       target_field: cloudflare_logpush.spectrum_event.client.ip
       if: ctx.json?.ClientIP != ''
@@ -291,13 +331,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_89000825
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_ip_a8992b97
       field: source.ip
       copy_from: cloudflare_logpush.spectrum_event.client.ip
       ignore_empty_value: true
   - convert:
+      tag: convert_json_ClientPort_to_cloudflare_logpush_spectrum_event_client_port_97bd15e1
       field: json.ClientPort
       target_field: cloudflare_logpush.spectrum_event.client.port
       if: ctx.json?.ClientPort != ''
@@ -305,28 +348,35 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bae35766
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_port_8f859f67
       field: source.port
       copy_from: cloudflare_logpush.spectrum_event.client.port
       ignore_empty_value: true
   - rename:
+      tag: rename_json_ClientMatchedIpFirewall_to_cloudflare_logpush_spectrum_event_client_matched_ip_firewall_2a24f1a2
       field: json.ClientMatchedIpFirewall
       target_field: cloudflare_logpush.spectrum_event.client.matched_ip_firewall
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientProto_to_cloudflare_logpush_spectrum_event_client_protocol_ab852cb8
       field: json.ClientProto
       target_field: cloudflare_logpush.spectrum_event.client.protocol
       ignore_missing: true
   - set:
+      tag: set_network_transport_26276eaf
       field: network.transport
       copy_from: cloudflare_logpush.spectrum_event.client.protocol
       ignore_empty_value: true
   - lowercase:
+      tag: lowercase_network_transport_bc8c1c12
       field: network.transport
       ignore_missing: true
   - convert:
+      tag: convert_json_ClientTcpRtt_to_cloudflare_logpush_spectrum_event_client_tcp_rtt_69f1bb02
       field: json.ClientTcpRtt
       target_field: cloudflare_logpush.spectrum_event.client.tcp_rtt
       if: ctx.json?.ClientTcpRtt != ''
@@ -334,46 +384,57 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_dc5d4cd7
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_ClientTlsCipher_to_cloudflare_logpush_spectrum_event_client_tls_cipher_abbca2ae
       field: json.ClientTlsCipher
       target_field: cloudflare_logpush.spectrum_event.client.tls.cipher
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientTlsClientHelloServerName_to_cloudflare_logpush_spectrum_event_client_tls_client_hello_server_name_c9681c0f
       field: json.ClientTlsClientHelloServerName
       target_field: cloudflare_logpush.spectrum_event.client.tls.client_hello_server_name
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientTlsProtocol_to_cloudflare_logpush_spectrum_event_client_tls_protocol_a7adcec0
       field: json.ClientTlsProtocol
       target_field: cloudflare_logpush.spectrum_event.client.tls.protocol
       ignore_missing: true
   - grok:
+      tag: grok_cloudflare_logpush_spectrum_event_client_tls_protocol_2ca0b268
       if: ctx.cloudflare_logpush?.spectrum_event?.client?.tls?.protocol != 'none' && ctx.cloudflare_logpush?.spectrum_event?.client?.tls?.protocol != 'unknown'
       field: cloudflare_logpush.spectrum_event.client.tls.protocol
       patterns:
         - "^%{DATA:tls.version_protocol}v%{DATA:tls.version}$"
       ignore_failure: true
   - lowercase:
+      tag: lowercase_tls_version_protocol_b840a1f9
       field: tls.version_protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_ClientTlsStatus_to_cloudflare_logpush_spectrum_event_client_tls_status_7dd6b8c0
       field: json.ClientTlsStatus
       target_field: cloudflare_logpush.spectrum_event.client.tls.status
       ignore_missing: true
   - rename:
+      tag: rename_json_ColoCode_to_cloudflare_logpush_spectrum_event_colo_code_13aaf6cc
       field: json.ColoCode
       target_field: cloudflare_logpush.spectrum_event.colo.code
       ignore_missing: true
   - rename:
+      tag: rename_json_IpFirewall_to_cloudflare_logpush_spectrum_event_ip_firewall_fc31aa13
       field: json.IpFirewall
       target_field: cloudflare_logpush.spectrum_event.ip_firewall
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginProto_to_cloudflare_logpush_spectrum_event_origin_protocol_b28a7b72
       field: json.OriginProto
       target_field: cloudflare_logpush.spectrum_event.origin.protocol
       ignore_missing: true
   - convert:
+      tag: convert_json_OriginTcpRtt_to_cloudflare_logpush_spectrum_event_origin_tcp_rtt_7c870d0d
       field: json.OriginTcpRtt
       target_field: cloudflare_logpush.spectrum_event.origin.tcp_rtt
       if: ctx.json?.OriginTcpRtt != ''
@@ -381,57 +442,69 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2e32fcb0
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_OriginTlsCipher_to_cloudflare_logpush_spectrum_event_origin_tls_cipher_233b05dc
       field: json.OriginTlsCipher
       target_field: cloudflare_logpush.spectrum_event.origin.tls.cipher
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginTlsFingerprint_to_cloudflare_logpush_spectrum_event_origin_tls_fingerprint_6157979e
       field: json.OriginTlsFingerprint
       target_field: cloudflare_logpush.spectrum_event.origin.tls.fingerprint
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginTlsMode_to_cloudflare_logpush_spectrum_event_origin_tls_mode_2f051e70
       field: json.OriginTlsMode
       target_field: cloudflare_logpush.spectrum_event.origin.tls.mode
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginTlsProtocol_to_cloudflare_logpush_spectrum_event_origin_tls_protocol_97e4e7ae
       field: json.OriginTlsProtocol
       target_field: cloudflare_logpush.spectrum_event.origin.tls.protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_OriginTlsStatus_to_cloudflare_logpush_spectrum_event_origin_tls_status_3d757d94
       field: json.OriginTlsStatus
       target_field: cloudflare_logpush.spectrum_event.origin.tls.status
       ignore_failure: true
   - rename:
+      tag: rename_json_ProxyProtocol_to_cloudflare_logpush_spectrum_event_proxy_protocol_13f4be6c
       field: json.ProxyProtocol
       target_field: cloudflare_logpush.spectrum_event.proxy.protocol
       ignore_missing: true
   - append:
+      tag: append_related_ip_30d15214
       field: related.ip
       value: '{{{source.ip}}}'
       if: ctx.source?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_e2ed7178
       field: related.ip
       value: '{{{cloudflare_logpush.spectrum_event.client.ip}}}'
       if: ctx.cloudflare_logpush?.spectrum_event?.client?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_51dd17d0
       field: related.ip
       value: '{{{destination.ip}}}'
       if: ctx.destination?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_76f92f90
       field: related.ip
       value: '{{{cloudflare_logpush.spectrum_event.origin.ip}}}'
       if: ctx.cloudflare_logpush?.spectrum_event?.origin?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - community_id:
+      tag: community_id_d2308e7a
       target_field: network.community_id
       ignore_failure: true
   - remove:
@@ -441,6 +514,7 @@ processors:
         - _conf
       ignore_missing: true
   - remove:
+      tag: remove_7430f9e6
       field:
         - cloudflare_logpush.spectrum_event.timestamp
         - cloudflare_logpush.spectrum_event.origin.bytes
@@ -458,6 +532,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - script:
+        tag: script_a3eb5add
         description: Drops null/empty values recursively.
         lang: painless
         source: |

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
@@ -413,6 +413,7 @@ processors:
         ctx.cloudflare_logpush.spectrum_event.client.tls.protocol != 'unknown'
       on_failure:
         - append:
+            tag: append_error_message_3249e827
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - lowercase:
@@ -437,6 +438,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0c1625d2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:

--- a/packages/cloudflare_logpush/data_stream/workers_trace/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/elasticsearch/ingest_pipeline/default.yml
@@ -34,9 +34,9 @@ processors:
       field: event.kind
       value: event
       tag: set_event_kind
-## AWS S3 input does _id Based Deduplication and generates "_id" by default.
-## When "Data Deduplication" is not enabled, this field must be removed.
-## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
+  ## AWS S3 input does _id Based Deduplication and generates "_id" by default.
+  ## When "Data Deduplication" is not enabled, this field must be removed.
+  ## https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-aws-s3#_document_id_generation
   - remove:
       field: _id
       tag: remove_id_based_deduplication
@@ -57,6 +57,7 @@ processors:
       tag: date_event_timestamp
       on_failure:
       - append:
+          tag: append_error_message_c14f4a20
           field: error.message
           value: |-
             Processor "{{{ _ingest.on_failure_processor_type }}}" with tag "{{{ _ingest.on_failure_processor_tag }}}" in pipeline "{{{ _ingest.on_failure_pipeline }}}" failed with message "{{{ _ingest.on_failure_message }}}"
@@ -142,21 +143,25 @@ processors:
       ignore_missing: true
       tag: rename_script_version
   - convert:
+      tag: convert_json_CPUTimeMs_to_cloudflare_logpush_workers_trace_cpu_time_ms_29cf5c42
       field: json.CPUTimeMs
       target_field: cloudflare_logpush.workers_trace.cpu_time_ms
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1d0f189c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_WallTimeMs_to_cloudflare_logpush_workers_trace_wall_time_ms_e1d87cac
       field: json.WallTimeMs
       target_field: cloudflare_logpush.workers_trace.wall_time_ms
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_43f21cf6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.45.0-preview01"
+version: "1.45.0-preview03"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
cloudflare_logpush: add a tag key to each processor

Run `elastic-package modify -m pipeline-tag` to add a tag key to each processor.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 



## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/cloudflare_logpush directory.
- Run the following command to run tests.

> elastic-package test -v
