### PR TITLE
[Cisco Asa] Changes the grok pattern for message 305011 from using `%{IP:destination.address}` to `%{IPORHOST:destination.address}`, allowing the destination address to be a hostname or pool name

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -8,7 +8,7 @@
   changes:
     - description: Improve integration documentation
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/999999
+      link: https://github.com/elastic/integrations/pull/17273
 - version: "2.44.1"
   changes:
     - description: Fix parsing of 717022 messages.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,9 +1,14 @@
 # newer versions go on top
-- version: "2.45.1"
+- version: "2.45.2"
   changes:
     - description: Fix grok pattern for 305011 messages to accept pool names as destination address.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/999999
+      link: https://github.com/elastic/integrations/pull/18969
+- version: "2.45.1"
+  changes:
+    - description: Remove top level note from docs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/18969
 - version: "2.45.0"
   changes:
     - description: Improve integration documentation

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,14 +1,14 @@
 # newer versions go on top
 - version: "2.45.1"
   changes:
-    - description: Remove top level note from docs
+    - description: Fix grok pattern for 305011 messages to accept pool names as destination address.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/18969
+      link: https://github.com/elastic/integrations/pull/999999
 - version: "2.45.0"
   changes:
     - description: Improve integration documentation
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/17273
+      link: https://github.com/elastic/integrations/pull/999999
 - version: "2.44.1"
   changes:
     - description: Fix parsing of 717022 messages.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log
@@ -19,3 +19,4 @@ Jul  1 09:27:13 216.160.83.56 : %ASA-6-113039: Group <Group_VPN> User <support\c
 Jun 14 01:22:47 81.2.69.142 %ASA-5-304001: 192.168.14.22 Accessed URL mirror:http://mirror.example.com/path/to/resource
 Jul  1 09:27:13 216.160.83.56 : %ASA-6-113005: AAA user authentication Rejected : reason = AAA failure : server = 81.2.69.142 : user = 123 : user IP = 89.160.20.112
 Jul  1 09:27:13 216.160.83.56 : %ASA-6-113005: AAA user authentication Rejected : reason = Account has been disabled : server = 81.2.69.144 : user = alice : user IP = 89.160.20.128
+May  4 01:46:45 host-fw-01.example.local : %ASA-6-305011: Built dynamic TCP translation from inside-zone:192.0.2.15/61400 to external-zone:external-pool/61400

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -1750,6 +1750,100 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-05-04T01:46:45.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "external-zone",
+                    "source_interface": "inside-zone"
+                }
+            },
+            "destination": {
+                "address": "external-pool",
+                "domain": "external-pool",
+                "port": 61400
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "nat-slot",
+                "category": [
+                    "network",
+                    "configuration"
+                ],
+                "code": "305011",
+                "kind": "event",
+                "original": "May  4 01:46:45 host-fw-01.example.local : %ASA-6-305011: Built dynamic TCP translation from inside-zone:192.0.2.15/61400 to external-zone:external-pool/61400",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "creation"
+                ]
+            },
+            "host": {
+                "hostname": "host-fw-01.example.local"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "network": {
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "external-zone"
+                    }
+                },
+                "hostname": "host-fw-01.example.local",
+                "ingress": {
+                    "interface": {
+                        "name": "inside-zone"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host-fw-01.example.local",
+                    "external-pool"
+                ],
+                "ip": [
+                    "192.0.2.15"
+                ]
+            },
+            "source": {
+                "address": "192.0.2.15",
+                "as": {
+                    "number": 64500,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Las Vegas",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 36.17497,
+                        "lon": -115.13722
+                    },
+                    "region_iso_code": "US-NV",
+                    "region_name": "Nevada"
+                },
+                "ip": "192.0.2.15",
+                "port": 61400
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -640,7 +640,7 @@ processors:
       field: "message"
       description: "305011"
       patterns:
