### PR TITLE
[system][auth] Populate user.target.name and ECS fields for PAM chauthtok events

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.19.0"
+  changes:
+    - description: Populate user.target.name and ECS fields for PAM chauthtok events
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/19247
 - version: "2.18.0"
   changes:
     - description: Fix System integration log collection on SLES versions lower than 15.

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11-preserve-original.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11-preserve-original.json-expected.json
@@ -1283,9 +1283,17 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "password-changed",
+                "category": [
+                    "iam"
+                ],
                 "created": "2024-11-04T22:55:09.330Z",
                 "kind": "event",
-                "original": "pam_unix(passwd:chauthtok): password changed for fred"
+                "original": "pam_unix(passwd:chauthtok): password changed for fred",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
             },
             "host": {
                 "hostname": "bullseye",
@@ -1333,7 +1341,10 @@
                     "id": "0"
                 },
                 "id": "1000",
-                "name": "fred"
+                "name": "fred",
+                "target": {
+                    "name": "fred"
+                }
             }
         },
         {

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-debian11.json-expected.json
@@ -1241,9 +1241,17 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "password-changed",
+                "category": [
+                    "iam"
+                ],
                 "created": "2024-11-04T22:55:09.330Z",
                 "kind": "event",
-                "original": "pam_unix(passwd:chauthtok): password changed for fred"
+                "original": "pam_unix(passwd:chauthtok): password changed for fred",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
             },
             "host": {
                 "hostname": "bullseye",
@@ -1288,7 +1296,10 @@
                     "id": "0"
                 },
                 "id": "1000",
-                "name": "fred"
+                "name": "fred",
+                "target": {
+                    "name": "fred"
+                }
             }
         },
         {

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-auth-ubuntu1204.log-expected.json
@@ -2463,9 +2463,17 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "password-changed",
+                "category": [
+                    "iam"
+                ],
                 "kind": "event",
                 "original": "Feb 24 00:12:07 precise32 passwd[4491]: pam_unix(passwd:chauthtok): password changed for tsg",
-                "timezone": "+0000"
+                "outcome": "success",
+                "timezone": "+0000",
+                "type": [
+                    "change"
+                ]
             },
             "host": {
                 "hostname": "precise32"
@@ -2490,7 +2498,10 @@
                 "auth": {}
             },
             "user": {
-                "name": "tsg"
+                "name": "tsg",
+                "target": {
+                    "name": "tsg"
+                }
             }
         },
         {

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log
@@ -1,0 +1,1 @@
+2026-05-17T17:57:47.009102+00:00 host12345 passwd[9999999]: pam_unix(passwd:chauthtok): password changed for user123

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log
@@ -1,1 +1,2 @@
 2026-05-17T17:57:47.009102+00:00 host12345 passwd[9999999]: pam_unix(passwd:chauthtok): password changed for user123
+2026-05-17T17:57:48.123456+00:00 host12345 passwd[9999999]: pam_unix(passwd:chauthtok): new password not acceptable

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log-config.yml
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log-config.yml
@@ -1,0 +1,4 @@
+fields:
+  input.type: log
+dynamic_fields:
+  "event.ingested": "^.*$"

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log-expected.json
@@ -45,6 +45,43 @@
                     "name": "user123"
                 }
             }
