### PR TITLE
Add @elastic/sit-crest-contractors as co-owners for security-service-integrations packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,17 +40,17 @@
 /packages/auditd_manager @elastic/sec-linux-platform
 /packages/auth0 @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/authentik @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/aws @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/aws/changelog.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/sit-crest-contractors @elastic/obs-infraobs-integrations
+/packages/aws @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations
+/packages/aws/changelog.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/apigateway_logs @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/apigateway_metrics @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/awshealth @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/billing @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/cloudfront_logs @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/cloudtrail @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/cloudtrail @elastic/security-service-integrations
 /packages/aws/data_stream/cloudwatch_logs @elastic/obs-ds-hosted-services
 /packages/aws/data_stream/cloudwatch_metrics @elastic/obs-ds-hosted-services
-/packages/aws/data_stream/config @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/config @elastic/security-service-integrations
 /packages/aws/data_stream/dynamodb @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/ebs @elastic/obs-ds-hosted-services
 /packages/aws/data_stream/ec2_logs @elastic/obs-ds-hosted-services
@@ -60,10 +60,10 @@
 /packages/aws/data_stream/elb_metrics @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/emr_logs @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/emr_metrics @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/firewall_logs @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/aws/data_stream/firewall_metrics @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/aws/data_stream/guardduty @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/aws/data_stream/inspector @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/firewall_logs @elastic/security-service-integrations
+/packages/aws/data_stream/firewall_metrics @elastic/security-service-integrations
+/packages/aws/data_stream/guardduty @elastic/security-service-integrations
+/packages/aws/data_stream/inspector @elastic/security-service-integrations
 /packages/aws/data_stream/kafka_metrics @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/kinesis @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/lambda @elastic/obs-infraobs-integrations
@@ -71,27 +71,27 @@
 /packages/aws/data_stream/natgateway @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/rds @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/redshift @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/route53_public_logs @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/aws/data_stream/route53_resolver_logs @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/route53_public_logs @elastic/security-service-integrations
+/packages/aws/data_stream/route53_resolver_logs @elastic/security-service-integrations
 /packages/aws/data_stream/s3_daily_storage @elastic/obs-ds-hosted-services
 /packages/aws/data_stream/s3_request @elastic/obs-ds-hosted-services
 /packages/aws/data_stream/s3_storage_lens @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/s3access @elastic/obs-ds-hosted-services
-/packages/aws/data_stream/securityhub_findings @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/aws/data_stream/securityhub_findings_full_posture @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/aws/data_stream/securityhub_insights @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/securityhub_findings @elastic/security-service-integrations
+/packages/aws/data_stream/securityhub_findings_full_posture @elastic/security-service-integrations
+/packages/aws/data_stream/securityhub_insights @elastic/security-service-integrations
 /packages/aws/data_stream/sns @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/sqs @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/transitgateway @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/usage @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/vpcflow @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/vpcflow @elastic/security-service-integrations
 /packages/aws/data_stream/vpn @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/waf @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/waf @elastic/security-service-integrations
 /packages/aws/kibana @elastic/obs-ds-hosted-services @elastic/obs-infraobs-integrations
-/packages/aws/manifest.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/sit-crest-contractors @elastic/obs-infraobs-integrations
-/packages/aws_bedrock @elastic/security-service-integrations @elastic/sit-crest-contractors @elastic/obs-infraobs-integrations
+/packages/aws/manifest.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/obs-infraobs-integrations
+/packages/aws_bedrock @elastic/security-service-integrations @elastic/obs-infraobs-integrations
 /packages/aws_bedrock/data_stream/guardrails @elastic/obs-infraobs-integrations
-/packages/aws_bedrock/data_stream/invocation @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws_bedrock/data_stream/invocation @elastic/security-service-integrations
 /packages/aws_bedrock/data_stream/runtime @elastic/obs-infraobs-integrations
 /packages/aws_billing @elastic/obs-infraobs-integrations 
 /packages/aws_cloudtrail_otel @elastic/obs-infraobs-integrations
@@ -103,15 +103,15 @@
 /packages/aws_waf_otel @elastic/obs-infraobs-integrations
 /packages/awsfargate @elastic/obs-infraobs-integrations
 /packages/awsfirehose @elastic/obs-ds-hosted-services
-/packages/azure @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/azure/data_stream/aadgraphactivitylogs @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/azure @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations
+/packages/azure/data_stream/aadgraphactivitylogs @elastic/security-service-integrations
 /packages/azure/data_stream/activitylogs @elastic/obs-infraobs-integrations
-/packages/azure/data_stream/application_gateway @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/azure/data_stream/application_gateway @elastic/security-service-integrations
 /packages/azure/data_stream/auditlogs @elastic/obs-infraobs-integrations
 /packages/azure/data_stream/eventhub @elastic/obs-ds-hosted-services
 /packages/azure/data_stream/events @elastic/obs-ds-hosted-services
-/packages/azure/data_stream/firewall_logs @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/azure/data_stream/graphactivitylogs @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/azure/data_stream/firewall_logs @elastic/security-service-integrations
+/packages/azure/data_stream/graphactivitylogs @elastic/security-service-integrations
 /packages/azure/data_stream/identity_protection @elastic/obs-infraobs-integrations
 /packages/azure/data_stream/platformlogs @elastic/obs-infraobs-integrations
 /packages/azure/data_stream/provisioning @elastic/obs-infraobs-integrations
@@ -262,8 +262,8 @@
 /packages/fortinet_fortimail @elastic/integration-experience
 /packages/fortinet_fortimanager @elastic/integration-experience
 /packages/fortinet_fortiproxy @elastic/integration-experience
