### PR TITLE
[QNAP NAS]: grok fails on Users field with asterisks in user.name parsing

### DIFF
--- a/packages/qnap_nas/changelog.yml
+++ b/packages/qnap_nas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.4"
+  changes:
+    - description: Relax grok user.name capture in SHARED pattern to use %{DATA} instead of %{USER}, allowing usernames containing asterisks (AD machine accounts, masked usernames) to parse correctly.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/18841
 - version: "1.25.3"
   changes:
     - description: Remove top level note from docs

--- a/packages/qnap_nas/changelog.yml
+++ b/packages/qnap_nas/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Relax grok user.name capture in SHARED pattern to use %{DATA} instead of %{USER}, allowing usernames containing asterisks (AD machine accounts, masked usernames) to parse correctly.
       type: bugfix
-      link: https://github.com/elastic/integrations/issues/18841
+      link: https://github.com/elastic/integrations/pull/19177
 - version: "1.25.3"
   changes:
     - description: Remove top level note from docs

--- a/packages/qnap_nas/data_stream/log/_dev/test/pipeline/test-access.log
+++ b/packages/qnap_nas/data_stream/log/_dev/test/pipeline/test-access.log
@@ -9,3 +9,5 @@
 <30>Oct 30 20:43:19 qnap-nas01 qulogd[14629]: conn log: Users: admin.user, Source IP: 10.50.36.33, Computer name: user-laptop, Connection type: Samba, Accessed resources: path/to/files/picture.jpg, Action: Read
 <30>Oct 30 20:43:19 qnap-nas01 qulogd[14629]: conn log: Users: admin.user, Source IP: 10.50.36.33, Computer name: user-laptop, Connection type: Samba, Accessed resources: path/to/files/picture.jpg, Action: Add
 <28>Jan 29 08:47:53 qnap-nas01 qulogd[15278]: conn log: Users: domain\admin.user, Source IP: 10.50.36.33, Computer name: ---, Connection type: HTTPS, Accessed resources: Administration, Action: Login Fail
+<28>May  6 07:08:13 qnap-nas01 qulogd[2554]: conn log: Users: TESTDOMAIN\PC-TEST-0001*, Source IP: 10.50.36.33, Computer name: pc-test-0001, Connection type: SAMBA, Accessed resources: ---, Action: Login Fail
+<28>May  6 04:07:56 qnap-nas01 qulogd[1743]: conn log: Users: **test*ldap***testhost-smb-abc123**lower*test**.w.n, Source IP: 10.10.10.10, Computer name: Unknown, Connection type: SAMBA, Accessed resources: ---, Action: Login Fail

--- a/packages/qnap_nas/data_stream/log/_dev/test/pipeline/test-access.log-expected.json
+++ b/packages/qnap_nas/data_stream/log/_dev/test/pipeline/test-access.log-expected.json
@@ -732,6 +732,137 @@
                 "domain": "domain",
                 "name": "admin.user"
             }
+        },
+        {
+            "@timestamp": "2026-05-06T07:08:13.000-05:00",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "login-fail",
+                "category": [
+                    "authentication"
+                ],
+                "created": "2026-05-06T07:08:13.000-05:00",
+                "kind": "event",
+                "original": "<28>May  6 07:08:13 qnap-nas01 qulogd[2554]: conn log: Users: TESTDOMAIN\\PC-TEST-0001*, Source IP: 10.50.36.33, Computer name: pc-test-0001, Connection type: SAMBA, Accessed resources: ---, Action: Login Fail",
+                "outcome": "failure",
+                "provider": "conn-log",
+                "timezone": "-05:00",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "qnap-nas01"
+            },
+            "log": {
+                "syslog": {
+                    "priority": 28
+                }
+            },
+            "observer": {
+                "product": "NAS",
+                "type": "nas",
+                "vendor": "QNAP"
+            },
+            "process": {
+                "name": "qulogd",
+                "pid": 2554
+            },
+            "qnap": {
+                "nas": {
+                    "connection_type": "SAMBA"
+                }
+            },
+            "related": {
+                "hosts": [
+                    "pc-test-0001"
+                ],
+                "ip": [
+                    "10.50.36.33"
+                ],
+                "user": [
+                    "PC-TEST-0001*"
+                ]
+            },
+            "source": {
+                "address": "10.50.36.33",
+                "domain": "pc-test-0001",
+                "ip": "10.50.36.33"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "domain": "TESTDOMAIN",
+                "name": "PC-TEST-0001*"
+            }
+        },
+        {
+            "@timestamp": "2026-05-06T04:07:56.000-05:00",
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "login-fail",
+                "category": [
+                    "authentication"
+                ],
+                "created": "2026-05-06T04:07:56.000-05:00",
+                "kind": "event",
+                "original": "<28>May  6 04:07:56 qnap-nas01 qulogd[1743]: conn log: Users: **test*ldap***testhost-smb-abc123**lower*test**.w.n, Source IP: 10.10.10.10, Computer name: Unknown, Connection type: SAMBA, Accessed resources: ---, Action: Login Fail",
+                "outcome": "failure",
+                "provider": "conn-log",
+                "timezone": "-05:00",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "name": "qnap-nas01"
+            },
+            "log": {
+                "syslog": {
+                    "priority": 28
+                }
+            },
+            "observer": {
+                "product": "NAS",
+                "type": "nas",
+                "vendor": "QNAP"
+            },
+            "process": {
+                "name": "qulogd",
+                "pid": 1743
+            },
+            "qnap": {
+                "nas": {
+                    "connection_type": "SAMBA"
+                }
+            },
+            "related": {
+                "hosts": [
+                    "Unknown"
+                ],
+                "ip": [
+                    "10.10.10.10"
+                ],
+                "user": [
+                    "**test*ldap***testhost-smb-abc123**lower*test**.w.n"
+                ]
+            },
+            "source": {
+                "address": "10.10.10.10",
+                "domain": "Unknown",
+                "ip": "10.10.10.10"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "**test*ldap***testhost-smb-abc123**lower*test**.w.n"
+            }
         }
     ]
 }

