### PR TITLE
[ti_google_threat_intelligence] - Respect threat list availability delay

### DIFF
--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Prevent threat list data streams from requesting hourly packages before they are available.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/19097
 - version: "0.9.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,8 +1,11 @@
 # newer versions go on top
-- version: "0.9.1"
+- version: "0.10.0"
   changes:
     - description: Prevent threat list data streams from requesting hourly packages before they are available.
       type: bugfix
+      link: https://github.com/elastic/integrations/pull/19097
+    - description: Add configurable availability delay for threat list data streams.
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/19097
 - version: "0.9.0"
   changes:

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.1"
+  changes:
+    - description: Prevent threat list data streams from requesting hourly packages before they are available.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "0.9.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_google_threat_intelligence/data_stream/cryptominer/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/cryptominer/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/cryptominer/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/cryptominer/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/cryptominer/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.8.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/cryptominer/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/cryptominer/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/cryptominer/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/cryptominer/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/cryptominer/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/cryptominer/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/cryptominer/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Cryptominer events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/first-stage-delivery-vectors/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/first-stage-delivery-vectors/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/first-stage-delivery-vectors/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/first-stage-delivery-vectors/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/first_stage_delivery_vectors/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull First Stage Delivery Vectors events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/infostealer/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/infostealer/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/infostealer/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/infostealer/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/infostealer/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/infostealer/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/infostealer/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/infostealer/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/infostealer/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/infostealer/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/infostealer/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/infostealer/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Infostealer events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/iot/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/iot/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/iot/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/iot/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/iot/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/iot/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/iot/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/iot/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/iot/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/iot/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/iot/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/iot/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Internet of Things events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/linux/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/linux/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/linux/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/linux/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/linux/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/linux/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/linux/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/linux/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/linux/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/linux/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/linux/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/linux/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Linux events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/malicious_network_infrastructure/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/malicious_network_infrastructure/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/malicious_network_infrastructure/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/malicious_network_infrastructure/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/malicious-network-infrastructure/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/malicious-network-infrastructure/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/malicious-network-infrastructure/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/malicious-network-infrastructure/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/malicious_network_infrastructure/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/malicious_network_infrastructure/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/malicious_network_infrastructure/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/malicious_network_infrastructure/manifest.yml
@@ -13,11 +13,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Malicious Network Infrastructure events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/malware/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/malware/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/malware/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/malware/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/malware/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/malware/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/malware/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/malware/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/malware/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/malware/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/malware/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/malware/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Malware events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/mobile/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/mobile/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/mobile/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/mobile/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/mobile/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/mobile/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/mobile/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/mobile/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/mobile/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/mobile/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/mobile/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/mobile/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Mobile events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/osx/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/osx/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/osx/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/osx/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/osx/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/osx/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/osx/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/osx/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/osx/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/osx/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/osx/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/osx/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull OS X events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/phishing/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/phishing/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/phishing/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/phishing/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/phishing/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/phishing/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/phishing/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/phishing/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/phishing/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/phishing/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/phishing/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/phishing/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Phishing events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/ransomware/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/ransomware/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/ransomware/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/ransomware/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/ransomware/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/ransomware/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/ransomware/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/ransomware/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/ransomware/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/ransomware/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/ransomware/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/ransomware/manifest.yml
@@ -13,11 +13,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Ransomware events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/threat_actor/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/threat_actor/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/threat_actor/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/threat_actor/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/threat-actor/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/threat-actor/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/threat-actor/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/threat-actor/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/threat_actor/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/threat_actor/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/threat_actor/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/threat_actor/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Threat Actor events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/trending/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/trending/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/trending/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/trending/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/trending/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/trending/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/trending/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/trending/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/trending/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/trending/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/trending/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/trending/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Daily Top trending events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/data_stream/vulnerability_weaponization/_dev/test/system/test-default-config.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/vulnerability_weaponization/_dev/test/system/test-default-config.yml
@@ -5,8 +5,8 @@ vars:
   access_token: xxxx
 data_stream:
   vars:
-    initial_interval: 1h
-    interval: 1h
+    initial_interval: 2h
+    interval: 24h
     preserve_original_event: true
 assert:
   hit_count: 4

