### PR TITLE
[otel_collector_internal_telemetry] Document data_stream.dataset and fix queries for TBS dashboards

### DIFF
--- a/packages/otel_collector_internal_telemetry/changelog.yml
+++ b/packages/otel_collector_internal_telemetry/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Document `data_stream.dataset`: `collectortelemetry` and fix queries for TBS dashboards.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TODO
+      link: https://github.com/elastic/integrations/pull/19049
 - version: "1.2.0"
   changes:
     - description: Add tailsamplingprocessor specific visualizations and dashboards.

--- a/packages/otel_collector_internal_telemetry/changelog.yml
+++ b/packages/otel_collector_internal_telemetry/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.2.1"
   changes:
-    - description: Document `data_stream.dataset`: `collectortelemetry` and fix queries for TBS dashboards.
+    - description: Document setting data_stream.dataset to collectortelemetry and fix queries for TBS dashboards.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/19049
 - version: "1.2.0"

--- a/packages/otel_collector_internal_telemetry/changelog.yml
+++ b/packages/otel_collector_internal_telemetry/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Document `data_stream.dataset`: `collectortelemetry` and fix queries for TBS dashboards.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TODO
 - version: "1.2.0"
   changes:
     - description: Add tailsamplingprocessor specific visualizations and dashboards.

