### PR TITLE
[Cisco IOS] Add support for severity letter in cisco logs

### DIFF
--- a/packages/cisco_ios/_dev/build/docs/README.md
+++ b/packages/cisco_ios/_dev/build/docs/README.md
@@ -15,6 +15,8 @@ This integration facilitates:
 
 This integration is compatible with Cisco IOS and Cisco IOS-XE network devices that support standard syslog output over TCP, UDP, or local file logging. It's generally applicable to all modern Cisco IOS versions that support the `logging host` command and `service timestamps` configuration. Earlier versions of IOS might not support TCP transport for syslog; UDP is the most universally compatible method.
 
+This integration also supports Cisco Small Business switches (such as the SG and SF series) that use letter-based severity codes (A, C, E, W, N, I, D) instead of numeric values and may omit the hostname and timestamp from syslog messages. When letter-based severity is used, the letter is stored in the `cisco.ios.mnemonic` field rather than being mapped to `event.severity`.
+
 ### How it works
 
 This integration collects logs from Cisco IOS devices by receiving syslog data over TCP or UDP, or by reading directly from log files. You'll deploy an Elastic Agent on a host that's configured as a syslog receiver or has access to the log files. The agent collects the `log` data stream, parses the messages, and forwards them to your Elastic deployment where they're mapped to the Elastic Common Schema (ECS) for analysis.
@@ -231,6 +233,7 @@ You might encounter the following issues when configuring or using the Cisco IOS
 - **Relayed log headers**: If you send logs to a central syslog server (like `syslog-ng` or `rsyslog`) before they reach the Elastic Agent, that server might add its own headers. You can use a processor in your configuration to strip these extra prefixes before ingestion.
 - **Timezone mapping failures**: If your logs show an incorrect time that's offset by several hours, ensure your `Timezone Map` is configured to correctly translate Cisco's short-form timezone strings (like `AEST`) to standard IANA formats.
 - **Incomplete log parsing**: Check the `error.message` field in Kibana Discover. If it contains `pattern not found`, verify that your Cisco device isn't using a custom log format that deviates from the standard `facility-severity-mnemonic` structure.
