### PR TITLE
[CI] Add features/* branch support to changeset detection and publish pipeline

### DIFF
--- a/.buildkite/scripts/build_packages.sh
+++ b/.buildkite/scripts/build_packages.sh
@@ -27,6 +27,7 @@ skipPublishing() {
         return 1
     fi
 
+    # feature/* and other non-publishing branches fall through here
     return 0
 }
 

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -648,7 +648,7 @@ get_from_changeset() {
         from="${previous_successful_commit}"
         if [[ "${previous_successful_commit}" == "null" ]]; then
             if [[ "${BUILDKITE_BRANCH}" =~ ${LONG_RUNNING_BRANCH_PATTERN} ]]; then
-                # First push of a new backport or feature/* branch: only CI infrastructure files
+                # First push of a new long-running branch (matches LONG_RUNNING_BRANCH_PATTERN): only CI infrastructure files
                 # changed, no package code was modified — skip package testing.
                 from="${BUILDKITE_COMMIT}"
             else

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -10,6 +10,8 @@ platform_type_lowercase="${platform_type,,}"
 
 SCRIPTS_BUILDKITE_PATH="${WORKSPACE}/.buildkite/scripts"
 
+readonly LONG_RUNNING_BRANCH_PATTERN="^(backport-|feature/)"
+
 export ELASTIC_PACKAGE_BIN=${WORKSPACE}/build/elastic-package
 
 API_BUILDKITE_PIPELINES_URL="https://api.buildkite.com/v2/organizations/elastic/pipelines/"
@@ -639,13 +641,13 @@ get_from_changeset() {
         from="${BUILDKITE_COMMIT}^"
     fi
 
-    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ^(backport-|feature/) ]]; then
+    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ${LONG_RUNNING_BRANCH_PATTERN} ]]; then
         local previous_successful_commit
         previous_successful_commit=$(get_previous_successful_commit "${BUILDKITE_PIPELINE_SLUG}" "${BUILDKITE_BRANCH}")
 
         from="${previous_successful_commit}"
         if [[ "${previous_successful_commit}" == "null" ]]; then
-            if [[ "${BUILDKITE_BRANCH}" =~ ^(backport-|feature/) ]]; then
+            if [[ "${BUILDKITE_BRANCH}" =~ ${LONG_RUNNING_BRANCH_PATTERN} ]]; then
                 # First push of a new backport or feature/* branch: only CI infrastructure files
                 # changed, no package code was modified — skip package testing.
                 from="${BUILDKITE_COMMIT}"
@@ -662,7 +664,7 @@ get_to_changeset() {
     # Changeset that triggered the build
     local to="${BUILDKITE_COMMIT}"
 
-    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ^(backport-|feature/) ]]; then
+    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ${LONG_RUNNING_BRANCH_PATTERN} ]]; then
         to="origin/${BUILDKITE_BRANCH}"
     fi
     echo "${to}"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -639,14 +639,14 @@ get_from_changeset() {
         from="${BUILDKITE_COMMIT}^"
     fi
 
-    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
+    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ^(backport-|feature/) ]]; then
         local previous_successful_commit
         previous_successful_commit=$(get_previous_successful_commit "${BUILDKITE_PIPELINE_SLUG}" "${BUILDKITE_BRANCH}")
 
         from="${previous_successful_commit}"
         if [[ "${previous_successful_commit}" == "null" ]]; then
-            if [[ "${BUILDKITE_BRANCH}" =~ ^backport- ]]; then
-                # First push of a new backport branch: only CI infrastructure files
+            if [[ "${BUILDKITE_BRANCH}" =~ ^(backport-|feature/) ]]; then
+                # First push of a new backport or feature/* branch: only CI infrastructure files
                 # changed, no package code was modified — skip package testing.
                 from="${BUILDKITE_COMMIT}"
             else
@@ -662,7 +662,7 @@ get_to_changeset() {
     # Changeset that triggered the build
     local to="${BUILDKITE_COMMIT}"
 
-    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
+    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ^(backport-|feature/) ]]; then
         to="origin/${BUILDKITE_BRANCH}"
     fi
     echo "${to}"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -42,7 +42,7 @@ spec:
       name: integrations
       description: 'Pipeline for the Integrations project'
     spec:
-      branch_configuration: "main backport-*"
+      branch_configuration: "main backport-* feature/*"
       pipeline_file: ".buildkite/pipeline.yml"
       provider_settings:
         build_pull_request_forks: false
@@ -53,9 +53,9 @@ spec:
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null && build.source == 'api')
       repository: elastic/integrations
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: '!main !backport-*'
+      cancel_intermediate_builds_branch_filter: '!main !backport-* !feature/*'
       skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: '!main !backport-*'
+      skip_intermediate_builds_branch_filter: '!main !backport-* !feature/*'
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:

--- a/docs/ci_pipelines.md
+++ b/docs/ci_pipelines.md
@@ -67,7 +67,7 @@ More details about this CI pipeline:
 - This CI pipeline tries to test the minimum packages possible::
     - In the Pull Request context, it is checked the files modified/added/deleted in the given PR:
         - Those packages with changes (`packages/*`) will be added to the list of packages to be tested.
-        - If files outside `packages` folder are updated (e.g. `go.mod` , `.buildkite/*`), all packages are going to be tested. There are some exceptions to this, for instance the `.github/CODEOWNERS` file or `.docs/` folder ([files excluded](https://github.com/elastic/integrations/blob/376fc891a1e6c662b4ef1897b118044faf51e7bf/.buildkite/scripts/common.sh#L695)).
+        - If files outside `packages` folder are updated (for example `go.mod` , `.buildkite/*`), all packages are going to be tested. There are some exceptions to this, for instance the `.github/CODEOWNERS` file or `.docs/` folder ([files excluded](https://github.com/elastic/integrations/blob/376fc891a1e6c662b4ef1897b118044faf51e7bf/.buildkite/scripts/common.sh#L695)).
     - In branches context (`main`, `backport-*`, or `feature/*`):
         - The latest Buildkite build that finished successfully in that branch is retrieved, and all the file changes in the working copy between the changeset of that build and the merged commit are obtained.
         - Given all those changes, the packages selected to be tested follow the same rules as in the PR.

--- a/docs/ci_pipelines.md
+++ b/docs/ci_pipelines.md
@@ -12,7 +12,7 @@ Currently, there are five different pipelines:
 
 ## Pull Requests and pushes to specific branches
 
-In every push to a Pull Request as well as commits to `main` or `backport-*` branches, this pipeline is triggered automatically: https://buildkite.com/elastic/integrations
+In every push to a Pull Request as well as commits to `main`, `backport-*`, or `feature/*` branches, this pipeline is triggered automatically: https://buildkite.com/elastic/integrations
 
 This pipeline is in charge of testing the packages with a local Elastic stack.
 
@@ -62,13 +62,13 @@ These environment variables can be defined in different locations:
 More details about this CI pipeline:
 
 - Builds running in a Pull Request are canceled if a new commit is pushed to the PR branch.
-- Builds running from `main` or `backport-*` branches are finished even if new commits are merged.
+- Builds running from `main`, `backport-*`, or `feature/*` branches are finished even if new commits are merged.
 - As part of the Pull Requests, there are some benchmark files created and this data is pushed to the PR as a comment.
 - This CI pipeline tries to test the minimum packages possible::
     - In the Pull Request context, it is checked the files modified/added/deleted in the given PR:
         - Those packages with changes (`packages/*`) will be added to the list of packages to be tested.
         - If files outside `packages` folder are updated (e.g. `go.mod` , `.buildkite/*`), all packages are going to be tested. There are some exceptions to this, for instance the `.github/CODEOWNERS` file or `.docs/` folder ([files excluded](https://github.com/elastic/integrations/blob/376fc891a1e6c662b4ef1897b118044faf51e7bf/.buildkite/scripts/common.sh#L695)).
-    - In branches context (`main` or `backport-*`):
+    - In branches context (`main`, `backport-*`, or `feature/*`):
         - The latest Buildkite build that finished successfully in that branch is retrieved, and all the file changes in the working copy between the changeset of that build and the merged commit are obtained.
         - Given all those changes, the packages selected to be tested follow the same rules as in the PR.
 - Container logs, as they could contain sensitive information, are uploaded to a private Google Bucket.
@@ -225,3 +225,13 @@ from the UI: https://buildkite.com/elastic/integrations-backport/
 
 More information about this pipeline and how to create these hotfixes in:
 https://www.elastic.co/guide/en/integrations-developer/current/developer-workflow-support-old-package.html
+
+## Feature branches
+
+`feature/*` branches are long-lived branches used for developing larger features before merging into `main`. They follow the same CI process as Pull Requests, ensuring all checks pass before code is integrated.
+
+- Every push to a `feature/*` branch triggers the main CI pipeline (https://buildkite.com/elastic/integrations), running the same package tests as a regular Pull Request.
+- Pull Requests targeting a `feature/*` branch also trigger CI checks, so all changes must pass CI before being merged into the feature branch.
+- Intermediate builds are cancelled or skipped when new commits arrive, consistent with `backport-*` branches.
+- Changeset detection works the same as for `backport-*` branches: only packages modified since the last successful build are tested. On the first push to a new `feature/*` branch, no package tests are run if only CI infrastructure files changed.
+- Publishing is **not** triggered for `feature/*` branches. Packages are published only when PRs are merged into `main` or `backport-*` branches.


### PR DESCRIPTION
## Proposed commit message

### WHAT

Extends CI branch handling to treat `feature/*` branches the same as `backport-*` branches in two places:

**`common.sh`** — `get_from_changeset` / `get_to_changeset`

- The outer guard in both functions previously only matched `main` and `backport-*`, making the inner `feature/` check inside `get_from_changeset` unreachable (dead code) — `feature/*` branches never entered the block.
- Both outer guards are updated to `^(backport-|feature/)` so `feature/*` branches benefit from the same previous-successful-commit logic.
- On the first push of a `feature/*` branch (no previous successful build), `from` is set to `BUILDKITE_COMMIT` rather than `origin/${BUILDKITE_BRANCH}^`, avoiding spurious full-repo diffs that would trigger unnecessary package testing.

**`catalog-info.yaml`** — `integrations` pipeline

- `branch_configuration` extended from `"main backport-*"` to `"main backport-* feature/*"` so the integrations pipeline is triggered for `feature/*` branches.
- `cancel_intermediate_builds_branch_filter` and `skip_intermediate_builds_branch_filter` updated to include `!feature/*` so intermediate builds on `feature/*` branches are properly cancelled/skipped, consistent with `main` and `backport-*`.

**`docs/ci_pipelines.md`**

- Updated the pipeline trigger description, build-cancellation bullet, and changeset-detection bullet to include `feature/*` alongside `main` and `backport-*`.
- Added a new "Feature branches" section documenting that changes are integrated via Pull Requests with CI checks, that changeset detection follows the same logic as `backport-*` branches, and that publishing is restricted to `main` and `backport-*` only.

### WHY

`feature/*` branches are used for long-lived feature development that requires the same CI protections as `backport-*` branches: accurate changeset detection against a baseline and CI build triggering. The `integrations-publish` pipeline intentionally remains restricted to `main` and `backport-*` branches only.

## Author's Checklist

- [x] Verified that `feature/*` branches were previously excluded from the `get_from_changeset`/`get_to_changeset` logic (dead code — inner check was unreachable)
- [x] Verified that `integrations-publish` pipeline does NOT trigger on `feature/*` branches
- [x] Updated `docs/ci_pipelines.md` to document the new `feature/*` branch workflow


---

> This PR was drafted with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).