### PR TITLE
[Cisco ASA] Handle different timezones

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for timezone mapping.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/19303
+      link: https://github.com/elastic/integrations/pull/19201
 - version: "2.45.3"
   changes:
     - description: Allow underscores in hostnames and pool names for ASA 305011 and 305012 messages.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.4"
+  changes:
+    - description: Add support for timezone mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19303
 - version: "2.45.3"
   changes:
     - description: Allow underscores in hostnames and pool names for ASA 305011 and 305012 messages.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log
@@ -1,3 +1,3 @@
 Sep 25 15:47:07 host1.example.com : Sep 25 15:47:07 EDT: %ASA-auth-4-113004: AAA user authentication Successful : server = myservername : user = myusername
 Jan 22 14:05:11 test.example.com : Jan 22 14:05:11 PST: %ASA-svc-4-722051: Group <GroupPolicy_NAME> User <user_NAME> IP <81.2.69.144> IPv4 Address <10.20.0.1> IPv6 address <::> assigned to session
-<190>May 14 15:10:46 81.2.69.144 : May 14 15:10:46 WEST: %ASA-session-6-106015: Deny TCP (no connection) from 81.2.69.144/5044 to 10.20.0.1/49786 flags ACK on interface ARCSIGHT-SIEMPRD
+<190>May 14 15:10:46 81.2.69.144 : May 14 15:10:46 WEST: %ASA-session-6-106015: Deny TCP (no connection) from 81.2.69.144/5044 to 10.20.0.1/49786 flags ACK on interface something

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log
@@ -1,2 +1,3 @@
 Sep 25 15:47:07 host1.example.com : Sep 25 15:47:07 EDT: %ASA-auth-4-113004: AAA user authentication Successful : server = myservername : user = myusername
 Jan 22 14:05:11 test.example.com : Jan 22 14:05:11 PST: %ASA-svc-4-722051: Group <GroupPolicy_NAME> User <user_NAME> IP <81.2.69.144> IPv4 Address <10.20.0.1> IPv6 address <::> assigned to session
+<190>May 14 15:10:46 81.2.69.144 : May 14 15:10:46 WEST: %ASA-session-6-106015: Deny TCP (no connection) from 81.2.69.144/5044 to 10.20.0.1/49786 flags ACK on interface ARCSIGHT-SIEMPRD

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log-config.yml
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log-config.yml
@@ -9,3 +9,5 @@ fields:
         tz_long: America/New_York
       - tz_short: PST
         tz_long: -08:00
+      - tz_short: WEST
+        tz_long: Europe/Lisbon

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log-expected.json
@@ -143,7 +143,7 @@
             "@timestamp": "2026-05-14T15:10:46.000+01:00",
             "cisco": {
                 "asa": {
-                    "source_interface": "ARCSIGHT-SIEMPRD",
+                    "source_interface": "something",
                     "suffix": "session"
                 }
             },
@@ -162,7 +162,7 @@
                 ],
                 "code": "106015",
                 "kind": "event",
-                "original": "<190>May 14 15:10:46 81.2.69.144 : May 14 15:10:46 WEST: %ASA-session-6-106015: Deny TCP (no connection) from 81.2.69.144/5044 to 10.20.0.1/49786 flags ACK on interface ARCSIGHT-SIEMPRD",
+                "original": "<190>May 14 15:10:46 81.2.69.144 : May 14 15:10:46 WEST: %ASA-session-6-106015: Deny TCP (no connection) from 81.2.69.144/5044 to 10.20.0.1/49786 flags ACK on interface something",
                 "outcome": "failure",
                 "severity": 6,
                 "timezone": "Europe/Lisbon",
@@ -195,7 +195,7 @@
                 "hostname": "81.2.69.144",
                 "ingress": {
                     "interface": {
-                        "name": "ARCSIGHT-SIEMPRD"
+                        "name": "something"
                     }
                 },
                 "product": "asa",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-tz-mapping.log-expected.json
@@ -138,6 +138,99 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-05-14T15:10:46.000+01:00",
+            "cisco": {
+                "asa": {
+                    "source_interface": "ARCSIGHT-SIEMPRD",
+                    "suffix": "session"
+                }
+            },
+            "destination": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "port": 49786
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106015",
+                "kind": "event",
+                "original": "<190>May 14 15:10:46 81.2.69.144 : May 14 15:10:46 WEST: %ASA-session-6-106015: Deny TCP (no connection) from 81.2.69.144/5044 to 10.20.0.1/49786 flags ACK on interface ARCSIGHT-SIEMPRD",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "Europe/Lisbon",
+                "type": [
+                    "connection",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "81.2.69.144"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "network": {
+                "community_id": "1:IA7HSqWUrFucOAJHDtcer3TQq0k=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "hostname": "81.2.69.144",
+                "ingress": {
+                    "interface": {
+                        "name": "ARCSIGHT-SIEMPRD"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "81.2.69.144"
+                ],
+                "ip": [
+                    "81.2.69.144",
+                    "10.20.0.1"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.144",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144",
+                "port": 5044
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -38,7 +38,7 @@ processors:
         # Beginning with version 6.3, Firepower Threat Defense provides the option to enable timestamp as per RFC 5424.
         FTD_DATE: "(?:%{TIMESTAMP_ISO8601}|%{ASA_DATE})"
         ASA_DATE: "(?:%{DAY} )?%{MONTH}  *%{MONTHDAY}(?: %{YEAR})? %{TIME}(?: %{TZ:_temp_.tz})?"
-        TZ: "(?:[APMCE][SD]T|UTC)"
+        TZ: "[A-Z]{1,7}([+-]\\d{1,2}|[+-]\\d{2}:\\d{2})?"
         TIMESTAMP_ISO8601: "%{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE:_temp_.tz}?"
         ISO8601_TIMEZONE: "(?:Z|[+-]%{HOUR}(?::?%{MINUTE}))"
         PROCESS: "(?:[^%\\s:\\[]+)"
@@ -55,6 +55,7 @@ processors:
         - '%{GREEDYDATA:_temp_.full_message}'
       pattern_definitions:
         ASA_DATE: "(?:%{DAY} )?%{MONTH}  *%{MONTHDAY}(?: %{YEAR})? %{TIME}(?: %{TZ:_temp_.tz})?"
+        TZ: "[A-Z]{1,7}([+-]\\d{1,2}|[+-]\\d{2}:\\d{2})?"
   - script:
       lang: painless
       tag: script_log_syslog

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.45.3"
+version: "2.45.4"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Summary

- Broadened the `TZ` grok pattern in the Cisco ASA ingest pipeline from a narrow US-only set (`[APMCE][SD]T|UTC`) to a flexible uppercase pattern (`[A-Z]{1,7}`) that captures any timezone abbreviation (e.g. WEST, AEST, IST, CET, NZST) along with optional UTC offsets.
- Added an explicit `TZ` pattern definition to the `grok_extra_timestamp` processor, which previously relied on the built-in narrow grok default.
- Added a pipeline test case for a log line with `WEST` timezone, including `tz_map` config mapping `WEST` to `Europe/Lisbon`.

## Test plan

- [x] Pipeline test `test-asa-tz-mapping` passes with the new WEST test case
- [x] Existing pipeline tests continue to pass (no regressions with hostnames like `single` being mismatched as timezones, since the pattern is restricted to uppercase)