### PR TITLE
[cisco_asa] Fix source and destination address parsing

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.7"
+  changes:
+    - description: Fix parse_750002 and parse_750003 grok pattern to handle source and destination adresses as IPs and domains.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19218
 - version: "2.45.6"
   changes:
     - description: Fix parse_113015 grok pattern to handle usernames with special characters.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -80,6 +80,12 @@ Apr 27 2020 02:03:03 dev01: %ASA-6-602303: IPSEC: An outbound LAN-to-LAN SA (SPI
 Apr 27 2020 02:03:03 dev01: %ASA-6-602304: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xF81283) between 81.2.69.144 and 192.168.2.2 (user= admin) has been deleted.
 Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:81.2.69.144:7777 Remote:192.168.2.2:7777 Username:admin Received a IKE_INIT_SA request
 Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:81.2.69.144:7777 Remote:192.168.2.2:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database
+Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:host1.test.com:7777 Remote:host2.test.com:7777 Username:admin Received a IKE_INIT_SA request
+Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:host1.test.com:7777 Remote:host2.test.com:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database
+Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:host1.test.com:7777 Remote:192.168.2.2:7777 Username:admin Received a IKE_INIT_SA request
+Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:host1.test.com:7777 Remote:192.168.2.2:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database
+Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:81.2.69.144:7777 Remote:host2.test.com:7777 Username:admin Received a IKE_INIT_SA request
+Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:81.2.69.144:7777 Remote:host2.test.com:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database
 Apr 27 2020 02:03:03 dev01: %ASA-5-713120: Group = 100.60.140.10, IP = 192.168.1.1, PHASE 2 COMPLETED (msgid=bbe383e88)
 Apr 27 2020 02:03:03 dev01: %ASA-5-713202: IP = 192.168.157.61, Duplicate first packet detected. Ignoring packet.
 Apr 27 2020 02:03:03 dev01: %ASA-6-713905: Group = 100.60.140.10, IP = 192.168.1.1, All IPSec SA proposals found unacceptable!

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -5914,6 +5914,401 @@
         },
         {
             "@timestamp": "2020-04-27T02:03:03.000Z",
+            "destination": {
+                "address": "host2.test.com",
+                "domain": "host2.test.com",
+                "port": 7777
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "connection-started",
+                "category": [
+                    "network"
+                ],
+                "code": "750002",
+                "kind": "event",
+                "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:host1.test.com:7777 Remote:host2.test.com:7777 Username:admin Received a IKE_INIT_SA request",
+                "outcome": "success",
+                "reason": "Received a IKE_INIT_SA request",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01",
+                    "host2.test.com",
+                    "host1.test.com"
+                ],
+                "user": [
+                    "admin"
+                ]
+            },
+            "source": {
+                "address": "host1.test.com",
+                "domain": "host1.test.com",
+                "port": 7777
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2020-04-27T02:03:03.000Z",
+            "destination": {
+                "address": "host2.test.com",
+                "domain": "host2.test.com",
+                "port": 7777
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "750003",
+                "kind": "event",
+                "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:host1.test.com:7777 Remote:host2.test.com:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database",
+                "outcome": "failure",
+                "reason": "Negotiation aborted due to ERROR: Failed to locate an item in the database",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "warning"
+            },
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01",
+                    "host2.test.com",
+                    "host1.test.com"
+                ],
+                "user": [
+                    "admin"
+                ]
+            },
+            "source": {
+                "address": "host1.test.com",
+                "domain": "host1.test.com",
+                "port": 7777
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2020-04-27T02:03:03.000Z",
+            "destination": {
+                "address": "192.168.2.2",
+                "ip": "192.168.2.2",
+                "port": 7777
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "connection-started",
+                "category": [
+                    "network"
+                ],
+                "code": "750002",
+                "kind": "event",
+                "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:host1.test.com:7777 Remote:192.168.2.2:7777 Username:admin Received a IKE_INIT_SA request",
+                "outcome": "success",
+                "reason": "Received a IKE_INIT_SA request",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01",
+                    "host1.test.com"
+                ],
+                "ip": [
+                    "192.168.2.2"
+                ],
+                "user": [
+                    "admin"
+                ]
+            },
+            "source": {
+                "address": "host1.test.com",
+                "domain": "host1.test.com",
+                "port": 7777
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2020-04-27T02:03:03.000Z",
+            "destination": {
+                "address": "192.168.2.2",
+                "ip": "192.168.2.2",
+                "port": 7777
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "750003",
+                "kind": "event",
+                "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:host1.test.com:7777 Remote:192.168.2.2:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database",
+                "outcome": "failure",
+                "reason": "Negotiation aborted due to ERROR: Failed to locate an item in the database",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "warning"
+            },
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01",
+                    "host1.test.com"
+                ],
+                "ip": [
+                    "192.168.2.2"
+                ],
+                "user": [
+                    "admin"
+                ]
+            },
+            "source": {
+                "address": "host1.test.com",
+                "domain": "host1.test.com",
+                "port": 7777
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2020-04-27T02:03:03.000Z",
+            "destination": {
+                "address": "host2.test.com",
+                "domain": "host2.test.com",
+                "port": 7777
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "connection-started",
+                "category": [
+                    "network"
+                ],
+                "code": "750002",
+                "kind": "event",
+                "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:81.2.69.144:7777 Remote:host2.test.com:7777 Username:admin Received a IKE_INIT_SA request",
+                "outcome": "success",
+                "reason": "Received a IKE_INIT_SA request",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01",
+                    "host2.test.com"
+                ],
+                "ip": [
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "admin"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.144",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144",
+                "port": 7777
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2020-04-27T02:03:03.000Z",
+            "destination": {
+                "address": "host2.test.com",
+                "domain": "host2.test.com",
+                "port": 7777
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "750003",
+                "kind": "event",
+                "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:81.2.69.144:7777 Remote:host2.test.com:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database",
+                "outcome": "failure",
+                "reason": "Negotiation aborted due to ERROR: Failed to locate an item in the database",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "warning"
+            },
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01",
+                    "host2.test.com"
+                ],
+                "ip": [
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "admin"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.144",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144",
+                "port": 7777
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "admin"
+            }
+        },
+        {
+            "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
                 "version": "8.17.0"
             },

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log
@@ -16,3 +16,9 @@ Apr 27 2020 02:03:03 dev01: %ASA-5-434004: SFR requested device to bypass furthe
 <140>Feb 02 2025 14:02:35: %ASA-4-106103: access-list TEST_ACL_LIST denied tcp for user 'username' outside/81.2.69.142(51950) -> inside/89.160.20.112(443) hit-cnt 1 first hit [0xd3e666fa, 0x0]
 Aug 05 2025 11:47:09: %ASA-5-750002: Local:2a02:cf40::6:500 Remote:2a02:cf40:0000:0000:0000:0000:0000:0001:50329 Username:Unknown IKEv2 Received a IKE_INIT_SA request
 Aug 05 2025 11:47:09: %ASA-5-750003: Local:2a02:cf40::6:500 Remote:2a02:cf40:0000:0000:0000:0000:0000:0001:50329 Username:Unknown IKEv2 Negotiation aborted due to ERROR: Auth exchange failed
