### PR TITLE
aws: restore stable endInclusive bound to findings filter for inspector data stream

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.19.2"
+  changes:
+    - description: Restore a stable endInclusive bound to Inspector findings filter to prevent potential nextToken invalidation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19144
 - version: "6.19.1"
   changes:
     - description: Fix aws.lambda.message flattened field handling.

--- a/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
@@ -27,14 +27,15 @@ request.transforms:
       target: body.sortCriteria
       value: '{"field":"LAST_OBSERVED_AT","sortOrder":"ASC"}'
       value_type: json
-{{!-- The upper time bound (endInclusive) has been removed from lastObservedAt because
-      httpjson re-evaluates (now) on every pagination page. When the value changes, AWS
-      rejects the nextToken. A CEL rewrite can reintroduce the upper bound safely since
-      it can pin the value once per collection interval. --}}
+{{!-- endInclusive is a static far-future epoch value because using (now) caused
+      nextToken invalidation when the value changed between pagination pages. A CEL
+      rewrite can use a dynamic upper bound safely since it can pin the value once per
+      collection interval. Inspector validates that dates fall within
+      [1970-01-01, 2033-01-01). --}}
   - set:
       target: body.filterCriteria.lastObservedAt
-      value: '[{ "startInclusive": [[mul (div (toInt .cursor.last_observe_datetime) 1000) 1000]] }]'
-      default: '[{ "startInclusive": [[mul (div (toInt (now (parseDuration "-{{initial_interval}}")).Unix) 1000) 1000]] }]'
+      value: '[{ "startInclusive": [[mul (div (toInt .cursor.last_observe_datetime) 1000) 1000]], "endInclusive": 1956528000 }]'
+      default: '[{ "startInclusive": [[mul (div (toInt (now (parseDuration "-{{initial_interval}}")).Unix) 1000) 1000]], "endInclusive": 1956528000 }]'
       value_type: json
   - set:
       target: header.Authorization

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.19.1
+version: 6.19.2
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
aws: restore stable endInclusive bound to findings filter for inspector data stream

The previous fix (cd8d67e) removed endInclusive entirely from the
Inspector lastObservedAt filter to prevent nextToken invalidation
caused by (now) re-evaluation during pagination. However, Inspector
may enforce the same oneOf schema constraint as Security Hub, which
rejects filters missing the upper bound.

Use a static far-future epoch value (2032-01-01T00:00:00Z) instead.
Inspector validates that dates fall within [1970-01-01, 2033-01-01),
likely due to a 32-bit epoch representation, so the value must stay
below that ceiling. The static value never changes between pagination
pages, avoiding the original nextToken invalidation.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
