### PR TITLE
Add backport release commit helper script and improve hotfix workflow docs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,6 +68,10 @@ steps:
       provider: gcp
       image: "${IMAGE_UBUNTU_X86_64}"
 
+  - label: ":bash: Dev scripts unit tests"
+    key: "check-dev-scripts"
+    command: ".buildkite/scripts/run_dev_scripts_tests.sh"
+
   - label: ":junit: Sources Junit annotate"
     agents:
       # requires at least "bash", "curl" and "git"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -912,7 +912,7 @@ teardown_test_package() {
 
 # list all directories that are packages from the root of the repository
 list_all_directories() {
-    mage -d "${WORKSPACE}" listPackages
+    mage -d "${WORKSPACE}" listPackages |grep -E '^packages/elastic_package_registry$'
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -801,6 +801,8 @@ is_pr_affected() {
         'CONTRIBUTING\.md'
         'README\.md'
         '\.agents/skills/'
+        'dev/scripts/'
+        '\.buildkite/scripts/run_dev_scripts_tests\.sh'
     )
     local non_package_regex
     non_package_regex="^($(IFS='|'; echo "${non_package_patterns[*]}"))"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -912,7 +912,7 @@ teardown_test_package() {
 
 # list all directories that are packages from the root of the repository
 list_all_directories() {
-    mage -d "${WORKSPACE}" listPackages |grep -E '^packages/elastic_package_registry$'
+    mage -d "${WORKSPACE}" listPackages
 }
 
 check_package() {

--- a/.buildkite/scripts/run_dev_scripts_tests.sh
+++ b/.buildkite/scripts/run_dev_scripts_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Runs unit tests for scripts in dev/scripts/.
+# TODO: migrate to the bats framework (https://github.com/bats-core/bats-core)
+#       for better test isolation, TAP output, and native setup/teardown support.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/.buildkite/scripts/run_dev_scripts_tests.sh
+++ b/.buildkite/scripts/run_dev_scripts_tests.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Runs unit tests for scripts in dev/scripts/.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="${REPO_ROOT}/dev/scripts/get_release_commit.sh"
+
+pass=0
+fail=0
+
+assert_equals() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "${actual}" == "${expected}" ]]; then
+        echo "PASS: ${description}"
+        (( pass++ )) || true
+    else
+        echo "FAIL: ${description} — expected '${expected}', got '${actual}'"
+        (( fail++ )) || true
+    fi
+}
+
+assert_exit_code() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "${actual}" == "${expected}" ]]; then
+        echo "PASS: ${description}"
+        (( pass++ )) || true
+    else
+        echo "FAIL: ${description} — expected exit code '${expected}', got '${actual}'"
+        (( fail++ )) || true
+    fi
+}
+
+echo "--- Running get_release_commit.sh tests"
+
+# Package at packages/<p>/ with unquoted version
+result="$("${SCRIPT}" -p prometheus -v 1.24.2)"
+assert_equals "finds commit for package at packages/<p>/ (unquoted version)" "43bb655db0" "${result}"
+
+# Package at packages/<p>/ with quoted version
+result="$("${SCRIPT}" -p zscaler_zpa -v 1.23.3)"
+assert_equals "finds commit for package at packages/<p>/ (quoted version)" "8b024204a8" "${result}"
+
+# Version previously released as beta (9.3.8-beta.2 -> 9.3.8)
+result="$("${SCRIPT}" -p security_detection_engine -v 9.3.8)"
+assert_equals "finds commit for version promoted from beta" "fd04de398f" "${result}"
+
+# Unknown package
+exit_code=0
+"${SCRIPT}" -p no_such_package -v 1.0.0 > /dev/null 2>&1 || exit_code=$?
+assert_exit_code "exits non-zero for unknown package" "1" "${exit_code}"
+
+# Unknown version
+exit_code=0
+"${SCRIPT}" -p prometheus -v 9.99.99 > /dev/null 2>&1 || exit_code=$?
+assert_exit_code "exits non-zero for unknown version" "1" "${exit_code}"
+
+# Missing -p flag
+exit_code=0
+"${SCRIPT}" -v 1.0.0 > /dev/null 2>&1 || exit_code=$?
+assert_exit_code "exits non-zero when -p is missing" "1" "${exit_code}"
+
+# Missing -v flag
+exit_code=0
+"${SCRIPT}" -p prometheus > /dev/null 2>&1 || exit_code=$?
+assert_exit_code "exits non-zero when -v is missing" "1" "${exit_code}"
+
+# Invalid flag
+exit_code=0
+"${SCRIPT}" -z > /dev/null 2>&1 || exit_code=$?
+assert_exit_code "exits non-zero for invalid flag" "1" "${exit_code}"
+
+echo "--- Results: ${pass} passed, ${fail} failed"
+if [[ "${fail}" -gt 0 ]]; then
+    exit 1
+fi

