### PR TITLE
[AWS][CloudWatch] Add record timestamp if missing from the original event

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.17.0"
+  changes:
+    - description: Add ingest timestamp to AWS CloudWatch logs if timestamp is not present in the event.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19078
 - version: "6.16.0"
   changes:
     - description: Add fail guard for unsupported VPC Flow Log formats so unrecognised records surface as pipeline errors instead of indexing silently unparsed.

--- a/packages/aws/data_stream/cloudwatch_logs/_dev/test/pipeline/test-cloudwatch-ec2.log-expected.json
+++ b/packages/aws/data_stream/cloudwatch_logs/_dev/test/pipeline/test-cloudwatch-ec2.log-expected.json
@@ -1,6 +1,7 @@
 {
     "expected": [
         {
+            "@timestamp": "2010-02-08T12.00.00",
             "cloud": {
                 "provider": "aws"
             },
@@ -17,6 +18,7 @@
             ]
         },
         {
+            "@timestamp": "2010-02-08T12.00.00",
             "cloud": {
                 "provider": "aws"
             },
@@ -33,6 +35,7 @@
             ]
         },
         {
+            "@timestamp": "2010-02-08T12.00.00",
             "cloud": {
                 "provider": "aws"
             },
@@ -49,6 +52,7 @@
             ]
         },
         {
+            "@timestamp": "2010-02-08T12.00.00",
             "cloud": {
                 "provider": "aws"
             },
@@ -65,6 +69,7 @@
             ]
         },
         {
+            "@timestamp": "2010-02-08T12.00.00",
             "cloud": {
                 "provider": "aws"
             },
@@ -81,6 +86,7 @@
             ]
         },
         {
+            "@timestamp": "2010-02-08T12.00.00",
             "cloud": {
                 "provider": "aws"
             },

--- a/packages/aws/data_stream/cloudwatch_logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,5 @@
+dynamic_fields:
+  "@timestamp": ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/aws/data_stream/cloudwatch_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/elasticsearch/ingest_pipeline/default.yml
@@ -16,6 +16,10 @@ processors:
   - set:
       field: event.kind
       value: event
+  - set:
+      field: '@timestamp'
+      value: "{{{_ingest.timestamp}}}"
+      override: false
 on_failure:
   - set:
       field: event.kind

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.16.0
+version: 6.17.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

This PR enhance the AWS CloudWatch logs integration by adding `@timestamp` if the original event does not include one.

This change allows the AWS CW pipeline to be used by any ingest system that does not include a timestamp. For example, FileBeat input does include a timestamp. But another system that ingest through bulk API may not include one.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
