### PR TITLE
[CI] Fix typos in messages from CI scripts and docs

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -284,7 +284,7 @@ fi
 echo "--- Check if the base commit exists."
 if [ ! -z "$BASE_COMMIT" ]; then
   if ! commitExists "$BASE_COMMIT" "$SOURCE_BRANCH"; then
-    buildkite-agent annotate "The entered commit hasn't found in the **${SOURCE_BRANCH}** branch" --style "error"
+    buildkite-agent annotate "The entered commit was not found in the **${SOURCE_BRANCH}** branch" --style "error"
     exit 1
   fi
 fi

--- a/.buildkite/scripts/test_integrations_with_serverless.sh
+++ b/.buildkite/scripts/test_integrations_with_serverless.sh
@@ -64,12 +64,12 @@ echo "Done."
 echo "--- Get from and to changesets"
 from="$(get_from_changeset)"
 if [[ "${from}" == "" ]]; then
-    echo "Missing \"from\" changset".
+    echo "Missing \"from\" changeset".
     exit 1
 fi
 to="$(get_to_changeset)"
 if [[ "${to}" == "" ]]; then
-    echo "Missing \"to\" changset".
+    echo "Missing \"to\" changeset".
     exit 1
 fi
 echo "Checking with commits: from: '${from}' to: '${to}'"

--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -27,12 +27,12 @@ EOF
 echo "--- Get from and to changesets"
 from="$(get_from_changeset)"
 if [[ "${from}" == "" ]]; then
-    echo "Missing \"from\" changset".
+    echo "Missing \"from\" changeset".
     exit 1
 fi
 to="$(get_to_changeset)"
 if [[ "${to}" == "" ]]; then
-    echo "Missing \"to\" changset".
+    echo "Missing \"to\" changeset".
     exit 1
 fi
 

--- a/docs/extend/testing-validation.md
+++ b/docs/extend/testing-validation.md
@@ -77,7 +77,7 @@ mapped_pages:
 
 `elastic-package` provides different types of test runners. See [*Test an integration*](/extend/testing.md) to learn about the various methods for testing packages.
 
-The `test` subcommand requires a reference to the live {{stack}}. This can be set up with `elastic=package stack up` command.
+The `test` subcommand requires a reference to the live {{stack}}. This can be set up with `elastic-package stack up` command.
 
 ## Review test coverage [_review_test_coverage]
 

--- a/magefile.go
+++ b/magefile.go
@@ -190,7 +190,7 @@ func ReportFailedTests(ctx context.Context, testResultsFolder string) error {
 		var err error
 		maxIssues, err = strconv.Atoi(maxIssuesString)
 		if err != nil {
-			return fmt.Errorf("failed to convert to int env. variable CI_MAX_TESTS_REPORTED %s: %w", maxIssuesString, err)
+			return fmt.Errorf("failed to convert env. variable CI_MAX_TESTS_REPORTED to int (%s): %w", maxIssuesString, err)
 		}
 	}
 
@@ -255,7 +255,7 @@ func IsSubscriptionCompatible() error {
 func KibanaConstraintPackage() error {
 	constraint, err := citools.KibanaConstraintPackage("manifest.yml")
 	if err != nil {
-		return fmt.Errorf("faile")
+		return fmt.Errorf("failed to get Kibana constraint")
 	}
 	if constraint == nil {
 		fmt.Println("null")


### PR DESCRIPTION
## Proposed commit message

Update messages in CI scripts and fix typo in docs related to testing and validation.

## Related issues

- Part of https://github.com/elastic/integrations/issues/18990
- Part of https://github.com/elastic/integrations/issues/18275
- Fixes https://github.com/elastic/integrations/issues/18936