--- a/.buildkite/scripts/run_dev_scripts_tests.sh
+++ b/.buildkite/scripts/run_dev_scripts_tests.sh
@@ -10,6 +10,12 @@ SCRIPT="${REPO_ROOT}/dev/scripts/get_release_commit.sh"
 pass=0
 fail=0
 
+DUMMY_REPO=""
+cleanup() {
+    [[ -n "$DUMMY_REPO" ]] && teardown_dummy_repo "$DUMMY_REPO"
+}
+trap cleanup EXIT
+
 assert_equals() {
     local description="$1"
     local expected="$2"
@@ -34,6 +40,47 @@ assert_exit_code() {
         echo "FAIL: ${description} — expected exit code '${expected}', got '${actual}'"
         (( fail++ )) || true
     fi
+}
+
+setup_dummy_repo() {
+    # Creates a minimal git repo with two package layouts and two versions each:
+    #   packages/flat_pkg/manifest.yml            (flat:   packages/<pkg>/)
+    #   packages/group/nested_pkg/manifest.yml    (nested: packages/<group>/<pkg>/)
+    # Each package gets two commits (1.0.0 then 1.1.0 / 2.0.0 then 2.1.0) so tests
+    # can verify the script finds the right commit rather than just the latest one.
+    # Commit hashes for the first versions are stored in .state/ inside the repo.
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    git -C "$tmpdir" init -q
+    git -C "$tmpdir" config user.email "test@test.com"
+    git -C "$tmpdir" config user.name "Test"
+
+    mkdir -p "${tmpdir}/packages/flat_pkg"
+    printf 'name: flat_pkg\nversion: 1.0.0\n' > "${tmpdir}/packages/flat_pkg/manifest.yml"
+    git -C "$tmpdir" add .
+    git -C "$tmpdir" commit -q -m "Release flat_pkg 1.0.0"
+    mkdir -p "${tmpdir}/.state"
+    git -C "$tmpdir" rev-parse --short HEAD > "${tmpdir}/.state/flat_pkg_1.0.0"
+
+    printf 'name: flat_pkg\nversion: 1.1.0\n' > "${tmpdir}/packages/flat_pkg/manifest.yml"
+    git -C "$tmpdir" add .
+    git -C "$tmpdir" commit -q -m "Release flat_pkg 1.1.0"
+
+    mkdir -p "${tmpdir}/packages/group/nested_pkg"
+    printf 'name: nested_pkg\nversion: 2.0.0\n' > "${tmpdir}/packages/group/nested_pkg/manifest.yml"
+    git -C "$tmpdir" add .
+    git -C "$tmpdir" commit -q -m "Release nested_pkg 2.0.0"
+    git -C "$tmpdir" rev-parse --short HEAD > "${tmpdir}/.state/nested_pkg_2.0.0"
+
+    printf 'name: nested_pkg\nversion: 2.1.0\n' > "${tmpdir}/packages/group/nested_pkg/manifest.yml"
+    git -C "$tmpdir" add .
+    git -C "$tmpdir" commit -q -m "Release nested_pkg 2.1.0"
+
+    echo "$tmpdir"
+}
+
+teardown_dummy_repo() {
+    rm -rf "$1"
 }
 
 echo "--- Running get_release_commit.sh tests"
@@ -74,6 +121,21 @@ assert_exit_code "exits non-zero when -v is missing" "1" "${exit_code}"
 exit_code=0
 "${SCRIPT}" -z > /dev/null 2>&1 || exit_code=$?
 assert_exit_code "exits non-zero for invalid flag" "1" "${exit_code}"
+
+echo "--- Running get_release_commit.sh tests (dummy repo)"
+DUMMY_REPO="$(setup_dummy_repo)"
+DUMMY_FLAT_COMMIT="$(cat "${DUMMY_REPO}/.state/flat_pkg_1.0.0")"
+DUMMY_NESTED_COMMIT="$(cat "${DUMMY_REPO}/.state/nested_pkg_2.0.0")"
+
+# Flat layout: packages/<pkg>/ — queries v1.0.0, not the latest v1.1.0
+result="$(cd "$DUMMY_REPO" && "${SCRIPT}" -p flat_pkg -v 1.0.0)"
+assert_equals "finds correct commit for packages/<p>/ (not the latest)" "${DUMMY_FLAT_COMMIT}" "${result}"
+
+# Nested layout: packages/<group>/<pkg>/ — queries v2.0.0, not the latest v2.1.0
+result="$(cd "$DUMMY_REPO" && "${SCRIPT}" -p nested_pkg -v 2.0.0)"
+assert_equals "finds correct commit for packages/<group>/<p>/ (not the latest)" "${DUMMY_NESTED_COMMIT}" "${result}"
+
+teardown_dummy_repo "$DUMMY_REPO"
 
 echo "--- Results: ${pass} passed, ${fail} failed"
 if [[ "${fail}" -gt 0 ]]; then

--- a/dev/scripts/get_release_commit.sh
+++ b/dev/scripts/get_release_commit.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Finds the commit on main where a package version was released.
+# Usage: ./get_release_commit.sh <package_name> <version>
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 -p <package_name> -v <version>" >&2
+    exit 1
+}
+
+PACKAGE_NAME=""
+VERSION=""
+
+while getopts ":p:v:h" opt; do
+    case "${opt}" in
+        p) PACKAGE_NAME="${OPTARG}" ;;
+        v) VERSION="${OPTARG}" ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option ${OPTARG}"
+            usage
+            exit 1
+            ;;
+        :)
+            echo "Missing argument for -${OPTARG}"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${PACKAGE_NAME}" || -z "${VERSION}" ]]; then
+    usage
+fi
+
+# Find the manifest.yml that declares the given package name.
+# Packages live at packages/<p>/ or packages/<folder>/<p>/ (one level of nesting).
+MANIFEST=""
+while IFS= read -r candidate; do
+    # name field must match exactly (allow optional quotes and trailing whitespace)
+    if grep -E "^name: ['\"]?${PACKAGE_NAME}['\"]?[[:space:]]*$" "$candidate" > /dev/null; then
+        MANIFEST="$candidate"
+        break
+    fi
+done < <(find packages -mindepth 2 -maxdepth 3 -name "manifest.yml")
+
+if [[ -z "$MANIFEST" ]]; then
+    echo "Error: package '${PACKAGE_NAME}' not found." >&2
+    exit 1
+fi
+
+# Use -G with an anchored regex so that versions like "9.3.8" are not confused
+# with "9.3.8-beta.2" (which -S would treat as the same string occurrence count).
+ESCAPED_VERSION="${VERSION//./\\.}"
+# mapfile requires bash 4+; macOS ships bash 3.2, so use a while-read loop instead.
+COMMITS=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && COMMITS+=("$line")
+done < <(
+    git log --oneline \
+        -G "^version: ['\"]?${ESCAPED_VERSION}['\"]?[[:space:]]*$" \
+        -- "$MANIFEST" \
+        | awk 'NF {print $1}' | sort -u
+)
+
+# Among matching commits, keep only those that *added* (not removed) the version.
+FOUND=""
+for COMMIT in "${COMMITS[@]}"; do
+    if git show "$COMMIT" -- "$MANIFEST" \
+            | grep -E "^\+version: ['\"]?${VERSION}['\"]?[[:space:]]*$" > /dev/null; then
+        FOUND="$COMMIT"
+        break
+    fi
+done
+
+if [[ -z "$FOUND" ]]; then
+    echo "Error: no commit found that released version '${VERSION}' of package '${PACKAGE_NAME}'." >&2
+    exit 1
+fi
+
+echo "$FOUND"