-/packages/gcp @elastic/security-service-integrations @elastic/sit-crest-contractors @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services
-/packages/gcp/data_stream/audit @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/gcp @elastic/security-service-integrations @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services
+/packages/gcp/data_stream/audit @elastic/security-service-integrations
 /packages/gcp/data_stream/billing @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/cloudrun_metrics @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/cloudsql_mysql @elastic/obs-infraobs-integrations
@@ -271,16 +271,16 @@
 /packages/gcp/data_stream/cloudsql_sqlserver @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/compute @elastic/obs-ds-hosted-services
 /packages/gcp/data_stream/dataproc @elastic/obs-infraobs-integrations
-/packages/gcp/data_stream/dns @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/gcp/data_stream/dns @elastic/security-service-integrations
 /packages/gcp/data_stream/firestore @elastic/obs-infraobs-integrations
-/packages/gcp/data_stream/firewall @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/gcp/data_stream/firewall @elastic/security-service-integrations
 /packages/gcp/data_stream/gke @elastic/obs-ds-hosted-services
 /packages/gcp/data_stream/loadbalancing_logs @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/loadbalancing_metrics @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/pubsub @elastic/obs-ds-hosted-services
 /packages/gcp/data_stream/redis @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/storage @elastic/obs-ds-hosted-services
-/packages/gcp/data_stream/vpcflow @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/gcp/data_stream/vpcflow @elastic/security-service-integrations
 /packages/gcp_metrics @elastic/obs-ds-hosted-services
 /packages/gcp_pubsub @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/gcp_vertexai @elastic/obs-infraobs-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,17 +13,17 @@
 
 # Package owners below.
 # Please keep the list sorted.
-/packages/1password @elastic/security-service-integrations
-/packages/abnormal_security @elastic/security-service-integrations
+/packages/1password @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/abnormal_security @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/activemq @elastic/obs-infraobs-integrations
 /packages/activemq_otel @elastic/obs-infraobs-integrations
-/packages/admin_by_request_epm @elastic/security-service-integrations
+/packages/admin_by_request_epm @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/agentless_hello_world @elastic/ingest-managed-jobs
 /packages/airflow @elastic/obs-infraobs-integrations
 /packages/airflow_otel @elastic/obs-infraobs-integrations
-/packages/airlock_digital @elastic/security-service-integrations
-/packages/akamai @elastic/security-service-integrations
-/packages/amazon_security_lake @elastic/security-service-integrations
+/packages/airlock_digital @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/akamai @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/amazon_security_lake @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/apache @elastic/obs-infraobs-integrations
 /packages/apache_input_otel @elastic/ecosystem
 /packages/apache_otel @elastic/obs-infraobs-integrations
@@ -32,25 +32,25 @@
 /packages/apache_tomcat_otel @elastic/obs-infraobs-integrations
 /packages/apm @elastic/obs-ds-intake-services
 /packages/arista_ngfw @elastic/integration-experience
-/packages/armis @elastic/security-service-integrations
-/packages/atlassian_bitbucket @elastic/security-service-integrations
-/packages/atlassian_confluence @elastic/security-service-integrations
-/packages/atlassian_jira @elastic/security-service-integrations
+/packages/armis @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/atlassian_bitbucket @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/atlassian_confluence @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/atlassian_jira @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/auditd @elastic/sec-linux-platform
 /packages/auditd_manager @elastic/sec-linux-platform
-/packages/auth0 @elastic/security-service-integrations
-/packages/authentik @elastic/security-service-integrations
-/packages/aws @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations
-/packages/aws/changelog.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/obs-infraobs-integrations
+/packages/auth0 @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/authentik @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/changelog.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/sit-crest-contractors @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/apigateway_logs @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/apigateway_metrics @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/awshealth @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/billing @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/cloudfront_logs @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/cloudtrail @elastic/security-service-integrations
+/packages/aws/data_stream/cloudtrail @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws/data_stream/cloudwatch_logs @elastic/obs-ds-hosted-services
 /packages/aws/data_stream/cloudwatch_metrics @elastic/obs-ds-hosted-services
-/packages/aws/data_stream/config @elastic/security-service-integrations
+/packages/aws/data_stream/config @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws/data_stream/dynamodb @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/ebs @elastic/obs-ds-hosted-services
 /packages/aws/data_stream/ec2_logs @elastic/obs-ds-hosted-services
@@ -60,10 +60,10 @@
 /packages/aws/data_stream/elb_metrics @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/emr_logs @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/emr_metrics @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/firewall_logs @elastic/security-service-integrations
-/packages/aws/data_stream/firewall_metrics @elastic/security-service-integrations
-/packages/aws/data_stream/guardduty @elastic/security-service-integrations
-/packages/aws/data_stream/inspector @elastic/security-service-integrations
+/packages/aws/data_stream/firewall_logs @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/firewall_metrics @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/guardduty @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/inspector @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws/data_stream/kafka_metrics @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/kinesis @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/lambda @elastic/obs-infraobs-integrations
@@ -71,47 +71,47 @@
 /packages/aws/data_stream/natgateway @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/rds @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/redshift @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/route53_public_logs @elastic/security-service-integrations
-/packages/aws/data_stream/route53_resolver_logs @elastic/security-service-integrations
+/packages/aws/data_stream/route53_public_logs @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/route53_resolver_logs @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws/data_stream/s3_daily_storage @elastic/obs-ds-hosted-services
 /packages/aws/data_stream/s3_request @elastic/obs-ds-hosted-services
 /packages/aws/data_stream/s3_storage_lens @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/s3access @elastic/obs-ds-hosted-services
-/packages/aws/data_stream/securityhub_findings @elastic/security-service-integrations
-/packages/aws/data_stream/securityhub_findings_full_posture @elastic/security-service-integrations
-/packages/aws/data_stream/securityhub_insights @elastic/security-service-integrations
+/packages/aws/data_stream/securityhub_findings @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/securityhub_findings_full_posture @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/aws/data_stream/securityhub_insights @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws/data_stream/sns @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/sqs @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/transitgateway @elastic/obs-infraobs-integrations
 /packages/aws/data_stream/usage @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/vpcflow @elastic/security-service-integrations
