### PR TITLE
[darktrace] Add agentless deployment

### DIFF
--- a/packages/darktrace/_dev/build/docs/README.md
+++ b/packages/darktrace/_dev/build/docs/README.md
@@ -8,6 +8,11 @@ Use the Darktrace integration to collect and parse data from the REST APIs or vi
 
 For example, you could use the data from this integration to know which model is breached and analyse model breaches, and also know about system health, changes in monitored traffic, and any errors experienced by Darktrace Security Modules or probe instances.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The Darktrace integration collects logs for three types of events: AI Analyst Alert, Model Breach Alert and System Status Alert.

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/18991
 - version: "2.0.0"
   changes:
     - description: Fix model defeat handling when nested conditions exist and so defeat ID can be non-numeric. 

--- a/packages/darktrace/changelog.yml
+++ b/packages/darktrace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.0.0"
   changes:
     - description: Fix model defeat handling when nested conditions exist and so defeat ID can be non-numeric. 

--- a/packages/darktrace/data_stream/ai_analyst_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/ai_analyst_alert/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/darktrace/data_stream/model_breach_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/model_breach_alert/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/darktrace/data_stream/system_status_alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/darktrace/data_stream/system_status_alert/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/darktrace/docs/README.md
+++ b/packages/darktrace/docs/README.md
@@ -8,6 +8,11 @@ Use the Darktrace integration to collect and parse data from the REST APIs or vi
 
 For example, you could use the data from this integration to know which model is breached and analyse model breaches, and also know about system health, changes in monitored traffic, and any errors experienced by Darktrace Security Modules or probe instances.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The Darktrace integration collects logs for three types of events: AI Analyst Alert, Model Breach Alert and System Status Alert.

--- a/packages/darktrace/manifest.yml
+++ b/packages/darktrace/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.3"
+format_version: "3.3.2"
 name: darktrace
 title: Darktrace
-version: "2.0.0"
+version: "2.1.0"
 description: Collect logs from Darktrace with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - network_security
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.19.2 || ^9.0.5"
 screenshots:
   - src: /img/darktrace-screenshot.png
     title: Darktrace Model Breach Alert Dashboard Screenshot
@@ -24,6 +24,14 @@ policy_templates:
   - name: darktrace
     title: Darktrace logs
     description: Collect logs from Darktrace.
+    deployment_modes:
+     default:
+       enabled: true
+     agentless:
+       enabled: true
+       organization: security
+       division: engineering
+       team: security-service-integrations
     inputs:
       - type: httpjson
         title: Collect Darktrace logs via API


### PR DESCRIPTION
## Proposed commit message

```
darktrace: add agentless deployment
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/darktrace directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #18930