--- a/packages/qnap_nas/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qnap_nas/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -66,7 +66,7 @@ processors:
         - '^%{SHARED}, Application: %{DATA:qnap.nas.application}, Category: %{DATA:qnap.nas.category}, Content: %{DATA:message}$'
         - '^%{SHARED}, Connection type: %{DATA:qnap.nas.connection_type}, Accessed resources: %{RESOURCE}, Action: %{DATA:event.action}$'
       pattern_definitions:
-        SHARED: 'Users: (---|(%{DATA:user.domain}\\)?%{USER:user.name}), Source IP: (---|127.0.0.1|%{IP:source.address}), Computer name: (---|%{HOSTNAME:source.domain})'
+        SHARED: 'Users: (---|(%{DATA:user.domain}\\)?%{DATA:user.name}), Source IP: (---|127.0.0.1|%{IP:source.address}), Computer name: (---|%{HOSTNAME:source.domain})'
         RESOURCE: '(\[%{DATA:qnap.nas.application}\] )?(---|%{FILE_PATH:qnap.nas.file.path}|%{DATA:qnap.nas.application})'
         FILE_PATH: '[_%\(\)!$@:.,+~\-\s[:alnum:]]*(\/[_%\(\)!$@:.,+~\-\s[:alnum:]]*)+'
   - grok:

--- a/packages/qnap_nas/manifest.yml
+++ b/packages/qnap_nas/manifest.yml
@@ -1,6 +1,6 @@
 name: qnap_nas
 title: QNAP NAS
-version: "1.25.3"
+version: "1.25.4"
 description: Collect logs from QNAP NAS devices with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
<!-- Type of change
  Please label this PR with one of the following labels, depending on the scope of your change:
  - Bug
  -->

## Proposed commit message

**WHAT:** Changed `%{USER:user.name}` to `%{DATA:user.name}` in the `SHARED` grok pattern definition inside the QNAP NAS ingest pipeline (`default.yml`, line 69). The built-in `USER` grok pattern matches only `[a-zA-Z0-9._-]+`, which excludes the asterisk character (`*`).

**WHY:** QNAP NAS logs can contain asterisks in the `Users` field in two real-world scenarios: Active Directory machine account names (e.g., `DOMAIN\PC-TEST-0001*`) and obfuscated/masked usernames (e.g., `**test*ldap***`). Any such log line caused the grok processor to fail entirely, dropping the event. Switching to `%{DATA}` captures any character sequence up to the next delimiter, preserving all surrounding pattern structure while correctly handling these username formats.

## Checklist

 - [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
 - [ ] I have verified that all data streams collect metrics or logs.
 - [x] I have added an entry to my package's `changelog.yml` file.
 - [ ] I have verified that Kibana version constraints are current according to
  [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
 - [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist
 - [x] Confirm grok change does not regress any existing test fixtures
 - [x] Confirm new fixtures (AD machine account `TESTDOMAIN\PC-TEST-0001*` and masked username `**test*ldap***testhost-smb-abc123**lower*test**.w.n`) are included in expected output

## How to test this PR locally
  ```bash
  cd packages/qnap_nas
  elastic-package test 
```

Verify that all existing fixtures still pass and the two new fixtures parse user.name (and user.domain where applicable) correctly.

## Related issues

  - Closes #18841

## Screenshots

  N/A — pipeline-only change, no UI or dashboard impact.