### PR TITLE
sentinel_one: expose max_executions and persist worklist in cursor

### DIFF
--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.7.0"
+  changes:
+    - description: Expose max_executions for the application data stream and persist worklist in cursor across restarts.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18976
 - version: "2.6.0"
   changes:
     - description: Add ILM Policy for unified alert data stream.

--- a/packages/sentinel_one/data_stream/application/_dev/test/policy/test-all.expected
+++ b/packages/sentinel_one/data_stream/application/_dev/test/policy/test-all.expected
@@ -10,6 +10,7 @@ inputs:
           data_stream:
             dataset: sentinel_one.application
           interval: 30s
+          max_executions: 500
           processors:
             - add_fields:
                 fields:
@@ -23,7 +24,7 @@ inputs:
                 target: environment
           program: |-
             (
-              (has(state.?worklist.data) && size(state.worklist.data) > 0) ?
+              (has(state.?cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
                 state
               :
                 state.with(
@@ -33,7 +34,7 @@ inputs:
                       "skipCount": ["true"],
                       "limit": [string(state.batch_size)],
                       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-                      ?"cursor": state.?next_page.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -44,11 +45,13 @@ inputs:
                   ).do_request().as(resp, (resp.StatusCode == 200) ?
                     resp.Body.decode_json().as(body,
                       {
-                        "worklist": body,
-                        "next_page": {
-                          ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                        "cursor": {
+                          "worklist": body,
+                          "next_page": {
+                            ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                          },
+                          "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
                         },
-                        "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
                       }
                     )
                   :
@@ -67,23 +70,24 @@ inputs:
                       },
                       "want_more": false,
                       "offset": 0,
+                      "cursor": {},
                     }
                   )
                 )
             ).as(state,
               state.with(
-                !has(state.worklist) ? // Exit early due to GET failure.
+                !has(state.?cursor.worklist) ? // Exit early due to GET failure.
                   state
-                : (has(state.worklist.data) && size(state.worklist.data) > 0) ?
+                : (has(state.cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
                   request(
                     "GET",
                     state.url.trim_right("/") + "/web/api/v2.1/application-management/inventory/endpoints?" + {
                       "skipCount": ["true"],
-                      "applicationName": [string(state.worklist.data[0].applicationName)],
-                      "applicationVendor": [string(state.worklist.data[0].applicationVendor)],
+                      "applicationName": [string(state.cursor.worklist.data[0].applicationName)],
+                      "applicationVendor": [string(state.cursor.worklist.data[0].applicationVendor)],
                       "limit": [string(state.batch_size)],
                       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-                      ?"cursor": state.?next_chain.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.next_chain.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -93,23 +97,33 @@ inputs:
                     }
                   ).do_request().as(resp, (resp.StatusCode == 200) ?
                     resp.Body.decode_json().as(body,
-                      {
-                        "events": (has(body.data) && body.data.size() > 0) ?
-                          body.data.map(e,
-                            {
-                              "message": e.encode_json(),
-                            }
-                          )
-                        :
-                          [{"message": "retry"}],
-                        "next_chain": {
-                          ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
-                        },
-                        "worklist": {
-                          "data": (body.?pagination.nextCursor.orValue(null) != null) ? state.worklist.data : tail(state.worklist.data),
-                        },
-                        "want_more": state.?fetch_more.orValue(false) ? state.fetch_more : (body.?pagination.nextCursor.orValue(null) != null),
-                      }
+                      (body.?pagination.nextCursor.orValue(null) != null).as(has_more_endpoints,
+                        {
+                          "data": has_more_endpoints ? state.cursor.worklist.data : tail(state.cursor.worklist.data),
+                        }.as(new_worklist,
+                          {
+                            "events": (has(body.data) && body.data.size() > 0) ?
+                              body.data.map(e,
+                                {
+                                  "message": e.encode_json(),
+                                }
+                              )
+                            :
+                              [{"message": "retry"}],
+                            "want_more": state.?cursor.fetch_more.orValue(false) ? state.cursor.fetch_more : has_more_endpoints,
+                            "cursor": {
+                              "worklist": new_worklist,
+                              "next_page": {
+                                ?"token": state.?cursor.next_page.token,
+                              },
+                              "next_chain": {
+                                ?"token": has_more_endpoints ? optional.of(body.pagination.nextCursor) : optional.none(),
+                              },
+                              "fetch_more": state.?cursor.fetch_more.orValue(false),
+                            },
+                          }
+                        )
+                      )
                     )
                   :
                     {
@@ -132,6 +146,7 @@ inputs:
                   {
                     "events": [],
                     "want_more": false,
+                    "cursor": {},
                   }
               )
             )

--- a/packages/sentinel_one/data_stream/application/_dev/test/policy/test-all.yml
+++ b/packages/sentinel_one/data_stream/application/_dev/test/policy/test-all.yml
@@ -85,6 +85,7 @@ data_stream:
   vars:
     interval: 30s
     batch_size: 100
+    max_executions: 500
     site_ids: 123
     tags:
       - forwarded

--- a/packages/sentinel_one/data_stream/application/_dev/test/policy/test-default.expected
+++ b/packages/sentinel_one/data_stream/application/_dev/test/policy/test-default.expected
@@ -10,9 +10,10 @@ inputs:
           data_stream:
             dataset: sentinel_one.application
           interval: 24h
+          max_executions: 1000
           program: |-
             (
-              (has(state.?worklist.data) && size(state.worklist.data) > 0) ?
+              (has(state.?cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
                 state
               :
                 state.with(
@@ -22,7 +23,7 @@ inputs:
                       "skipCount": ["true"],
                       "limit": [string(state.batch_size)],
                       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-                      ?"cursor": state.?next_page.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -33,11 +34,13 @@ inputs:
                   ).do_request().as(resp, (resp.StatusCode == 200) ?
                     resp.Body.decode_json().as(body,
                       {
-                        "worklist": body,
-                        "next_page": {
-                          ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                        "cursor": {
+                          "worklist": body,
+                          "next_page": {
+                            ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                          },
+                          "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
                         },
-                        "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
                       }
                     )
                   :
@@ -56,23 +59,24 @@ inputs:
                       },
                       "want_more": false,
                       "offset": 0,
+                      "cursor": {},
                     }
                   )
                 )
             ).as(state,
               state.with(
-                !has(state.worklist) ? // Exit early due to GET failure.
+                !has(state.?cursor.worklist) ? // Exit early due to GET failure.
                   state
-                : (has(state.worklist.data) && size(state.worklist.data) > 0) ?
+                : (has(state.cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
                   request(
                     "GET",
                     state.url.trim_right("/") + "/web/api/v2.1/application-management/inventory/endpoints?" + {
                       "skipCount": ["true"],
-                      "applicationName": [string(state.worklist.data[0].applicationName)],
-                      "applicationVendor": [string(state.worklist.data[0].applicationVendor)],
+                      "applicationName": [string(state.cursor.worklist.data[0].applicationName)],
+                      "applicationVendor": [string(state.cursor.worklist.data[0].applicationVendor)],
                       "limit": [string(state.batch_size)],
                       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-                      ?"cursor": state.?next_chain.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.next_chain.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -82,23 +86,33 @@ inputs:
                     }
                   ).do_request().as(resp, (resp.StatusCode == 200) ?
                     resp.Body.decode_json().as(body,
-                      {
-                        "events": (has(body.data) && body.data.size() > 0) ?
-                          body.data.map(e,
-                            {
-                              "message": e.encode_json(),
-                            }
-                          )
-                        :
-                          [{"message": "retry"}],
-                        "next_chain": {
-                          ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
-                        },
-                        "worklist": {
-                          "data": (body.?pagination.nextCursor.orValue(null) != null) ? state.worklist.data : tail(state.worklist.data),
-                        },
-                        "want_more": state.?fetch_more.orValue(false) ? state.fetch_more : (body.?pagination.nextCursor.orValue(null) != null),
-                      }
+                      (body.?pagination.nextCursor.orValue(null) != null).as(has_more_endpoints,
+                        {
+                          "data": has_more_endpoints ? state.cursor.worklist.data : tail(state.cursor.worklist.data),
+                        }.as(new_worklist,
+                          {
+                            "events": (has(body.data) && body.data.size() > 0) ?
+                              body.data.map(e,
+                                {
+                                  "message": e.encode_json(),
+                                }
+                              )
+                            :
+                              [{"message": "retry"}],
+                            "want_more": state.?cursor.fetch_more.orValue(false) ? state.cursor.fetch_more : has_more_endpoints,
+                            "cursor": {
+                              "worklist": new_worklist,
+                              "next_page": {
+                                ?"token": state.?cursor.next_page.token,
+                              },
+                              "next_chain": {
+                                ?"token": has_more_endpoints ? optional.of(body.pagination.nextCursor) : optional.none(),
+                              },
+                              "fetch_more": state.?cursor.fetch_more.orValue(false),
+                            },
+                          }
+                        )
+                      )
                     )
                   :
                     {
@@ -121,6 +135,7 @@ inputs:
                   {
                     "events": [],
                     "want_more": false,
+                    "cursor": {},
                   }
               )
             )

--- a/packages/sentinel_one/data_stream/application/_dev/test/policy/test-default.yml
+++ b/packages/sentinel_one/data_stream/application/_dev/test/policy/test-default.yml
@@ -5,6 +5,7 @@ data_stream:
   vars:
     interval: 24h
     batch_size: 1000
+    max_executions: 1000
     enable_request_tracer: false
     preserve_original_event: false
     http_client_timeout: 30s

--- a/packages/sentinel_one/data_stream/application/agent/stream/cel.yml.hbs
+++ b/packages/sentinel_one/data_stream/application/agent/stream/cel.yml.hbs
@@ -1,5 +1,6 @@
 config_version: 2
 interval: {{interval}}
+max_executions: {{max_executions}}
 resource.tracer:
   enabled: {{enable_request_tracer}}
   filename: "../../logs/cel/http-request-trace-*.ndjson"
@@ -25,7 +26,7 @@ redact:
     - api_token
 program: |-
   (
-    (has(state.?worklist.data) && size(state.worklist.data) > 0) ?
+    (has(state.?cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
       state
     :
       state.with(
@@ -35,7 +36,7 @@ program: |-
             "skipCount": ["true"],
             "limit": [string(state.batch_size)],
             ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-            ?"cursor": state.?next_page.token.optMap(v, [v]),
+            ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
           }.format_query()
         ).with(
           {
@@ -46,11 +47,13 @@ program: |-
         ).do_request().as(resp, (resp.StatusCode == 200) ?
           resp.Body.decode_json().as(body,
             {
-              "worklist": body,
-              "next_page": {
-                ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+              "cursor": {
+                "worklist": body,
+                "next_page": {
+                  ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                },
+                "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
               },
-              "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
             }
           )
         :
@@ -69,23 +72,24 @@ program: |-
             },
             "want_more": false,
             "offset": 0,
+            "cursor": {},
           }
         )
       )
   ).as(state,
     state.with(
-      !has(state.worklist) ? // Exit early due to GET failure.
+      !has(state.?cursor.worklist) ? // Exit early due to GET failure.
         state
-      : (has(state.worklist.data) && size(state.worklist.data) > 0) ?
+      : (has(state.cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
         request(
           "GET",
           state.url.trim_right("/") + "/web/api/v2.1/application-management/inventory/endpoints?" + {
             "skipCount": ["true"],
-            "applicationName": [string(state.worklist.data[0].applicationName)],
-            "applicationVendor": [string(state.worklist.data[0].applicationVendor)],
+            "applicationName": [string(state.cursor.worklist.data[0].applicationName)],
+            "applicationVendor": [string(state.cursor.worklist.data[0].applicationVendor)],
             "limit": [string(state.batch_size)],
             ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-            ?"cursor": state.?next_chain.token.optMap(v, [v]),
+            ?"cursor": state.?cursor.next_chain.token.optMap(v, [v]),
           }.format_query()
         ).with(
           {
@@ -95,23 +99,33 @@ program: |-
           }
         ).do_request().as(resp, (resp.StatusCode == 200) ?
           resp.Body.decode_json().as(body,
-            {
-              "events": (has(body.data) && body.data.size() > 0) ?
-                body.data.map(e,
-                  {
-                    "message": e.encode_json(),
-                  }
-                )
-              :
-                [{"message": "retry"}],
-              "next_chain": {
-                ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
-              },
-              "worklist": {
-                "data": (body.?pagination.nextCursor.orValue(null) != null) ? state.worklist.data : tail(state.worklist.data),
-              },
-              "want_more": state.?fetch_more.orValue(false) ? state.fetch_more : (body.?pagination.nextCursor.orValue(null) != null),
-            }
+            (body.?pagination.nextCursor.orValue(null) != null).as(has_more_endpoints,
+              {
+                "data": has_more_endpoints ? state.cursor.worklist.data : tail(state.cursor.worklist.data),
+              }.as(new_worklist,
+                {
+                  "events": (has(body.data) && body.data.size() > 0) ?
+                    body.data.map(e,
+                      {
+                        "message": e.encode_json(),
+                      }
+                    )
+                  :
+                    [{"message": "retry"}],
+                  "want_more": state.?cursor.fetch_more.orValue(false) ? state.cursor.fetch_more : has_more_endpoints,
+                  "cursor": {
+                    "worklist": new_worklist,
+                    "next_page": {
+                      ?"token": state.?cursor.next_page.token,
+                    },
+                    "next_chain": {
+                      ?"token": has_more_endpoints ? optional.of(body.pagination.nextCursor) : optional.none(),
+                    },
+                    "fetch_more": state.?cursor.fetch_more.orValue(false),
+                  },
+                }
+              )
+            )
           )
         :
           {
@@ -134,6 +148,7 @@ program: |-
         {
           "events": [],
           "want_more": false,
+          "cursor": {},
         }
     )
   )

--- a/packages/sentinel_one/data_stream/application/manifest.yml
+++ b/packages/sentinel_one/data_stream/application/manifest.yml
@@ -23,6 +23,15 @@ streams:
         multi: false
         required: true
         show_user: false
+      - name: max_executions
+        type: integer
+        title: Maximum Executions
+        description: >-
+          Maximum number of CEL program re-evaluations per collection interval. The application stream makes two API calls per worklist entry (inventory + endpoints), so large estates may need a higher budget than the input default of 1000. Set to 0 for unlimited.
+        default: 1000
+        multi: false
+        required: true
+        show_user: false
       - name: site_ids
         type: text
         title: Site IDs

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: sentinel_one
 title: SentinelOne
-version: "2.6.0"
+version: "2.7.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
sentinel_one: expose max_executions and persist worklist in cursor

Expose max_executions as a configurable variable for the application
data stream so operators can raise the execution budget for large
estates where the two-level worklist traversal (inventory pages x
endpoint pages) exceeds the default of 1000.

Move the worklist, pagination tokens, and fetch_more flag into the
cursor instead of the state root. The CEL input persists the cursor
after each successful event publish, so an interrupted traversal
resumes where it left off on the next interval rather than starting
over from scratch.

Closes #18974
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #18974

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
