### PR TITLE
atlassian_jira: include timezone in audit query timestamp parameters

### DIFF
--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.1"
+  changes:
+    - description: Fix query timestamp parameter formatting.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19040
 - version: "1.31.0"
   changes:
     - description: Prevent updating fleet health status to degraded when pagination completes.

--- a/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -36,10 +36,10 @@ request.transforms:
   - set:
       target: url.params.from
       value: "[[.cursor.last_timestamp]]"
-      default: '[[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15:04:05.999"]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15:04:05.999Z"]]'
   - set:
       target: url.params.to
-      value: '[[formatDate (now) "2006-01-02T15:04:05.999"]]'
+      value: '[[formatDate (now) "2006-01-02T15:04:05.999Z"]]'
   - set:
       target: url.params.offset
       value: '0'

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.31.0"
+version: "1.31.1"
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
atlassian_jira: include timezone in audit query timestamp parameters

The from and to query parameters sent to the Jira Cloud audit
records API omitted the timezone designator, using the Go format
"2006-01-02T15:04:05.999" instead of "2006-01-02T15:04:05.999Z".

When the API is accessed through the Cloud ID gateway URL
(api.atlassian.com/ex/jira/{cloudId}), which scoped API tokens
require, timestamps without a timezone cause the API to return an
empty records array despite matching records existing.

The Atlassian OpenAPI spec does not document the expected format
for these string parameters, but the example response in both the
spec and the rendered docs uses the format
"2014-03-19T18:45:42.967+0000" (ISO 8601 with offset), and Java
client SDKs generated from the spec represent them as
OffsetDateTime. The cursor value in this same file was already
writing timestamps with "Z".

Fixes #18138
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #18138

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
