### PR TITLE
[rubrik] Move request templating out of CEL programs

### DIFF
--- a/packages/rubrik/changelog.yml
+++ b/packages/rubrik/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "0.9.4"
+  changes:
+    - description: |
+        Move request templating out of CEL programs.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18987
 - version: "0.9.3"
   changes:
     - description: |

--- a/packages/rubrik/data_stream/drives/agent/stream/cel.yml.hbs
+++ b/packages/rubrik/data_stream/drives/agent/stream/cel.yml.hbs
@@ -38,6 +38,9 @@ processors:
 
 state:
   index: 0
+  page_size: {{pageSize}}
+  filters:
+    {{filters}}
   queries:
     - |
         query AllClusterListQuery($first: Int, $after: String) {
@@ -78,21 +81,20 @@ program: |-
         "Body": {
           "query": state.queries[state.index],
           "variables": {
-              {{#if pageSize}}
-              "first": {{pageSize}},
-              {{/if}}
-              "after": has(state.cursor) ? state.cursor.after : null,
-              "filter": [
-                {{#if filters}}
-                  {{#each filters}}
-                    {
-                      "field": "{{field}}",
-                      "texts": [{{#each values}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}]
-                    }{{#unless @last}},{{/unless}}
-                  {{/each}}
-                {{/if}}
-              ]
-            }
+            ?"first": state.?page_size.orValue(null) != null ? optional.of(int(state.page_size)) : optional.none(),
+            "after": has(state.cursor) ? state.cursor.after : null,
+            "filter": (
+              state.?filters.orValue(null) == null ?
+                []
+              : type(state.filters) == list ?
+                state.filters
+              :
+                state.?filters.filter.orValue([])
+            ).map(f, {
+              "field": f.field,
+              "texts": f.?texts.or(f.?values).orValue([]),
+            }),
+          }
         }.encode_json(),
       }
     ).do_request().as(resp, (resp.StatusCode == 200) ?

--- a/packages/rubrik/data_stream/drives/manifest.yml
+++ b/packages/rubrik/data_stream/drives/manifest.yml
@@ -52,7 +52,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: "# filter:\n#   - field: \"location\"\n#     texts: \n#       - \"prod-lab.local\"\n"
+        default: "# - field: \"location\"\n#   texts:\n#     - \"prod-lab.local\"\n"
         description: >-
           Specify filters for refining the data. Filters must be defined as an array of Filter objects. Refer to the [Rubrik API documentation](https://rubrikinc.github.io/rubrik-api-documentation/schema/reference/filter.doc.html) for valid fields.
       - name: resource_timeout

--- a/packages/rubrik/data_stream/filesets/agent/stream/cel.yml.hbs
+++ b/packages/rubrik/data_stream/filesets/agent/stream/cel.yml.hbs
@@ -38,6 +38,9 @@ processors:
 
 state:
     index: 0
+    page_size: {{pageSize}}
+    filters:
+      {{filters}}
     queries:
       - |
         query LinuxFilesetTemplateListQuery($first: Int, $filter: [Filter!]) {
@@ -129,19 +132,18 @@ program: |-
         "Body": {
           "query": state.queries[state.index],
           "variables": {
-            {{#if pageSize}}
-            "first": {{pageSize}},
-            {{/if}}
-            "filter": [
-              {{#if filters}}
-                {{#each filters}}
-                  {
-                    "field": "{{field}}",
-                    "texts": [{{#each values}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}]
-                  }{{#unless @last}},{{/unless}}
-                {{/each}}
-              {{/if}}
-            ]
+            ?"first": state.?page_size.orValue(null) != null ? optional.of(int(state.page_size)) : optional.none(),
+            "filter": (
+              state.?filters.orValue(null) == null ?
+                []
+              : type(state.filters) == list ?
+                state.filters
+              :
+                state.?filters.filter.orValue([])
+            ).map(f, {
+              "field": f.field,
+              "texts": f.?texts.or(f.?values).orValue([]),
+            }),
           }
         }.encode_json(),
       }

--- a/packages/rubrik/data_stream/filesets/manifest.yml
+++ b/packages/rubrik/data_stream/filesets/manifest.yml
@@ -60,7 +60,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: "# filter:\n#   - field: \"location\"\n#     texts: \n#       - \"prod-lab.local\"\n"
+        default: "# - field: \"location\"\n#   texts:\n#     - \"prod-lab.local\"\n"
         description: >-
           Specify filters for refining the data. Filters must be defined as an array of Filter objects. Refer to the [Rubrik API documentation](https://rubrikinc.github.io/rubrik-api-documentation/schema/reference/filter.doc.html) for valid fields.
 elasticsearch:

--- a/packages/rubrik/data_stream/global_cluster_performance/agent/stream/cel.yml.hbs
+++ b/packages/rubrik/data_stream/global_cluster_performance/agent/stream/cel.yml.hbs
@@ -38,6 +38,7 @@ processors:
 
 state:
     index: 0
+    page_size: {{pageSize}}
     queries:
       - |
         query ClusterGlobalPerformance($first: Int, $after: String) {
@@ -81,9 +82,7 @@ program: |-
         "Body": {
           "query": state.queries[state.index],
           "variables": {
-            {{#if pageSize}}
-            "first": {{pageSize}},
-            {{/if}}
+            ?"first": state.?page_size.orValue(null) != null ? optional.of(int(state.page_size)) : optional.none(),
             "after": has(state.cursor) ? state.cursor.after : null,
           }
         }.encode_json(),

--- a/packages/rubrik/data_stream/managed_volumes/agent/stream/cel.yml.hbs
+++ b/packages/rubrik/data_stream/managed_volumes/agent/stream/cel.yml.hbs
@@ -38,6 +38,9 @@ processors:
 
 state:
   index: 0
+  page_size: {{pageSize}}
+  filters:
+    {{filters}}
   queries:
     - |
       query getManagedVolumes($first: Int, $after: String, $filter: [Filter!]) {
@@ -83,21 +86,20 @@ program: |-
         "Body": {
           "query": state.queries[state.index],
           "variables": {
-              {{#if pageSize}}
-              "first": {{pageSize}},
-              {{/if}}
-              "after": has(state.cursor) ? state.cursor.after : null,
-              "filter": [
-                {{#if filters}}
-                  {{#each filters}}
-                    {
-                      "field": "{{field}}",
-                      "texts": [{{#each values}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}]
-                    }{{#unless @last}},{{/unless}}
-                  {{/each}}
-                {{/if}}
-              ]
-            }
+            ?"first": state.?page_size.orValue(null) != null ? optional.of(int(state.page_size)) : optional.none(),
+            "after": has(state.cursor) ? state.cursor.after : null,
+            "filter": (
+              state.?filters.orValue(null) == null ?
+                []
+              : type(state.filters) == list ?
+                state.filters
+              :
+                state.?filters.filter.orValue([])
+            ).map(f, {
+              "field": f.field,
+              "texts": f.?texts.or(f.?values).orValue([]),
+            }),
+          }
         }.encode_json(),
       }
     ).do_request().as(resp, (resp.StatusCode == 200) ?

--- a/packages/rubrik/data_stream/managed_volumes/manifest.yml
+++ b/packages/rubrik/data_stream/managed_volumes/manifest.yml
@@ -52,7 +52,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: "# filter:\n#   - field: \"location\"\n#     texts: \n#       - \"prod-lab.local\"\n"
+        default: "# - field: \"location\"\n#   texts:\n#     - \"prod-lab.local\"\n"
         description: >-
           Specify filters for refining the data. Filters must be defined as an array of Filter objects. Refer to the [Rubrik API documentation](https://rubrikinc.github.io/rubrik-api-documentation/schema/reference/filter.doc.html) for valid fields.
       - name: resource_timeout

--- a/packages/rubrik/data_stream/mssql_databases/agent/stream/cel.yml.hbs
+++ b/packages/rubrik/data_stream/mssql_databases/agent/stream/cel.yml.hbs
@@ -38,6 +38,9 @@ processors:
 
 state:
   index: 0
+  page_size: {{pageSize}}
+  filters:
+    {{filters}}
   queries:
     - |
         query MssqlDatabases($first: Int $after: String $filter: [Filter!]) {
@@ -74,21 +77,20 @@ program: |-
         "Body": {
           "query": state.queries[state.index],
           "variables": {
-              {{#if pageSize}}
-              "first": {{pageSize}},
-              {{/if}}
-              "after": has(state.cursor) ? state.cursor.after : null,
-              "filter": [
-                {{#if filters}}
-                  {{#each filters}}
-                    {
-                      "field": "{{field}}",
-                      "texts": [{{#each values}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}]
-                    }{{#unless @last}},{{/unless}}
-                  {{/each}}
-                {{/if}}
-              ]
-            }
+            ?"first": state.?page_size.orValue(null) != null ? optional.of(int(state.page_size)) : optional.none(),
+            "after": has(state.cursor) ? state.cursor.after : null,
+            "filter": (
+              state.?filters.orValue(null) == null ?
+                []
+              : type(state.filters) == list ?
+                state.filters
+              :
+                state.?filters.filter.orValue([])
+            ).map(f, {
+              "field": f.field,
+              "texts": f.?texts.or(f.?values).orValue([]),
+            }),
+          }
         }.encode_json(),
       }
     ).do_request().as(resp, (resp.StatusCode == 200) ?

--- a/packages/rubrik/data_stream/mssql_databases/manifest.yml
+++ b/packages/rubrik/data_stream/mssql_databases/manifest.yml
@@ -60,7 +60,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: "# filter:\n#   - field: \"location\"\n#     texts: \n#       - \"prod-lab.local\"\n"
+        default: "# - field: \"location\"\n#   texts:\n#     - \"prod-lab.local\"\n"
         description: >-
           Specify filters for refining the data. Filters must be defined as an array of Filter objects. Refer to the [Rubrik API documentation](https://rubrikinc.github.io/rubrik-api-documentation/schema/reference/filter.doc.html) for valid fields.
       - name: resource_timeout

--- a/packages/rubrik/data_stream/physical_hosts/agent/stream/cel.yml.hbs
+++ b/packages/rubrik/data_stream/physical_hosts/agent/stream/cel.yml.hbs
@@ -38,6 +38,9 @@ processors:
 
 state:
   index: 0
+  page_size: {{pageSize}}
+  filters:
+    {{filters}}
   queries:
     - |
       query LinuxPhysicalHosts($first: Int, $after: String, $filter: [Filter!]) {
@@ -104,21 +107,20 @@ program: |-
         "Body": {
           "query": state.queries[state.index],
           "variables": {
-              {{#if pageSize}}
-              "first": {{pageSize}},
-              {{/if}}
-              "after": has(state.cursor) ? state.cursor.after : null,
-              "filter": [
-                {{#if filters}}
-                  {{#each filters}}
-                    {
-                      "field": "{{field}}",
-                      "texts": [{{#each values}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}]
-                    }{{#unless @last}},{{/unless}}
-                  {{/each}}
-                {{/if}}
-              ]
-            }
+            ?"first": state.?page_size.orValue(null) != null ? optional.of(int(state.page_size)) : optional.none(),
+            "after": has(state.cursor) ? state.cursor.after : null,
+            "filter": (
+              state.?filters.orValue(null) == null ?
+                []
+              : type(state.filters) == list ?
+                state.filters
+              :
+                state.?filters.filter.orValue([])
+            ).map(f, {
+              "field": f.field,
+              "texts": f.?texts.or(f.?values).orValue([]),
+            }),
+          }
         }.encode_json(),
       }
     ).do_request().as(resp, (resp.StatusCode == 200) ?

--- a/packages/rubrik/data_stream/physical_hosts/manifest.yml
+++ b/packages/rubrik/data_stream/physical_hosts/manifest.yml
@@ -60,7 +60,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: "# filter:\n#   - field: \"location\"\n#     texts: \n#       - \"prod-lab.local\"\n"
+        default: "# - field: \"location\"\n#   texts:\n#     - \"prod-lab.local\"\n"
         description: >-
           Specify filters for refining the data. Filters must be defined as an array of Filter objects. Refer to the [Rubrik API documentation](https://rubrikinc.github.io/rubrik-api-documentation/schema/reference/filter.doc.html) for valid fields.
       - name: resource_timeout

--- a/packages/rubrik/data_stream/tasks/agent/stream/cel.yml.hbs
+++ b/packages/rubrik/data_stream/tasks/agent/stream/cel.yml.hbs
@@ -107,16 +107,7 @@ program: |-
           "variables": {
               "chartView": "OBJECT_BACKUP_TASK_SUMMARY_BY_SLA_CHART",
               "reportRoom": "REPORT_ROOM_NONE",
-              "filter": [
-                {{#if filters}}
-                  {{#each filters}}
-                    {
-                      "field": "{{field}}",
-                      "texts": [{{#each values}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}]
-                    }{{#unless @last}},{{/unless}}
-                  {{/each}}
-                {{/if}}
-              ]
+              "filter": [],
             }
         }.encode_json(),
       }

--- a/packages/rubrik/data_stream/virtual_machines/agent/stream/cel.yml.hbs
+++ b/packages/rubrik/data_stream/virtual_machines/agent/stream/cel.yml.hbs
@@ -38,6 +38,9 @@ processors:
 
 state:
   index: 0
+  page_size: {{pageSize}}
+  filters:
+    {{filters}}
   queries:
     - |
         query VirtualMachinesQuery($first: Int, $after: String, $filter: [Filter!]) {
@@ -77,21 +80,20 @@ program: |-
         "Body": {
           "query": state.queries[state.index],
           "variables": {
-              {{#if pageSize}}
-              "first": {{pageSize}},
-              {{/if}}
-              "after": has(state.cursor) ? state.cursor.after : null,
-              "filter": [
-                {{#if filters}}
-                  {{#each filters}}
-                    {
-                      "field": "{{field}}",
-                      "texts": [{{#each values}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}]
-                    }{{#unless @last}},{{/unless}}
-                  {{/each}}
-                {{/if}}
-              ]
-            }
+            ?"first": state.?page_size.orValue(null) != null ? optional.of(int(state.page_size)) : optional.none(),
+            "after": has(state.cursor) ? state.cursor.after : null,
+            "filter": (
+              state.?filters.orValue(null) == null ?
+                []
+              : type(state.filters) == list ?
+                state.filters
+              :
+                state.?filters.filter.orValue([])
+            ).map(f, {
+              "field": f.field,
+              "texts": f.?texts.or(f.?values).orValue([]),
+            }),
+          }
         }.encode_json(),
       }
     ).do_request().as(resp, (resp.StatusCode == 200) ?

--- a/packages/rubrik/data_stream/virtual_machines/manifest.yml
+++ b/packages/rubrik/data_stream/virtual_machines/manifest.yml
@@ -52,7 +52,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: "# filter:\n#   - field: \"location\"\n#     texts: \n#       - \"prod-lab.local\"\n"
+        default: "# - field: \"location\"\n#   texts:\n#     - \"prod-lab.local\"\n"
         description: >-
           Specify filters for refining the data. Filters must be defined as an array of Filter objects. Refer to the [Rubrik API documentation](https://rubrikinc.github.io/rubrik-api-documentation/schema/reference/filter.doc.html) for valid fields.
       - name: resource_timeout

--- a/packages/rubrik/manifest.yml
+++ b/packages/rubrik/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: rubrik
 title: "Rubrik RSC Metrics"
-version: 0.9.3
+version: 0.9.4
 source:
   license: "Elastic-2.0"
 description: "Collect Metrics from Rubrik RSC with Elastic Agent."


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
[rubrik] Move request templating out of CEL programs

Move page size and filter configuration into CEL input state so the
program bodies no longer contain Handlebars templates. The programs now
read optional state values and build the GraphQL variables in CEL before
encoding the request body.

For filter configuration, pass the yaml variable directly into state and
normalize it in CEL. This keeps the template simple while allowing both
a bare list of filter objects and the older wrapped filter shape. Update
the filter defaults to show the bare list shape that the filters
variable is intended to hold.

Existing filter configs keep working because CEL still accepts values in
the filters state, while also accepting texts there to match the
documented example.

Use an empty filter list for the tasks stream, which does not declare a
filters variable, so its request body stays equivalent without carrying
unused state.
```

## Checklist

This makes `celfmt -extract -i data_stream/NAME/agent/stream/cel.yml.hbs` work.

It fixes the tasks stream to not use a variable that doesn't exist.

It fixes filter variable default values to show a format that works with with the previous (and new) usage.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 