--- a/packages/ti_google_threat_intelligence/data_stream/vulnerability_weaponization/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/vulnerability_weaponization/agent/stream/cel.yml.hbs
@@ -24,54 +24,89 @@ redact:
   fields:
     - access_token
 program: |
-  state.?cursor.last_timestamp.orValue(
-    (now - duration(state.initial_interval)).format("2006010215")
-  ).as(start_time, state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/v3/threat_lists/vulnerability-weaponization/" + start_time + "?" + {
-        ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
-        "limit": ["4000"],
-        "x-tool": ["Elastic"],
-        "User-Agent": ["v0.7.0"], // Keep this in sync with 'version' in package level manifest.yml.
-      }.format_query()
-    ).with({
-      "Header": {
-        "x-apikey": [state.access_token]
-      }
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      resp.Body.decode_json().as(body, {
-        "events": (
-          has(body.iocs) && size(body.iocs) > 0 ?
-            body.iocs.map(e, {
-              "message": e.encode_json(),
+  state.?cursor.last_timestamp.orValue("").as(cursor,
+    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+      (
+        cursor != "" ?
+          cursor
+        :
+          (now - duration(state.initial_interval)).format("2006010215")
+      ).parse_time("2006010215").as(raw_start_time,
+        (
+          raw_start_time > latest_available_time && cursor != "" ?
+            state.with({
+              "events": [{"message": "retry"}],
+              "cursor": {
+                "last_timestamp": raw_start_time.format("2006010215"),
+              },
+              "want_more": false,
             })
           :
-            [{"message": "retry"}]
-        ),
-        "cursor": {
-          "last_timestamp": (start_time.parse_time("2006010215") + duration("1h")).format("2006010215"),
-        },
-        "want_more": (start_time.parse_time("2006010215") + duration("1h")) < (now.format("2006010215")).parse_time("2006010215")
-      })
-    :
-      {
-        "events": {
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/vulnerability-weaponization/: " + (
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        },
-        "want_more": false,
-      }
+            (raw_start_time > latest_available_time ? latest_available_time : raw_start_time).as(start_time,
+              start_time.format("2006010215").as(start_time_str,
+                state.with(
+                  request(
+                    "GET",
+                    state.url.trim_right("/") + "/api/v3/threat_lists/vulnerability-weaponization/" + start_time_str + "?" + {
+                      ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
+                      "limit": ["4000"],
+                      "x-tool": ["Elastic"],
+                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                    }.format_query()
+                  ).with({
+                    "Header": {
+                      "x-apikey": [state.access_token]
+                    }
+                  }).do_request().as(resp, resp.StatusCode == 200 ?
+                    (start_time + duration("1h")).as(next_time,
+                      resp.Body.decode_json().as(body, {
+                        "events": (
+                          has(body.iocs) && size(body.iocs) > 0 ?
+                            body.iocs.map(e, {
+                              "message": e.encode_json(),
+                            })
+                          :
+                            [{"message": "retry"}]
+                        ),
+                        "cursor": {
+                          "last_timestamp": next_time.format("2006010215"),
+                        },
+                        "want_more": next_time <= latest_available_time,
+                      })
+                    )
+                  :
+                    resp.StatusCode == 400 && string(resp.Body).contains("NotAvailableYet") ?
+                      {
+                        "events": [{"message": "retry"}],
+                        "cursor": {
+                          "last_timestamp": start_time_str,
+                        },
+                        "want_more": false,
+                      }
+                    :
+                      {
+                        "events": {
+                          "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET " + state.url.trim_right("/") + "/api/v3/threat_lists/vulnerability-weaponization/: " + (
+                              size(resp.Body) != 0 ?
+                                string(resp.Body)
+                              :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                          },
+                        },
+                        "want_more": false,
+                      }
+                  )
+                )
+              )
+            )
+        )
+      )
     )
-  ))
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_google_threat_intelligence/data_stream/vulnerability_weaponization/agent/stream/cel.yml.hbs
+++ b/packages/ti_google_threat_intelligence/data_stream/vulnerability_weaponization/agent/stream/cel.yml.hbs
@@ -16,6 +16,7 @@ resource.timeout: {{http_client_timeout}}
 resource.url: {{url}}
 state:
   initial_interval: {{initial_interval}}
+  availability_delay: {{availability_delay}}
   access_token: {{access_token}}
 {{#if query}}
   query: {{query}}
@@ -25,7 +26,8 @@ redact:
     - access_token
 program: |
   state.?cursor.last_timestamp.orValue("").as(cursor,
-    (now - duration("2h")).format("2006010215").parse_time("2006010215").as(latest_available_time,
+    // Format then parse to truncate now-availability_delay to the hour for time comparisons.
+    (now - duration(state.availability_delay)).format("2006010215").parse_time("2006010215").as(latest_available_time,
       (
         cursor != "" ?
           cursor
@@ -51,7 +53,7 @@ program: |
                       ?"query": has(state.query) ? optional.of([state.query]) : optional.none(),
                       "limit": ["4000"],
                       "x-tool": ["Elastic"],
-                      "User-Agent": ["v0.9.1"], // Keep this in sync with 'version' in package level manifest.yml.
+                      "User-Agent": ["v0.10.0"], // Keep this in sync with 'version' in package level manifest.yml.
                     }.format_query()
                   ).with({
                     "Header": {

--- a/packages/ti_google_threat_intelligence/data_stream/vulnerability_weaponization/manifest.yml
+++ b/packages/ti_google_threat_intelligence/data_stream/vulnerability_weaponization/manifest.yml
@@ -14,11 +14,19 @@ streams:
         required: true
         show_user: true
         default: 2h
-        description: How far back to pull Vulnerability Weaponization events from the Google Threat Intelligence API. Must be at least 2h because the API has a 2-hour delay in data availability. Supported units are h.
+        description: How far back to pull events from the Google Threat Intelligence API. Requests newer than the availability delay are clamped to the latest available package. Supported units are h.
+      - name: availability_delay
+        type: text
+        title: Availability Delay
+        multi: false
+        required: true
+        show_user: false
+        default: 2h
+        description: Time between a threat list package hour and when Google makes that package available. Supported units are h, m and s.
       - name: interval
         type: text
         title: Interval
-        description: Duration between consecutive requests to the Google Threat Intelligence API. It must be set to a value greater than 1 hour as threat lists are generated hourly and the API returns errors when requesting data prematurely. Supported units are h.
+        description: Duration between consecutive scheduled requests to the Google Threat Intelligence API. The CEL program only requests threat list packages after the configured availability delay, so a 1h interval safely checks each hourly package once it is available. Supported units are h.
         default: 1h
         multi: false
         required: true

--- a/packages/ti_google_threat_intelligence/manifest.yml
+++ b/packages/ti_google_threat_intelligence/manifest.yml
@@ -3,7 +3,7 @@ name: ti_google_threat_intelligence
 title: Google Threat Intelligence
 # This version must match the User-Agent version used in CEL code.
 # Remember to update the User-Agent in CEL code when changing this version.
-version: "0.9.1"
+version: "0.10.0"
 description: Collect Threat Intelligence Events from Google Threat Intelligence using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:

--- a/packages/ti_google_threat_intelligence/manifest.yml
+++ b/packages/ti_google_threat_intelligence/manifest.yml
@@ -3,7 +3,7 @@ name: ti_google_threat_intelligence
 title: Google Threat Intelligence
 # This version must match the User-Agent version used in CEL code.
 # Remember to update the User-Agent in CEL code when changing this version.
-version: "0.9.0"
+version: "0.9.1"
 description: Collect Threat Intelligence Events from Google Threat Intelligence using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Bug
- Enhancement

## Proposed commit message
```
tti_google_threat_intelligence: respect threat list availability delay

Google Threat Intelligence hourly threat lists are only available after
a two-hour delay. The package defaulted the initial interval to 2h, but
the CEL cursor still advanced toward the current hour and could request
T-1h packages that Google rejects as NotAvailableYet.

Stop hourly threat-list streams at the documented T-2h boundary and
treat NotAvailableYet responses as dropped retry events so the same
hour can be retried later without degrading the input. Update system
tests to start at the T-2h boundary so an accidental immediate T-1h
request fails the hit count assertion.

Move the availability delay into each threat list manifest so future API
timing changes do not require CEL code changes. Clarify that the 1h
interval is safe because the CEL guard enforces the availability delay,
and document why the time value is formatted and parsed before
comparison.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