+/packages/aws/data_stream/vpcflow @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws/data_stream/vpn @elastic/obs-infraobs-integrations
-/packages/aws/data_stream/waf @elastic/security-service-integrations
+/packages/aws/data_stream/waf @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws/kibana @elastic/obs-ds-hosted-services @elastic/obs-infraobs-integrations
-/packages/aws/manifest.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/obs-infraobs-integrations
-/packages/aws_bedrock @elastic/security-service-integrations @elastic/obs-infraobs-integrations
+/packages/aws/manifest.yml @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/sit-crest-contractors @elastic/obs-infraobs-integrations
+/packages/aws_bedrock @elastic/security-service-integrations @elastic/sit-crest-contractors @elastic/obs-infraobs-integrations
 /packages/aws_bedrock/data_stream/guardrails @elastic/obs-infraobs-integrations
-/packages/aws_bedrock/data_stream/invocation @elastic/security-service-integrations
+/packages/aws_bedrock/data_stream/invocation @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws_bedrock/data_stream/runtime @elastic/obs-infraobs-integrations
 /packages/aws_billing @elastic/obs-infraobs-integrations 
 /packages/aws_cloudtrail_otel @elastic/obs-infraobs-integrations
 /packages/aws_logs @elastic/obs-ds-hosted-services
 /packages/aws_mq @elastic/obs-infraobs-integrations
-/packages/aws_securityhub @elastic/security-service-integrations
+/packages/aws_securityhub @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/aws_bedrock_agentcore @elastic/obs-infraobs-integrations
 /packages/aws_vpcflow_otel @elastic/obs-infraobs-integrations
 /packages/aws_waf_otel @elastic/obs-infraobs-integrations
 /packages/awsfargate @elastic/obs-infraobs-integrations
 /packages/awsfirehose @elastic/obs-ds-hosted-services
-/packages/azure @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations
-/packages/azure/data_stream/aadgraphactivitylogs @elastic/security-service-integrations
+/packages/azure @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/azure/data_stream/aadgraphactivitylogs @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/azure/data_stream/activitylogs @elastic/obs-infraobs-integrations
-/packages/azure/data_stream/application_gateway @elastic/security-service-integrations
+/packages/azure/data_stream/application_gateway @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/azure/data_stream/auditlogs @elastic/obs-infraobs-integrations
 /packages/azure/data_stream/eventhub @elastic/obs-ds-hosted-services
 /packages/azure/data_stream/events @elastic/obs-ds-hosted-services
-/packages/azure/data_stream/firewall_logs @elastic/security-service-integrations
-/packages/azure/data_stream/graphactivitylogs @elastic/security-service-integrations
+/packages/azure/data_stream/firewall_logs @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/azure/data_stream/graphactivitylogs @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/azure/data_stream/identity_protection @elastic/obs-infraobs-integrations
 /packages/azure/data_stream/platformlogs @elastic/obs-infraobs-integrations
 /packages/azure/data_stream/provisioning @elastic/obs-infraobs-integrations
@@ -126,8 +126,8 @@
 /packages/azure_application_insights/data_stream/app_state @elastic/obs-infraobs-integrations
 /packages/azure_billing @elastic/obs-infraobs-integrations
 /packages/azure_billing/data_stream/billing @elastic/obs-infraobs-integrations
-/packages/azure_blob_storage @elastic/security-service-integrations
-/packages/azure_frontdoor @elastic/security-service-integrations
+/packages/azure_blob_storage @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/azure_frontdoor @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/azure_functions @elastic/obs-infraobs-integrations
 /packages/azure_functions/data_stream/functionapplogs @elastic/obs-infraobs-integrations
 /packages/azure_functions/data_stream/metrics @elastic/obs-infraobs-integrations
@@ -141,38 +141,38 @@
 /packages/azure_metrics/data_stream/database_account @elastic/obs-ds-hosted-services
 /packages/azure_metrics/data_stream/monitor @elastic/obs-ds-hosted-services
 /packages/azure_metrics/data_stream/storage_account @elastic/obs-ds-hosted-services
-/packages/azure_network_watcher_nsg @elastic/security-service-integrations
-/packages/azure_network_watcher_vnet @elastic/security-service-integrations
+/packages/azure_network_watcher_nsg @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/azure_network_watcher_vnet @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/azure_openai @elastic/obs-infraobs-integrations
 /packages/barracuda @elastic/integration-experience
 /packages/barracuda_cloudgen_firewall @elastic/integration-experience
-/packages/bbot @elastic/security-service-integrations
+/packages/bbot @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/beaconing @elastic/sec-applied-ml @elastic/kibana-management 
 /packages/beat @elastic/stack-monitoring
-/packages/beelzebub @elastic/security-service-integrations
-/packages/beyondinsight_password_safe @elastic/security-service-integrations
-/packages/beyondtrust_pra @elastic/security-service-integrations
-/packages/bitdefender @elastic/security-service-integrations
-/packages/bitsight @elastic/security-service-integrations
-/packages/bitwarden @elastic/security-service-integrations
-/packages/blacklens @elastic/security-service-integrations
+/packages/beelzebub @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/beyondinsight_password_safe @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/beyondtrust_pra @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/bitdefender @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/bitsight @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/bitwarden @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/blacklens @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/bluecoat @elastic/integration-experience
-/packages/box_events @elastic/security-service-integrations
-/packages/canva @elastic/security-service-integrations
-/packages/carbon_black_cloud @elastic/security-service-integrations
-/packages/carbonblack_edr @elastic/security-service-integrations
+/packages/box_events @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/canva @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/carbon_black_cloud @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/carbonblack_edr @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cassandra @elastic/obs-infraobs-integrations
 /packages/cassandra_otel @elastic/obs-infraobs-integrations
 /packages/cef @elastic/integration-experience