+Aug 05 2025 11:47:09: %ASA-5-750002: Local:host1.test.com:500 Remote:host2.test.com:50329 Username:Unknown IKEv2 Received a IKE_INIT_SA request
+Aug 05 2025 11:47:09: %ASA-5-750003: Local:host1.test.com:500 Remote:host2.test.com:50329 Username:Unknown IKEv2 Negotiation aborted due to ERROR: Auth exchange failed
+Aug 05 2025 11:47:09: %ASA-5-750002: Local:host1.test.com:500 Remote:2a02:cf40:0000:0000:0000:0000:0000:0001:50329 Username:Unknown IKEv2 Received a IKE_INIT_SA request
+Aug 05 2025 11:47:09: %ASA-5-750003: Local:host1.test.com:500 Remote:2a02:cf40:0000:0000:0000:0000:0000:0001:50329 Username:Unknown IKEv2 Negotiation aborted due to ERROR: Auth exchange failed
+Aug 05 2025 11:47:09: %ASA-5-750002: Local:2a02:cf40::6:500 Remote:host2.test.com:50329 Username:Unknown IKEv2 Received a IKE_INIT_SA request
+Aug 05 2025 11:47:09: %ASA-5-750003: Local:2a02:cf40::6:500 Remote:host2.test.com:50329 Username:Unknown IKEv2 Negotiation aborted due to ERROR: Auth exchange failed

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -1522,6 +1522,383 @@
             "user": {
                 "name": "Unknown"
             }
