### PR TITLE
ti_threatconnect: fix precision loss of indicator IDs above 2^53

### DIFF
--- a/packages/ti_threatconnect/_dev/deploy/docker/files/config-indicator.yml
+++ b/packages/ti_threatconnect/_dev/deploy/docker/files/config-indicator.yml
@@ -352,7 +352,7 @@ rules:
           {
             "data": [
               {
-                "id": 738669,
+                "id": 9007199254918487,
                 "dateAdded": "2023-08-24T06:28:17Z",
                 "securityLabels": {
                   "data": [
@@ -368,7 +368,7 @@ rules:
                 },
                 "ownerId": 51,
                 "ownerName": "Elastic",
-                "webLink": "https://app.threatconnect.com/#/details/indicators/738667/overview",
+                "webLink": "https://app.threatconnect.com/#/details/indicators/9007199254918487/overview",
                 "tags": {
                   "data": [
                     {
@@ -391,14 +391,16 @@ rules:
                     }
                   ]
                 },
-                "type": "URL",
+                "type": "Address",
                 "lastModified": "2023-12-05T06:47:59Z",
-                "threatAssessRating": 0,
-                "threatAssessConfidence": 0,
-                "threatAssessScore": 281,
+                "confidence": 75,
+                "rating": 4,
+                "threatAssessRating": 4,
+                "threatAssessConfidence": 75,
+                "threatAssessScore": 502,
                 "threatAssessScoreObserved": 0,
                 "threatAssessScoreFalsePositive": 0,
-                "summary": "http://www.testingmcafeesites.com/testcat_pc1.html",
+                "summary": "67.43.156.12",
                 "privateFlag": false,
                 "active": true,
                 "activeLocked": false,
@@ -528,11 +530,11 @@ rules:
                     }
                   ]
                 },
-                "text": "http://www.testingmcafeesites.com/testcat_pc.html",
-                "legacyLink": "https://app.threatconnect.com/auth/indicators/details/url.xhtml?orgid=738667&owner=Elastic"
+                "ip": "67.43.156.12",
+                "legacyLink": "https://app.threatconnect.com/auth/indicators/details/address.xhtml?address=67.43.156.12&owner=Elastic"
               },
               {
-                "id": 736759,
+                "id": 9007199254918489,
                 "dateAdded": "2023-08-24T06:19:58Z",
                 "securityLabels": {
                   "data": [
@@ -548,7 +550,7 @@ rules:
                 },
                 "ownerId": 51,
                 "ownerName": "Elastic",
-                "webLink": "https://app.threatconnect.com/#/details/indicators/736758/overview",
+                "webLink": "https://app.threatconnect.com/#/details/indicators/9007199254918489/overview",
                 "tags": {
                   "data": [
                     {
@@ -571,14 +573,16 @@ rules:
                     }
                   ]
                 },
-                "type": "EmailAddress",
+                "type": "Address",
                 "lastModified": "2023-12-06T06:38:53Z",
-                "threatAssessRating": 0,
-                "threatAssessConfidence": 0,
-                "threatAssessScore": 281,
+                "confidence": 75,
+                "rating": 4,
+                "threatAssessRating": 4,
+                "threatAssessConfidence": 75,
+                "threatAssessScore": 833,
                 "threatAssessScoreObserved": 0,
                 "threatAssessScoreFalsePositive": 0,
-                "summary": "test.user@elastic.co",
+                "summary": "67.43.156.13",
                 "privateFlag": false,
                 "active": true,
                 "activeLocked": false,
@@ -671,8 +675,8 @@ rules:
                   ]
                 },
                 "attributes": {},
-                "address": "test.user@elastic.co",
-                "legacyLink": "https://app.threatconnect.com/auth/indicators/details/emailaddress.xhtml?emailaddress=test.user%40elastic.co&owner=Elastic"
+                "ip": "67.43.156.13",
+                "legacyLink": "https://app.threatconnect.com/auth/indicators/details/address.xhtml?address=67.43.156.13&owner=Elastic"
               }
             ]
           }

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix precision loss of indicator IDs above 2^53 by using decode_json_string_numbers in the CEL program.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/19110
 - version: "2.1.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.1"