-/packages/cel @elastic/security-service-integrations
+/packages/cel @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/ceph @elastic/obs-infraobs-integrations
 /packages/checkpoint @elastic/integration-experience
-/packages/checkpoint_email @elastic/security-service-integrations
-/packages/checkpoint_harmony_endpoint @elastic/security-service-integrations
-/packages/cisa_kevs @elastic/security-service-integrations
+/packages/checkpoint_email @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/checkpoint_harmony_endpoint @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/cisa_kevs @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cisco_aironet @elastic/integration-experience
 /packages/cisco_asa @elastic/integration-experience
-/packages/cisco_duo @elastic/security-service-integrations
+/packages/cisco_duo @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cisco_ftd @elastic/integration-experience
 /packages/cisco_ios @elastic/integration-experience
 /packages/cisco_ise @elastic/integration-experience
@@ -180,7 +180,7 @@
 /packages/cisco_meraki_metrics @elastic/obs-infraobs-integrations
 /packages/cisco_nexus @elastic/integration-experience
 /packages/cisco_secure_email_gateway @elastic/integration-experience
-/packages/cisco_secure_endpoint @elastic/security-service-integrations
+/packages/cisco_secure_endpoint @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cisco_umbrella @elastic/integration-experience
 /packages/citrix_adc @elastic/obs-infraobs-integrations @elastic/integration-experience
 /packages/citrix_adc/data_stream/interface @elastic/obs-infraobs-integrations
@@ -190,13 +190,13 @@
 /packages/citrix_adc/data_stream/system @elastic/obs-infraobs-integrations
 /packages/citrix_adc/data_stream/vpn @elastic/obs-infraobs-integrations
 /packages/citrix_waf @elastic/integration-experience
-/packages/claroty_ctd @elastic/security-service-integrations
-/packages/claroty_xdome @elastic/security-service-integrations
+/packages/claroty_ctd @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/claroty_xdome @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cloud_asset_inventory @elastic/cloud-services
 /packages/cloud_defend @elastic/cloud-services
 /packages/cloud_security_posture @elastic/cloud-services
-/packages/cloudflare @elastic/security-service-integrations
-/packages/cloudflare_logpush @elastic/security-service-integrations
+/packages/cloudflare @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/cloudflare_logpush @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cockroachdb @elastic/obs-infraobs-integrations
 /packages/cockroachdb_otel @elastic/obs-infraobs-integrations
 /packages/containerd @elastic/obs-ds-hosted-services
@@ -206,26 +206,26 @@
 /packages/couchdb @elastic/obs-infraobs-integrations
 /packages/couchdb_otel @elastic/obs-infraobs-integrations
 /packages/cribl @elastic/integration-experience
-/packages/crowdstrike @elastic/security-service-integrations
+/packages/crowdstrike @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/cursor @elastic/integration-experience
-/packages/cyberark_epm @elastic/security-service-integrations
-/packages/cyberark_pta @elastic/security-service-integrations
-/packages/cyberarkpas @elastic/security-service-integrations
-/packages/cybereason @elastic/security-service-integrations
-/packages/cyera @elastic/security-service-integrations
-/packages/cylance @elastic/security-service-integrations
-/packages/darktrace @elastic/security-service-integrations
-/packages/dataminr_pulse @elastic/security-service-integrations
+/packages/cyberark_epm @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/cyberark_pta @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/cyberarkpas @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/cybereason @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/cyera @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/cylance @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/darktrace @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/dataminr_pulse @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/ded @elastic/sec-applied-ml @elastic/kibana-management
 /packages/dga @elastic/sec-applied-ml
-/packages/digital_guardian @elastic/security-service-integrations
+/packages/digital_guardian @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/docker @elastic/obs-ds-hosted-services
 /packages/docker_input_otel @elastic/ecosystem
 /packages/docker_otel @elastic/obs-ds-hosted-services
 /packages/elastic_agent @elastic/elastic-agent-data-plane @elastic/elastic-agent-control-plane
 /packages/elastic_connectors @elastic/search-extract-and-transform
 /packages/elastic_package_registry @elastic/ecosystem
-/packages/elastic_security @elastic/security-service-integrations
+/packages/elastic_security @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/elasticapm_input_otel @elastic/ecosystem
 /packages/elasticsearch @elastic/stack-monitoring
 /packages/aws_elb_otel @elastic/obs-infraobs-integrations
@@ -234,36 +234,36 @@
 /packages/endace/data_stream/flow @elastic/sec-linux-platform
 /packages/endace/data_stream/log @elastic/integration-experience
 /packages/enterprisesearch @elastic/stack-monitoring
-/packages/entityanalytics_ad @elastic/security-service-integrations
-/packages/entityanalytics_entra_id @elastic/security-service-integrations
-/packages/entityanalytics_okta @elastic/security-service-integrations
-/packages/entro @elastic/security-service-integrations
+/packages/entityanalytics_ad @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/entityanalytics_entra_id @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/entityanalytics_okta @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/entro @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/envoyproxy @elastic/obs-infraobs-integrations
 /packages/envoyproxy_otel @elastic/obs-infraobs-integrations
-/packages/eset_protect @elastic/security-service-integrations
+/packages/eset_protect @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/ess_billing @elastic/customer-architects @elastic/obs-infraobs-integrations
 /packages/etcd @elastic/obs-infraobs-integrations
 /packages/etcd_otel @elastic/obs-infraobs-integrations
