### PR TITLE
[CI] detect package changes on first push of long-running branches

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -648,9 +648,16 @@ get_from_changeset() {
         from="${previous_successful_commit}"
         if [[ "${previous_successful_commit}" == "null" ]]; then
             if [[ "${BUILDKITE_BRANCH}" =~ ${LONG_RUNNING_BRANCH_PATTERN} ]]; then
-                # First push of a new long-running branch (matches LONG_RUNNING_BRANCH_PATTERN): only CI infrastructure files
-                # changed, no package code was modified — skip package testing.
-                from="${BUILDKITE_COMMIT}"
+                # First push of a new long-running branch. Use the merge-base with main to scope
+                # the diff to commits exclusive to this branch. If those commits contain package
+                # changes, test them; otherwise (e.g. CI infra-only first commit) skip package testing.
+                local merge_base
+                merge_base=$(git merge-base "${BUILDKITE_COMMIT}" "origin/main")
+                if git diff --name-only "${merge_base}" "${BUILDKITE_COMMIT}" | grep -E '^packages/' > /dev/null; then
+                    from="${merge_base}"
+                else
+                    from="${BUILDKITE_COMMIT}"
+                fi
             else
                 from="origin/${BUILDKITE_BRANCH}^"
             fi

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -626,45 +626,45 @@ get_previous_successful_commit() {
 }
 
 get_from_changeset() {
-    local from=""
     if [ "${BUILDKITE_PULL_REQUEST}" != "false" ]; then
         echo "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
         return
     fi
 
-    local previous_commit
-    previous_commit=$(get_previous_commit "${BUILDKITE_PIPELINE_SLUG}" "${BUILDKITE_BRANCH}")
-
-    if [[ "${previous_commit}" != "null" ]] ; then
-        from="${previous_commit}"
-    else
-        from="${BUILDKITE_COMMIT}^"
-    fi
-
-    if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ${LONG_RUNNING_BRANCH_PATTERN} ]]; then
-        local previous_successful_commit
-        previous_successful_commit=$(get_previous_successful_commit "${BUILDKITE_PIPELINE_SLUG}" "${BUILDKITE_BRANCH}")
-
-        from="${previous_successful_commit}"
-        if [[ "${previous_successful_commit}" == "null" ]]; then
-            if [[ "${BUILDKITE_BRANCH}" =~ ${LONG_RUNNING_BRANCH_PATTERN} ]]; then
-                # First push of a new long-running branch. Use the merge-base with main to scope
-                # the diff to commits exclusive to this branch. If those commits contain package
-                # changes, test them; otherwise (e.g. CI infra-only first commit) skip package testing.
-                local merge_base
-                merge_base=$(git merge-base "${BUILDKITE_COMMIT}" "origin/main")
-                if git diff --name-only "${merge_base}" "${BUILDKITE_COMMIT}" | grep -E '^packages/' > /dev/null; then
-                    from="${merge_base}"
-                else
-                    from="${BUILDKITE_COMMIT}"
-                fi
-            else
-                from="origin/${BUILDKITE_BRANCH}^"
-            fi
+    if [[ "${BUILDKITE_BRANCH}" != "main" && ! "${BUILDKITE_BRANCH}" =~ ${LONG_RUNNING_BRANCH_PATTERN} ]]; then
+        local previous_commit
+        previous_commit=$(get_previous_commit "${BUILDKITE_PIPELINE_SLUG}" "${BUILDKITE_BRANCH}")
+        if [[ "${previous_commit}" != "null" ]]; then
+            echo "${previous_commit}"
+        else
+            echo "${BUILDKITE_COMMIT}^"
         fi
+        return
     fi
 
