### PR TITLE
catalog-info: fix cron format

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -195,7 +195,7 @@ spec:
       schedules:
         main_daily:
           branch: "main"
-          cronline: "30 0 * 1-5"
+          cronline: "30 0 * * 1-5"
           message: "Run the daily jobs"
           env:
             TEST_PACKAGES_7_BRANCH: "true"
@@ -203,19 +203,19 @@ spec:
             REPUBLISH_PACKAGES: "true"
         main_daily_8_version:
           branch: "main"
-          cronline: "30 1 * 1-5"
+          cronline: "30 1 * * 1-5"
           message: "Run the daily jobs for 8.x"
           env:
             TEST_PACKAGES_8_BRANCH: "true"
         main_daily_9_version:
           branch: "main"
-          cronline: "30 3 * 1-5"
+          cronline: "30 3 * * 1-5"
           message: "Run the daily jobs for 9.x"
           env:
             TEST_PACKAGES_9_BRANCH: "true"
         main_daily_basic_subscription:
           branch: "main"
-          cronline: "30 4 * 1-5"
+          cronline: "30 4 * * 1-5"
           message: "Run the daily jobs for basic subscription"
           env:
             TEST_PACKAGES_BASIC_SUBSCRIPTION: "true"


### PR DESCRIPTION
It seems the validation we use to know if the entities are valid on a PR basis does not detect those misconfigurations :/


```
Validated (Backstage Entity) Component integrations ✓
Validated (RRE) Resource buildkite-pipeline-integrations ✓
Validated (RRE) Resource buildkite-pipeline-integrations-test-stack ✓
Validated (RRE) Resource pipeline-integrations-schedule-daily ✓
Validated (RRE) Resource pipeline-integrations-schedule-weekly ✓
Validated (RRE) Resource pipeline-integrations-serverless ✓
Validated (RRE) Resource pipeline-integrations-backport ✓
Validated (RRE) Resource buildkite-pipeline-integrations-publish ✓
```

https://github.com/elastic/integrations/actions/runs/25500866493/job/74833055478