### PR TITLE
[mongodb_atlas] Guard against null value for hostlist.

### DIFF
--- a/packages/mongodb_atlas/changelog.yml
+++ b/packages/mongodb_atlas/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Guard against null value for hostlist in disk, hardware, mongod_audit, mongod_database and process data streams.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/19042
 - version: "1.2.1"
   changes:
     - description: Fix `source.address` handling in alert pipeline to be ECS-aligned (write parsed IPs to `source.ip`, hostnames to `source.domain`).

--- a/packages/mongodb_atlas/changelog.yml
+++ b/packages/mongodb_atlas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Guard against null value for hostlist in disk, hardware, mongod_audit, mongod_database and process data streams.
+      type: bugfix
+      link: tba
 - version: "1.2.1"
   changes:
     - description: Fix `source.address` handling in alert pipeline to be ECS-aligned (write parsed IPs to `source.ip`, hostnames to `source.domain`).

--- a/packages/mongodb_atlas/data_stream/disk/agent/stream/input.yml.hbs
+++ b/packages/mongodb_atlas/data_stream/disk/agent/stream/input.yml.hbs
@@ -37,7 +37,7 @@ redact:
   fields: ~
 program: |
   (
-    (has(state.host_list) && size(state.host_list) > 0) ?
+    (has(state.host_list) && state.host_list != null && size(state.host_list) > 0) ?
       state
     :
       state.with(

--- a/packages/mongodb_atlas/data_stream/hardware/agent/stream/input.yml.hbs
+++ b/packages/mongodb_atlas/data_stream/hardware/agent/stream/input.yml.hbs
@@ -36,7 +36,7 @@ redact:
   fields: ~
 program: |
       (
-        (has(state.hostlist) && size(state.hostlist) > 0) ?
+        (has(state.hostlist) && state.hostlist != null && size(state.hostlist) > 0) ?
           state
         :
           state.with(

--- a/packages/mongodb_atlas/data_stream/mongod_audit/agent/stream/input.yml.hbs
+++ b/packages/mongodb_atlas/data_stream/mongod_audit/agent/stream/input.yml.hbs
@@ -35,7 +35,7 @@ redact:
   fields: ~
 program: |
     (
-      (has(state.hostlist) && size(state.hostlist) > 0) ?
+      (has(state.hostlist) && state.hostlist != null && size(state.hostlist) > 0) ?
         state
       :
         (

--- a/packages/mongodb_atlas/data_stream/mongod_database/agent/stream/input.yml.hbs
+++ b/packages/mongodb_atlas/data_stream/mongod_database/agent/stream/input.yml.hbs
@@ -35,7 +35,7 @@ redact:
   fields: ~
 program: |
     (
-      (has(state.hostlist) && size(state.hostlist) > 0) ?
+      (has(state.hostlist) && state.hostlist != null && size(state.hostlist) > 0) ?
         state
       :
         (

--- a/packages/mongodb_atlas/data_stream/process/agent/stream/input.yml.hbs
+++ b/packages/mongodb_atlas/data_stream/process/agent/stream/input.yml.hbs
@@ -36,7 +36,7 @@ redact:
   fields: ~
 program: |
       (
-        (has(state.hostlist) && size(state.hostlist) > 0) ?
+        (has(state.hostlist) && state.hostlist != null && size(state.hostlist) > 0) ?
           state
         :
           state.with(

--- a/packages/mongodb_atlas/manifest.yml
+++ b/packages/mongodb_atlas/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: mongodb_atlas
 title: "MongoDB Atlas"
-version: 1.2.1
+version: 1.2.2
 source:
   license: "Elastic-2.0"
 description: This Elastic integration collects logs and metrics from MongoDB Atlas instance.


### PR DESCRIPTION


## Proposed commit message

```
packages/mongodb_atlas/data_stream/:
- disk, hardware, mongod_audit, mongod_database and process 
```
Guard against null value for hostlist.
The CEL program uses size() on state.hostlist after a has() check, however, has() does not guarantee the value is non-null, which can still lead to errors when calling size(null). 

Therefore add explicit != null checks to it.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