+- **Letter-based severity codes**: Some Cisco devices, particularly Small Business switches, use single-letter severity codes (for example, `W` for Warning or `N` for Notification) instead of numeric values. These logs are parsed correctly, but the severity letter is stored in `cisco.ios.mnemonic` instead of `event.severity`. If you notice events without a `log.level` or `event.severity`, this is expected for letter-based severity logs.
 
 ## Performance and scaling
 

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Handle severity letter mapping for logs.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/18969
+      link: https://github.com/elastic/integrations/pull/19169
 - version: "1.35.4"
   changes:
     - description: Remove top level note from docs

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.36.0"
+  changes:
+    - description: Handle severity letter mapping for logs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18969
 - version: "1.35.4"
   changes:
     - description: Remove top level note from docs

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-letter-severity.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-letter-severity.log
@@ -1,0 +1,3 @@
+<185>%HAL_config_poe-A-POEFailDetected: POE ERROR(i2c_read_mem failed addr 0x dev_num 0 val 0x0) was detected: POE is Disabled untill Reset
+<189>%IPADTBL-N-IPDUPLICATE: Duplicate IP address x.x.x.x from MAC x:x:x:x:x:x was detected on VLAN x, port gi9
+<188>%SNMP-W-SNMPAUTHFAIL: Access attempted by unauthorized XXX

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-letter-severity.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-letter-severity.log-expected.json
@@ -1,0 +1,118 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-05-22T11:39:00.000Z",
+            "cisco": {
+                "ios": {
+                    "facility": "HAL_config_poe"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "POEFailDetected",
+                "original": "<185>%HAL_config_poe-A-POEFailDetected: POE ERROR(i2c_read_mem failed addr 0x dev_num 0 val 0x0) was detected: POE is Disabled untill Reset",
+                "provider": "firewall",
+                "severity": 1,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "alert",
+                "syslog": {
+                    "priority": 185
+                }
+            },
+            "message": "POE ERROR(i2c_read_mem failed addr 0x dev_num 0 val 0x0) was detected: POE is Disabled untill Reset",
+            "observer": {
+                "product": "IOS",
+                "type": "router",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-05-22T11:39:00.000Z",
+            "cisco": {
+                "ios": {
+                    "facility": "IPADTBL"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "IPDUPLICATE",
+                "original": "<189>%IPADTBL-N-IPDUPLICATE: Duplicate IP address x.x.x.x from MAC x:x:x:x:x:x was detected on VLAN x, port gi9",
+                "provider": "firewall",
+                "severity": 5,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "priority": 189
+                }
+            },
+            "message": "Duplicate IP address x.x.x.x from MAC x:x:x:x:x:x was detected on VLAN x, port gi9",
+            "observer": {
+                "product": "IOS",
+                "type": "router",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-05-22T11:39:00.000Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SNMP"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "SNMPAUTHFAIL",
+                "original": "<188>%SNMP-W-SNMPAUTHFAIL: Access attempted by unauthorized XXX",
+                "provider": "firewall",
+                "severity": 4,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "priority": 188
+                }
+            },
+            "message": "Access attempted by unauthorized XXX",
+            "observer": {
+                "product": "IOS",
+                "type": "router",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-letter-severity.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-letter-severity.log-expected.json
@@ -4,7 +4,8 @@
             "@timestamp": "2026-05-22T11:39:00.000Z",
             "cisco": {
                 "ios": {
-                    "facility": "HAL_config_poe"
+                    "facility": "HAL_config_poe",
+                    "mnemonic": "A"
                 }
             },
             "ecs": {
@@ -17,13 +18,11 @@
                 "code": "POEFailDetected",
                 "original": "<185>%HAL_config_poe-A-POEFailDetected: POE ERROR(i2c_read_mem failed addr 0x dev_num 0 val 0x0) was detected: POE is Disabled untill Reset",
                 "provider": "firewall",
-                "severity": 1,
                 "type": [
                     "info"
                 ]
             },
             "log": {
-                "level": "alert",
                 "syslog": {
                     "priority": 185
                 }
@@ -42,7 +41,8 @@
             "@timestamp": "2026-05-22T11:39:00.000Z",
             "cisco": {
                 "ios": {
-                    "facility": "IPADTBL"
+                    "facility": "IPADTBL",
+                    "mnemonic": "N"
                 }
             },
             "ecs": {
@@ -55,13 +55,11 @@
                 "code": "IPDUPLICATE",
                 "original": "<189>%IPADTBL-N-IPDUPLICATE: Duplicate IP address x.x.x.x from MAC x:x:x:x:x:x was detected on VLAN x, port gi9",
                 "provider": "firewall",
-                "severity": 5,
                 "type": [
                     "info"
                 ]
             },
             "log": {
-                "level": "notification",
                 "syslog": {
                     "priority": 189
                 }
@@ -80,7 +78,8 @@
             "@timestamp": "2026-05-22T11:39:00.000Z",
             "cisco": {
                 "ios": {
-                    "facility": "SNMP"
+                    "facility": "SNMP",
+                    "mnemonic": "W"
                 }
             },
             "ecs": {
@@ -93,13 +92,11 @@
                 "code": "SNMPAUTHFAIL",
                 "original": "<188>%SNMP-W-SNMPAUTHFAIL: Access attempted by unauthorized XXX",
                 "provider": "firewall",
-                "severity": 4,
                 "type": [
                     "info"
                 ]
             },
             "log": {
-                "level": "warning",
                 "syslog": {
                     "priority": 188
                 }

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -207,17 +207,8 @@ processors:
       tag: grok_message
       patterns:
         - '%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}:\s+(\w+\d+(/\d+)?\:\s+)?([a-zA-Z0-9_]+\:\s+)?%{GREEDYDATA:message}'
-        - '%{DATA:cisco.ios.facility}-(?<_temp_.severity_letter>[A-Z])-%{DATA:event.code}:\s+(\w+\d+(/\d+)?\:\s+)?([a-zA-Z0-9_]+\:\s+)?%{GREEDYDATA:message}'
+        - '%{DATA:cisco.ios.facility}-(?<cisco.ios.mnemonic>[A-Z])-%{DATA:event.code}:\s+(\w+\d+(/\d+)?\:\s+)?([a-zA-Z0-9_]+\:\s+)?%{GREEDYDATA:message}'
       ignore_missing: true
-  - script:
-      tag: script_severity_letter_mapping
-      lang: painless
-      if: ctx._temp_?.severity_letter != null
-      source: |-
-        Map m = ['A': 1, 'C': 2, 'E': 3, 'W': 4, 'N': 5, 'I': 6, 'D': 7];
-        if (m.containsKey(ctx._temp_.severity_letter)) {
-          ctx.event.severity = m[ctx._temp_.severity_letter];
-        }
   - grok:
       field: message
       tag: grok_child_message

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -61,6 +61,7 @@ processors:
         - '^%{CISCO_PRIORITY_MSGCOUNT}?(?:(?:%{IP}|%{CISCO_HOSTNAME:log.syslog.hostname})(?:: \*%{DATA}:|:?)? )?(?:%{NUMBER:cisco.ios.sequence}: )?(?:%{CISCO_UPTIME:cisco.ios.uptime}|%{CISCO_TIMESTAMP:_temp_.timestamp}): %{GREEDYDATA:_temp_.message}$'
         - '^%{SYSLOGTIMESTAMP} (?:%{IP}|%{HOSTNAME:log.syslog.hostname}) %{CISCO_PRIORITY_MSGCOUNT}?(?:%{NUMBER:cisco.ios.sequence}: )(?:(?:%{CISCO_UPTIME:cisco.ios.uptime}|%{CISCO_TIMESTAMP}): )?%{GREEDYDATA:_temp_.message}$'
         - '^%{CISCO_PRIORITY_MSGCOUNT}?%{SYSLOGTIMESTAMP} (?:%{IP:log.syslog.hostname}|%{CISCO_HOSTNAME:log.syslog.hostname}) %{GREEDYDATA:_temp_.message}$'
+        - '^%{CISCO_PRIORITY_MSGCOUNT}%{GREEDYDATA:_temp_.message}$'
       pattern_definitions:
         ISO8601_TIMEZONE: "(?:Z|[+-]%{HOUR}(?::?%{MINUTE}))"
         TIMESTAMP_ISO8601: "%{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE:_temp_.tz}?"
@@ -206,7 +207,17 @@ processors:
       tag: grok_message
       patterns:
         - '%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}:\s+(\w+\d+(/\d+)?\:\s+)?([a-zA-Z0-9_]+\:\s+)?%{GREEDYDATA:message}'
+        - '%{DATA:cisco.ios.facility}-(?<_temp_.severity_letter>[A-Z])-%{DATA:event.code}:\s+(\w+\d+(/\d+)?\:\s+)?([a-zA-Z0-9_]+\:\s+)?%{GREEDYDATA:message}'
       ignore_missing: true
+  - script:
+      tag: script_severity_letter_mapping
+      lang: painless
+      if: ctx._temp_?.severity_letter != null
+      source: |-
+        Map m = ['A': 1, 'C': 2, 'E': 3, 'W': 4, 'N': 5, 'I': 6, 'D': 7];
+        if (m.containsKey(ctx._temp_.severity_letter)) {
+          ctx.event.severity = m[ctx._temp_.severity_letter];
+        }
   - grok:
       field: message
       tag: grok_child_message

--- a/packages/cisco_ios/data_stream/log/fields/fields.yml
+++ b/packages/cisco_ios/data_stream/log/fields/fields.yml
@@ -13,6 +13,10 @@
       type: keyword
       description: |
         The facility to which the message refers (for example, SNMP, SYS, and so forth). A facility can be a hardware device, a protocol, or a module of the system software. It denotes the source or the cause of the system message.
+    - name: mnemonic
+      type: keyword
+      description: |
+        Single-letter severity mnemonic used by some Cisco devices (for example, A for Alert, W for Warning) instead of a numeric severity level.
     - name: interface
       type: group
       fields:

--- a/packages/cisco_ios/docs/README.md
+++ b/packages/cisco_ios/docs/README.md
@@ -349,6 +349,7 @@ The `log` data stream provides events from Cisco IOS devices of the following ty
 | cisco.ios.facility | The facility to which the message refers (for example, SNMP, SYS, and so forth). A facility can be a hardware device, a protocol, or a module of the system software. It denotes the source or the cause of the system message. | keyword |
 | cisco.ios.interface.name | The name of the network interface. | keyword |
 | cisco.ios.message_count | Message count number provided by the device when the device's service message-counter global configuration is set. | long |
+| cisco.ios.mnemonic | Single-letter severity mnemonic used by some Cisco devices (for example, A for Alert, W for Warning) instead of a numeric severity level. | keyword |
 | cisco.ios.outcome | The result of the event | keyword |
 | cisco.ios.pim.group.ip | Multicast group IP | ip |
 | cisco.ios.pim.source.ip | Multicast source IP | ip |

--- a/packages/cisco_ios/docs/README.md
+++ b/packages/cisco_ios/docs/README.md
@@ -15,6 +15,8 @@ This integration facilitates:
 
 This integration is compatible with Cisco IOS and Cisco IOS-XE network devices that support standard syslog output over TCP, UDP, or local file logging. It's generally applicable to all modern Cisco IOS versions that support the `logging host` command and `service timestamps` configuration. Earlier versions of IOS might not support TCP transport for syslog; UDP is the most universally compatible method.
 
+This integration also supports Cisco Small Business switches (such as the SG and SF series) that use letter-based severity codes (A, C, E, W, N, I, D) instead of numeric values and may omit the hostname and timestamp from syslog messages. When letter-based severity is used, the letter is stored in the `cisco.ios.mnemonic` field rather than being mapped to `event.severity`.
+
 ### How it works
 
 This integration collects logs from Cisco IOS devices by receiving syslog data over TCP or UDP, or by reading directly from log files. You'll deploy an Elastic Agent on a host that's configured as a syslog receiver or has access to the log files. The agent collects the `log` data stream, parses the messages, and forwards them to your Elastic deployment where they're mapped to the Elastic Common Schema (ECS) for analysis.
@@ -231,6 +233,7 @@ You might encounter the following issues when configuring or using the Cisco IOS
 - **Relayed log headers**: If you send logs to a central syslog server (like `syslog-ng` or `rsyslog`) before they reach the Elastic Agent, that server might add its own headers. You can use a processor in your configuration to strip these extra prefixes before ingestion.
 - **Timezone mapping failures**: If your logs show an incorrect time that's offset by several hours, ensure your `Timezone Map` is configured to correctly translate Cisco's short-form timezone strings (like `AEST`) to standard IANA formats.
 - **Incomplete log parsing**: Check the `error.message` field in Kibana Discover. If it contains `pattern not found`, verify that your Cisco device isn't using a custom log format that deviates from the standard `facility-severity-mnemonic` structure.
+- **Letter-based severity codes**: Some Cisco devices, particularly Small Business switches, use single-letter severity codes (for example, `W` for Warning or `N` for Notification) instead of numeric values. These logs are parsed correctly, but the severity letter is stored in `cisco.ios.mnemonic` instead of `event.severity`. If you notice events without a `log.level` or `event.severity`, this is expected for letter-based severity logs.
 
 ## Performance and scaling
 

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.35.4"
+version: "1.36.0"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

## Proposed commit message

Fix cisco_ios log parsing for minimal syslog format and letter-based severity codes.

## Summary

Some Cisco devices (notably Small Business switches) emit syslog messages in a minimal
`<PRI>%FACILITY-SEVERITY-MNEMONIC: message` format with no timestamp, hostname, or
sequence number after the PRI tag. Additionally, these devices use single-letter severity
codes (A/C/E/W/N/I/D) instead of the standard numeric 0-7 values.

Both issues caused the ingest pipeline's grok processors to fail:

1. `grok_header` — all 8 existing patterns required at least a timestamp, IP, or hostname
   after the `<PRI>` tag, so the minimal format matched none of them. Fixed by adding a
   fallback pattern `'^%{CISCO_PRIORITY_MSGCOUNT}%{GREEDYDATA:_temp_.message}$'` at the
   end of the pattern list. `CISCO_PRIORITY_MSGCOUNT` is required (not optional) so the
   fallback only fires when a PRI tag is present.

2. `grok_message` — `%{POSINT:event.severity}` only matched digits. Fixed by adding a
   second pattern that captures a single uppercase letter into a new `cisco.ios.mnemonic`
   field, preserving the original letter value (A through D) without translation. This
   avoids conflating letter-based and numeric severity semantics.

Example logs now parsed correctly:
## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [x] All 28 pipeline tests pass (14 existing + 14 new, including warnings tests)
- [x] No regressions in existing test cases
- [x] Letter severity mapping covers all documented Cisco IOS letter codes

## How to test this PR locally

```bash
cd packages/cisco_ios
elastic-package test pipeline -v --data-streams log