### PR TITLE
ti_recordedfuture: fix triggered_alert query parameter format

### DIFF
--- a/packages/ti_recordedfuture/_dev/deploy/docker/files/config-cel.yml
+++ b/packages/ti_recordedfuture/_dev/deploy/docker/files/config-cel.yml
@@ -3,7 +3,7 @@ rules:
     methods: ['GET']
     query_params:
       limit: 2
-      triggered: "{triggered:20[0-9]{2}.*}"
+      triggered: '{triggered:\[20[0-9]{2}.*}'
     request_headers:
       X-RFToken:
         - "xxxx"
@@ -198,7 +198,7 @@ rules:
     methods: ['GET']
     query_params:
       limit: 2
-      triggered: "{triggered:2500.*}"
+      triggered: '{triggered:\[2500.*}'
     request_headers:
       X-RFToken:
         - "xxxx"
@@ -391,7 +391,7 @@ rules:
     methods: ['GET']
     query_params:
       limit: 2
-      triggered: "{triggered:3000.*}"
+      triggered: '{triggered:\[3000.*}'
     request_headers:
       X-RFToken:
         - "xxxx"

--- a/packages/ti_recordedfuture/changelog.yml
+++ b/packages/ti_recordedfuture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Fix triggered_alert cursor not advancing due to incorrect query parameter format for the Recorded Future v3 alerts API.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18999
 - version: "2.5.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_recordedfuture/data_stream/triggered_alert/agent/stream/cel.yml.hbs
+++ b/packages/ti_recordedfuture/data_stream/triggered_alert/agent/stream/cel.yml.hbs
@@ -30,7 +30,7 @@ program: |
         state.url.trim_right("/") + "/v3/alerts?" + {
           "direction": ["desc"],
           "limit": [string(state.batch_size)],
-          "triggered": [string(state.start_time) + " to now"],
+          "triggered": ["[" + string(state.start_time) + ",]"],
         }.format_query()
       ).with({
         "Header":{
@@ -53,7 +53,7 @@ program: |
             :
               state.?cursor.last_timestamp
           },
-          "want_more": has(body.data) && body.data.size() > 0,
+          "want_more": has(body.data) && body.data.size() >= int(state.batch_size),
         })
       :
         {

--- a/packages/ti_recordedfuture/manifest.yml
+++ b/packages/ti_recordedfuture/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_recordedfuture
 title: Recorded Future
-version: "2.5.0"
+version: "2.5.1"
 description: Ingest threat intelligence and alert data from Recorded Future with Elastic Agent.
 type: integration
 format_version: 3.3.2


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
ti_recordedfuture: fix triggered_alert query parameter format

The triggered_alert data stream sent the Recorded Future v3 alerts API
a "triggered" query parameter in the form "x to now". This is not a
documented range format; the API docs specify bracket notation
"[x, y]" or "[x,]" for open-ended ranges. The undocumented form
caused the API to interpret the filter at day granularity, returning
the same results regardless of the timestamp portion, so the cursor
computed the same value every iteration and the input looped to
max_executions (DEGRADED).

Change the format to "[x,]" (documented open-ended range) and tighten
the want_more guard from "> 0" to ">= batch_size" so a partial page
terminates pagination. Update the system test mock regexes to require
the bracket prefix, catching regressions to the old format.

See https://docs.recordedfuture.com/reference/alerts-search for the
TriggeredQueryParameter documentation.

Fixes #18900
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #18900

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