--- a/docs/extend/developer-workflow-support-old-package.md
+++ b/docs/extend/developer-workflow-support-old-package.md
@@ -5,11 +5,18 @@ mapped_pages:
 
 # Release a bug fix for supporting older package version [developer-workflow-support-old-package]
 
-In some cases, when we drop the support for an older version of the stack and later on find out needing to add a bug fix to some old package version, we have to make some manual changes to release the bug fix to users. For example: in this [PR](https://github.com/elastic/integrations/pull/3688) (AWS package version 1.23.4), support for Kibana version 7.x was dropped and bumped the AWS package version from 1.19.5 to 1.20.0. But we found a bug in the EC2 dashboard that needs to be fixed with Kibana version 7.x. So instead of adding a new AWS package version 1.23.5, we need to fix it between 1.19.5 and 1.20.0. This means creating a new version (e.g. 1.19.6) based on 1.19.5.
+In some cases, when we drop the support for an older version of the stack and later on find out needing to add a bug fix to some old package version, we have to make some manual changes to release the bug fix to users. For example: in this [PR](https://github.com/elastic/integrations/pull/3688) (AWS package version 1.23.4), support for Kibana version 7.x was dropped and bumped the AWS package version from 1.19.5 to 1.20.0. But we found a bug in the EC2 dashboard that needs to be fixed with Kibana version 7.x, so instead of adding a new AWS package version 1.23.5, we need to fix it between 1.19.5 and 1.20.0. This means creating a new version (e.g. 1.19.6) based on 1.19.5.
 
-Follow these detailed steps to release a fix for a given package version:
+**Overview of the process:**
 
-1. **Find git commit (package version) that needs to be fixed**
+1. Find the git commit that introduced the target package version.
+2. Run the **integrations-backport** pipeline to create the backport branch.
+3. Create a PR with the bug fix against that backport branch.
+4. Update the changelog in `main` to include the new version.
+
+**Detailed steps:**
+
+1. **Find the git commit for the target package version**
 
     In the example above, the commit to be fixed is the one right before this [PR](https://github.com/elastic/integrations/pull/3688) updating package `aws`:
 
@@ -26,24 +33,28 @@ Follow these detailed steps to release a fix for a given package version:
 
         * Using the helper script `dev/scripts/get_release_commit.sh`, which finds the commit directly from the package name and version:
 
+            Syntax:
             ```bash
             ./dev/scripts/get_release_commit.sh -p <package_name> -v <version>
+            ```
 
-            # following the example
+            Example:
+            ```bash
             $ ./dev/scripts/get_release_commit.sh -p aws -v 1.19.5
             8cb321075afb9b77ea965e1373a03a603d9c9796
             ```
 
         * Alternatively, using `git log`:
 
+            Syntax:
             ```bash
-            cd packages/<package_name>
-            git log --grep "#<pr_id>" .
-            git log -n 1 <merge_commit>^ .
+            git log --grep "#<pr_id>" -- packages/<package_name>
+            git log -n 1 <merge_commit>^ -- packages/<package_name>
+            ```
 
-            # following the example
-            $ cd packages/aws
-            $ git log --grep "#3688"
+            Example:
+            ```bash
+            $ git log --grep "#3688" -- packages/aws
             commit aa63e1f6a61d2a017e1f88af2735db129cc68e0c
             Author: Joe Reuter <xx@email.de>
             Date:   Mon Aug 8 17:14:55 2022 +0200
@@ -59,7 +70,7 @@ Follow these detailed steps to release a fix for a given package version:
                 * inline again
 
                 * format
-            $ git log -n 1 aa63e1f6a61d2a017e1f88af2735db129cc68e0c^ .
+            $ git log -n 1 aa63e1f6a61d2a017e1f88af2735db129cc68e0c^ -- packages/aws
             commit 8cb321075afb9b77ea965e1373a03a603d9c9796
             Author: Mario Castro <xx@gmail.com>
             Date:   Thu Aug 4 16:52:06 2022 +0200
@@ -75,6 +86,10 @@ Follow these detailed steps to release a fix for a given package version:
 
     Pipeline’s inputs:
 
+    * **PACKAGE_NAME** (default: "") — enter the package name, as defined in the `name` field of manifest.yml, for example `aws`
+    * **PACKAGE_VERSION** (default: "") — enter the package version, for example: 1.19.7, 1.0.0-beta1
+    * **BASE_COMMIT** (default: "") — enter the commit from the previous step (for example: 8cb321075afb9b77ea965e1373a03a603d9c9796)
+    * **REMOVE_OTHER_PACKAGES** (default: "false") — If set to "true", all packages from the **packages** folder except the target package will be removed from the created branch. This will help to reduce CI time on the backport branch and avoid CI errors unrelated to the package being fixed, since only the affected package needs to be tested and published.
     * **DRY_RUN** (default: "true")
 
         * **`true`** — Performs checks and a local dry run only. It will:
@@ -87,51 +102,46 @@ Follow these detailed steps to release a fix for a given package version:
 
             The branch will **not** be pushed to the upstream repository.
 
-        * **`false`** — Does everything above, plus creates a commit and pushes the local branch to the upstream repository ([https://github.com/elastic/integrations.git](https://github.com/elastic/integrations)). The branch will be named `backport-${PACKAGE_NAME}-${TRIMMED_PACKAGE_VERSION}` (e.g. `backport-aws-1.19`).
-
-    * **BASE_COMMIT** (default: "") - enter the commit from the previous step (8cb321075afb9b77ea965e1373a03a603d9c9796)
-    * **PACKAGE_NAME** (default: "") - enter the package name, as defined in the `name` field of manifest.yml, for example `aws`
-    * **PACKAGE_VERSION** (default: "") - enter the package version, for example: 1.19.7, 1.0.0-beta1
-    * **REMOVE_OTHER_PACKAGES** (default: "false") If **REMOVE_OTHER_PACKAGES** is defined as "true" all packages from the **packages** folder, except the defined package, will be removed from the created branch.
+        * **`false`** — Does everything above, plus creates a commit and pushes the local branch to the upstream repository ([https://github.com/elastic/integrations](https://github.com/elastic/integrations)). The branch will be named `backport-<package_name>-<major>.<minor>` (e.g. `backport-aws-1.19`).
 
 3. **Create a PR for the bug fix**
 
     Create a new branch in your own remote (it is advised **not to use** a branch name starting with `backport-`), and apply bugfixes there. Remember to update the version in the package manifest (update patch version like `1.19.<x+1>`) and add a new changelog entry for this patch version.
 
-    Once ready, open a PR selecting as a base branch the one created above: `backport-<package_name>-<package_major_version>.<package_minor_version>` (e.g. `backport-aws-1.19`).
+    Once ready, open a PR selecting as a base branch the one created above: `backport-<package_name>-<major>.<minor>` (e.g. `backport-aws-1.19`).
 
-    Once this PR is merged, this new version of the package is going to be published automatically following the usual CI/CD jobs.
+    Once this PR is merged, this new version of the package is going to be published automatically following the usual CI/CD jobs. Wait for the package to appear in the [Elastic Package Registry](https://epr.elastic.co/) before proceeding to the next step.
 
     If it is needed to release a new fix for that version, there is no need to create a new branch. Just create a new PR to merge a new branch onto the same backport branch created previously.
 
 4. **Update changelog in main**
 
-    Once PR has been merged in the corresponding backport branch (e.g. `backport-aws-1.19`) and the package has been published, a new Pull Request should be created manually to update the changelog in the main branch to include the new version published in the backport branch. Take into account to add the changelog entry following the version order.
+    Once PR has been merged in the corresponding backport branch (e.g. `backport-aws-1.19`) and the package has been published, a new Pull Request should be created manually to update the changelog in the main branch to include the new version published in the backport branch. Make sure to add the changelog entry following the version order.
 
     In order to keep track, this new PR should have a reference (relates) to the backport PR too in its description.
 
-5. **Known issues and their solutions:**
+## Known issues
 
-    1. Missing shellinit command:
+1. Missing `elastic-package stack shellinit` in backport branch:
 
-        * Example of the error:
+    * Example of the error:
 
-            `Error: could not create kibana client: undefined environment variable: ELASTIC_PACKAGE_KIBANA_HOST. If you have started the Elastic stack using the elastic-package tool, please load stack environment variables using 'eval "$(elastic-package stack shellinit)"' or set their values manually`
+        `Error: could not create kibana client: undefined environment variable: ELASTIC_PACKAGE_KIBANA_HOST. If you have started the Elastic stack using the elastic-package tool, please load stack environment variables using 'eval "$(elastic-package stack shellinit)"' or set their values manually`
 
-        * **Solution**: add elastic-package stack shellinit command in `.buildkite/scripts/common.sh`.
+    * **Solution**: add elastic-package stack shellinit command in `.buildkite/scripts/common.sh`.
 
-            * `eval "$(elastic-package stack shellinit)"`
+        * `eval "$(elastic-package stack shellinit)"`
 
-                Example: [https://github.com/elastic/integrations/blob/0226f93e0b1493d963a297e2072f79431f6cc443/.buildkite/scripts/common.sh#L828](https://github.com/elastic/integrations/blob/0226f93e0b1493d963a297e2072f79431f6cc443/.buildkite/scripts/common.sh#L828)
+            Example: [https://github.com/elastic/integrations/blob/0226f93e0b1493d963a297e2072f79431f6cc443/.buildkite/scripts/common.sh#L828](https://github.com/elastic/integrations/blob/0226f93e0b1493d963a297e2072f79431f6cc443/.buildkite/scripts/common.sh#L828)
 
-    2. Not found license file:
+2. License file not found in backport branch:
 
-        * Example of the error:
+    * Example of the error:
 
-            `Error: checking package failed: building package failed: copying license text file: failure while looking for license "licenses/Elastic-2.0.txt" in repository: failed to find repository license: stat /opt/buildkite-agent/builds/bk-agent-prod-gcp-1703092724145948143/elastic/integrations/licenses/Elastic-2.0.txt: no such file or directory`
+        `Error: checking package failed: building package failed: copying license text file: failure while looking for license "licenses/Elastic-2.0.txt" in repository: failed to find repository license: stat /opt/buildkite-agent/builds/bk-agent-prod-gcp-1703092724145948143/elastic/integrations/licenses/Elastic-2.0.txt: no such file or directory`
 
-        * **Solution**: Remove line defining `ELASTIC_PACKAGE_REPOSITORY_LICENSE` environment variable.
+    * **Solution**: Remove line defining `ELASTIC_PACKAGE_REPOSITORY_LICENSE` environment variable.
 
-            * Example: [https://github.com/elastic/integrations/blob/0daff27f0e0195a483771a50d60ab28ca2830f75/.buildkite/pipeline.yml#L17](https://github.com/elastic/integrations/blob/0daff27f0e0195a483771a50d60ab28ca2830f75/.buildkite/pipeline.yml#L17)
+        * Example: [https://github.com/elastic/integrations/blob/0daff27f0e0195a483771a50d60ab28ca2830f75/.buildkite/pipeline.yml#L17](https://github.com/elastic/integrations/blob/0daff27f0e0195a483771a50d60ab28ca2830f75/.buildkite/pipeline.yml#L17)
 
 

--- a/docs/extend/developer-workflow-support-old-package.md
+++ b/docs/extend/developer-workflow-support-old-package.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Release a bug fix for supporting older package version [developer-workflow-support-old-package]
 
-In some cases, when we drop the support for an older version of the stack and later on find out needing to add a bug fix to some old package version, we have to make some manual changes to release the bug fix to users. For example: in this [PR](https://github.com/elastic/integrations/pull/3688) (AWS package version 1.23.4), support for Kibana version 7.x was dropped and bumped the AWS package version from 1.19.5 to 1.20.0. But we found a bug in the EC2 dashboard that needs to be fixed with Kibana version 7.x, so instead of adding a new AWS package version 1.23.5, we need to fix it between 1.19.5 and 1.20.0. This means creating a new version (e.g. 1.19.6) based on 1.19.5.
+Sometimes, when we drop the support for an earlier version of the stack and later on find out needing to add a bug fix to some old package version, we have to make some manual changes to release the bug fix to users. For example: in this [PR](https://github.com/elastic/integrations/pull/3688) (AWS package version 1.23.4), support for Kibana version 7.x was dropped and bumped the AWS package version from 1.19.5 to 1.20.0. But we found a bug in the EC2 dashboard that needs to be fixed with Kibana version 7.x, so instead of adding a new AWS package version 1.23.5, we need to fix it between 1.19.5 and 1.20.0. This means creating a new version (for example, 1.19.6) based on 1.19.5.
 
 **Overview of the process:**
 
@@ -80,7 +80,7 @@ In some cases, when we drop the support for an older version of the stack and la
 
 2. Run the **integrations-backport** pipeline [https://buildkite.com/elastic/integrations-backport](https://buildkite.com/elastic/integrations-backport) for creating the backport branch. ![buildkite build](images/build.png "")
 
-    **Please, pay attention!**, if you just run the pipeline it’ll wait for your inputs, nothing will happen without that.
+    **Pay attention:** if you just run the pipeline it’ll wait for your inputs, nothing will happen without that.
 
     ![waiting input step](images/backport_input_step.png)
 

--- a/docs/extend/developer-workflow-support-old-package.md
+++ b/docs/extend/developer-workflow-support-old-package.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Release a bug fix for supporting older package version [developer-workflow-support-old-package]
 
-In some cases, when we drop the support for an older version of the stack and later on find out needing to add a bug fix to the some old package version, we have to make some manual changes to release the bug fix to users. For example: in this [PR](https://github.com/elastic/integrations/pull/3688) (AWS package version 1.23.4), support for Kibana version 7.x was dropped and bumped the AWS package version from 1.19.5 to 1.20.0. But we found a bug in the EC2 dashboard that needs to be fixed with Kibana version 7.x. So instead of adding a new AWS package version 1.23.5, we need to fix it between 1.19.5 and 1.20.0.
+In some cases, when we drop the support for an older version of the stack and later on find out needing to add a bug fix to some old package version, we have to make some manual changes to release the bug fix to users. For example: in this [PR](https://github.com/elastic/integrations/pull/3688) (AWS package version 1.23.4), support for Kibana version 7.x was dropped and bumped the AWS package version from 1.19.5 to 1.20.0. But we found a bug in the EC2 dashboard that needs to be fixed with Kibana version 7.x. So instead of adding a new AWS package version 1.23.5, we need to fix it between 1.19.5 and 1.20.0. This means creating a new version (e.g. 1.19.6) based on 1.19.5.
 
 Follow these detailed steps to release a fix for a given package version:
 
@@ -24,36 +24,48 @@ Follow these detailed steps to release a fix for a given package version:
 
     * Using the command line:
 
-        ```bash
-        cd packages/<package_name>
-        git log --grep "#<pr_id>" .
-        git log -n 1 <merge_commit>^ .
+        * Using the helper script `dev/scripts/get_release_commit.sh`, which finds the commit directly from the package name and version:
 
-        # following the example
-        $ cd packages/aws
-        $ git log --grep "#3688"
-        commit aa63e1f6a61d2a017e1f88af2735db129cc68e0c
-        Author: Joe Reuter <xx@email.de>
-        Date:   Mon Aug 8 17:14:55 2022 +0200
+            ```bash
+            ./dev/scripts/get_release_commit.sh -p <package_name> -v <version>
 
-            Inline all aws dashboards (#3688)
+            # following the example
+            $ ./dev/scripts/get_release_commit.sh -p aws -v 1.19.5
+            8cb321075afb9b77ea965e1373a03a603d9c9796
+            ```
 
-            * inline all aws dashboards
+        * Alternatively, using `git log`:
 
-            * format
+            ```bash
+            cd packages/<package_name>
+            git log --grep "#<pr_id>" .
+            git log -n 1 <merge_commit>^ .
 
-            * apply the right format
+            # following the example
+            $ cd packages/aws
+            $ git log --grep "#3688"
+            commit aa63e1f6a61d2a017e1f88af2735db129cc68e0c
+            Author: Joe Reuter <xx@email.de>
+            Date:   Mon Aug 8 17:14:55 2022 +0200
 
-            * inline again
+                Inline all aws dashboards (#3688)
 
-            * format
-        $ git log -n 1 aa63e1f6a61d2a017e1f88af2735db129cc68e0c^ .
-        commit 8cb321075afb9b77ea965e1373a03a603d9c9796
-        Author: Mario Castro <xx@gmail.com>
-        Date:   Thu Aug 4 16:52:06 2022 +0200
+                * inline all aws dashboards
 
-            Move lightweight manifest to integration for EBS data stream (#3856)
-        ```
+                * format
+
+                * apply the right format
+
+                * inline again
+
+                * format
+            $ git log -n 1 aa63e1f6a61d2a017e1f88af2735db129cc68e0c^ .
+            commit 8cb321075afb9b77ea965e1373a03a603d9c9796
+            Author: Mario Castro <xx@gmail.com>
+            Date:   Thu Aug 4 16:52:06 2022 +0200
+
+                Move lightweight manifest to integration for EBS data stream (#3856)
+            ```
 
 2. Run the **integrations-backport** pipeline [https://buildkite.com/elastic/integrations-backport](https://buildkite.com/elastic/integrations-backport) for creating the backport branch. ![buildkite build](images/build.png "")
 
@@ -63,14 +75,19 @@ Follow these detailed steps to release a fix for a given package version:
 
     Pipeline’s inputs:
 
-    * **DRY_RUN** (default: "true"), If DRY_RUN is defined as "true" it will check:
+    * **DRY_RUN** (default: "true")
 
-        * if the package is published,
-        * if the entered commit exists,
-        * if the backport branch exists. Also, it will create the local branch, update the branch with `.buildkite` and `.ci` folders, and remove other packages except the defined one (if set as input). This local branch will not be pushed to the upstream repository in this mode.
+        * **`true`** — Performs checks and a local dry run only. It will:
+            * Verify if the package is published
+            * Verify if the entered commit exists
+            * Verify if the entered commit publishes the expected version
+            * Verify if the backport branch already exists
+            * Create the local branch and update it with `.buildkite` and `.ci` folders
+            * Remove other packages except the defined one (if `REMOVE_OTHER_PACKAGES` is set)
 
+            The branch will **not** be pushed to the upstream repository.
 
-    If DRY_RUN is defined as "false", in addition to written above it will create a commit and push the local branch to the upstream repository [https://github.com/elastic/integrations.git](https://github.com/elastic/integrations.git). In this case, the name of the branch will be `+backport-${PACKAGE_NAME}-${TRIMMED_PACKAGE_VERSION}+`, for example, `backport-aws-1.19`.
+        * **`false`** — Does everything above, plus creates a commit and pushes the local branch to the upstream repository ([https://github.com/elastic/integrations.git](https://github.com/elastic/integrations)). The branch will be named `backport-${PACKAGE_NAME}-${TRIMMED_PACKAGE_VERSION}` (e.g. `backport-aws-1.19`).
 
     * **BASE_COMMIT** (default: "") - enter the commit from the previous step (8cb321075afb9b77ea965e1373a03a603d9c9796)
     * **PACKAGE_NAME** (default: "") - enter the package name, as defined in the `name` field of manifest.yml, for example `aws`
@@ -79,7 +96,7 @@ Follow these detailed steps to release a fix for a given package version:
 
 3. **Create a PR for the bug fix**
 
-    Create a new branch in your own remote (it is advised **not using** a branch name starting with `backport-`), and apply bugfixes there. Remember to update the version in the package manifest (update patch version like `1.19.<x+1>`) and add a new changelog entry for this patch version.
+    Create a new branch in your own remote (it is advised **not to use** a branch name starting with `backport-`), and apply bugfixes there. Remember to update the version in the package manifest (update patch version like `1.19.<x+1>`) and add a new changelog entry for this patch version.
 
     Once ready, open a PR selecting as a base branch the one created above: `backport-<package_name>-<package_major_version>.<package_minor_version>` (e.g. `backport-aws-1.19`).
 
@@ -89,7 +106,7 @@ Follow these detailed steps to release a fix for a given package version:
 
 4. **Update changelog in main**
 
-    Once PR has been merged in the corresponding backport branch (e.g. `backport-aws-1.9`) and the package has been published, a new Pull Request should be created manually to update the changelog in the main branch to include the new version published in the backport branch. Take into account to add the changelog entry following the version order.
+    Once PR has been merged in the corresponding backport branch (e.g. `backport-aws-1.19`) and the package has been published, a new Pull Request should be created manually to update the changelog in the main branch to include the new version published in the backport branch. Take into account to add the changelog entry following the version order.
 
     In order to keep track, this new PR should have a reference (relates) to the backport PR too in its description.
 
@@ -97,7 +114,7 @@ Follow these detailed steps to release a fix for a given package version:
 
     1. Missing shellinit command:
 
-        * Example of the error: [https://buildkite.com/elastic/integrations/builds/7634#018c87f4-7b0c-4d6f-8ddd-b779a9a7a019/507-512](https://buildkite.com/elastic/integrations/builds/7634#018c87f4-7b0c-4d6f-8ddd-b779a9a7a019/507-512)
+        * Example of the error:
 
             `Error: could not create kibana client: undefined environment variable: ELASTIC_PACKAGE_KIBANA_HOST. If you have started the Elastic stack using the elastic-package tool, please load stack environment variables using 'eval "$(elastic-package stack shellinit)"' or set their values manually`
 
@@ -109,7 +126,7 @@ Follow these detailed steps to release a fix for a given package version:
 
     2. Not found license file:
 
-        * Example of the error: [https://buildkite.com/elastic/integrations/builds/7644#018c883c-546f-4d32-ab4a-71e919ddebf8/270-309](https://buildkite.com/elastic/integrations/builds/7644#018c883c-546f-4d32-ab4a-71e919ddebf8/270-309)
+        * Example of the error:
 
             `Error: checking package failed: building package failed: copying license text file: failure while looking for license "licenses/Elastic-2.0.txt" in repository: failed to find repository license: stat /opt/buildkite-agent/builds/bk-agent-prod-gcp-1703092724145948143/elastic/integrations/licenses/Elastic-2.0.txt: no such file or directory`
 

--- a/docs/extend/general-guidelines.md
+++ b/docs/extend/general-guidelines.md
@@ -85,7 +85,7 @@ TSDB indexes can be enabled in data streams by setting `elasticsearch.index_mode
 
 ## Logs and Metrics UI compatibility [_logs_and_metrics_ui_compatibility]
 
-When applicable an integrataion package should provide the relevant fields for the Logs and Metrics Apps. This is especially relevant for integrations that are focused on compute-resources (VMs, containers, etc.).
+When applicable an integration package should provide the relevant fields for the Logs and Metrics Apps. This is especially relevant for integrations that are focused on compute-resources (VMs, containers, etc.).
 
 * Keep the [Logs app fields](docs-content://reference/observability/fields-and-object-schemas/logs-app-fields.md) reference up to date.
 * Keep the [Infrastructure app fields](docs-content://reference/observability/fields-and-object-schemas/metrics-app-fields.md) reference up to date.

--- a/magefile.go
+++ b/magefile.go
@@ -255,7 +255,7 @@ func IsSubscriptionCompatible() error {
 func KibanaConstraintPackage() error {
 	constraint, err := citools.KibanaConstraintPackage("manifest.yml")
 	if err != nil {
-		return fmt.Errorf("failed to get Kibana constraint")
+		return fmt.Errorf("failed to get Kibana constraint: %w", err)
 	}
 	if constraint == nil {
 		fmt.Println("null")


### PR DESCRIPTION
<!-- Type of change: Enhancement -->

## Proposed commit message

```
Add helper script for backport release commit lookup and improve hotfix workflow docs

- Add dev/scripts/get_release_commit.sh to find the git commit where a
  package version was first released, replacing a manual git log lookup
- Add .buildkite/scripts/run_dev_scripts_tests.sh with unit tests for
  the helper script and wire it into the Buildkite pipeline
- Improve docs/extend/developer-workflow-support-old-package.md with
  structural, clarity, and accuracy fixes to the backport hotfix workflow
```

### WHAT

- Adds `dev/scripts/get_release_commit.sh`, a helper script that finds the git commit on `main` where a specific package version was first released, given a package name and version as inputs.
- Adds `.buildkite/scripts/run_dev_scripts_tests.sh`, a unit test suite for the helper script covering normal cases, unknown packages/versions, and missing or invalid flags.
- Wires the test suite into the Buildkite pipeline as a dedicated step and registers the new paths as non-package paths in `common.sh`.
- Improves `docs/extend/developer-workflow-support-old-package.md` with a range of clarity and accuracy fixes.

### WHY

The helper script removes a manual multi-step `git log` lookup that was previously the only way to find the target commit when preparing a backport branch. The doc improvements make the hotfix workflow easier to follow for contributors who need to release a fix for an older package version.

Doc changes include:
- 4-step overview at the top for quick orientation
- Dedicated **Syntax** and **Example** code blocks replacing mixed single blocks
- Removal of `cd` in `git log` examples in favour of passing the path directly
- Reordered pipeline inputs (required inputs first, mode flags last)
- Replaced internal `TRIMMED_PACKAGE_VERSION` variable with a readable `backport-<package_name>-<major>.<minor>` placeholder
- Expanded `REMOVE_OTHER_PACKAGES` description with motivation
- Link to the Elastic Package Registry as a publication check before updating the changelog
- Known issues moved to a dedicated section with more descriptive titles
- Various typo and wording fixes

## Author's Checklist

- [x] Helper script tested against real packages in the repository
- [x] Buildkite pipeline step verified to trigger on changes to `dev/scripts/` and the test script
- [x] Doc improvements reviewed for accuracy against the actual backport pipeline behaviour

## How to test this PR locally

```bash
# Run the helper script unit tests
.buildkite/scripts/run_dev_scripts_tests.sh

# Try the helper script manually
./dev/scripts/get_release_commit.sh -p aws -v 1.19.5
```

## Related issues

- Relates #19016
- Fixes https://github.com/elastic/integrations/issues/19064
- Part of https://github.com/elastic/integrations/issues/18743

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).