-/packages/extrahop @elastic/security-service-integrations
+/packages/extrahop @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/f5_bigip @elastic/integration-experience
 /packages/falco @elastic/integration-experience
 /packages/filelog_otel @elastic/ecosystem
 /packages/filestream @elastic/elastic-agent-data-plane
 /packages/fim @elastic/sec-linux-platform
 /packages/fireeye @elastic/integration-experience
-/packages/first_epss @elastic/security-service-integrations
+/packages/first_epss @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/fleet_server @elastic/fleet
 /packages/forcepoint_web @elastic/integration-experience
 /packages/forescout @elastic/integration-experience
-/packages/forgerock @elastic/security-service-integrations
+/packages/forgerock @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/fortinet_forticlient @elastic/integration-experience
 /packages/fortinet_fortiedr @elastic/integration-experience
 /packages/fortinet_fortigate @elastic/integration-experience
 /packages/fortinet_fortimail @elastic/integration-experience
 /packages/fortinet_fortimanager @elastic/integration-experience
 /packages/fortinet_fortiproxy @elastic/integration-experience
-/packages/gcp @elastic/security-service-integrations @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services
-/packages/gcp/data_stream/audit @elastic/security-service-integrations
+/packages/gcp @elastic/security-service-integrations @elastic/sit-crest-contractors @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services
+/packages/gcp/data_stream/audit @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/gcp/data_stream/billing @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/cloudrun_metrics @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/cloudsql_mysql @elastic/obs-infraobs-integrations
@@ -271,32 +271,32 @@
 /packages/gcp/data_stream/cloudsql_sqlserver @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/compute @elastic/obs-ds-hosted-services
 /packages/gcp/data_stream/dataproc @elastic/obs-infraobs-integrations
-/packages/gcp/data_stream/dns @elastic/security-service-integrations
+/packages/gcp/data_stream/dns @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/gcp/data_stream/firestore @elastic/obs-infraobs-integrations
-/packages/gcp/data_stream/firewall @elastic/security-service-integrations
+/packages/gcp/data_stream/firewall @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/gcp/data_stream/gke @elastic/obs-ds-hosted-services
 /packages/gcp/data_stream/loadbalancing_logs @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/loadbalancing_metrics @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/pubsub @elastic/obs-ds-hosted-services
 /packages/gcp/data_stream/redis @elastic/obs-infraobs-integrations
 /packages/gcp/data_stream/storage @elastic/obs-ds-hosted-services
-/packages/gcp/data_stream/vpcflow @elastic/security-service-integrations
+/packages/gcp/data_stream/vpcflow @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/gcp_metrics @elastic/obs-ds-hosted-services
-/packages/gcp_pubsub @elastic/security-service-integrations
+/packages/gcp_pubsub @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/gcp_vertexai @elastic/obs-infraobs-integrations
 /packages/gcp_audit_otel @elastic/obs-infraobs-integrations
 /packages/gcp_vpcflow_otel @elastic/obs-infraobs-integrations
 /packages/gigamon @elastic/integration-experience
-/packages/github @elastic/security-service-integrations
-/packages/gitlab @elastic/security-service-integrations
+/packages/github @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/gitlab @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/goflow2 @elastic/integration-experience
 /packages/golang @elastic/obs-infraobs-integrations
-/packages/google_cloud_storage @elastic/security-service-integrations
-/packages/google_scc @elastic/security-service-integrations
-/packages/google_secops @elastic/security-service-integrations
-/packages/google_workspace @elastic/security-service-integrations
+/packages/google_cloud_storage @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/google_scc @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/google_secops @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/google_workspace @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/grafana @elastic/obs-infraobs-integrations
-/packages/greenhouse @elastic/security-service-integrations
+/packages/greenhouse @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/hadoop @elastic/obs-infraobs-integrations
 /packages/haproxy @elastic/obs-infraobs-integrations
 /packages/haproxy_otel @elastic/obs-infraobs-integrations
@@ -305,75 +305,75 @@
 /packages/hostmetrics_input_otel @elastic/obs-infraobs-integrations
 /packages/hpe_aruba_cx @elastic/integration-experience
 /packages/hta @elastic/sec-applied-ml
-/packages/http_endpoint @elastic/security-service-integrations
+/packages/http_endpoint @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/httpcheck_otel @elastic/ecosystem
-/packages/httpjson @elastic/security-service-integrations
-/packages/ibm_qradar @elastic/security-service-integrations
+/packages/httpjson @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ibm_qradar @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/ibmmq @elastic/obs-infraobs-integrations
 /packages/ibmmq_otel @elastic/obs-infraobs-integrations
 /packages/iis @elastic/obs-infraobs-integrations
 /packages/iis_input_otel @elastic/ecosystem
 /packages/iis_otel @elastic/obs-infraobs-integrations
 /packages/imperva @elastic/integration-experience
-/packages/imperva_cloud_waf @elastic/security-service-integrations
+/packages/imperva_cloud_waf @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/influxdb @elastic/obs-infraobs-integrations
 /packages/influxdb_otel @elastic/obs-infraobs-integrations
-/packages/infoblox @elastic/security-service-integrations
-/packages/infoblox_bloxone_ddi @elastic/security-service-integrations
+/packages/infoblox @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/infoblox_bloxone_ddi @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/infoblox_nios @elastic/integration-experience
 /packages/infoblox_threat_defense @elastic/integration-experience
 /packages/iptables @elastic/integration-experience
-/packages/ironscales @elastic/security-service-integrations
-/packages/island_browser @elastic/security-service-integrations
+/packages/ironscales @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/island_browser @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/istio @elastic/obs-ds-hosted-services
 /packages/jaeger_input_otel @elastic/ecosystem
-/packages/jamf_compliance_reporter @elastic/security-service-integrations
-/packages/jamf_pro @elastic/security-service-integrations
-/packages/jamf_protect @elastic/security-service-integrations
+/packages/jamf_compliance_reporter @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/jamf_pro @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/jamf_protect @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/jolokia_input @elastic/obs-infraobs-integrations
 /packages/journald @elastic/elastic-agent-data-plane
