### PR TITLE
[elastic_agent] Fix Overview dashboard hiding data due to an unintended default filter

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.1"
+  changes:
+    - description: Fix Overview dashboard hiding data due to an unintended default filter.
+      type: bugfix
+      link: "https://github.com/elastic/integrations/issues/18941"
 - version: "2.9.0"
   changes:
     - description: Add TSDB dimensions and complete/fix metric_type declarations across elastic_agent metrics data streams.

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
@@ -28,7 +28,6 @@
                 "9b87225b-2e22-4928-99aa-7317b14f1455": {
                     "explicitInput": {
                         "enhancements": {},
-                        "existsSelected": true,
                         "fieldName": "host.os.type",
                         "grow": true,
                         "id": "9b87225b-2e22-4928-99aa-7317b14f1455",

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.9.0
+version: 2.9.1
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.6.0


### PR DESCRIPTION
## Proposed commit message

WHAT: Remove the default `existsSelected` constraint from the Platform (host.os.type) options-list control in the Overview dashboard.

WHY: PR #18251 replaced `host.os.family` with `host.os.type` in the Platform filter control. While `host.os.type` provides cleaner OS grouping, it is not as universally populated as `host.os.family` across all agent metrics data streams. The pre-existing `existsSelected: true` default became a data-hiding filter after the field swap, causing the dashboard to appear empty when navigating from Fleet's "Agent Info Metrics" link. Removing the default constraint ensures all data is shown unless the user explicitly selects a platform.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes https://github.com/elastic/integrations/issues/18941
- Caused by #18251
