### PR TITLE
[backport] Copy .github/CODEOWNERS from main to backport branch

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -210,6 +210,11 @@ updateBackportBranchContents() {
     git checkout "$SOURCE_BRANCH" -- ".github/workflows"
     git add .github/workflows
 
+    # This should be copied from the main branch before running "removeOtherPackages" function
+    echo "--- Copying .github/CODEOWNERS from $SOURCE_BRANCH..."
+    git checkout "$SOURCE_BRANCH" -- ".github/CODEOWNERS"
+    git add .github/CODEOWNERS
+
     # Copy tools.go so we have the dev scripts dependencies required
     echo "--- Copying tools.go from $SOURCE_BRANCH..."
     git checkout "$SOURCE_BRANCH" -- "tools.go"


### PR DESCRIPTION
## Proposed commit message

Copy `.github/CODEOWNERS` from the `main` branch into newly created backport branches.

**WHAT:** In `updateBackportBranchContents`, after restoring `.github/workflows` from `main`, also restore `.github/CODEOWNERS` from `main` and stage it for the commit.

**WHY:** The backport branch is created from a historical `BASE_COMMIT`, so its `.github/CODEOWNERS` can be outdated — missing owners or packages added after that commit. GitHub uses the CODEOWNERS file from the **base branch** of a pull request to assign reviewers, so any PR targeting the backport branch would use the stale file. Copying from `main` ensures reviewer assignment is correct and consistent. It also provides a fresh, up-to-date starting point for `removeOtherPackages`, which subsequently strips CODEOWNERS entries for removed packages.

From GitHub documentation ([link](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)):
> Each CODEOWNERS file assigns the code owners for a single branch in the repository. Thus, you can assign different code owners for different branches, such as @octo-org/codeowners-team for a code base on the default branch and @ octocat for a GitHub Pages site on the gh-pages branch.



## Author's Checklist

- [x] Verify backport branch creation in dry-run mode shows correct `.github/CODEOWNERS` diff - https://buildkite.com/elastic/integrations-backport/builds/247

## How to test this PR locally

Run the backport pipeline in dry-run mode (`DRY_RUN=true`) for any package. Confirm the diff output includes `.github/CODEOWNERS` and that its contents match `main`.


---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).