### PR TITLE
[snort,amazon_security_lake,cloudflare_logpush] Fix text-auditor typo families (#18960)

### DIFF
--- a/packages/amazon_security_lake/data_stream/application_activity/fields/device-fields.yml
+++ b/packages/amazon_security_lake/data_stream/application_activity/fields/device-fields.yml
@@ -66,7 +66,7 @@
               description: 'The BIOS version. For example: LENOVO G5ETA2WW (2.62).'
             - name: chassis
               type: keyword
-              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Windows Chassis Types.
+              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Chassis Types.
             - name: cpu_bits
               type: long
               description: 'The cpu architecture, the number of bits used for addressing in memory. For example: 32 or 64.'

--- a/packages/amazon_security_lake/data_stream/discovery/fields/device-fields.yml
+++ b/packages/amazon_security_lake/data_stream/discovery/fields/device-fields.yml
@@ -66,7 +66,7 @@
               description: 'The BIOS version. For example: LENOVO G5ETA2WW (2.62).'
             - name: chassis
               type: keyword
-              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Windows Chassis Types.
+              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Chassis Types.
             - name: cpu_bits
               type: long
               description: 'The cpu architecture, the number of bits used for addressing in memory. For example: 32 or 64.'

--- a/packages/amazon_security_lake/data_stream/event/fields/device-fields.yml
+++ b/packages/amazon_security_lake/data_stream/event/fields/device-fields.yml
@@ -66,7 +66,7 @@
               description: 'The BIOS version. For example: LENOVO G5ETA2WW (2.62).'
             - name: chassis
               type: keyword
-              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Windows Chassis Types.
+              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Chassis Types.
             - name: cpu_bits
               type: long
               description: 'The cpu architecture, the number of bits used for addressing in memory. For example: 32 or 64.'

--- a/packages/amazon_security_lake/data_stream/iam/fields/device-fields.yml
+++ b/packages/amazon_security_lake/data_stream/iam/fields/device-fields.yml
@@ -66,7 +66,7 @@
               description: 'The BIOS version. For example: LENOVO G5ETA2WW (2.62).'
             - name: chassis
               type: keyword
-              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Windows Chassis Types.
+              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Chassis Types.
             - name: cpu_bits
               type: long
               description: 'The cpu architecture, the number of bits used for addressing in memory. For example: 32 or 64.'

--- a/packages/amazon_security_lake/data_stream/network_activity/fields/device-fields.yml
+++ b/packages/amazon_security_lake/data_stream/network_activity/fields/device-fields.yml
@@ -66,7 +66,7 @@
               description: 'The BIOS version. For example: LENOVO G5ETA2WW (2.62).'
             - name: chassis
               type: keyword
-              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Windows Chassis Types.
+              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Chassis Types.
             - name: cpu_bits
               type: long
               description: 'The cpu architecture, the number of bits used for addressing in memory. For example: 32 or 64.'

--- a/packages/amazon_security_lake/data_stream/system_activity/fields/device-fields.yml
+++ b/packages/amazon_security_lake/data_stream/system_activity/fields/device-fields.yml
@@ -66,7 +66,7 @@
               description: 'The BIOS version. For example: LENOVO G5ETA2WW (2.62).'
             - name: chassis
               type: keyword
-              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Windows Chassis Types.
+              description: The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Chassis Types.
             - name: cpu_bits
               type: long
               description: 'The cpu architecture, the number of bits used for addressing in memory. For example: 32 or 64.'

--- a/packages/amazon_security_lake/docs/README.md
+++ b/packages/amazon_security_lake/docs/README.md
@@ -774,7 +774,7 @@ This is the `Event` dataset.
 | ocsf.device.hw_info.bios_date | The BIOS date. For example: 03/31/16. | keyword |
 | ocsf.device.hw_info.bios_manufacturer | The BIOS manufacturer. For example: LENOVO. | keyword |
 | ocsf.device.hw_info.bios_ver | The BIOS version. For example: LENOVO G5ETA2WW (2.62). | keyword |
-| ocsf.device.hw_info.chassis | The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Windows Chassis Types. | keyword |
+| ocsf.device.hw_info.chassis | The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows Chassis Types. | keyword |
 | ocsf.device.hw_info.cpu_bits | The cpu architecture, the number of bits used for addressing in memory. For example: 32 or 64. | long |
 | ocsf.device.hw_info.cpu_cores | The number of processor cores in all installed processors. For Example: 42. | long |
 | ocsf.device.hw_info.cpu_count | The number of physical processors on a system. For example: 1. | long |

--- a/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
@@ -276,8 +276,8 @@ streams:
           - forwarded
           - cloudflare_logpush-device_posture
   - input: azure-blob-storage
-    title: Device Posture Results logs logs
-    description: Collect Device Posture Results logs logs from Cloudflare via Azure Blob Storage.
+    title: Device Posture Results logs
+    description: Collect Device Posture Results logs from Cloudflare via Azure Blob Storage.
     enabled: false
     template_path: abs.yml.hbs
     vars:

--- a/packages/snort/data_stream/log/manifest.yml
+++ b/packages/snort/data_stream/log/manifest.yml
@@ -15,7 +15,7 @@ streams:
         required: true
         show_user: true
         title: Multi-line Alert Full logs
-        description: Enables multiline support if reading the Snort Alert Full log fomat
+        description: Enables multiline support if reading the Snort Alert Full log format
         type: bool
         multi: false
         default: false


### PR DESCRIPTION
Closes #18960.

The text-auditor bot flagged three typo families in user-facing text. This PR applies all three fixes exactly as suggested in the issue, scoped to the files and lines the bot enumerated.

## Changes

### 1. `fomat` → `format` (1 file, 1 line)

- `packages/snort/data_stream/log/manifest.yml:18` — Snort Alert Full log input description.

### 2. `Windows Windows` → `Windows` (7 files, 7 lines)

In the Amazon Security Lake `device.chassis` field description: `examples for Windows Windows Chassis Types` → `examples for Windows Chassis Types`.

- `packages/amazon_security_lake/data_stream/system_activity/fields/device-fields.yml:69`
- `packages/amazon_security_lake/data_stream/application_activity/fields/device-fields.yml:69`
- `packages/amazon_security_lake/data_stream/iam/fields/device-fields.yml:69`
- `packages/amazon_security_lake/data_stream/discovery/fields/device-fields.yml:69`
- `packages/amazon_security_lake/data_stream/event/fields/device-fields.yml:69`
- `packages/amazon_security_lake/data_stream/network_activity/fields/device-fields.yml:69`
- `packages/amazon_security_lake/docs/README.md:777`

### 3. `Device Posture Results logs logs` → `Device Posture Results logs` (1 file, 2 lines)

- `packages/cloudflare_logpush/data_stream/device_posture/manifest.yml:279` — input title
- `packages/cloudflare_logpush/data_stream/device_posture/manifest.yml:280` — input description

## Diff

`9 files changed, 10 insertions(+), 10 deletions(-)` — text-only, no schema or functional changes.

## Verification

- Each typo verified at HEAD before changing.
- No competing open PR addresses any of these three families (searched `text-auditor`, `fomat`, `Windows Windows`, `logs logs` across all PRs in this repo).
- README in `amazon_security_lake/docs/` is generated from the field manifests in some packages; here it's hand-maintained and the duplicate "Windows" appears verbatim, so it's edited directly.

## AI assistance

This PR was drafted with AI assistance. Verification (typo presence at HEAD, no-competing-PR check, diff stat) was reproduced on a fresh sparse-checkout of `main`.