-/packages/jumpcloud @elastic/security-service-integrations
+/packages/jumpcloud @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/juniper_junos @elastic/integration-experience
 /packages/juniper_netscreen @elastic/integration-experience
 /packages/juniper_srx @elastic/integration-experience
-/packages/jupiter_one @elastic/security-service-integrations
+/packages/jupiter_one @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/kafka @elastic/obs-infraobs-integrations
 /packages/kafka_connect @elastic/obs-infraobs-integrations
 /packages/kafka_input_otel @elastic/ecosystem
 /packages/kafka_log @elastic/obs-infraobs-integrations
 /packages/kafka_otel @elastic/obs-infraobs-integrations
-/packages/keeper_security_siem_integration @elastic/security-service-integrations
-/packages/keycloak @elastic/security-service-integrations
+/packages/keeper_security_siem_integration @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/keycloak @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/kibana @elastic/stack-monitoring
 /packages/kubeletstats_input_otel @elastic/ecosystem
 /packages/kubernetes @elastic/obs-ds-hosted-services
 /packages/kubernetes/kibana @elastic/obs-ds-hosted-services
 /packages/kubernetes_otel @elastic/obs-infraobs-integrations
-/packages/lastpass @elastic/security-service-integrations
+/packages/lastpass @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/linux @elastic/elastic-agent-data-plane
 /packages/lmd @elastic/sec-applied-ml @elastic/kibana-management
 /packages/log @elastic/elastic-agent-data-plane
 /packages/logstash @elastic/logstash
-/packages/lumos @elastic/security-service-integrations
-/packages/lyve_cloud @elastic/security-service-integrations
-/packages/m365_defender @elastic/security-service-integrations
+/packages/lumos @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/lyve_cloud @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/m365_defender @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/macos @elastic/sec-windows-platform
-/packages/mattermost @elastic/security-service-integrations
+/packages/mattermost @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/memcached @elastic/obs-infraobs-integrations
 /packages/memcached_otel @elastic/obs-infraobs-integrations
-/packages/menlo @elastic/security-service-integrations
-/packages/microsoft_defender_cloud @elastic/security-service-integrations
-/packages/microsoft_defender_endpoint @elastic/security-service-integrations
+/packages/menlo @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/microsoft_defender_cloud @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/microsoft_defender_endpoint @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/microsoft_dhcp @elastic/sec-windows-platform
 /packages/microsoft_dnsserver @elastic/sec-windows-platform
-/packages/microsoft_exchange_online_message_trace @elastic/security-service-integrations
+/packages/microsoft_exchange_online_message_trace @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/microsoft_exchange_server @elastic/sec-windows-platform
-/packages/microsoft_intune @elastic/security-service-integrations
-/packages/microsoft_sentinel @elastic/security-service-integrations
+/packages/microsoft_intune @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/microsoft_sentinel @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/microsoft_sqlserver @elastic/obs-infraobs-integrations
 /packages/microsoft_sqlserver_otel @elastic/obs-infraobs-integrations
-/packages/mimecast @elastic/security-service-integrations
-/packages/miniflux @elastic/security-service-integrations
+/packages/mimecast @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/miniflux @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/modsecurity @elastic/integration-experience
 /packages/mongodb @elastic/obs-infraobs-integrations
 /packages/mongodb_atlas @elastic/obs-infraobs-integrations
@@ -384,26 +384,26 @@
 /packages/mysql_input_otel @elastic/ecosystem
 /packages/nagios_xi @elastic/obs-infraobs-integrations
 /packages/nats @elastic/obs-infraobs-integrations
-/packages/neon_cyber @elastic/security-service-integrations
+/packages/neon_cyber @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/netbox @elastic/obs-infraobs-integrations
 /packages/netflow @elastic/integration-experience
 /packages/netscout @elastic/integration-experience
-/packages/netskope @elastic/security-service-integrations
+/packages/netskope @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/network_traffic @elastic/sec-linux-platform
-/packages/nextron_thor @elastic/security-service-integrations
+/packages/nextron_thor @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/nginx @elastic/obs-infraobs-integrations
 /packages/nginx_ingress_controller @elastic/obs-ds-hosted-services
 /packages/nginx_ingress_controller_otel @elastic/obs-infraobs-integrations
 /packages/nginx_otel @elastic/obs-infraobs-integrations
 /packages/nginx_input_otel @elastic/obs-infraobs-integrations
-/packages/nozomi_networks @elastic/security-service-integrations
+/packages/nozomi_networks @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/nvidia_gpu @elastic/obs-infraobs-integrations
 /packages/nvidia_gpu_otel @elastic/obs-infraobs-integrations
-/packages/o365 @elastic/security-service-integrations
+/packages/o365 @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/o365_metrics @elastic/obs-infraobs-integrations 
-/packages/okta @elastic/security-service-integrations
+/packages/okta @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/openai @elastic/obs-infraobs-integrations
-/packages/opencanary @elastic/security-service-integrations
+/packages/opencanary @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/oracle @elastic/obs-infraobs-integrations
 /packages/oracle_otel @elastic/obs-infraobs-integrations
 /packages/oracle_weblogic @elastic/obs-infraobs-integrations
@@ -413,18 +413,18 @@
 /packages/otlp_input_otel @elastic/ecosystem
 /packages/pad @elastic/sec-applied-ml @elastic/kibana-management
 /packages/panw @elastic/integration-experience
-/packages/panw_cortex_xdr @elastic/security-service-integrations
+/packages/panw_cortex_xdr @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/panw_metrics @elastic/obs-infraobs-integrations
 /packages/pfsense @elastic/integration-experience
 /packages/php_fpm @elastic/obs-infraobs-integrations