+        },
+        {
+            "@timestamp": "2026-05-17T17:57:48.123Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "password-changed",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-05-17T17:57:48.123456+00:00 host12345 passwd[9999999]: pam_unix(passwd:chauthtok): new password not acceptable",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "hostname": "host12345"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "pam_unix(passwd:chauthtok): new password not acceptable",
+            "process": {
+                "name": "passwd",
+                "pid": 9999999
+            },
+            "related": {
+                "hosts": [
+                    "host12345"
+                ]
+            },
+            "system": {
+                "auth": {}
+            }
         }
     ]
 }

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-chauthtok-iso8601.log-expected.json
@@ -1,0 +1,50 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-05-17T17:57:47.009Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "password-changed",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "original": "2026-05-17T17:57:47.009102+00:00 host12345 passwd[9999999]: pam_unix(passwd:chauthtok): password changed for user123",
+                "outcome": "success",
+                "type": [
+                    "change"
+                ]
+            },
+            "host": {
+                "hostname": "host12345"
+            },
+            "input": {
+                "type": "log"
+            },
+            "message": "pam_unix(passwd:chauthtok): password changed for user123",
+            "process": {
+                "name": "passwd",
+                "pid": 9999999
+            },
+            "related": {
+                "hosts": [
+                    "host12345"
+                ],
+                "user": [
+                    "user123"
+                ]
+            },
+            "system": {
+                "auth": {}
+            },
+            "user": {
+                "name": "user123",
+                "target": {
+                    "name": "user123"
+                }
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-extraction.log-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-pam-extraction.log-expected.json
@@ -100,9 +100,17 @@
                 "version": "8.11.0"
             },
             "event": {
+                "action": "password-changed",
+                "category": [
+                    "iam"
+                ],
                 "kind": "event",
                 "original": "Mar 15 10:30:03 webserver passwd[12347]: pam_unix(passwd:chauthtok): password changed for jsmith",
-                "timezone": "+0000"
+                "outcome": "success",
+                "timezone": "+0000",
+                "type": [
+                    "change"
+                ]
             },
             "host": {
                 "hostname": "webserver"
@@ -127,7 +135,10 @@
                 "auth": {}
             },
             "user": {
-                "name": "jsmith"
+                "name": "jsmith",
+                "target": {
+                    "name": "jsmith"
+                }
             }
         },
         {

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/message.yml
@@ -51,6 +51,28 @@ processors:
       patterns:
         - '^pam_unix(%{DATA}:%{WORD:_temp.category})'
       if: ctx.message != null && ctx.message.contains('pam_unix(')
+  - append:
+      tag: append_category_iam_chauthtok
+      field: event.category
+      value: iam
+      allow_duplicates: false
+      if: ctx._temp?.category == 'chauthtok'
+  - append:
+      tag: append_type_change_chauthtok
+      field: event.type
+      value: change
+      allow_duplicates: false
+      if: ctx._temp?.category == 'chauthtok'
+  - set:
+      tag: set_outcome_success_chauthtok
+      field: event.outcome
+      value: success
+      if: ctx._temp?.category == 'chauthtok'
+  - set:
+      tag: set_action_password_changed
+      field: event.action
+      value: password-changed
+      if: ctx._temp?.category == 'chauthtok'
   - grok:
       description: Extract rhost and user from PAM key-value messages.
       tag: grok-pam-kv
@@ -201,6 +223,12 @@ processors:
       ignore_missing: true
       ignore_failure: true
       if: ctx._temp?.pam_user != null && ctx._temp.pam_user != '' && (ctx.user?.name == null || ctx.user?.name == '')
+  - set:
+      tag: set_user_target_name_chauthtok
+      field: user.target.name
+      copy_from: user.name
+      ignore_empty_value: true
+      if: ctx._temp?.category == 'chauthtok' && ctx.user?.name != null && ctx.user?.name != ''
   - remove:
       tag: remove_temp
       field: _temp
@@ -366,6 +394,12 @@ processors:
       value: "{{{ user.effective.name }}}"
       allow_duplicates: false
       if: ctx.user?.effective?.name != null && ctx.user?.effective?.name != ''
+  - append:
+      tag: append_related-user-target-name
+      field: related.user
+      value: "{{{ user.target.name }}}"
+      allow_duplicates: false
+      if: ctx.user?.target?.name != null && ctx.user?.target?.name != ''
   - append:
       tag: append_related-ip
       field: related.ip

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.18.0"
+version: "2.19.0"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

For pam_unix(passwd:chauthtok) password change events, user.name holds the target user (not the actor). This adds user.target.name alongside user.name, indexes it in related.user, and sets event.category=iam, event.type=change, event.outcome=success, event.action=password-changed — fields that were previously absent for this event type. All changes are additive.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [ ] Review all changes to golden files are additive.

## Related issues

- Closes https://github.com/elastic/integrations/issues/19112
