### PR TITLE
chore(codeowners): reassign security_detection_engine team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -454,7 +454,7 @@
 /packages/salesforce @elastic/obs-infraobs-integrations
 /packages/santa @elastic/security-service-integrations
 /packages/security_ai_prompts @elastic/security-generative-ai
-/packages/security_detection_engine @elastic/protections
+/packages/security_detection_engine @elastic/threat-research-and-detection-engineering
 /packages/sentinel_one @elastic/security-service-integrations
 /packages/sentinel_one_cloud_funnel @elastic/security-service-integrations
 /packages/servicenow @elastic/security-service-integrations


### PR DESCRIPTION
## Summary
- Update `CODEOWNERS` so `/packages/security_detection_engine` is owned by `@elastic/threat-research-and-detection-engineering` instead of `@elastic/protections`.

## Validation
- Reviewed the single-line diff in `.github/CODEOWNERS`; no runtime or test impact.

## Risks / Known Gaps
- None beyond the usual review load for the newly assigned team on this package path.

Related issue: https://github.com/elastic/observability-robots/issues/2986