+  changes:
+    - description: Fix precision loss of indicator IDs above 2^53 by using decode_json_string_numbers in the CEL program.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "2.1.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_threatconnect/data_stream/indicator/_dev/test/scripts/env.txt
+++ b/packages/ti_threatconnect/data_stream/indicator/_dev/test/scripts/env.txt
@@ -1,0 +1,10 @@
+[!exec:echo] skip 'Skipping test requiring absent echo command'
+
+exec echo ${PACKAGE_NAME}
+stdout '^ti_threatconnect$'
+
+exec echo ${DATA_STREAM}
+stdout '^indicator$'
+
+exec echo ${CURRENT_VERSION}
+stdout '^[0-9]+\.[0-9]+\.[0-9]+$'

--- a/packages/ti_threatconnect/data_stream/indicator/_dev/test/scripts/large_id_precision.txt
+++ b/packages/ti_threatconnect/data_stream/indicator/_dev/test/scripts/large_id_precision.txt
@@ -1,0 +1,134 @@
+# Test that indicator IDs above 2^53 are preserved without float64
+# precision loss. The mock returns two Address indicators whose IDs
+# (9007199254918487 and 9007199254918489) both round to 9007199254918488
+# under IEEE 754 double-precision. After the fix, each document must
+# retain its original distinct ID.
+
+[!external_stack] skip 'Skipping external stack test.'
+[!exec:jq] skip 'Skipping test requiring absent jq command'
+
+use_stack -profile ${CONFIG_PROFILES}/${PROFILE}
+install_agent -profile ${CONFIG_PROFILES}/${PROFILE} -network_name NETWORK_NAME
+docker_up -profile ${CONFIG_PROFILES}/${PROFILE} -network ${NETWORK_NAME} tc-precision-mock
+add_package -profile ${CONFIG_PROFILES}/${PROFILE}
+add_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} test_config.yaml DATA_STREAM_NAME
+
+get_docs -profile ${CONFIG_PROFILES}/${PROFILE} -want 2 -confirm 30s -timeout 5m ${DATA_STREAM_NAME}
+cp stdout got_docs.json
+
+# Exactly 2 documents.
+exec jq '.hits.total.value' got_docs.json
+stdout '^2$'
+
+# Extract all threat_connect.indicator.id values, sorted.
+exec jq -r '[.hits.hits[]._source.threat_connect.indicator.id] | sort | .[]' got_docs.json
+stdout '9007199254918487'
+stdout '9007199254918489'
+
+# Verify the IDs are distinct (not both 9007199254918488).
+exec jq '[.hits.hits[]._source.threat_connect.indicator.id] | unique | length' got_docs.json
+stdout '^2$'
+
+# Verify each ID maps to the correct IP.
+exec jq -r '.hits.hits[] | select(._source.threat_connect.indicator.id == "9007199254918487") | ._source.threat_connect.indicator.ip' got_docs.json
+stdout '^67\.43\.156\.12$'
+
+exec jq -r '.hits.hits[] | select(._source.threat_connect.indicator.id == "9007199254918489") | ._source.threat_connect.indicator.ip' got_docs.json
+stdout '^67\.43\.156\.13$'
+
+remove_package_policy -profile ${CONFIG_PROFILES}/${PROFILE} ${DATA_STREAM_NAME}
+uninstall_agent -profile ${CONFIG_PROFILES}/${PROFILE} -timeout 1m
+docker_down tc-precision-mock
+
+-- test_config.yaml --
+input: cel
+vars:
+  url: http://tc-precision-mock:8090
+  access_id: "1234"
+  secret_key: xxxx
+data_stream:
+  vars:
+    interval: 30s
+    batch_size: 2
+    initial_interval: 24h
+    preserve_original_event: true
+
+-- tc-precision-mock/docker-compose.yml --
+version: '2.3'
+services:
+  tc-precision-mock:
+    image: docker.elastic.co/observability/stream:v0.18.0
+    hostname: tc-precision-mock
+    ports:
+      - 8090
+    environment:
+      PORT: "8090"
+    volumes:
+      - ./config.yml:/config.yml
+    command:
+      - http-server
+      - --addr=:8090
+      - --config=/config.yml
+
+-- tc-precision-mock/config.yml --
+rules:
+  - path: /api/v3/indicators
+    methods: ["GET"]
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - application/json
+        body: |-
+          {
+            "data": [
+              {
+                "id": 9007199254918487,
+                "dateAdded": "2023-12-05T06:00:00Z",
+                "securityLabels": {},
+                "ownerId": 51,
+                "ownerName": "Elastic",
+                "webLink": "https://app.threatconnect.com/#/details/indicators/9007199254918487/overview",
+                "tags": {},
+                "type": "Address",
+                "lastModified": "2023-12-05T07:00:00Z",
+                "confidence": 75,
+                "rating": 4,
+                "threatAssessRating": 4,
+                "threatAssessConfidence": 75,
+                "threatAssessScore": 502,
+                "threatAssessScoreObserved": 0,
+                "threatAssessScoreFalsePositive": 0,
+                "summary": "67.43.156.12",
+                "privateFlag": false,
+                "active": true,
+                "activeLocked": false,
+                "ip": "67.43.156.12",
+                "legacyLink": "https://app.threatconnect.com/auth/indicators/details/address.xhtml?address=67.43.156.12&owner=Elastic"
+              },
+              {
+                "id": 9007199254918489,
+                "dateAdded": "2023-12-05T06:00:00Z",
+                "securityLabels": {},
+                "ownerId": 51,
+                "ownerName": "Elastic",
+                "webLink": "https://app.threatconnect.com/#/details/indicators/9007199254918489/overview",
+                "tags": {},
+                "type": "Address",
+                "lastModified": "2023-12-06T06:38:53Z",
+                "confidence": 75,
+                "rating": 4,
+                "threatAssessRating": 4,
+                "threatAssessConfidence": 75,
+                "threatAssessScore": 833,
+                "threatAssessScoreObserved": 0,
+                "threatAssessScoreFalsePositive": 0,
+                "summary": "67.43.156.13",
+                "privateFlag": false,
+                "active": true,
+                "activeLocked": false,
+                "ip": "67.43.156.13",
+                "legacyLink": "https://app.threatconnect.com/auth/indicators/details/address.xhtml?address=67.43.156.13&owner=Elastic"
+              }
+            ]
+          }

