### PR TITLE
[dataminr_pulse] Enable for 9.x stacks

### DIFF
--- a/packages/dataminr_pulse/changelog.yml
+++ b/packages/dataminr_pulse/changelog.yml
@@ -1,5 +1,10 @@
+- version: "0.2.0"
+  changes:
+    - description: Enable for 9.x stacks.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/19122
 - version: "0.1.0"
   changes:
-    - description: Initial release
+    - description: Initial release.
       type: enhancement
       link: https://github.com/elastic/integrations/issues/17886

--- a/packages/dataminr_pulse/manifest.yml
+++ b/packages/dataminr_pulse/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: dataminr_pulse
 title: Dataminr Pulse
-version: 0.1.0
+version: 0.2.0
 description: Collect real-time alerts from Dataminr Pulse API
 icons:
   - src: /img/Dataminr_Logo-Mark_Full-Color_RGB.svg

--- a/packages/dataminr_pulse/manifest.yml
+++ b/packages/dataminr_pulse/manifest.yml
@@ -14,7 +14,7 @@ categories:
   - threat_intel
 conditions:
   kibana:
-    version: "^8.19.0"
+    version: "^8.19.0 || ^9.0.0"
   elastic:
     subscription: basic
 policy_templates:


### PR DESCRIPTION
## Proposed commit message

```
[dataminr_pulse] Enable for 9.x stacks
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 