### PR TITLE
[claroty_xdome] - Fix CEL handling for nullable API response arrays

### DIFF
--- a/packages/claroty_xdome/_dev/deploy/docker/files/config.yml
+++ b/packages/claroty_xdome/_dev/deploy/docker/files/config.yml
@@ -509,7 +509,7 @@ rules:
             - 'application/json'
         body: |-
           {
-            "devices":[]
+            "devices": null
           }
   - path: /api/v1/alerts/2/devices
     methods: ['POST']
@@ -916,7 +916,7 @@ rules:
             - 'application/json'
         body: |-
           {
-            "devices":[]
+            "devices": null
           }
   - path: /api/v1/vulnerabilities/ALTWZXRU/devices
     methods: ['POST']

--- a/packages/claroty_xdome/changelog.yml
+++ b/packages/claroty_xdome/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix CEL handling for nullable API response arrays.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/19147
 - version: "1.0.2"
   changes:
     - description: Remove the recommendations field from vulnerabilities requests.

--- a/packages/claroty_xdome/changelog.yml
+++ b/packages/claroty_xdome/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.3"
+  changes:
+    - description: Fix CEL handling for nullable API response arrays.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.0.2"
   changes:
     - description: Remove the recommendations field from vulnerabilities requests.

--- a/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
@@ -87,22 +87,25 @@ program: |
             }
           ).do_request().as(resp, (resp.StatusCode == 200) ?
             resp.Body.decode_json().as(body,
-              ((has(body.alerts) && body.alerts != null) ? body.alerts : []).as(alerts,
+              (has(body.alerts) && body.alerts != null && size(body.alerts) > 0) ?
                 {
                   "worklist": {
-                    "alerts": alerts,
+                    "alerts": body.alerts,
                   },
                   "next": 0,
-                  "offset": (size(alerts) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
-                  "want_more": size(alerts) > 0,
+                  "offset": int(state.offset) + int(state.batch_size),
+                  "want_more": true,
                   "cursor": {
-                    ?"last_timestamp": (size(alerts) > 0) ?
-                      optional.of(alerts[size(alerts) - 1].updated_time)
-                    :
-                      state.?cursor.last_timestamp,
+                    "last_timestamp": body.alerts[size(body.alerts) - 1].updated_time,
                   },
                 }
-              )
+              :
+                {
+                  "want_more": false,
+                  "cursor": {
+                    ?"last_timestamp": state.?cursor.last_timestamp,
+                  },
+                }
             )
           :
             {

--- a/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
@@ -306,19 +306,29 @@ program: |
           }
         ).do_request().as(resp, (resp.StatusCode == 200) ?
           bytes(resp.Body).decode_json().as(body,
-            ((has(body.devices) && body.devices != null) ? body.devices : []).as(devices,
+            (has(body.devices) && body.devices != null && size(body.devices) > 0) ?
               {
-                "events": (size(devices) > 0) ?
-                  devices.map(evt,
-                    {
-                      "message": evt.with(
-                        {
-                          "alert_info": state.worklist.alerts[int(state.next)],
-                        }
-                      ).encode_json(),
-                    }
-                  )
-                : (has(state.device_offset) && int(state.device_offset) == 0) ?
+                "events": body.devices.map(evt,
+                  {
+                    "message": evt.with(
+                      {
+                        "alert_info": state.worklist.alerts[int(state.next)],
+                      }
+                    ).encode_json(),
+                  }
+                ),
+                "device_offset": int(state.device_offset) + int(state.batch_size),
+                "next": state.next,
+                "worklist": state.worklist,
+                "start_time": state.start_time,
+                "initial_interval": state.initial_interval,
+                "batch_size": state.batch_size,
+                "api_token": state.api_token,
+                "offset": state.offset,
+              }
+            :
+              {
+                "events": (has(state.device_offset) && int(state.device_offset) == 0) ?
                   [
                     {
                       "message": {
@@ -328,20 +338,15 @@ program: |
                   ]
                 :
                   [{}],
-                "device_offset": (size(devices) > 0) ? (int(state.device_offset) + int(state.batch_size)) : 0,
-                "next": (size(devices) > 0) ?
-                  state.next
-                : (int(state.next) + 1 < size(state.worklist.alerts)) ? (int(state.next) + 1) : 0, // size(devices) > 0
-                "worklist": (size(devices) > 0) ?
-                  state.worklist
-                : (int(state.next) + 1 < size(state.worklist.alerts)) ? state.worklist : {},
+                "device_offset": 0,
+                "next": (int(state.next) + 1 < size(state.worklist.alerts)) ? (int(state.next) + 1) : 0,
+                "worklist": (int(state.next) + 1 < size(state.worklist.alerts)) ? state.worklist : {},
                 "start_time": state.start_time,
                 "initial_interval": state.initial_interval,
                 "batch_size": state.batch_size,
                 "api_token": state.api_token,
                 "offset": state.offset,
               }
-            )
           )
         :
           {

--- a/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
@@ -337,7 +337,11 @@ program: |
                     },
                   ]
                 :
-                  [{}],
+                  [
+                    dyn({
+                      "retry": true,
+                    }),
+                  ],
                 "device_offset": 0,
                 "next": (int(state.next) + 1 < size(state.worklist.alerts)) ? (int(state.next) + 1) : 0,
                 "worklist": (int(state.next) + 1 < size(state.worklist.alerts)) ? state.worklist : {},
@@ -387,7 +391,8 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if processors}}
 processors:
+- drop_event.when.equals.retry: true
+{{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
@@ -102,6 +102,7 @@ program: |
               :
                 {
                   "want_more": false,
+                  "offset": 0,
                   "cursor": {
                     ?"last_timestamp": state.?cursor.last_timestamp,
                   },

--- a/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/alert/agent/stream/cel.yml.hbs
@@ -23,7 +23,7 @@ redact:
     - api_token
 program: |
   (
-    (has(state.?worklist.alerts) && size(state.worklist.alerts) > 0) ?
+    (has(state.?worklist.alerts) && state.worklist.alerts != null && size(state.worklist.alerts) > 0) ?
       state
     :
       (
@@ -87,18 +87,22 @@ program: |
             }
           ).do_request().as(resp, (resp.StatusCode == 200) ?
             resp.Body.decode_json().as(body,
-              {
-                "worklist": body,
-                "next": 0,
-                "offset": (size(body.alerts) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
-                "want_more": size(body.alerts) > 0,
-                "cursor": {
-                  ?"last_timestamp": (has(body.alerts) && size(body.alerts) > 0) ?
-                    optional.of(body.alerts[size(body.alerts) - 1].updated_time)
-                  :
-                    state.?cursor.last_timestamp,
-                },
-              }
+              ((has(body.alerts) && body.alerts != null) ? body.alerts : []).as(alerts,
+                {
+                  "worklist": {
+                    "alerts": alerts,
+                  },
+                  "next": 0,
+                  "offset": (size(alerts) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
+                  "want_more": size(alerts) > 0,
+                  "cursor": {
+                    ?"last_timestamp": (size(alerts) > 0) ?
+                      optional.of(alerts[size(alerts) - 1].updated_time)
+                    :
+                      state.?cursor.last_timestamp,
+                  },
+                }
+              )
             )
           :
             {
@@ -125,7 +129,7 @@ program: |
     state.with(
       !has(state.worklist) ? // Exit early due to POST failure.
         state
-      : (has(state.worklist.alerts) && size(state.worklist.alerts) > 0) ?
+      : (has(state.worklist.alerts) && state.worklist.alerts != null && size(state.worklist.alerts) > 0) ?
         post_request(
           state.url.trim_right("/") + "/api/v1/alerts/" + string(int(state.worklist.alerts[state.next].id)) + "/devices",
           "application/json",
@@ -298,40 +302,42 @@ program: |
           }
         ).do_request().as(resp, (resp.StatusCode == 200) ?
           bytes(resp.Body).decode_json().as(body,
-            {
-              "events": (has(body.devices) && size(body.devices) > 0) ?
-                body.devices.orValue([]).map(evt,
-                  {
-                    "message": evt.with(
-                      {
+            ((has(body.devices) && body.devices != null) ? body.devices : []).as(devices,
+              {
+                "events": (size(devices) > 0) ?
+                  devices.map(evt,
+                    {
+                      "message": evt.with(
+                        {
+                          "alert_info": state.worklist.alerts[int(state.next)],
+                        }
+                      ).encode_json(),
+                    }
+                  )
+                : (has(state.device_offset) && int(state.device_offset) == 0) ?
+                  [
+                    {
+                      "message": {
                         "alert_info": state.worklist.alerts[int(state.next)],
-                      }
-                    ).encode_json(),
-                  }
-                )
-              : (has(state.device_offset) && int(state.device_offset) == 0) ?
-                [
-                  {
-                    "message": {
-                      "alert_info": state.worklist.alerts[int(state.next)],
-                    }.encode_json(),
-                  },
-                ]
-              :
-                [{}],
-              "device_offset": (size(body.devices) > 0) ? (int(state.device_offset) + int(state.batch_size)) : 0,
-              "next": (size(body.devices) > 0) ?
-                state.next
-              : (int(state.next) + 1 < size(state.worklist.alerts)) ? (int(state.next) + 1) : 0, // size(body.devices) > 0
-              "worklist": (size(body.devices) > 0) ?
-                state.worklist
-              : (int(state.next) + 1 < size(state.worklist.alerts)) ? state.worklist : {},
-              "start_time": state.start_time,
-              "initial_interval": state.initial_interval,
-              "batch_size": state.batch_size,
-              "api_token": state.api_token,
-              "offset": state.offset,
-            }
+                      }.encode_json(),
+                    },
+                  ]
+                :
+                  [{}],
+                "device_offset": (size(devices) > 0) ? (int(state.device_offset) + int(state.batch_size)) : 0,
+                "next": (size(devices) > 0) ?
+                  state.next
+                : (int(state.next) + 1 < size(state.worklist.alerts)) ? (int(state.next) + 1) : 0, // size(devices) > 0
+                "worklist": (size(devices) > 0) ?
+                  state.worklist
+                : (int(state.next) + 1 < size(state.worklist.alerts)) ? state.worklist : {},
+                "start_time": state.start_time,
+                "initial_interval": state.initial_interval,
+                "batch_size": state.batch_size,
+                "api_token": state.api_token,
+                "offset": state.offset,
+              }
+            )
           )
         :
           {

--- a/packages/claroty_xdome/data_stream/event/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/event/agent/stream/cel.yml.hbs
@@ -84,25 +84,27 @@ program: |
       }
     ).do_request().as(resp, (resp.StatusCode == 200) ?
       resp.Body.decode_json().as(body,
-        {
-          "events": body.ot_activity_events.map(e,
-            {
-              "message": e.encode_json(),
-            }
-          ),
-          "offset": (size(body.ot_activity_events) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
-          "want_more": size(body.ot_activity_events) > 0,
-          "cursor": {
-            ?"last_timestamp": (has(body.ot_activity_events) && size(body.ot_activity_events) > 0) ?
-              optional.of(body.ot_activity_events[size(body.ot_activity_events) - 1].detection_time)
-            :
-              state.?cursor.last_timestamp,
-          },
-          "start_time": state.start_time,
-          "initial_interval": state.initial_interval,
-          "batch_size": state.batch_size,
-          "api_token": state.api_token,
-        }
+        ((has(body.ot_activity_events) && body.ot_activity_events != null) ? body.ot_activity_events : []).as(events,
+          {
+            "events": events.map(e,
+              {
+                "message": e.encode_json(),
+              }
+            ),
+            "offset": (size(events) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
+            "want_more": size(events) > 0,
+            "cursor": {
+              ?"last_timestamp": (size(events) > 0) ?
+                optional.of(events[size(events) - 1].detection_time)
+              :
+                state.?cursor.last_timestamp,
+            },
+            "start_time": state.start_time,
+            "initial_interval": state.initial_interval,
+            "batch_size": state.batch_size,
+            "api_token": state.api_token,
+          }
+        )
       )
     :
       {

--- a/packages/claroty_xdome/data_stream/event/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/event/agent/stream/cel.yml.hbs
@@ -84,27 +84,36 @@ program: |
       }
     ).do_request().as(resp, (resp.StatusCode == 200) ?
       resp.Body.decode_json().as(body,
-        ((has(body.ot_activity_events) && body.ot_activity_events != null) ? body.ot_activity_events : []).as(events,
+        (has(body.ot_activity_events) && body.ot_activity_events != null && size(body.ot_activity_events) > 0) ?
           {
-            "events": events.map(e,
+            "events": body.ot_activity_events.map(e,
               {
                 "message": e.encode_json(),
               }
             ),
-            "offset": (size(events) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
-            "want_more": size(events) > 0,
+            "offset": int(state.offset) + int(state.batch_size),
+            "want_more": true,
             "cursor": {
-              ?"last_timestamp": (size(events) > 0) ?
-                optional.of(events[size(events) - 1].detection_time)
-              :
-                state.?cursor.last_timestamp,
+              "last_timestamp": body.ot_activity_events[size(body.ot_activity_events) - 1].detection_time,
             },
             "start_time": state.start_time,
             "initial_interval": state.initial_interval,
             "batch_size": state.batch_size,
             "api_token": state.api_token,
           }
-        )
+        :
+          {
+            "events": [],
+            "offset": 0,
+            "want_more": false,
+            "cursor": {
+              ?"last_timestamp": state.?cursor.last_timestamp,
+            },
+            "start_time": state.start_time,
+            "initial_interval": state.initial_interval,
+            "batch_size": state.batch_size,
+            "api_token": state.api_token,
+          }
       )
     :
       {

--- a/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -100,22 +100,25 @@ program: |
             }
           ).do_request().as(resp, (resp.StatusCode == 200) ?
             resp.Body.decode_json().as(body,
-              ((has(body.vulnerabilities) && body.vulnerabilities != null) ? body.vulnerabilities : []).as(vulnerabilities,
+              (has(body.vulnerabilities) && body.vulnerabilities != null && size(body.vulnerabilities) > 0) ?
                 {
                   "worklist": {
-                    "vulnerabilities": vulnerabilities,
+                    "vulnerabilities": body.vulnerabilities,
                   },
                   "next": 0,
-                  "offset": (size(vulnerabilities) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
-                  "want_more": size(vulnerabilities) > 0,
+                  "offset": int(state.offset) + int(state.batch_size),
+                  "want_more": true,
                   "cursor": {
-                    ?"last_timestamp": (size(vulnerabilities) > 0) ?
-                      optional.of(vulnerabilities[size(vulnerabilities) - 1].published_date)
-                    :
-                      state.?cursor.last_timestamp,
+                    "last_timestamp": body.vulnerabilities[size(body.vulnerabilities) - 1].published_date,
                   },
                 }
-              )
+              :
+                {
+                  "want_more": false,
+                  "cursor": {
+                    ?"last_timestamp": state.?cursor.last_timestamp,
+                  },
+                }
             )
           :
             {

--- a/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -23,7 +23,7 @@ redact:
     - api_token
 program: |
   (
-    (has(state.?worklist.vulnerabilities) && size(state.worklist.vulnerabilities) > 0) ?
+    (has(state.?worklist.vulnerabilities) && state.worklist.vulnerabilities != null && size(state.worklist.vulnerabilities) > 0) ?
       state
     :
       (
@@ -100,18 +100,22 @@ program: |
             }
           ).do_request().as(resp, (resp.StatusCode == 200) ?
             resp.Body.decode_json().as(body,
-              {
-                "worklist": body,
-                "next": 0,
-                "offset": (size(body.vulnerabilities) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
-                "want_more": size(body.vulnerabilities) > 0,
-                "cursor": {
-                  ?"last_timestamp": (has(body.vulnerabilities) && size(body.vulnerabilities) > 0) ?
-                    optional.of(body.vulnerabilities[size(body.vulnerabilities) - 1].published_date)
-                  :
-                    state.?cursor.last_timestamp,
-                },
-              }
+              ((has(body.vulnerabilities) && body.vulnerabilities != null) ? body.vulnerabilities : []).as(vulnerabilities,
+                {
+                  "worklist": {
+                    "vulnerabilities": vulnerabilities,
+                  },
+                  "next": 0,
+                  "offset": (size(vulnerabilities) > 0) ? (int(state.offset) + int(state.batch_size)) : 0,
+                  "want_more": size(vulnerabilities) > 0,
+                  "cursor": {
+                    ?"last_timestamp": (size(vulnerabilities) > 0) ?
+                      optional.of(vulnerabilities[size(vulnerabilities) - 1].published_date)
+                    :
+                      state.?cursor.last_timestamp,
+                  },
+                }
+              )
             )
           :
             {
@@ -138,7 +142,7 @@ program: |
     state.with(
       !has(state.worklist) ? // Exit early due to POST failure.
         state
-      : (has(state.worklist.vulnerabilities) && size(state.worklist.vulnerabilities) > 0) ?
+      : (has(state.worklist.vulnerabilities) && state.worklist.vulnerabilities != null && size(state.worklist.vulnerabilities) > 0) ?
         post_request(
           state.url.trim_right("/") + "/api/v1/vulnerabilities/" + string(state.worklist.vulnerabilities[state.next].id) + "/devices",
           "application/json",
@@ -313,40 +317,42 @@ program: |
           }
         ).do_request().as(resp, (resp.StatusCode == 200) ?
           bytes(resp.Body).decode_json().as(body,
-            {
-              "events": (has(body.devices) && size(body.devices) > 0) ?
-                body.devices.orValue([]).map(evt,
-                  {
-                    "message": evt.with(
-                      {
+            ((has(body.devices) && body.devices != null) ? body.devices : []).as(devices,
+              {
+                "events": (size(devices) > 0) ?
+                  devices.map(evt,
+                    {
+                      "message": evt.with(
+                        {
+                          "vulnerability_info": state.worklist.vulnerabilities[int(state.next)],
+                        }
+                      ).encode_json(),
+                    }
+                  )
+                : (has(state.device_offset) && int(state.device_offset) == 0) ?
+                  [
+                    {
+                      "message": {
                         "vulnerability_info": state.worklist.vulnerabilities[int(state.next)],
-                      }
-                    ).encode_json(),
-                  }
-                )
-              : (has(state.device_offset) && int(state.device_offset) == 0) ?
-                [
-                  {
-                    "message": {
-                      "vulnerability_info": state.worklist.vulnerabilities[int(state.next)],
-                    }.encode_json(),
-                  },
-                ]
-              :
-                [{}],
-              "device_offset": (size(body.devices) > 0) ? (int(state.device_offset) + int(state.batch_size)) : 0,
-              "next": (size(body.devices) > 0) ?
-                state.next
-              : (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? (int(state.next) + 1) : 0, // size(body.devices) > 0
-              "worklist": (size(body.devices) > 0) ?
-                state.worklist
-              : (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? state.worklist : {},
-              "start_time": state.start_time,
-              "initial_interval": state.initial_interval,
-              "batch_size": state.batch_size,
-              "api_token": state.api_token,
-              "offset": state.offset,
-            }
+                      }.encode_json(),
+                    },
+                  ]
+                :
+                  [{}],
+                "device_offset": (size(devices) > 0) ? (int(state.device_offset) + int(state.batch_size)) : 0,
+                "next": (size(devices) > 0) ?
+                  state.next
+                : (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? (int(state.next) + 1) : 0, // size(devices) > 0
+                "worklist": (size(devices) > 0) ?
+                  state.worklist
+                : (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? state.worklist : {},
+                "start_time": state.start_time,
+                "initial_interval": state.initial_interval,
+                "batch_size": state.batch_size,
+                "api_token": state.api_token,
+                "offset": state.offset,
+              }
+            )
           )
         :
           {

--- a/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -352,7 +352,11 @@ program: |
                     },
                   ]
                 :
-                  [{}],
+                  [
+                    dyn({
+                      "retry": true,
+                    }),
+                  ],
                 "device_offset": 0,
                 "next": (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? (int(state.next) + 1) : 0,
                 "worklist": (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? state.worklist : {},
@@ -402,7 +406,8 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if processors}}
 processors:
+- drop_event.when.equals.retry: true
+{{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -115,6 +115,7 @@ program: |
               :
                 {
                   "want_more": false,
+                  "offset": 0,
                   "cursor": {
                     ?"last_timestamp": state.?cursor.last_timestamp,
                   },

--- a/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/claroty_xdome/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -321,19 +321,29 @@ program: |
           }
         ).do_request().as(resp, (resp.StatusCode == 200) ?
           bytes(resp.Body).decode_json().as(body,
-            ((has(body.devices) && body.devices != null) ? body.devices : []).as(devices,
+            (has(body.devices) && body.devices != null && size(body.devices) > 0) ?
               {
-                "events": (size(devices) > 0) ?
-                  devices.map(evt,
-                    {
-                      "message": evt.with(
-                        {
-                          "vulnerability_info": state.worklist.vulnerabilities[int(state.next)],
-                        }
-                      ).encode_json(),
-                    }
-                  )
-                : (has(state.device_offset) && int(state.device_offset) == 0) ?
+                "events": body.devices.map(evt,
+                  {
+                    "message": evt.with(
+                      {
+                        "vulnerability_info": state.worklist.vulnerabilities[int(state.next)],
+                      }
+                    ).encode_json(),
+                  }
+                ),
+                "device_offset": int(state.device_offset) + int(state.batch_size),
+                "next": state.next,
+                "worklist": state.worklist,
+                "start_time": state.start_time,
+                "initial_interval": state.initial_interval,
+                "batch_size": state.batch_size,
+                "api_token": state.api_token,
+                "offset": state.offset,
+              }
+            :
+              {
+                "events": (has(state.device_offset) && int(state.device_offset) == 0) ?
                   [
                     {
                       "message": {
@@ -343,20 +353,15 @@ program: |
                   ]
                 :
                   [{}],
-                "device_offset": (size(devices) > 0) ? (int(state.device_offset) + int(state.batch_size)) : 0,
-                "next": (size(devices) > 0) ?
-                  state.next
-                : (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? (int(state.next) + 1) : 0, // size(devices) > 0
-                "worklist": (size(devices) > 0) ?
-                  state.worklist
-                : (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? state.worklist : {},
+                "device_offset": 0,
+                "next": (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? (int(state.next) + 1) : 0,
+                "worklist": (int(state.next) + 1 < size(state.worklist.vulnerabilities)) ? state.worklist : {},
                 "start_time": state.start_time,
                 "initial_interval": state.initial_interval,
                 "batch_size": state.batch_size,
                 "api_token": state.api_token,
                 "offset": state.offset,
               }
-            )
           )
         :
           {

--- a/packages/claroty_xdome/manifest.yml
+++ b/packages/claroty_xdome/manifest.yml
@@ -1,6 +1,6 @@
 name: claroty_xdome
 title: "Claroty xDome"
-version: 1.0.2
+version: 1.0.3
 description: "Collect logs from Claroty xDome with Elastic Agent."
 type: integration
 format_version: 3.3.2


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
packages/claroty_xdome: handle nullable CEL response arrays

Branch on non-empty Claroty response arrays before mapping them or
advancing pagination state so null responses do not degrade CEL streams.
Return no worklist when top-level alert and vulnerability responses are
empty or null, and reset parent offsets so stale pagination state does
not carry into the next collection interval.

Preserve device-page handling for parent-only events and worklist
advancement, and add nullable device-response coverage alongside the
existing empty-array coverage.

Mark synthetic device-page events as retries and drop them with a
Filebeat processor. This keeps placeholder events from reaching ingest
while still allowing CEL state to advance across empty device pages.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