--- a/packages/otel_collector_internal_telemetry/docs/README.md
+++ b/packages/otel_collector_internal_telemetry/docs/README.md
@@ -10,6 +10,8 @@ The OTel collector dashboards are compatible with the metrics defined [here in t
 
 Furthermore, the package also contains dashboards to visualize metrics from the `tailsamplingprocessor`. Those metrics are documented [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/documentation.md).
 
+The dashboards query metrics from the `collectortelemetry` dataset. Set the resource attribute `data_stream.dataset` to `collectortelemetry` on the collector that emits internal telemetry (see below).
+
 ### How it works
 
 The dashboards rely on field names defined in above documentations.
@@ -18,11 +20,13 @@ The dashboards rely on field names defined in above documentations.
 
 You need to follow [the documentation](https://opentelemetry.io/docs/collector/internal-telemetry/) of the OpenTelemetry collector to setup and send internal telemetry to your cluster.
 
-The most important prerequisite is to define the `telemetry` section under `service`:
+The most important prerequisite is to define the `telemetry` section under `service` and to set `data_stream.dataset` to `collectortelemetry`. 
 
 ```
 service:
   telemetry:
+    resource:
+      data_stream.dataset: 'collectortelemetry'
     metrics:
       readers:
         - periodic:

--- a/packages/otel_collector_internal_telemetry/kibana/dashboard/otel_collector_internal_telemetry-tail-sampling-processor-otel.json
+++ b/packages/otel_collector_internal_telemetry/kibana/dashboard/otel_collector_internal_telemetry-tail-sampling-processor-otel.json
@@ -13,7 +13,7 @@
                 "c0ffee00-0000-4000-8000-000000000001": {
                     "explicitInput": {
                         "controlType": "VALUES_FROM_QUERY",
-                        "esqlQuery": "TS metrics-collectortelemetry.otel.otel-*\n| STATS BY service.instance.id, service.name \n| EVAL identifier = CONCAT(service.instance.id, \" (\",service.name,\")\")\n| KEEP identifier\n| STATS BY identifier\n| STATS identifiers = VALUES(identifier)\n| EVAL identifiers = MV_APPEND(identifiers, \"--ALL--\")\n| MV_EXPAND identifiers\n| RENAME identifiers AS identifier\n| SORT identifier\n",
+                        "esqlQuery": "TS metrics-collectortelemetry.otel-*\n| STATS BY service.instance.id, service.name \n| EVAL identifier = CONCAT(service.instance.id, \" (\",service.name,\")\")\n| KEEP identifier\n| STATS BY identifier\n| STATS identifiers = VALUES(identifier)\n| EVAL identifiers = MV_APPEND(identifiers, \"--ALL--\")\n| MV_EXPAND identifiers\n| RENAME identifiers AS identifier\n| SORT identifier\n",
                         "selectedOptions": [
                             "--ALL--"
                         ],
@@ -30,7 +30,7 @@
                 "c0ffee00-0000-4000-8000-000000000002": {
                     "explicitInput": {
                         "controlType": "VALUES_FROM_QUERY",
-                        "esqlQuery": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| STATS BY policy\n| KEEP policy\n| STATS policies = VALUES(policy)\n| EVAL policies = MV_APPEND(policies, \"--ALL--\")\n| MV_EXPAND policies\n| RENAME policies AS policy\n| SORT policy\n",
+                        "esqlQuery": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| STATS BY policy\n| KEEP policy\n| STATS policies = VALUES(policy)\n| EVAL policies = MV_APPEND(policies, \"--ALL--\")\n| MV_EXPAND policies\n| RENAME policies AS policy\n| SORT policy\n",
                         "selectedOptions": [
                             "--ALL--"
                         ],
@@ -130,11 +130,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -144,7 +144,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -192,7 +192,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -202,7 +202,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -277,7 +277,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -307,11 +307,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -321,7 +321,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -369,7 +369,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -379,7 +379,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -460,7 +460,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -490,11 +490,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -504,7 +504,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -552,7 +552,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"dropped\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"dropped\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -562,7 +562,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"dropped\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"dropped\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -643,7 +643,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"dropped\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_count_traces_sampled IS NOT NULL\n| WHERE decision == \"dropped\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, policy, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| WHERE ?tail_policy == \"--ALL--\" OR (policy IS NOT NULL AND ?tail_policy == policy)\n| EVAL series_label = CONCAT(policy, \" · \", _collector)\n| KEEP @timestamp, otelcol_processor_tail_sampling_count_traces_sampled, series_label\n| STATS trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,

--- a/packages/otel_collector_internal_telemetry/kibana/dashboard/otel_collector_internal_telemetry-tailsamplingprocessor-57f9048c-023d-47a4-b7e3-7f6a3e5a497b.json
+++ b/packages/otel_collector_internal_telemetry/kibana/dashboard/otel_collector_internal_telemetry-tailsamplingprocessor-57f9048c-023d-47a4-b7e3-7f6a3e5a497b.json
@@ -17,7 +17,7 @@
                 "c0ffee00-0000-4000-8000-000000000001": {
                     "explicitInput": {
                         "controlType": "VALUES_FROM_QUERY",
-                        "esqlQuery": "TS metrics-collectortelemetry.otel.otel-*\n| STATS BY service.instance.id, service.name \n| EVAL identifier = CONCAT(service.instance.id, \" (\",service.name,\")\")\n| KEEP identifier\n| STATS BY identifier\n| STATS identifiers = VALUES(identifier)\n| EVAL identifiers = MV_APPEND(identifiers, \"--ALL--\")\n| MV_EXPAND identifiers\n| RENAME identifiers AS identifier\n| SORT identifier\n",
+                        "esqlQuery": "TS metrics-collectortelemetry.otel-*\n| STATS BY service.instance.id, service.name \n| EVAL identifier = CONCAT(service.instance.id, \" (\",service.name,\")\")\n| KEEP identifier\n| STATS BY identifier\n| STATS identifiers = VALUES(identifier)\n| EVAL identifiers = MV_APPEND(identifiers, \"--ALL--\")\n| MV_EXPAND identifiers\n| RENAME identifiers AS identifier\n| SORT identifier\n",
                         "selectedOptions": [
                             "--ALL--"
                         ],
@@ -87,11 +87,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -101,7 +101,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -129,7 +129,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| STATS traces_on_memory = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory)\n| KEEP traces_on_memory\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| STATS traces_on_memory = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory)\n| KEEP traces_on_memory\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -139,7 +139,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| STATS traces_on_memory = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory)\n| KEEP traces_on_memory\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| STATS traces_on_memory = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory)\n| KEEP traces_on_memory\n"
                             },
                             "visualization": {
                                 "applyColorTo": "value",
@@ -162,7 +162,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| STATS traces_on_memory = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory)\n| KEEP traces_on_memory\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| STATS traces_on_memory = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory)\n| KEEP traces_on_memory\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -191,11 +191,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -205,7 +205,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -253,7 +253,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_new_trace_id_received IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id\n| STATS new_traces_per_sec = SUM(RATE(otelcol_processor_tail_sampling_new_trace_id_received)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_new_trace_id_received IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id\n| STATS new_traces_per_sec = SUM(RATE(otelcol_processor_tail_sampling_new_trace_id_received)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -263,7 +263,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_new_trace_id_received IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id\n| STATS new_traces_per_sec = SUM(RATE(otelcol_processor_tail_sampling_new_trace_id_received)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_new_trace_id_received IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id\n| STATS new_traces_per_sec = SUM(RATE(otelcol_processor_tail_sampling_new_trace_id_received)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -338,7 +338,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_new_trace_id_received IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id\n| STATS new_traces_per_sec = SUM(RATE(otelcol_processor_tail_sampling_new_trace_id_received)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_new_trace_id_received IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_new_trace_id_received, service.instance.id\n| STATS new_traces_per_sec = SUM(RATE(otelcol_processor_tail_sampling_new_trace_id_received)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -367,11 +367,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -381,7 +381,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -429,7 +429,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_trace_dropped_too_early IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id\n| STATS dropped_too_early_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_trace_dropped_too_early)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_trace_dropped_too_early IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id\n| STATS dropped_too_early_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_trace_dropped_too_early)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -439,7 +439,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_trace_dropped_too_early IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id\n| STATS dropped_too_early_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_trace_dropped_too_early)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_trace_dropped_too_early IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id\n| STATS dropped_too_early_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_trace_dropped_too_early)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -520,7 +520,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_trace_dropped_too_early IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id\n| STATS dropped_too_early_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_trace_dropped_too_early)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_trace_dropped_too_early IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_trace_dropped_too_early, service.instance.id\n| STATS dropped_too_early_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_trace_dropped_too_early)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -579,11 +579,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -593,7 +593,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -641,7 +641,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id\n| STATS traces_buffered = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id\n| STATS traces_buffered = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -651,7 +651,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id\n| STATS traces_buffered = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id\n| STATS traces_buffered = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -726,7 +726,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id\n| STATS traces_buffered = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_traces_on_memory IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_traces_on_memory, service.instance.id\n| STATS traces_buffered = MEDIAN(otelcol_processor_tail_sampling_sampling_traces_on_memory) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -755,11 +755,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -769,7 +769,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -817,7 +817,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_policy_evaluation_error IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id\n| STATS policy_errors_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_policy_evaluation_error)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_policy_evaluation_error IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id\n| STATS policy_errors_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_policy_evaluation_error)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -827,7 +827,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_policy_evaluation_error IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id\n| STATS policy_errors_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_policy_evaluation_error)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_policy_evaluation_error IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id\n| STATS policy_errors_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_policy_evaluation_error)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -902,7 +902,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_policy_evaluation_error IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id\n| STATS policy_errors_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_policy_evaluation_error)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_sampling_policy_evaluation_error IS NOT NULL\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| KEEP @timestamp, otelcol_processor_tail_sampling_sampling_policy_evaluation_error, service.instance.id\n| STATS policy_errors_per_sec = SUM(RATE(otelcol_processor_tail_sampling_sampling_policy_evaluation_error)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), service.instance.id\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -931,11 +931,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -945,7 +945,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -993,7 +993,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1003,7 +1003,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1078,7 +1078,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -1108,11 +1108,11 @@
                                     "fieldFormats": {},
                                     "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                     "managed": false,
-                                    "name": "metrics-collectortelemetry.otel.otel-*",
+                                    "name": "metrics-collectortelemetry.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-collectortelemetry.otel.otel-*",
+                                    "title": "metrics-collectortelemetry.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1122,7 +1122,7 @@
                                         {
                                             "id": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-collectortelemetry.otel.otel-*"
+                                            "title": "metrics-collectortelemetry.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -1170,7 +1170,7 @@
                                             ],
                                             "index": "a9f3c1e8d7b6543210fedcba9876543210abcdefabcdef0123456789abcd",
                                             "query": {
-                                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1180,7 +1180,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                                "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1261,7 +1261,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "TS metrics-collectortelemetry.otel.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
+                        "esql": "TS metrics-collectortelemetry.otel-*\n| WHERE otelcol_processor_tail_sampling_global_count_traces_sampled IS NOT NULL\n| WHERE decision == \"not_sampled\"\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, service.instance.id, service.name\n| EVAL _collector = CONCAT(service.instance.id, \" (\", service.name, \")\")\n| WHERE ?instance == \"--ALL--\" OR _collector == ?instance\n| EVAL series_label = _collector\n| KEEP @timestamp, otelcol_processor_tail_sampling_global_count_traces_sampled, series_label\n| STATS global_trace_decisions_per_sec = SUM(RATE(otelcol_processor_tail_sampling_global_count_traces_sampled)) BY Time = BUCKET(@timestamp, 100, ?_tstart, ?_tend), series_label\n"
                     },
                     "syncColors": false,
                     "syncCursor": true,

--- a/packages/otel_collector_internal_telemetry/manifest.yml
+++ b/packages/otel_collector_internal_telemetry/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.2
 name: otel_collector_internal_telemetry
 title: "OpenTelemetry Collector Internal Telemetry"
-version: 1.2.0
+version: 1.2.1
 source:
   license: "Apache-2.0"
 description: "This package contains dashboards that visualize the internal telemetry from the OpenTelemetry Collector"


### PR DESCRIPTION
Queries in the Dashboards for tailsampling processor (TBS) used double `otel` which resulted in not fetching data for the dashboards.

The PR fixes the queries and also document that users must set `data_stream.dataset` to `collectortelemetry`.

This was reported by @ty-elastic. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