+        },
+        {
+            "@timestamp": "2025-08-05T11:47:09.000Z",
+            "destination": {
+                "address": "host2.test.com",
+                "domain": "host2.test.com",
+                "port": 50329
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "connection-started",
+                "category": [
+                    "network"
+                ],
+                "code": "750002",
+                "kind": "event",
+                "original": "Aug 05 2025 11:47:09: %ASA-5-750002: Local:host1.test.com:500 Remote:host2.test.com:50329 Username:Unknown IKEv2 Received a IKE_INIT_SA request",
+                "outcome": "success",
+                "reason": "IKEv2 Received a IKE_INIT_SA request",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host2.test.com",
+                    "host1.test.com"
+                ],
+                "user": [
+                    "Unknown"
+                ]
+            },
+            "source": {
+                "address": "host1.test.com",
+                "domain": "host1.test.com",
+                "port": 500
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "Unknown"
+            }
+        },
+        {
+            "@timestamp": "2025-08-05T11:47:09.000Z",
+            "destination": {
+                "address": "host2.test.com",
+                "domain": "host2.test.com",
+                "port": 50329
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "750003",
+                "kind": "event",
+                "original": "Aug 05 2025 11:47:09: %ASA-5-750003: Local:host1.test.com:500 Remote:host2.test.com:50329 Username:Unknown IKEv2 Negotiation aborted due to ERROR: Auth exchange failed",
+                "outcome": "failure",
+                "reason": "IKEv2 Negotiation aborted due to ERROR: Auth exchange failed",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host2.test.com",
+                    "host1.test.com"
+                ],
+                "user": [
+                    "Unknown"
+                ]
+            },
+            "source": {
+                "address": "host1.test.com",
+                "domain": "host1.test.com",
+                "port": 500
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "Unknown"
+            }
+        },
+        {
+            "@timestamp": "2025-08-05T11:47:09.000Z",
+            "destination": {
+                "address": "2a02:cf40:0000:0000:0000:0000:0000:0001",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:0000:0000:0000:0000:0000:0001",
+                "port": 50329
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "connection-started",
+                "category": [
+                    "network"
+                ],
+                "code": "750002",
+                "kind": "event",
+                "original": "Aug 05 2025 11:47:09: %ASA-5-750002: Local:host1.test.com:500 Remote:2a02:cf40:0000:0000:0000:0000:0000:0001:50329 Username:Unknown IKEv2 Received a IKE_INIT_SA request",
+                "outcome": "success",
+                "reason": "IKEv2 Received a IKE_INIT_SA request",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host1.test.com"
+                ],
+                "ip": [
+                    "2a02:cf40:0000:0000:0000:0000:0000:0001"
+                ],
+                "user": [
+                    "Unknown"
+                ]
+            },
+            "source": {
+                "address": "host1.test.com",
+                "domain": "host1.test.com",
+                "port": 500
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "Unknown"
+            }
+        },
+        {
+            "@timestamp": "2025-08-05T11:47:09.000Z",
+            "destination": {
+                "address": "2a02:cf40:0000:0000:0000:0000:0000:0001",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:0000:0000:0000:0000:0000:0001",
+                "port": 50329
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "750003",
+                "kind": "event",
+                "original": "Aug 05 2025 11:47:09: %ASA-5-750003: Local:host1.test.com:500 Remote:2a02:cf40:0000:0000:0000:0000:0000:0001:50329 Username:Unknown IKEv2 Negotiation aborted due to ERROR: Auth exchange failed",
+                "outcome": "failure",
+                "reason": "IKEv2 Negotiation aborted due to ERROR: Auth exchange failed",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host1.test.com"
+                ],
+                "ip": [
+                    "2a02:cf40:0000:0000:0000:0000:0000:0001"
+                ],
+                "user": [
+                    "Unknown"
+                ]
+            },
+            "source": {
+                "address": "host1.test.com",
+                "domain": "host1.test.com",
+                "port": 500
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "Unknown"
+            }
+        },
+        {
+            "@timestamp": "2025-08-05T11:47:09.000Z",
+            "destination": {
+                "address": "host2.test.com",
+                "domain": "host2.test.com",
+                "port": 50329
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "connection-started",
+                "category": [
+                    "network"
+                ],
+                "code": "750002",
+                "kind": "event",
+                "original": "Aug 05 2025 11:47:09: %ASA-5-750002: Local:2a02:cf40::6:500 Remote:host2.test.com:50329 Username:Unknown IKEv2 Received a IKE_INIT_SA request",
+                "outcome": "success",
+                "reason": "IKEv2 Received a IKE_INIT_SA request",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host2.test.com"
+                ],
+                "ip": [
+                    "2a02:cf40::6"
+                ],
+                "user": [
+                    "Unknown"
+                ]
+            },
+            "source": {
+                "address": "2a02:cf40::6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40::6",
+                "port": 500
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "Unknown"
+            }
+        },
+        {
+            "@timestamp": "2025-08-05T11:47:09.000Z",
+            "destination": {
+                "address": "host2.test.com",
+                "domain": "host2.test.com",
+                "port": 50329
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "750003",
+                "kind": "event",
+                "original": "Aug 05 2025 11:47:09: %ASA-5-750003: Local:2a02:cf40::6:500 Remote:host2.test.com:50329 Username:Unknown IKEv2 Negotiation aborted due to ERROR: Auth exchange failed",
+                "outcome": "failure",
+                "reason": "IKEv2 Negotiation aborted due to ERROR: Auth exchange failed",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "log": {
+                "level": "notification"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host2.test.com"
+                ],
+                "ip": [
+                    "2a02:cf40::6"
+                ],
+                "user": [
+                    "Unknown"
+                ]
+            },
+            "source": {
+                "address": "2a02:cf40::6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40::6",
+                "port": 500
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "Unknown"
+            }
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1224,7 +1224,7 @@ processors:
       tag: parse_750002
       field: "message"
       patterns:
-        - "Local:%{IP:source.address}:%{NUMBER:source.port} Remote:%{IP:destination.address}:%{NUMBER:destination.port} Username:%{DATA:user.name} %{GREEDYDATA:event.reason}"
+        - "Local:%{IPORHOST:source.address}:%{NUMBER:source.port} Remote:%{IPORHOST:destination.address}:%{NUMBER:destination.port} Username:%{DATA:user.name} %{GREEDYDATA:event.reason}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '713120'"
       tag: parse_713120
@@ -1248,7 +1248,7 @@ processors:
       tag: parse_750003
       field: "message"
       patterns:
-        - "Local:%{IP:source.address}:%{NUMBER:source.port} Remote:%{IP:destination.address}:%{NUMBER:destination.port} Username:%{DATA:user.name} %{GREEDYDATA:event.reason}"
+        - "Local:%{IPORHOST:source.address}:%{NUMBER:source.port} Remote:%{IPORHOST:destination.address}:%{NUMBER:destination.port} Username:%{DATA:user.name} %{GREEDYDATA:event.reason}"
   - grok:
       if: '["713905", "713904", "713906", "713902", "713901"].contains(ctx._temp_.cisco.message_id)'
       tag: parse_713901-713906

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.45.6"
+version: "2.45.7"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Summary

Fix source and destination address parsing by changing the Grok pattern for parse_750002 and parse_750003 from `IP` to `IPORHOST`. Added several tests for each combination. 

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)