### PR TITLE
[miniflux] Add agentless deployment

### DIFF
--- a/packages/miniflux/_dev/build/docs/README.md
+++ b/packages/miniflux/_dev/build/docs/README.md
@@ -8,6 +8,11 @@ Use the Miniflux integration to extract RSS feed content. Then visualize that da
 
 For example, if you wanted to be notified for a new feed entry you could set up an alert. 
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Datastreams
 
 This integration collects the following logs:

--- a/packages/miniflux/changelog.yml
+++ b/packages/miniflux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.0.1"
   changes:
     - description: Add missing request trace enabled default option.

--- a/packages/miniflux/changelog.yml
+++ b/packages/miniflux/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19233
 - version: "1.0.1"
   changes:
     - description: Add missing request trace enabled default option.

--- a/packages/miniflux/docs/README.md
+++ b/packages/miniflux/docs/README.md
@@ -8,6 +8,11 @@ Use the Miniflux integration to extract RSS feed content. Then visualize that da
 
 For example, if you wanted to be notified for a new feed entry you could set up an alert. 
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Datastreams
 
 This integration collects the following logs:

--- a/packages/miniflux/manifest.yml
+++ b/packages/miniflux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.5
 name: miniflux
 title: "Miniflux RSS reader"
-version: 1.0.1
+version: 1.1.0
 source:
   license: "Elastic-2.0"
 description: Collect RSS feed content from the Miniflux API with Elastic Agent.
@@ -12,7 +12,7 @@ categories:
   - web
 conditions:
   kibana:
-    version: "^8.17.4 || ^9.0.0"
+    version: "^8.19.4 || ~9.0.7 || ^9.1.4"
   elastic:
     subscription: "basic"
 screenshots:
@@ -33,6 +33,14 @@ policy_templates:
   - name: miniflux
     title: Miniflux data
     description: Collect Miniflux data.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: cel
         title: Collect First EPSS data via API


### PR DESCRIPTION
## Proposed commit message

```
miniflux: add agentless support and update kibana version constraint

Bumps the Kibana version constraint to avoid an issue where agentless 
integration data fields ('organization', 'division', 'team') are 
overwritten by package agentless metadata on the agent policy.

Ref: https://github.com/elastic/kibana/pull/230479
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/miniflux directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #19228