### PR TITLE
Fix text auditor typo batch

### DIFF
--- a/docs/extend/add-mapping.md
+++ b/docs/extend/add-mapping.md
@@ -94,7 +94,7 @@ This can be done in two ways:
     Example explicit field definition:
 
     ```yaml
-    - name: cloud.acount.id
+    - name: cloud.account.id
       level: extended
       type: keyword
       ignore_above: 1024

--- a/docs/extend/developer-workflow-import-beat.md
+++ b/docs/extend/developer-workflow-import-beat.md
@@ -34,7 +34,7 @@ The import procedure heavily uses on the *import-beats* script. If you are inter
 
 3. Use the `elastic-package stack up -v -d` command to boot up required dependencies:
 
-    1. Elasticseach instance:
+    1. Elasticsearch instance:
 
         * Kibana’s dependency
 

--- a/packages/bluecoat/data_stream/director/fields/fields.yml
+++ b/packages/bluecoat/data_stream/director/fields/fields.yml
@@ -1180,7 +1180,7 @@
       fields:
         - name: alias_host
           type: keyword
-          description: This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer.
+          description: This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer.
         - name: domain
           type: keyword
         - name: host_dst

--- a/packages/bluecoat/docs/README.md
+++ b/packages/bluecoat/docs/README.md
@@ -675,7 +675,7 @@ The `director` dataset collects Blue Coat Director logs.
 | rsa.misc.workspace | This key captures Workspace Description | keyword |
 | rsa.network.ad_computer_dst | Deprecated, use host.dst | keyword |
 | rsa.network.addr |  | keyword |
-| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer. | keyword |
+| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer. | keyword |
 | rsa.network.dinterface | This key should only be used when it’s a Destination Interface | keyword |
 | rsa.network.dmask | This key is used for Destionation Device network mask | keyword |
 | rsa.network.dns_a_record |  | keyword |

--- a/packages/cylance/data_stream/protect/fields/fields.yml
+++ b/packages/cylance/data_stream/protect/fields/fields.yml
@@ -1180,7 +1180,7 @@
       fields:
         - name: alias_host
           type: keyword
-          description: This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer.
+          description: This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer.
         - name: domain
           type: keyword
         - name: host_dst

--- a/packages/cylance/docs/README.md
+++ b/packages/cylance/docs/README.md
@@ -592,7 +592,7 @@ The `protect` dataset collects CylanceProtect logs.
 | rsa.misc.workspace | This key captures Workspace Description | keyword |
 | rsa.network.ad_computer_dst | Deprecated, use host.dst | keyword |
 | rsa.network.addr |  | keyword |
-| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer. | keyword |
+| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer. | keyword |
 | rsa.network.dinterface | This key should only be used when it’s a Destination Interface | keyword |
 | rsa.network.dmask | This key is used for Destionation Device network mask | keyword |
 | rsa.network.dns_a_record |  | keyword |

--- a/packages/fortinet_forticlient/data_stream/log/fields/fields.yml
+++ b/packages/fortinet_forticlient/data_stream/log/fields/fields.yml
@@ -1180,7 +1180,7 @@
       fields:
         - name: alias_host
           type: keyword
-          description: This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer.
+          description: This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer.
         - name: domain
           type: keyword
         - name: host_dst

--- a/packages/fortinet_forticlient/docs/README.md
+++ b/packages/fortinet_forticlient/docs/README.md
@@ -832,7 +832,7 @@ An example event for `log` looks as following:
 | rsa.misc.workspace | This key captures Workspace Description | keyword |
 | rsa.network.ad_computer_dst | Deprecated, use host.dst | keyword |
 | rsa.network.addr |  | keyword |
-| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer. | keyword |
+| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer. | keyword |
 | rsa.network.dinterface | This key should only be used when it’s a Destination Interface | keyword |
 | rsa.network.dmask | This key is used for Destionation Device network mask | keyword |
 | rsa.network.dns_a_record |  | keyword |

--- a/packages/juniper_junos/data_stream/log/fields/fields.yml
+++ b/packages/juniper_junos/data_stream/log/fields/fields.yml
@@ -1180,7 +1180,7 @@
       fields:
         - name: alias_host
           type: keyword
-          description: This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer.
+          description: This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer.
         - name: domain
           type: keyword
         - name: host_dst

--- a/packages/juniper_junos/docs/README.md
+++ b/packages/juniper_junos/docs/README.md
@@ -778,7 +778,7 @@ An example event for `log` looks as following:
 | rsa.misc.workspace | This key captures Workspace Description | keyword |
 | rsa.network.ad_computer_dst | Deprecated, use host.dst | keyword |
 | rsa.network.addr |  | keyword |
-| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer. | keyword |
+| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer. | keyword |
 | rsa.network.dinterface | This key should only be used when it’s a Destination Interface | keyword |
 | rsa.network.dmask | This key is used for Destionation Device network mask | keyword |
 | rsa.network.dns_a_record |  | keyword |

--- a/packages/juniper_netscreen/data_stream/log/fields/fields.yml
+++ b/packages/juniper_netscreen/data_stream/log/fields/fields.yml
@@ -1180,7 +1180,7 @@
       fields:
         - name: alias_host
           type: keyword
-          description: This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer.
+          description: This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer.
         - name: domain
           type: keyword
         - name: host_dst

--- a/packages/juniper_netscreen/docs/README.md
+++ b/packages/juniper_netscreen/docs/README.md
@@ -765,7 +765,7 @@ An example event for `log` looks as following:
 | rsa.misc.workspace | This key captures Workspace Description | keyword |
 | rsa.network.ad_computer_dst | Deprecated, use host.dst | keyword |
 | rsa.network.addr |  | keyword |
-| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer. | keyword |
+| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer. | keyword |
 | rsa.network.dinterface | This key should only be used when it’s a Destination Interface | keyword |
 | rsa.network.dmask | This key is used for Destionation Device network mask | keyword |
 | rsa.network.dns_a_record |  | keyword |

--- a/packages/netscout/data_stream/sightline/fields/fields.yml
+++ b/packages/netscout/data_stream/sightline/fields/fields.yml
@@ -1180,7 +1180,7 @@
       fields:
         - name: alias_host
           type: keyword
-          description: This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer.
+          description: This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer.
         - name: domain
           type: keyword
         - name: host_dst

--- a/packages/netscout/docs/README.md
+++ b/packages/netscout/docs/README.md
@@ -676,7 +676,7 @@ The `sightline` dataset collects Arbor Peakflow SP logs.
 | rsa.misc.workspace | This key captures Workspace Description | keyword |
 | rsa.network.ad_computer_dst | Deprecated, use host.dst | keyword |
 | rsa.network.addr |  | keyword |
-| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer. | keyword |
+| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer. | keyword |
 | rsa.network.dinterface | This key should only be used when it’s a Destination Interface | keyword |
 | rsa.network.dmask | This key is used for Destionation Device network mask | keyword |
 | rsa.network.dns_a_record |  | keyword |

--- a/packages/radware/data_stream/defensepro/fields/fields.yml
+++ b/packages/radware/data_stream/defensepro/fields/fields.yml
@@ -1180,7 +1180,7 @@
       fields:
         - name: alias_host
           type: keyword
-          description: This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer.
+          description: This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer.
         - name: domain
           type: keyword
         - name: host_dst

--- a/packages/radware/docs/README.md
+++ b/packages/radware/docs/README.md
@@ -675,7 +675,7 @@ The `defensepro` dataset collects Radware DefensePro logs.
 | rsa.misc.workspace | This key captures Workspace Description | keyword |
 | rsa.network.ad_computer_dst | Deprecated, use host.dst | keyword |
 | rsa.network.addr |  | keyword |
-| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer. | keyword |
+| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer. | keyword |
 | rsa.network.dinterface | This key should only be used when it’s a Destination Interface | keyword |
 | rsa.network.dmask | This key is used for Destionation Device network mask | keyword |
 | rsa.network.dns_a_record |  | keyword |

--- a/packages/tomcat/data_stream/log/fields/fields.yml
+++ b/packages/tomcat/data_stream/log/fields/fields.yml
@@ -1180,7 +1180,7 @@
       fields:
         - name: alias_host
           type: keyword
-          description: This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer.
+          description: This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer.
         - name: domain
           type: keyword
         - name: host_dst

--- a/packages/tomcat/docs/README.md
+++ b/packages/tomcat/docs/README.md
@@ -600,7 +600,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | rsa.misc.workspace | This key captures Workspace Description | keyword |
 | rsa.network.ad_computer_dst | Deprecated, use host.dst | keyword |
 | rsa.network.addr |  | keyword |
-| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear.Also it captures the Device Hostname. Any Hostname that isnt ad.computer. | keyword |
+| rsa.network.alias_host | This key should be used when the source or destination context of a hostname is not clear. Also it captures the Device Hostname. Any Hostname that isn't ad.computer. | keyword |
 | rsa.network.dinterface | This key should only be used when it’s a Destination Interface | keyword |
 | rsa.network.dmask | This key is used for Destionation Device network mask | keyword |
 | rsa.network.dns_a_record |  | keyword |


### PR DESCRIPTION
## Summary
- Fixes the repeated `rsa.network.alias_host` punctuation/contraction typo across the listed package field definitions and generated docs.
- Fixes the remaining `cloud.account.id` and `Elasticsearch` typos in `docs/extend`.

## Root cause
The issue grouped concrete user-facing text defects: a duplicated sentence typo family plus two remaining contributor-doc typos.

## Code shape
This is a mechanical text-only change. I kept the edit scoped to the current actionable items and intentionally did not touch `dev/import-beats/variables_compact.go` because that tool was noted as deprecated in the issue thread. I also left `general-guidelines.md` alone because the issue thread says it was already fixed in #19120.

## Security assessment
Low risk: no executable code, dependencies, generated credentials, auth flow, or data parsing changed. The update only corrects static documentation and field-description text.

## Verification
- `rg -n "clear\.Also|isnt ad\.computer|cloud\.acount\.id|Elasticseach" packages docs` returns no matches.
- `rg -n "clear\. Also|isn't ad\.computer|cloud\.account\.id|Elasticsearch instance" packages docs`
- `git diff --check`

Note: `elastic-package` is not installed in my local environment, so I could not run package-level checks here.

Fixes #18743