--- a/packages/ti_threatconnect/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_threatconnect/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
               "Timestamp": [string(int(now))],
           }
       }))).do_request().as(resp, resp.StatusCode == 200 ?
-          bytes(resp.Body).decode_json().as(body, {
+          bytes(resp.Body).decode_json_string_numbers().as(body, {
               "events": body.data.map(e, {
                   "message": e.encode_json(),
               }),

--- a/packages/ti_threatconnect/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_threatconnect/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -90,7 +90,7 @@ program: |
               "Timestamp": [string(int(now))],
           }
       }))).do_request().as(resp, resp.StatusCode == 200 ?
-          bytes(resp.Body).decode_json_string_numbers().as(body, {
+          resp.Body.decode_json_string_numbers().as(body, {
               "events": body.data.map(e, {
                   "message": e.encode_json(),
               }),

--- a/packages/ti_threatconnect/data_stream/indicator/sample_event.json
+++ b/packages/ti_threatconnect/data_stream/indicator/sample_event.json
@@ -1,24 +1,24 @@
 {
     "@timestamp": "2023-12-05T06:38:53.000Z",
     "agent": {
-        "ephemeral_id": "bfc8c3c8-d6ef-467f-a80c-6c75059c9a7c",
-        "id": "8299ae35-ee0e-4107-9acb-1b6acfdda1fb",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "72cfcafd-0001-448f-a9f5-4f43ae4bd8f0",
+        "id": "1840389e-ac8c-4908-b641-1c2e303dc436",
+        "name": "elastic-agent-61982",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.19.0"
     },
     "data_stream": {
         "dataset": "ti_threatconnect.indicator",
-        "namespace": "53159",
+        "namespace": "50681",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "8299ae35-ee0e-4107-9acb-1b6acfdda1fb",
+        "id": "1840389e-ac8c-4908-b641-1c2e303dc436",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.19.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -27,7 +27,7 @@
         ],
         "dataset": "ti_threatconnect.indicator",
         "id": "test.user@elastic.co",
-        "ingested": "2024-08-02T06:30:51Z",
+        "ingested": "2026-05-21T09:09:46Z",
         "kind": "enrichment",
         "original": "{\"active\":true,\"activeLocked\":false,\"address\":\"test.user@elastic.co\",\"associatedGroups\":{\"data\":[{\"createdBy\":{\"firstName\":\"test\",\"id\":69,\"lastName\":\"user\",\"owner\":\"Elastic\",\"pseudonym\":\"testW\",\"userName\":\"test.user@elastic.co\"},\"dateAdded\":\"2023-12-05T06:38:33Z\",\"downVoteCount\":\"0\",\"id\":609427,\"lastModified\":\"2023-12-05T06:43:21Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/vulnerability/vulnerability.xhtml?vulnerability=609427\",\"name\":\"Test2 \",\"ownerId\":51,\"ownerName\":\"Elastic\",\"type\":\"Vulnerability\",\"upVoteCount\":\"0\",\"webLink\":\"https://app.threatconnect.com/#/details/groups/609427/overview\"},{\"createdBy\":{\"firstName\":\"test\",\"id\":69,\"lastName\":\"user\",\"owner\":\"Elastic\",\"pseudonym\":\"testW\",\"userName\":\"test.user@elastic.co\"},\"dateAdded\":\"2023-12-04T07:18:52Z\",\"documentDateAdded\":\"2023-12-04T07:18:53Z\",\"documentType\":\"PDF\",\"downVoteCount\":\"0\",\"fileName\":\"testthreatgroup.pdf\",\"fileSize\":24467,\"generatedReport\":true,\"id\":601237,\"lastModified\":\"2023-12-05T06:38:46Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/report/report.xhtml?report=601237\",\"name\":\"TestThreatGroup\",\"ownerId\":51,\"ownerName\":\"Elastic\",\"status\":\"Success\",\"type\":\"Report\",\"upVoteCount\":\"0\",\"webLink\":\"https://app.threatconnect.com/#/details/groups/601237/overview\"}]},\"associatedIndicators\":{\"data\":[{\"active\":true,\"activeLocked\":false,\"address\":\"testing@poverts.com\",\"confidence\":61,\"dateAdded\":\"2023-08-25T12:57:24Z\",\"id\":891599,\"lastModified\":\"2023-12-05T06:50:06Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/indicators/details/emailaddress.xhtml?emailaddress=testing%40poverts.com\\u0026owner=Elastic\",\"ownerId\":51,\"ownerName\":\"Elastic\",\"privateFlag\":false,\"rating\":3,\"summary\":\"testing@poverts.com\",\"type\":\"EmailAddress\",\"webLink\":\"https://app.threatconnect.com/#/details/indicators/891599/overview\"},{\"active\":true,\"activeLocked\":false,\"dateAdded\":\"2023-08-24T06:28:17Z\",\"id\":738667,\"lastModified\":\"2023-12-05T06:47:59Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/indicators/details/url.xhtml?orgid=738667\\u0026owner=Elastic\",\"ownerId\":51,\"ownerName\":\"Elastic\",\"privateFlag\":false,\"summary\":\"http://www.testingmcafeesites.com/testcat_pc.html\",\"text\":\"http://www.testingmcafeesites.com/testcat_pc.html\",\"type\":\"URL\",\"webLink\":\"https://app.threatconnect.com/#/details/indicators/738667/overview\"}]},\"attributes\":{},\"dateAdded\":\"2023-08-24T06:19:58Z\",\"id\":736758,\"lastModified\":\"2023-12-05T06:38:53Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/indicators/details/emailaddress.xhtml?emailaddress=test.user%40elastic.co\\u0026owner=Elastic\",\"ownerId\":51,\"ownerName\":\"Elastic\",\"privateFlag\":false,\"securityLabels\":{\"data\":[{\"color\":\"FFC000\",\"dateAdded\":\"2016-08-31T00:00:00Z\",\"description\":\"This security label is used for information that requires support to be effectively acted upon, yet carries risks to privacy, reputation, or operations if shared outside of the organizations involved. Information with this label can be shared with members of an organization and its clients.\",\"id\":3,\"name\":\"TLP:AMBER\",\"owner\":\"System\"}]},\"summary\":\"test.user@elastic.co\",\"tags\":{\"data\":[{\"description\":\"Adversaries may steal monetary resources from targets through extortion, social engineering, technical theft, or other methods aimed at their own financial gain at the expense of the availability of these resources for victims. Financial theft is the ultimate objective of several popular campaign types including extortion by ransomware,(Citation: FBI-ransomware) business email compromise (BEC) and fraud,(Citation: FBI-BEC) \\\"pig butchering,\\\"(Citation: wired-pig butchering) bank hacking,(Citation: DOJ-DPRK Heist) and exploiting cryptocurrency networks.(Citation: BBC-Ronin) \\n\\nAdversaries may [Compromise Accounts](https://attack.mitre.org/techniques/T1586) to conduct unauthorized transfers of funds.(Citation: Internet crime report 2022) In the case of business email compromise or email fraud, an adversary may utilize [Impersonation](https://attack.mitre.org/techniques/T1656) of a trusted entity. Once the social engineering is successful, victims can be deceived into sending money to financial accounts controlled by an adversary.(Citation: FBI-BEC) This creates the potential for multiple victims (i.e., compromised accounts as well as the ultimate monetary loss) in incidents involving financial theft.(Citation: VEC)\\n\\nExtortion by ransomware may occur, for example, when an adversary demands payment from a victim after [Data Encrypted for Impact](https://attack.mitre.org/techniques/T1486) (Citation: NYT-Colonial) and [Exfiltration](https://attack.mitre.org/tactics/TA0010) of data, followed by threatening public exposure unless payment is made to the adversary.(Citation: Mandiant-leaks)\\n\\nDue to the potentially immense business impact of financial theft, an adversary may abuse the possibility of financial theft and seeking monetary gain to divert attention from their true goals such as [Data Destruction](https://attack.mitre.org/techniques/T1485) and business disruption.(Citation: AP-NotPetya)\",\"id\":463701,\"lastUsed\":\"2023-12-04T06:44:44Z\",\"name\":\"Financial Theft\",\"platforms\":{\"count\":6,\"data\":[\"Linux\",\"macOS\",\"Windows\",\"Office 365\",\"SaaS\",\"Google Workspace\"]},\"techniqueId\":\"T1657\"}]},\"threatAssessConfidence\":0,\"threatAssessRating\":0,\"threatAssessScore\":281,\"threatAssessScoreFalsePositive\":0,\"threatAssessScoreObserved\":0,\"type\":\"EmailAddress\",\"webLink\":\"https://app.threatconnect.com/#/details/indicators/736758/overview\"}",
         "type": [
@@ -82,6 +82,9 @@
         "technique": {
             "id": [
                 "T1657"
+            ],
+            "name": [
+                "Financial Theft"
             ]
         }
     },

--- a/packages/ti_threatconnect/docs/README.md
+++ b/packages/ti_threatconnect/docs/README.md
@@ -65,24 +65,24 @@ An example event for `indicator` looks as following:
 {
     "@timestamp": "2023-12-05T06:38:53.000Z",
     "agent": {
-        "ephemeral_id": "bfc8c3c8-d6ef-467f-a80c-6c75059c9a7c",
-        "id": "8299ae35-ee0e-4107-9acb-1b6acfdda1fb",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "72cfcafd-0001-448f-a9f5-4f43ae4bd8f0",
+        "id": "1840389e-ac8c-4908-b641-1c2e303dc436",
+        "name": "elastic-agent-61982",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.19.0"
     },
     "data_stream": {
         "dataset": "ti_threatconnect.indicator",
-        "namespace": "53159",
+        "namespace": "50681",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "8299ae35-ee0e-4107-9acb-1b6acfdda1fb",
+        "id": "1840389e-ac8c-4908-b641-1c2e303dc436",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.19.0"
     },
     "event": {
         "agent_id_status": "verified",
@@ -91,7 +91,7 @@ An example event for `indicator` looks as following:
         ],
         "dataset": "ti_threatconnect.indicator",
         "id": "test.user@elastic.co",
-        "ingested": "2024-08-02T06:30:51Z",
+        "ingested": "2026-05-21T09:09:46Z",
         "kind": "enrichment",
         "original": "{\"active\":true,\"activeLocked\":false,\"address\":\"test.user@elastic.co\",\"associatedGroups\":{\"data\":[{\"createdBy\":{\"firstName\":\"test\",\"id\":69,\"lastName\":\"user\",\"owner\":\"Elastic\",\"pseudonym\":\"testW\",\"userName\":\"test.user@elastic.co\"},\"dateAdded\":\"2023-12-05T06:38:33Z\",\"downVoteCount\":\"0\",\"id\":609427,\"lastModified\":\"2023-12-05T06:43:21Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/vulnerability/vulnerability.xhtml?vulnerability=609427\",\"name\":\"Test2 \",\"ownerId\":51,\"ownerName\":\"Elastic\",\"type\":\"Vulnerability\",\"upVoteCount\":\"0\",\"webLink\":\"https://app.threatconnect.com/#/details/groups/609427/overview\"},{\"createdBy\":{\"firstName\":\"test\",\"id\":69,\"lastName\":\"user\",\"owner\":\"Elastic\",\"pseudonym\":\"testW\",\"userName\":\"test.user@elastic.co\"},\"dateAdded\":\"2023-12-04T07:18:52Z\",\"documentDateAdded\":\"2023-12-04T07:18:53Z\",\"documentType\":\"PDF\",\"downVoteCount\":\"0\",\"fileName\":\"testthreatgroup.pdf\",\"fileSize\":24467,\"generatedReport\":true,\"id\":601237,\"lastModified\":\"2023-12-05T06:38:46Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/report/report.xhtml?report=601237\",\"name\":\"TestThreatGroup\",\"ownerId\":51,\"ownerName\":\"Elastic\",\"status\":\"Success\",\"type\":\"Report\",\"upVoteCount\":\"0\",\"webLink\":\"https://app.threatconnect.com/#/details/groups/601237/overview\"}]},\"associatedIndicators\":{\"data\":[{\"active\":true,\"activeLocked\":false,\"address\":\"testing@poverts.com\",\"confidence\":61,\"dateAdded\":\"2023-08-25T12:57:24Z\",\"id\":891599,\"lastModified\":\"2023-12-05T06:50:06Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/indicators/details/emailaddress.xhtml?emailaddress=testing%40poverts.com\\u0026owner=Elastic\",\"ownerId\":51,\"ownerName\":\"Elastic\",\"privateFlag\":false,\"rating\":3,\"summary\":\"testing@poverts.com\",\"type\":\"EmailAddress\",\"webLink\":\"https://app.threatconnect.com/#/details/indicators/891599/overview\"},{\"active\":true,\"activeLocked\":false,\"dateAdded\":\"2023-08-24T06:28:17Z\",\"id\":738667,\"lastModified\":\"2023-12-05T06:47:59Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/indicators/details/url.xhtml?orgid=738667\\u0026owner=Elastic\",\"ownerId\":51,\"ownerName\":\"Elastic\",\"privateFlag\":false,\"summary\":\"http://www.testingmcafeesites.com/testcat_pc.html\",\"text\":\"http://www.testingmcafeesites.com/testcat_pc.html\",\"type\":\"URL\",\"webLink\":\"https://app.threatconnect.com/#/details/indicators/738667/overview\"}]},\"attributes\":{},\"dateAdded\":\"2023-08-24T06:19:58Z\",\"id\":736758,\"lastModified\":\"2023-12-05T06:38:53Z\",\"legacyLink\":\"https://app.threatconnect.com/auth/indicators/details/emailaddress.xhtml?emailaddress=test.user%40elastic.co\\u0026owner=Elastic\",\"ownerId\":51,\"ownerName\":\"Elastic\",\"privateFlag\":false,\"securityLabels\":{\"data\":[{\"color\":\"FFC000\",\"dateAdded\":\"2016-08-31T00:00:00Z\",\"description\":\"This security label is used for information that requires support to be effectively acted upon, yet carries risks to privacy, reputation, or operations if shared outside of the organizations involved. Information with this label can be shared with members of an organization and its clients.\",\"id\":3,\"name\":\"TLP:AMBER\",\"owner\":\"System\"}]},\"summary\":\"test.user@elastic.co\",\"tags\":{\"data\":[{\"description\":\"Adversaries may steal monetary resources from targets through extortion, social engineering, technical theft, or other methods aimed at their own financial gain at the expense of the availability of these resources for victims. Financial theft is the ultimate objective of several popular campaign types including extortion by ransomware,(Citation: FBI-ransomware) business email compromise (BEC) and fraud,(Citation: FBI-BEC) \\\"pig butchering,\\\"(Citation: wired-pig butchering) bank hacking,(Citation: DOJ-DPRK Heist) and exploiting cryptocurrency networks.(Citation: BBC-Ronin) \\n\\nAdversaries may [Compromise Accounts](https://attack.mitre.org/techniques/T1586) to conduct unauthorized transfers of funds.(Citation: Internet crime report 2022) In the case of business email compromise or email fraud, an adversary may utilize [Impersonation](https://attack.mitre.org/techniques/T1656) of a trusted entity. Once the social engineering is successful, victims can be deceived into sending money to financial accounts controlled by an adversary.(Citation: FBI-BEC) This creates the potential for multiple victims (i.e., compromised accounts as well as the ultimate monetary loss) in incidents involving financial theft.(Citation: VEC)\\n\\nExtortion by ransomware may occur, for example, when an adversary demands payment from a victim after [Data Encrypted for Impact](https://attack.mitre.org/techniques/T1486) (Citation: NYT-Colonial) and [Exfiltration](https://attack.mitre.org/tactics/TA0010) of data, followed by threatening public exposure unless payment is made to the adversary.(Citation: Mandiant-leaks)\\n\\nDue to the potentially immense business impact of financial theft, an adversary may abuse the possibility of financial theft and seeking monetary gain to divert attention from their true goals such as [Data Destruction](https://attack.mitre.org/techniques/T1485) and business disruption.(Citation: AP-NotPetya)\",\"id\":463701,\"lastUsed\":\"2023-12-04T06:44:44Z\",\"name\":\"Financial Theft\",\"platforms\":{\"count\":6,\"data\":[\"Linux\",\"macOS\",\"Windows\",\"Office 365\",\"SaaS\",\"Google Workspace\"]},\"techniqueId\":\"T1657\"}]},\"threatAssessConfidence\":0,\"threatAssessRating\":0,\"threatAssessScore\":281,\"threatAssessScoreFalsePositive\":0,\"threatAssessScoreObserved\":0,\"type\":\"EmailAddress\",\"webLink\":\"https://app.threatconnect.com/#/details/indicators/736758/overview\"}",
         "type": [
@@ -146,6 +146,9 @@ An example event for `indicator` looks as following:
         "technique": {
             "id": [
                 "T1657"
+            ],
+            "name": [
+                "Financial Theft"
             ]
         }
     },

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: "2.1.0"
+version: "2.1.1"
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - threat_intel
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.19.0 || ^9.1.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
ti_threatconnect: fix precision loss of indicator IDs above 2^53

The ThreatConnect API returns indicator IDs as JSON numbers. When
these exceed the IEEE 754 safe integer limit (2^53), the CEL
program's decode_json() rounds them through float64, causing
distinct IDs like 9007199254918487, 9007199254918488, and
9007199254918489 to all collapse to 9007199254918488.

Replace decode_json() with decode_json_string_numbers() so that
all JSON numbers are preserved as their literal string form. The
ingest pipeline already uses convert processors with explicit type
coercions for numeric fields, so string-valued numbers are handled
correctly downstream.

Add a script test that verifies indicator IDs above 2^53 are
preserved correctly. The test mock returns two Address indicators
whose IDs both round to the same float64 value and asserts that
both distinct values appear in threat_connect.indicator.id after
ingestion.

The minimum stack version is raised to 8.19.0/9.1.0, which is
the first version shipping a mito release that includes the
decode_json_string_numbers function.

Fixes elastic/integrations#19109
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Added script test (with large numbers) passes.
```
--- Test results for package: ti_threatconnect - START ---
╭──────────────────┬─────────────┬───────────┬────────────────────┬────────┬─────────────────╮
│ PACKAGE          │ DATA STREAM │ TEST TYPE │ TEST NAME          │ RESULT │    TIME ELAPSED │
├──────────────────┼─────────────┼───────────┼────────────────────┼────────┼─────────────────┤
│ ti_threatconnect │ indicator   │ script    │ env                │ PASS   │      46.96475ms │
│ ti_threatconnect │ indicator   │ script    │ large_id_precision │ PASS   │ 1m26.988814666s │
╰──────────────────┴─────────────┴───────────┴────────────────────┴────────┴─────────────────╯
--- Test results for package: ti_threatconnect - END   ---
Done
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/19109

## Screenshots

**Before (`id` is rounded)**
<img width="1282" height="161" alt="Screenshot 2026-05-21 at 2 32 20 PM" src="https://github.com/user-attachments/assets/b8a64437-5f42-4827-a780-ad07f9b146b7" />


**After (`id` is precise)**
<img width="1282" height="161" alt="Screenshot 2026-05-21 at 2 40 02 PM" src="https://github.com/user-attachments/assets/65ffe91b-b68d-4263-a1fe-10e96894da9b" />