-        - Built %{NOTSPACE} %{NOTSPACE:network.transport} translation from %{NOTSPACE:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port}(\(%{NOTSPACE:source.user.name}\))? to %{NOTSPACE:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port}
+        - Built %{NOTSPACE} %{NOTSPACE:network.transport} translation from %{NOTSPACE:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port}(\(%{NOTSPACE:source.user.name}\))? to %{NOTSPACE:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}/%{NUMBER:destination.port}
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313001'"
       tag: parse_313001

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.45.1"
+version: "2.45.2"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
**Suggested label:** Enhancement _(pick the matching GitHub label)_
## Proposed commit message
<!-- Mandatory
Explain here the changes you made on the PR.
Please explain:
- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes
This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.
If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.
The text here and the PR title will be subject to the PR review process.
-->
**Squash subject line** (from Sentinel / primary PR):
```
[Cisco Asa] Changes the grok pattern for message 305011 from using `%{IP:destination.address}` to `%{IPORHOST:destination.address}`, allowing the destination address to be a hostname or pool name
```
## Executive summary
The fix changes the grok pattern for message 305011 from using `%{IP:destination.address}` to `%{IPORHOST:destination.address}`, allowing the destination address to be a hostname or pool name (e.g., `external-pool`) rather than requiring a strict IP address. This resolves the MISSING_CASE error where NAT translations using named pools as destination addresses failed to parse. A test case with a pool-name destination is added along with its expected output.
## Root cause
The grok pattern for 305011 uses `%{IP:destination.address}` which only matches IPv4/IPv6 addresses, but Cisco ASA 305011 messages can also report pool names (e.g., `external-pool`) as the destination when a NAT pool is involved; the source side already uses the more permissive `%{IPORHOST}` pattern.
## Approach
Change the grok pattern for message ID 305011 (tag: parse_305011) in default.yml from `%{IP:destination.address}` to `%{IPORHOST:destination.address}` on line 643. This aligns with how the source address is already matched using `%{IPORHOST:source.address}` and with the downstream grok at line 2234 that already handles converting destination.address to either destination.ip or destination.domain. Add a new test fixture entry (sanitized event) to an existing test log file and its expected output JSON, then bump the patch version in the package manifest and CHANGELOG.
## Pipeline changes
- Modify parse_305011 grok pattern: change `%{IP:destination.address}` to `%{IPORHOST:destination.address}` so pool names and hostnames are accepted as destination addresses, consistent with the existing `%{IPORHOST:source.address}` on the same pattern.
## Field / mapping changes
—
## Sanitized log (`event_sanitized` excerpt)
```json
May  4 01:46:45 host-fw-01.example.local : %ASA-6-305011: Built dynamic TCP translation from inside-zone:192.0.2.15/61400 to external-zone:external-pool/61400
```
## Reviewer concerns
• The `destination.address` field will now contain non-IP values (pool names/hostnames) in some events; downstream queries or visualizations that assume `destination.address` is always an IP may need adjustment.
• The expected output maps `destination.address: external-pool` and `destination.domain: external-pool` but omits `destination.ip`, which is correct behavior — reviewers should confirm downstream ECS enrichment processors (e.g., IP geo/AS lookup) handle missing `destination.ip` gracefully without erroring.
• The PR link in changelog.yml uses a placeholder (`#999999`) and must be updated to the real PR number before merge.
## Risk and classification
- **Plan risk level**: low
- **Tags**: pipeline, test-fixture, ingest, processors
- **Impact**: medium
## Links
- **Issue**: (no issue number)
- **Issue title**: cisco_asa.log [MISSING_CASE]: Processor 'grok' with tag 'parse_305011' in pipeline 'logs-cisco_asa.log…
- **Pipeline case**: `a151c0933f9b24f6` (Integration Sentinel)
---
_This pull request was opened from the Integration Sentinel agent fix flow._
## Checklist
- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)
## Author's Checklist
<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 
## How to test this PR locally
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Add the sanitized event to test-non-canonical.log and provide its expected output in test-non-canonical.log-expected.json. Validate with `elastic-package test pipeline` to confirm the pattern now matches and that destination.address='external-pool' and destination.domain='external-pool' appear in the output (with no destination.ip). Also confirm existing 305011 IP-based test cases still produce destination.ip correctly.
From a checkout of this branch:
```bash
cd packages/cisco_asa
elastic-package test
```
## Screenshots
<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
_None attached from Sentinel — add if applicable._