-    echo "${from}"
+    local previous_successful_commit
+    previous_successful_commit=$(get_previous_successful_commit "${BUILDKITE_PIPELINE_SLUG}" "${BUILDKITE_BRANCH}")
+
+    if [[ "${previous_successful_commit}" != "null" ]]; then
+        echo "${previous_successful_commit}"
+        return
+    fi
+
+    if [[ "${BUILDKITE_BRANCH}" == "main" ]]; then
+        echo "origin/${BUILDKITE_BRANCH}^"
+        return
+    fi
+
+    # First push of a long-running branch: use merge-base with main to scope the diff to
+    # commits exclusive to this branch. Test them only if they contain package changes
+    # (e.g. a CI infra-only first commit should not trigger package testing).
+    local merge_base
+    merge_base=$(git merge-base "${BUILDKITE_COMMIT}" "origin/main")
+    if git diff --name-only "${merge_base}" "${BUILDKITE_COMMIT}" | grep -E '^packages/' > /dev/null; then
+        echo "${merge_base}"
+    else
+        echo "${BUILDKITE_COMMIT}"
+    fi
 }
 
 get_to_changeset() {

--- a/docs/ci_pipelines.md
+++ b/docs/ci_pipelines.md
@@ -71,6 +71,9 @@ More details about this CI pipeline:
     - In branches context (`main`, `backport-*`, or `feature/*`):
         - The latest Buildkite build that finished successfully in that branch is retrieved, and all the file changes in the working copy between the changeset of that build and the merged commit are obtained.
         - Given all those changes, the packages selected to be tested follow the same rules as in the PR.
+        - **First push (no previous successful build):**
+            - For `backport-*` and `feature/*` branches: the merge-base between the pushed commit and `origin/main` is computed to find commits exclusive to the branch. If those commits contain changes under `packages/`, the affected packages are tested. If only CI infrastructure files changed (e.g. `.buildkite/`, `dev/`), no package tests are run.
+            - For `main`: diffs against `origin/main^` (the previous commit on main).
 - Container logs, as they could contain sensitive information, are uploaded to a private Google Bucket.
 - Packages are tested running the Elastic stack with the minimum Kibana version supported according to their manifest (`.conditions.kibana.version`). If a package defines a Kibana version that is not released yet, `elastic-package` will be using the SNAPSHOT version. This can be overridden if the STACK_VERSION variable is defined in the environment.
   In the following table, there are some examples:
@@ -233,5 +236,5 @@ https://www.elastic.co/guide/en/integrations-developer/current/developer-workflo
 - Every push to a `feature/*` branch triggers the main CI pipeline (https://buildkite.com/elastic/integrations), running the same package tests as a regular Pull Request.
 - Pull Requests targeting a `feature/*` branch also trigger CI checks, so all changes must pass CI before being merged into the feature branch.
 - Intermediate builds are cancelled or skipped when new commits arrive, consistent with `backport-*` branches.
-- Changeset detection works the same as for `backport-*` branches: only packages modified since the last successful build are tested. On the first push to a new `feature/*` branch, no package tests are run if only CI infrastructure files changed.
+- Changeset detection works the same as for `backport-*` branches: only packages modified since the last successful build are tested. On the first push to a new `feature/*` branch, the merge-base with `origin/main` is used to find commits exclusive to the branch — packages are tested only if those commits contain changes under `packages/`; if only CI infrastructure files changed, no package tests are run.
 - Publishing is **not** triggered for `feature/*` branches. Packages are published only when PRs are merged into `main` or `backport-*` branches.

--- a/docs/ci_pipelines.md
+++ b/docs/ci_pipelines.md
@@ -72,7 +72,7 @@ More details about this CI pipeline:
         - The latest Buildkite build that finished successfully in that branch is retrieved, and all the file changes in the working copy between the changeset of that build and the merged commit are obtained.
         - Given all those changes, the packages selected to be tested follow the same rules as in the PR.
         - **First push (no previous successful build):**
-            - For `backport-*` and `feature/*` branches: the merge-base between the pushed commit and `origin/main` is computed to find commits exclusive to the branch. If those commits contain changes under `packages/`, the affected packages are tested. If only CI infrastructure files changed (e.g. `.buildkite/`, `dev/`), no package tests are run.
+            - For `backport-*` and `feature/*` branches: the merge-base between the pushed commit and `origin/main` is computed to find commits exclusive to the branch. If those commits contain changes under `packages/`, the affected packages are tested. If only CI infrastructure files changed (for example `.buildkite/`, `dev/`), no package tests are run.
             - For `main`: diffs against `origin/main^` (the previous commit on main).
 - Container logs, as they could contain sensitive information, are uploaded to a private Google Bucket.
 - Packages are tested running the Elastic stack with the minimum Kibana version supported according to their manifest (`.conditions.kibana.version`). If a package defines a Kibana version that is not released yet, `elastic-package` will be using the SNAPSHOT version. This can be overridden if the STACK_VERSION variable is defined in the environment.


### PR DESCRIPTION
## Summary

On the first push of a new `backport-*` or `feature/*` branch with no prior
successful build, `get_from_changeset()` was unconditionally returning an empty
diff range, causing package tests to be silently skipped even when the pushed
commit contained real `packages/` changes. Fixed by computing the merge-base
with `origin/main` and checking whether commits exclusive to the branch touch
`packages/` before deciding whether to run package tests.

## Proposed commit message

```
On the first push of a new `backport-*` or `feature/*` branch with no previous
successful build, `get_from_changeset()` set `from="${BUILDKITE_COMMIT}"`, making
`from==to` and producing an empty diff. This caused package tests to be silently
skipped even when the pushed commit contained real package changes (e.g. when
the backport pipeline had no CI infra changes to commit and pushed the branch
directly at `BASE_COMMIT`, the package version bump commit).

Fix by computing` git merge-base "${BUILDKITE_COMMIT}" "origin/main"` to find the
divergence point from main, then checking whether commits exclusive to the branch
contain packages/ changes:
- If yes: use the merge-base as `from` so the affected packages are tested.
- If no (CI infra-only first commit): keep `from="${BUILDKITE_COMMIT}"`, producing
  an empty diff and skipping package testing as intended.

Also refactor `get_from_changeset()` to use early returns, removing three levels
of nested if/else and a dead get_previous_commit call unreachable for `main` and
long-running branches.

Update `docs/ci_pipelines.md` to document the first-push behaviour for `backport-*`,
`feature/*`, and `main` branches.
```

### WHAT

`get_from_changeset()` in `.buildkite/scripts/common.sh` previously set
`from="${BUILDKITE_COMMIT}"` for all `backport-*` and `feature/*` branches
when no previous successful build existed (first push). Since
`get_to_changeset()` also resolves to `BUILDKITE_COMMIT` for these branches,
this produced an empty diff range and caused package tests to be silently
skipped — even when the pushed commit contained real package changes.

This happened in a specific scenario: when the backport pipeline created the
branch at `BASE_COMMIT` but had no CI infrastructure changes to commit, the
branch was pushed pointing directly at `BASE_COMMIT` (the package version
bump), which does contain `packages/` changes.

The fix computes `git merge-base "${BUILDKITE_COMMIT}" "origin/main"` to find
the divergence point from `main`, then checks whether commits exclusive to the
branch contain `packages/` changes:
- If yes → use the merge-base as `from`, so the affected packages are tested.
- If no (CI infra-only first commit) → keep `from="${BUILDKITE_COMMIT}"`, producing an empty diff and skipping package testing as intended.

The function is also refactored to use early returns, eliminating three levels
of nested `if`/`else` and removing a dead `get_previous_commit` call that was
unreachable for `main` and long-running branches.

`docs/ci_pipelines.md` is updated to document the first-push behaviour for
`backport-*`, `feature/*`, and `main` branches.

### WHY

On the first push of a new `backport-*` branch, package regressions could
merge without package validation because CI annotated "No packages to be
tested" and skipped integration tests entirely. The same gap existed for
`feature/*` branches.


## Author's Checklist

- [x] `grep -q` replaced with `grep -E ... > /dev/null` consistent with the SIGPIPE warning documented throughout `common.sh`.

## Related issues

- Closes #18961
- Closes #18959
- Follows #18962

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).