-/packages/ping_federate @elastic/security-service-integrations
-/packages/ping_one @elastic/security-service-integrations
+/packages/ping_federate @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ping_one @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/platform_observability @elastic/stack-monitoring
 /packages/postgresql @elastic/obs-infraobs-integrations
 /packages/postgresql_otel @elastic/obs-infraobs-integrations
-/packages/pps @elastic/security-service-integrations
+/packages/pps @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/prisma_access @elastic/integration-experience
-/packages/prisma_cloud @elastic/security-service-integrations
+/packages/prisma_cloud @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/problemchild @elastic/sec-applied-ml
 /packages/profiling_otel @elastic/ingest-otel-data
 /packages/profilingmetrics_otel @elastic/ingest-otel-data
@@ -435,44 +435,44 @@
 /packages/prometheus_input @elastic/obs-infraobs-integrations
 /packages/prometheus_input_otel @elastic/ecosystem
 /packages/prometheus_input_otel_raw @elastic/ecosystem
-/packages/proofpoint_essentials @elastic/security-service-integrations
-/packages/proofpoint_itm @elastic/security-service-integrations
-/packages/proofpoint_on_demand @elastic/security-service-integrations
-/packages/proofpoint_tap @elastic/security-service-integrations
-/packages/proofpoint_365totalprotection @elastic/security-service-integrations
+/packages/proofpoint_essentials @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/proofpoint_itm @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/proofpoint_on_demand @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/proofpoint_tap @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/proofpoint_365totalprotection @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/proxysg @elastic/integration-experience
 /packages/pulse_connect_secure @elastic/integration-experience
 /packages/qnap_nas @elastic/integration-experience
-/packages/qualys_gav @elastic/security-service-integrations
-/packages/qualys_vmdr @elastic/security-service-integrations
-/packages/qualys_was @elastic/security-service-integrations
+/packages/qualys_gav @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/qualys_vmdr @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/qualys_was @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/rabbitmq @elastic/obs-infraobs-integrations
 /packages/rabbitmq_otel @elastic/obs-infraobs-integrations
 /packages/radware @elastic/integration-experience
-/packages/rapid7_insightvm @elastic/security-service-integrations
+/packages/rapid7_insightvm @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/redis @elastic/obs-infraobs-integrations
 /packages/redis_input_otel @elastic/ecosystem
 /packages/redis_otel @elastic/obs-infraobs-integrations
 /packages/redisenterprise @elastic/obs-infraobs-integrations
 /packages/redisenterprise_otel @elastic/obs-infraobs-integrations
 /packages/rubrik @elastic/obs-infraobs-integrations
-/packages/sailpoint_identity_sc @elastic/security-service-integrations
+/packages/sailpoint_identity_sc @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/salesforce @elastic/obs-infraobs-integrations
-/packages/santa @elastic/security-service-integrations
+/packages/santa @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/security_ai_prompts @elastic/security-generative-ai
 /packages/security_detection_engine @elastic/threat-research-and-detection-engineering
-/packages/sentinel_one @elastic/security-service-integrations
-/packages/sentinel_one_cloud_funnel @elastic/security-service-integrations
-/packages/servicenow @elastic/security-service-integrations
-/packages/slack @elastic/security-service-integrations
+/packages/sentinel_one @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/sentinel_one_cloud_funnel @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/servicenow @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/slack @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/snort @elastic/integration-experience
-/packages/snyk @elastic/security-service-integrations
+/packages/snyk @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/sonicwall_firewall @elastic/integration-experience
 /packages/sophos @elastic/integration-experience
-/packages/sophos_central @elastic/security-service-integrations
-/packages/splunk @elastic/security-service-integrations
+/packages/sophos_central @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/splunk @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/spring_boot @elastic/obs-infraobs-integrations
-/packages/spycloud @elastic/security-service-integrations
+/packages/spycloud @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/sql_input @elastic/obs-infraobs-integrations
 /packages/sql_server_input_otel @elastic/ecosystem
 /packages/squid @elastic/integration-experience
@@ -480,14 +480,14 @@
 /packages/statsd_input @elastic/obs-infraobs-integrations
 /packages/statsd_input_otel @elastic/ecosystem
 /packages/stormshield @elastic/integration-experience
-/packages/sublime_security @elastic/security-service-integrations
+/packages/sublime_security @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/suricata @elastic/integration-experience
-/packages/swimlane @elastic/security-service-integrations
+/packages/swimlane @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/symantec_endpoint @elastic/integration-experience
-/packages/symantec_endpoint_security @elastic/security-service-integrations
+/packages/symantec_endpoint_security @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/synthetics @elastic/actionable-obs-team
 /packages/synthetics_dashboards @elastic/actionable-obs-team
-/packages/sysdig @elastic/security-service-integrations
+/packages/sysdig @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/syslog_router @elastic/integration-experience
 /packages/sysmon_linux @elastic/sec-linux-platform
 /packages/system @elastic/obs-infraobs-integrations
@@ -513,63 +513,63 @@
 /packages/system/manifest.yml @elastic/obs-infraobs-integrations @elastic/sec-linux-platform @elastic/sec-windows-platform
 /packages/system_audit @elastic/sec-linux-platform
 /packages/system_otel @elastic/ingest-otel-data
-/packages/tanium @elastic/security-service-integrations
+/packages/tanium @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/tcp @elastic/integration-experience
-/packages/teleport @elastic/security-service-integrations
-/packages/tenable_io @elastic/security-service-integrations
-/packages/tenable_ot_security @elastic/security-service-integrations
-/packages/tenable_sc @elastic/security-service-integrations
-/packages/tencent_cloud @elastic/security-service-integrations
+/packages/teleport @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/tenable_io @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/tenable_ot_security @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/tenable_sc @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/tencent_cloud @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/tetragon @elastic/integration-experience
 /packages/threat_map @elastic/integration-experience
