### PR TITLE
chore: security_detection_engine and elastic_agent ownership (9.2 backport)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -203,7 +203,7 @@
 /packages/digital_guardian @elastic/security-service-integrations
 /packages/docker @elastic/obs-ds-hosted-services
 /packages/docker_otel @elastic/obs-ds-hosted-services
-/packages/elastic_agent @elastic/elastic-agent
+/packages/elastic_agent @elastic/elastic-agent-data-plane @elastic/elastic-agent-control-plane
 /packages/elastic_connectors @elastic/search-extract-and-transform
 /packages/elastic_package_registry @elastic/ecosystem
 /packages/elastic_security @elastic/security-service-integrations
@@ -400,7 +400,7 @@
 /packages/salesforce @elastic/obs-infraobs-integrations
 /packages/santa @elastic/security-service-integrations
 /packages/security_ai_prompts @elastic/security-generative-ai
-/packages/security_detection_engine @elastic/protections
+/packages/security_detection_engine @elastic/threat-research-and-detection-engineering
 /packages/sentinel_one @elastic/security-service-integrations
 /packages/sentinel_one_cloud_funnel @elastic/security-service-integrations
 /packages/servicenow @elastic/security-service-integrations

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -11,7 +11,7 @@ conditions:
   elastic:
     subscription: basic
 owner:
-  github: elastic/elastic-agent
+  github: elastic/elastic-agent-control-plane
   type: elastic
 icons:
   - src: /img/logo_elastic_agent.svg

--- a/packages/security_detection_engine/manifest.yml
+++ b/packages/security_detection_engine/manifest.yml
@@ -16,7 +16,7 @@ icons:
     type: image/svg+xml
 name: security_detection_engine
 owner:
-  github: elastic/protections
+  github: elastic/threat-research-and-detection-engineering
   type: elastic
 source:
   license: Elastic-2.0


### PR DESCRIPTION
## Summary
Backport of #18971 to the `security_detection_engine` release branch.

- Update `CODEOWNERS` so `/packages/security_detection_engine` is owned by `@elastic/threat-research-and-detection-engineering` instead of `@elastic/protections`.
- Update `packages/security_detection_engine/manifest.yml` so `owner.github` is `elastic/threat-research-and-detection-engineering`.
- Update `CODEOWNERS` so `/packages/elastic_agent` is owned by `@elastic/elastic-agent-data-plane` and `@elastic/elastic-agent-control-plane`.
- Update `packages/elastic_agent/manifest.yml` so `owner.github` is `elastic/elastic-agent-control-plane`.

## Validation
- Metadata-only changes; no runtime or test impact expected.

## Risks / Known Gaps
- None beyond the usual review load for the newly assigned teams on these package paths.

Related issue: https://github.com/elastic/observability-robots/issues/2986

Made with [Cursor](https://cursor.com)