### PR TITLE
ti_misp: gate rate-limit header parsing behind opt-in toggle

### DIFF
--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.43.1"
+  changes:
+    - description: Disable `X-Rate-Limit-*` response header parsing by default. The agent went DEGRADED on MISP instances that do not have rate limiting enabled. A new `enable_rate_limit_headers` toggle (default off) lets users opt in when their MISP role enforces rate limits.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.43.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable `X-Rate-Limit-*` response header parsing by default. The agent went DEGRADED on MISP instances that do not have rate limiting enabled. A new `enable_rate_limit_headers` toggle (default off) lets users opt in when their MISP role enforces rate limits.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19041
 - version: "1.43.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -14,9 +14,11 @@ request.ssl: {{ssl}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
+{{#if enable_rate_limit_headers}}
 request.rate_limit.limit: '[[ .last_response.header.Get "X-Rate-Limit-Limit" ]]'
 request.rate_limit.remaining: '[[ .last_response.header.Get "X-Rate-Limit-Remaining" ]]'
 request.rate_limit.reset: '[[ add (toInt (.last_response.header.Get "X-Rate-Limit-Reset")) ((now).Unix) ]]'
+{{/if}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/ti_misp/data_stream/threat/manifest.yml
+++ b/packages/ti_misp/data_stream/threat/manifest.yml
@@ -43,6 +43,15 @@ streams:
         required: false
         show_user: false
         default: 30s
+      - name: enable_rate_limit_headers
+        type: bool
+        title: Enable MISP rate-limit response headers
+        description: >-
+          Enable this only if your MISP instance has "Enforce search rate limit" enabled on the API user's role. When enabled, the integration reads X-Rate-Limit-* response headers to pace requests. When disabled (the default), these headers are ignored, avoiding errors on MISP instances that do not return them.
+        multi: false
+        required: false
+        show_user: false
+        default: false
       - name: filters
         type: yaml
         title: MISP API Filters

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -14,9 +14,11 @@ request.ssl: {{ssl}}
 {{#if http_client_timeout}}
 request.timeout: {{http_client_timeout}}
 {{/if}}
+{{#if enable_rate_limit_headers}}
 request.rate_limit.limit: '[[ .last_response.header.Get "X-Rate-Limit-Limit" ]]'
 request.rate_limit.remaining: '[[ .last_response.header.Get "X-Rate-Limit-Remaining" ]]'
 request.rate_limit.reset: '[[ add (toInt (.last_response.header.Get "X-Rate-Limit-Reset")) ((now).Unix) ]]'
+{{/if}}
 {{#if proxy_url}}
 request.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/ti_misp/data_stream/threat_attributes/manifest.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/manifest.yml
@@ -61,6 +61,15 @@ streams:
         required: false
         show_user: false
         default: 30s
+      - name: enable_rate_limit_headers
+        type: bool
+        title: Enable MISP rate-limit response headers
+        description: >-
+          Enable this only if your MISP instance has "Enforce search rate limit" enabled on the API user's role. When enabled, the integration reads X-Rate-Limit-* response headers to pace requests. When disabled (the default), these headers are ignored, avoiding errors on MISP instances that do not return them.
+        multi: false
+        required: false
+        show_user: false
+        default: false
       - name: filters
         type: yaml
         title: MISP API Filters

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.43.0"
+version: "1.43.1"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.2"


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
ti_misp: gate rate-limit header parsing behind opt-in toggle

PR #18524 added unconditional request.rate_limit.* lines that read
X-Rate-Limit-* response headers from MISP. These headers are only
present when the MISP admin enables "Enforce search rate limit" on
the API user's role [1]. On instances without rate limiting enabled, the
templates evaluate to empty strings and valueTpl.Execute() sets the
agent health status to DEGRADED.

Wrap the three rate_limit lines in {{#if enable_rate_limit_headers}}
and add a new boolean variable (default false) to both data stream
manifests. The default-off toggle fixes the regression for the
majority of MISP deployments while preserving header-based rate
limiting for users who need it.

Fixes #18268

[1] - https://github.com/MISP/MISP/blob/2.5/app/Controller/Component/RateLimitComponent.php#L29
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/pull/18524
- Relates #18268 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