-/packages/thycotic_ss @elastic/security-service-integrations
-/packages/ti_abusech @elastic/security-service-integrations
-/packages/ti_anomali @elastic/security-service-integrations
-/packages/ti_anyrun @elastic/security-service-integrations
-/packages/ti_cif3 @elastic/security-service-integrations
-/packages/ti_crowdstrike @elastic/security-service-integrations
-/packages/ti_custom @elastic/security-service-integrations
-/packages/ti_cybersixgill @elastic/security-service-integrations
-/packages/ti_cyware_intel_exchange @elastic/security-service-integrations
-/packages/ti_domaintools @elastic/security-service-integrations
-/packages/ti_eclecticiq @elastic/security-service-integrations
-/packages/ti_eset @elastic/security-service-integrations
-/packages/ti_flashpoint @elastic/security-service-integrations
-/packages/ti_google_threat_intelligence @elastic/security-service-integrations
-/packages/ti_greynoise @elastic/security-service-integrations
-/packages/ti_maltiverse @elastic/security-service-integrations
-/packages/ti_mandiant_advantage @elastic/security-service-integrations
-/packages/ti_misp @elastic/security-service-integrations
-/packages/ti_opencti @elastic/security-service-integrations
-/packages/ti_otx @elastic/security-service-integrations
-/packages/ti_rapid7_threat_command @elastic/security-service-integrations
-/packages/ti_recordedfuture @elastic/security-service-integrations
-/packages/ti_strider @elastic/security-service-integrations
-/packages/ti_threatconnect @elastic/security-service-integrations
-/packages/ti_threatq @elastic/security-service-integrations
-/packages/ti_util @elastic/security-service-integrations
-/packages/tines @elastic/security-service-integrations
+/packages/thycotic_ss @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_abusech @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_anomali @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_anyrun @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_cif3 @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_crowdstrike @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_custom @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_cybersixgill @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_cyware_intel_exchange @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_domaintools @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_eclecticiq @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_eset @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_flashpoint @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_google_threat_intelligence @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_greynoise @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_maltiverse @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_mandiant_advantage @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_misp @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_opencti @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_otx @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_rapid7_threat_command @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_recordedfuture @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_strider @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_threatconnect @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_threatq @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/ti_util @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/tines @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/tomcat @elastic/obs-infraobs-integrations
 /packages/traefik @elastic/obs-infraobs-integrations
 /packages/traefik_otel @elastic/obs-infraobs-integrations
-/packages/trellix_edr_cloud @elastic/security-service-integrations
-/packages/trellix_epo_cloud @elastic/security-service-integrations
-/packages/trend_micro_vision_one @elastic/security-service-integrations
-/packages/trendmicro @elastic/security-service-integrations
-/packages/tychon @elastic/security-service-integrations
+/packages/trellix_edr_cloud @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/trellix_epo_cloud @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/trend_micro_vision_one @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/trendmicro @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/tychon @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/udp @elastic/integration-experience
 /packages/unifiedlogs @elastic/sec-windows-platform
 /packages/universal_profiling_agent @elastic/ingest-otel-data
 /packages/universal_profiling_collector @elastic/obs-ds-intake-services
 /packages/universal_profiling_symbolizer @elastic/obs-ds-intake-services
-/packages/varonis @elastic/security-service-integrations
-/packages/vectra_detect @elastic/security-service-integrations
-/packages/vectra_rux @elastic/security-service-integrations
+/packages/varonis @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/vectra_detect @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/vectra_rux @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/verifier_otel @elastic/cloud-services
 /packages/vsphere @elastic/obs-infraobs-integrations
 /packages/vsphere_otel @elastic/obs-infraobs-integrations
 /packages/watchguard_firebox @elastic/integration-experience
-/packages/websocket @elastic/security-service-integrations
+/packages/websocket @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/websphere_application_server @elastic/obs-infraobs-integrations
 /packages/windows @elastic/elastic-agent-data-plane @elastic/sec-windows-platform
 /packages/windows/data_stream/applocker_exe_and_dll @elastic/sec-windows-platform
@@ -585,17 +585,17 @@
 /packages/windows/data_stream/windows_defender @elastic/sec-windows-platform
 /packages/windows_etw @elastic/sec-windows-platform
 /packages/winlog @elastic/sec-windows-platform
-/packages/withsecure_elements @elastic/security-service-integrations
-/packages/wiz @elastic/security-service-integrations
+/packages/withsecure_elements @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/wiz @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/wmi @elastic/obs-infraobs-integrations
 /packages/zeek @elastic/integration-experience
-/packages/zerofox @elastic/security-service-integrations
-/packages/zeronetworks @elastic/security-service-integrations
+/packages/zerofox @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/zeronetworks @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/zipkin_input_otel @elastic/ecosystem
 /packages/zookeeper @elastic/obs-infraobs-integrations
 /packages/zookeeper_otel @elastic/obs-infraobs-integrations
-/packages/zoom @elastic/security-service-integrations
-/packages/zscaler_zia @elastic/security-service-integrations
-/packages/zscaler_zpa @elastic/security-service-integrations
+/packages/zoom @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/zscaler_zia @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/zscaler_zpa @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/otel_rum_dashboards @elastic/apm-agent-rum
 /packages/otel_android_dashboards @elastic/apm-agent-android @elastic/apm-agent-approvers


### PR DESCRIPTION
## Summary
- Adds `@elastic/sit-crest-contractors` as co-owners alongside `@elastic/security-service-integrations` in the CODEOWNERS file for all packages currently owned by that team (206 entries).

## Test plan
- [ ] Verify CODEOWNERS syntax is valid (CI check)
- [x] Confirm the `sit-crest-contractors` team exists in the elastic org


Made with [Cursor](https://cursor.com)