### PR TITLE
docs: update CI and GTI interval docs

### DIFF
--- a/docs/ci_pipelines.md
+++ b/docs/ci_pipelines.md
@@ -2,13 +2,14 @@
 
 This section describes the CI pipelines available in this repository.
 
-Currently, there are five different pipelines:
+Currently, this repository uses the following Buildkite pipelines and GitHub Actions workflows:
 - https://buildkite.com/elastic/integrations: pipeline in charge of testing all packages using a local Elastic stack. More info at [section](#pull-requests-and-pushes-to-specific-branches).
 - https://buildkite.com/elastic/integrations-serverless: pipeline in charge of testing all packages using a Elastic Serverless project. More info at [section](#serverless-pipeline).
 - https://buildkite.com/elastic/integrations-publish: pipeline to publish the new versions of packages. More info at [section](#publish-packages).
 - https://buildkite.com/elastic/integrations-schedule-daily/: pipeline running every night to test packages in different scenarios. More info at [section](#daily-job).
 - https://buildkite.com/elastic/integrations-schedule-weekly/: pipeline running once per week to test packages in different scenarios. More info at [section](#weekly-job).
 - https://buildkite.com/elastic/integrations-backport/: pipeline to create backport branches (just from UI). More info at [section](#backport-branches-pipeline).
+- [CI Trigger Security-ML Package Tests](https://github.com/elastic/integrations/blob/main/.github/workflows/trigger-package-tests-security-ml.yml): GitHub Actions workflow that dispatches Security-ML package tests for selected packages. More info at [section](#security-ml-package-tests).
 
 ## Pull Requests and pushes to specific branches
 
@@ -95,6 +96,21 @@ More details about this CI pipeline:
   | `8.12.0` | `^8.13.0`             | No  |
   | `8.14.0` | `^8.13.0`             | Yes |
 
+
+## Security-ML package tests
+
+The [CI Trigger Security-ML Package Tests](https://github.com/elastic/integrations/blob/main/.github/workflows/trigger-package-tests-security-ml.yml) GitHub Actions workflow runs on Pull Requests targeting `main` when they are opened, synchronized, or reopened and change one of the following paths:
+
+- `packages/beaconing/**`
+- `packages/ded/**`
+- `packages/dga/**`
+- `packages/hta/**`
+- `packages/lmd/**`
+- `packages/pad/**`
+- `packages/problemchild/**`
+- `.github/workflows/trigger-package-tests-security-ml.yml`
+
+The workflow only runs for Pull Requests from branches in this repository. Pull Requests from forks are skipped because the job condition requires `github.event.pull_request.head.repo.full_name == github.repository`. For matching same-repository Pull Requests, the workflow detects which of the supported packages changed and dispatches `itp-dispatch-integrations.yml` in `elastic/security-ml` on `main`. If the workflow file itself changed, all supported Security-ML packages are dispatched. The downstream Security-ML run reports its results back to the Pull Request, so contributors may see those results outside the Buildkite pipeline output.
 
 ## Publish packages
 

--- a/packages/ti_google_threat_intelligence/docs/README.md
+++ b/packages/ti_google_threat_intelligence/docs/README.md
@@ -56,8 +56,8 @@ Elastic Agent must be installed. For more details, check the Elastic Agent [inst
 - VirusTotal URL will work as the base URL for this integration: https://www.virustotal.com
 - An API key will be used to authenticate your request.
 - **Time Selection of Initial Interval and Interval**:
-  - Users need to specify the **initial interval** and **interval** in an hourly format, such as **2h**, **3h**, etc.
-**Note:** Please make sure both initial interval and interval are in hours and the initial interval is greater than 2 hours.
+  - Users need to specify the **initial interval** and **interval** as hourly durations, such as **2h** for the initial interval and **1h** for the interval.
+**Note:** Threat List streams enforce the Google Threat Intelligence availability delay before requesting hourly packages. Requests newer than the availability delay are clamped to the latest available package, so a **1h** interval safely checks each hourly package after it is available.
 
 ### Enabling the integration in Elastic:
 
@@ -163,7 +163,7 @@ These transforms are automatically started to populate `Threat Intelligence`, `A
 
 ## Troubleshooting
 
-1. If you see an error like `Package 2025031310 is not available until 2025-03-13 at 11:00 UTC because of privacy policy.`, ensure that your initial interval and interval are set in hours and the initial interval is greater than two hours.
+1. If you see an error like `Package 2025031310 is not available until 2025-03-13 at 11:00 UTC because of privacy policy.`, the requested hourly threat list package was not yet available from Google Threat Intelligence. Current Threat List streams enforce the configured availability delay and retry availability-delayed packages instead of requiring an initial interval greater than two hours.
 2. If events are not appearing in the transformed index, check if transforms are running without errors. If you encounter issues, refer to [Troubleshooting transforms](https://www.elastic.co/guide/en/elasticsearch/reference/current/transform-troubleshooting.html).
 3. If detection rules take longer to run, ensure you have specified index patterns and applied queries to make your source events more specific.
    **Note:** More events in index patterns mean more time needed for detection rules to run.


### PR DESCRIPTION
Closes #19115

## Summary

- Update the CI pipelines documentation to match the current Buildkite behavior.
- Clarify the Google Threat Intelligence integration interval documentation.

## Changes

- Document that pipeline execution is controlled by Buildkite pipeline conditions.
- Update the GTI docs so the interval wording matches the current package behavior.

## Testing

- `git diff --check -- docs/ci_pipelines.md packages/ti_google_threat_intelligence/docs/README.md`
- `git diff origin/main..HEAD --check`

## Known Issues

- `vale` and `elastic-package` were not run because they are not installed in this environment.
