### PR TITLE
[AWS][Lambda] Fix AWS Lambda data stream aws.lambda.message handling

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.19.1"
+  changes:
+    - description: Fix aws.lambda.message flattened field handling.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19250
 - version: "6.19.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-dotnet-json.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-dotnet-json.log-expected.json
@@ -4,7 +4,6 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
-                    "message": "{@users} have joined the group",
                     "request_id": "8f711428-7e55-46f9-ae88-2a65d4f85fc5",
                     "trace_id": "1-6408af34-50f56f5b5677a7d763973804",
                     "users": [
@@ -34,6 +33,7 @@
             "log": {
                 "level": "Information"
             },
+            "message": "{@users} have joined the group",
             "tags": [
                 "preserve_original_event"
             ]
@@ -42,7 +42,6 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
-                    "message": "{users} have joined the group",
                     "request_id": "8f711428-7e55-46f9-ae88-2a65d4f85fc5",
                     "trace_id": "1-6408af34-50f56f5b5677a7d763973804",
                     "users": [
@@ -66,6 +65,7 @@
             "log": {
                 "level": "Information"
             },
+            "message": "{users} have joined the group",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-dotnet-json.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-dotnet-json.log-expected.json
@@ -4,6 +4,10 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
+                    "message": {
+                        "message": "{@users} have joined the group",
+                        "timestamp": "2023-09-07T01:30:06.977Z"
+                    },
                     "request_id": "8f711428-7e55-46f9-ae88-2a65d4f85fc5",
                     "trace_id": "1-6408af34-50f56f5b5677a7d763973804",
                     "users": [
@@ -42,6 +46,10 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
+                    "message": {
+                        "message": "{users} have joined the group",
+                        "timestamp": "2023-09-07T01:30:06.977Z"
+                    },
                     "request_id": "8f711428-7e55-46f9-ae88-2a65d4f85fc5",
                     "trace_id": "1-6408af34-50f56f5b5677a7d763973804",
                     "users": [

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-dotnet-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-dotnet-plain.log-expected.json
@@ -22,6 +22,7 @@
             "event": {
                 "original": "2023/02/20/[$LATEST]4eaf8445ba7a4a93b999cb17fbfbecd8 2023-02-20T14:15:27.988000 INIT_START Runtime Version: dotnet:6.v13        Runtime Version ARN: arn:aws:lambda:ap-southeast-2::runtime:699f346a05dae24c58c45790bc4089f252bf17dae3997e79b17d939a288aa1ec"
             },
+            "message": "2023/02/20/[$LATEST]4eaf8445ba7a4a93b999cb17fbfbecd8 2023-02-20T14:15:27.988000 INIT_START Runtime Version: dotnet:6.v13        Runtime Version ARN: arn:aws:lambda:ap-southeast-2::runtime:699f346a05dae24c58c45790bc4089f252bf17dae3997e79b17d939a288aa1ec",
             "tags": [
                 "preserve_original_event"
             ]
@@ -47,6 +48,7 @@
             "event": {
                 "original": "2023/02/20/[$LATEST]4eaf8445ba7a4a93b999cb17fbfbecd8 2023-02-20T14:15:28.229000 START RequestId: bed25b38-d012-42e7-ba28-f272535fb80e Version: $LATEST"
             },
+            "message": "2023/02/20/[$LATEST]4eaf8445ba7a4a93b999cb17fbfbecd8 2023-02-20T14:15:28.229000 START RequestId: bed25b38-d012-42e7-ba28-f272535fb80e Version: $LATEST",
             "tags": [
                 "preserve_original_event"
             ]
@@ -144,6 +146,7 @@
             "event": {
                 "original": "2023/02/20/[$LATEST]4eaf8445ba7a4a93b999cb17fbfbecd8 2023-02-20T14:15:30.680000 END RequestId: bed25b38-d012-42e7-ba28-f272535fb80e"
             },
+            "message": "2023/02/20/[$LATEST]4eaf8445ba7a4a93b999cb17fbfbecd8 2023-02-20T14:15:30.680000 END RequestId: bed25b38-d012-42e7-ba28-f272535fb80e",
             "tags": [
                 "preserve_original_event"
             ]
@@ -176,6 +179,7 @@
             "event": {
                 "original": "2023/02/20/[$LATEST]4eaf8445ba7a4a93b999cb17fbfbecd8 2023-02-20T14:15:30.680000 REPORT RequestId: bed25b38-d012-42e7-ba28-f272535fb80e  Duration: 2450.99 ms   Billed Duration: 2451 ms Memory Size: 256 MB     Max Memory Used: 74 MB  Init Duration: 240.05 ms"
             },
+            "message": "2023/02/20/[$LATEST]4eaf8445ba7a4a93b999cb17fbfbecd8 2023-02-20T14:15:30.680000 REPORT RequestId: bed25b38-d012-42e7-ba28-f272535fb80e  Duration: 2450.99 ms   Billed Duration: 2451 ms Memory Size: 256 MB     Max Memory Used: 74 MB  Init Duration: 240.05 ms",
             "tags": [
                 "preserve_original_event"
             ]
@@ -203,6 +207,7 @@
             "event": {
                 "original": "XRAY TraceId: 1-63f3807f-5dbcb9910c96f50742707542       SegmentId: 16b362cd5f52cba0"
             },
+            "message": "XRAY TraceId: 1-63f3807f-5dbcb9910c96f50742707542       SegmentId: 16b362cd5f52cba0",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-golang-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-golang-plain.log-expected.json
@@ -153,6 +153,7 @@
             "event": {
                 "original": "END RequestId: dbda340c-xmpl-4031-8810-11bb609b4c71"
             },
+            "message": "END RequestId: dbda340c-xmpl-4031-8810-11bb609b4c71",
             "tags": [
                 "preserve_original_event"
             ]
@@ -184,6 +185,7 @@
             "event": {
                 "original": "REPORT RequestId: dbda340c-xmpl-4031-8810-11bb609b4c71\tDuration: 38.66 ms\tBilled Duration: 39 ms\tMemory Size: 128 MB\tMax Memory Used: 54 MB\tInit Duration: 203.69 ms\t"
             },
+            "message": "REPORT RequestId: dbda340c-xmpl-4031-8810-11bb609b4c71\tDuration: 38.66 ms\tBilled Duration: 39 ms\tMemory Size: 128 MB\tMax Memory Used: 54 MB\tInit Duration: 203.69 ms\t",
             "tags": [
                 "preserve_original_event"
             ]
@@ -212,6 +214,7 @@
             "event": {
                 "original": "XRAY TraceId: 1-5e7d7595-212fxmpl9ee07c4884191322\tSegmentId: 42ffxmpl0645f474\tSampled: true"
             },
+            "message": "XRAY TraceId: 1-5e7d7595-212fxmpl9ee07c4884191322\tSegmentId: 42ffxmpl0645f474\tSampled: true",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-java-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-java-plain.log-expected.json
@@ -28,11 +28,6 @@
         },
         {
             "@timestamp": "2025-03-20T11:07:58.223Z",
-            "aws": {
-                "lambda": {
-                    "message": "{\n    \"_HANDLER\": \"example.Handler\",\n    \"AWS_EXECUTION_ENV\": \"AWS_Lambda_java8\",\n    \"AWS_LAMBDA_FUNCTION_MEMORY_SIZE\": \"512\",\n}\nCONTEXT: "
-                }
-            },
             "cloud": {
                 "provider": "aws",
                 "service": {
@@ -45,17 +40,13 @@
             "event": {
                 "original": "{\n    \"_HANDLER\": \"example.Handler\",\n    \"AWS_EXECUTION_ENV\": \"AWS_Lambda_java8\",\n    \"AWS_LAMBDA_FUNCTION_MEMORY_SIZE\": \"512\",\n}\nCONTEXT: "
             },
+            "message": "{\n    \"_HANDLER\": \"example.Handler\",\n    \"AWS_EXECUTION_ENV\": \"AWS_Lambda_java8\",\n    \"AWS_LAMBDA_FUNCTION_MEMORY_SIZE\": \"512\",\n}\nCONTEXT: ",
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
             "@timestamp": "2025-03-20T11:07:58.223Z",
-            "aws": {
-                "lambda": {
-                    "message": "{\n    \"memoryLimit\": 512,\n    \"awsRequestId\": \"6bc28136-xmpl-4365-b021-0ce6b2e64ab0\",\n    \"functionName\": \"java-console\",\n}\nEVENT:"
-                }
-            },
             "cloud": {
                 "provider": "aws",
                 "service": {
@@ -68,17 +59,13 @@
             "event": {
                 "original": "{\n    \"memoryLimit\": 512,\n    \"awsRequestId\": \"6bc28136-xmpl-4365-b021-0ce6b2e64ab0\",\n    \"functionName\": \"java-console\",\n}\nEVENT:"
             },
+            "message": "{\n    \"memoryLimit\": 512,\n    \"awsRequestId\": \"6bc28136-xmpl-4365-b021-0ce6b2e64ab0\",\n    \"functionName\": \"java-console\",\n}\nEVENT:",
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
             "@timestamp": "2025-03-20T11:07:58.223Z",
-            "aws": {
-                "lambda": {
-                    "message": "{\n  \"records\": [\n    {\n      \"messageId\": \"19dd0b57-xmpl-4ac1-bd88-01bbb068cb78\",\n      \"receiptHandle\": \"MessageReceiptHandle\",\n      \"body\": \"Hello from SQS!\",\n    }\n  ]\n}"
-                }
-            },
             "cloud": {
                 "provider": "aws",
                 "service": {
@@ -91,6 +78,7 @@
             "event": {
                 "original": "{\n  \"records\": [\n    {\n      \"messageId\": \"19dd0b57-xmpl-4ac1-bd88-01bbb068cb78\",\n      \"receiptHandle\": \"MessageReceiptHandle\",\n      \"body\": \"Hello from SQS!\",\n    }\n  ]\n}"
             },
+            "message": "{\n  \"records\": [\n    {\n      \"messageId\": \"19dd0b57-xmpl-4ac1-bd88-01bbb068cb78\",\n      \"receiptHandle\": \"MessageReceiptHandle\",\n      \"body\": \"Hello from SQS!\",\n    }\n  ]\n}",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-java-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-java-plain.log-expected.json
@@ -103,6 +103,7 @@
             "event": {
                 "original": "END RequestId: 6bc28136-xmpl-4365-b021-0ce6b2e64ab0"
             },
+            "message": "END RequestId: 6bc28136-xmpl-4365-b021-0ce6b2e64ab0",
             "tags": [
                 "preserve_original_event"
             ]
@@ -134,6 +135,7 @@
             "event": {
                 "original": "REPORT RequestId: 6bc28136-xmpl-4365-b021-0ce6b2e64ab0\tDuration: 198.50 ms\tBilled Duration: 200 ms\tMemory Size: 512 MB\tMax Memory Used: 90 MB\tInit Duration: 524.75 ms"
             },
+            "message": "REPORT RequestId: 6bc28136-xmpl-4365-b021-0ce6b2e64ab0\tDuration: 198.50 ms\tBilled Duration: 200 ms\tMemory Size: 512 MB\tMax Memory Used: 90 MB\tInit Duration: 524.75 ms",
             "tags": [
                 "preserve_original_event"
             ]
@@ -160,6 +162,7 @@
             "event": {
                 "original": "2023/02/03/[$LATEST]851411a899b545eea2cffeba4cfbec81 2023-02-03T09:24:34.095000 INIT_START Runtime Version: java:11.v15    Runtime Version ARN: arn:aws:lambda:eu-central-1::runtime:0a25e3e7a1cc9ce404bc435eeb2ad358d8fa64338e618d0c224fe509403583ca"
             },
+            "message": "2023/02/03/[$LATEST]851411a899b545eea2cffeba4cfbec81 2023-02-03T09:24:34.095000 INIT_START Runtime Version: java:11.v15    Runtime Version ARN: arn:aws:lambda:eu-central-1::runtime:0a25e3e7a1cc9ce404bc435eeb2ad358d8fa64338e618d0c224fe509403583ca",
             "tags": [
                 "preserve_original_event"
             ]
@@ -233,6 +236,7 @@
             "event": {
                 "original": "2023/02/03/[$LATEST]851411a899b545eea2cffeba4cfbec81 2023-02-03T09:24:35.252000 START RequestId: 7fcf1548-d2d4-41cd-a9a8-6ae47c51f765 Version: $LATEST"
             },
+            "message": "2023/02/03/[$LATEST]851411a899b545eea2cffeba4cfbec81 2023-02-03T09:24:35.252000 START RequestId: 7fcf1548-d2d4-41cd-a9a8-6ae47c51f765 Version: $LATEST",
             "tags": [
                 "preserve_original_event"
             ]
@@ -426,6 +430,7 @@
             "event": {
                 "original": "2023/02/03/[$LATEST]851411a899b545eea2cffeba4cfbec81 2023-02-03T09:24:39.371000 END RequestId: 7fcf1548-d2d4-41cd-a9a8-6ae47c51f765"
             },
+            "message": "2023/02/03/[$LATEST]851411a899b545eea2cffeba4cfbec81 2023-02-03T09:24:39.371000 END RequestId: 7fcf1548-d2d4-41cd-a9a8-6ae47c51f765",
             "tags": [
                 "preserve_original_event"
             ]
@@ -458,6 +463,7 @@
             "event": {
                 "original": "2023/02/03/[$LATEST]851411a899b545eea2cffeba4cfbec81 2023-02-03T09:24:39.371000 REPORT RequestId: 7fcf1548-d2d4-41cd-a9a8-6ae47c51f765    Duration: 4118.98 ms    Billed Duration: 4119 ms    Memory Size: 512 MB    Max Memory Used: 152 MB    Init Duration: 1155.47 ms    "
             },
+            "message": "2023/02/03/[$LATEST]851411a899b545eea2cffeba4cfbec81 2023-02-03T09:24:39.371000 REPORT RequestId: 7fcf1548-d2d4-41cd-a9a8-6ae47c51f765    Duration: 4118.98 ms    Billed Duration: 4119 ms    Memory Size: 512 MB    Max Memory Used: 152 MB    Init Duration: 1155.47 ms    ",
             "tags": [
                 "preserve_original_event"
             ]
@@ -486,6 +492,7 @@
             "event": {
                 "original": "XRAY TraceId: 1-63dcd2d1-25f90b9d1c753a783547f4dd    SegmentId: 3a028fee19b895cb    Sampled: true"
             },
+            "message": "XRAY TraceId: 1-63dcd2d1-25f90b9d1c753a783547f4dd    SegmentId: 3a028fee19b895cb    Sampled: true",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-json-no-message.log
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-json-no-message.log
@@ -1,0 +1,14 @@
+{
+    "time": "2026-05-28T00:00:00.000Z",
+    "type": "platform.report",
+    "record": {
+        "requestId": "id-123",
+        "metrics": {
+            "durationMs": 1234.567,
+            "billedDurationMs": 1235,
+            "memorySizeMB": 256,
+            "maxMemoryUsedMB": 79
+        },
+        "status": "success"
+    }
+}

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-json-no-message.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-json-no-message.log-expected.json
@@ -1,0 +1,45 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2026-05-28T00:00:00.000Z",
+            "aws": {
+                "lambda": {
+                    "event_type": "platform.report",
+                    "message": {
+                        "metrics": {
+                            "billedDurationMs": 1235,
+                            "durationMs": 1234.567,
+                            "maxMemoryUsedMB": 79,
+                            "memorySizeMB": 256
+                        },
+                        "requestId": "id-123",
+                        "status": "success"
+                    },
+                    "metrics": {
+                        "billed_duration_ms": 1235,
+                        "duration_ms": 1234.567,
+                        "max_memory_used_mb": 79,
+                        "memory_size_mb": 256
+                    },
+                    "request_id": "id-123",
+                    "status": "success"
+                }
+            },
+            "cloud": {
+                "provider": "aws",
+                "service": {
+                    "name": "aws_lambda"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "{\n    \"time\": \"2026-05-28T00:00:00.000Z\",\n    \"type\": \"platform.report\",\n    \"record\": {\n        \"requestId\": \"id-123\",\n        \"metrics\": {\n            \"durationMs\": 1234.567,\n            \"billedDurationMs\": 1235,\n            \"memorySizeMB\": 256,\n            \"maxMemoryUsedMB\": 79\n        },\n        \"status\": \"success\"\n    }\n}"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-json-with-message.log
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-json-with-message.log
@@ -1,0 +1,15 @@
+{
+    "log.level": "info",
+    "@timestamp": "2026-05-28T00:00:00.000Z",
+    "message": "Lambda triggered",
+    "resource": {
+        "service.instance.id": "id-123",
+        "service.name": "service-name-redacted",
+        "service.version": ""
+    },
+    "otelcol.component.id": "awslambda",
+    "otelcol.component.kind": "receiver",
+    "otelcol.signal": "logs",
+    "invokedTrigger": "CloudWatchEvent",
+    "ecs.version": "1.6.0"
+}

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-json-with-message.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-json-with-message.log-expected.json
@@ -1,0 +1,41 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2025-03-20T11:07:58.223Z",
+            "aws": {
+                "lambda": {
+                    "message": {
+                        "@timestamp": "2026-05-28T00:00:00.000Z",
+                        "ecs.version": "1.6.0",
+                        "invokedTrigger": "CloudWatchEvent",
+                        "log.level": "info",
+                        "message": "Lambda triggered",
+                        "otelcol.component.id": "awslambda",
+                        "otelcol.component.kind": "receiver",
+                        "otelcol.signal": "logs",
+                        "resource": {
+                            "service.instance.id": "id-123",
+                            "service.name": "service-name-redacted"
+                        }
+                    }
+                }
+            },
+            "cloud": {
+                "provider": "aws",
+                "service": {
+                    "name": "aws_lambda"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "{\n    \"log.level\": \"info\",\n    \"@timestamp\": \"2026-05-28T00:00:00.000Z\",\n    \"message\": \"Lambda triggered\",\n    \"resource\": {\n        \"service.instance.id\": \"id-123\",\n        \"service.name\": \"service-name-redacted\",\n        \"service.version\": \"\"\n    },\n    \"otelcol.component.id\": \"awslambda\",\n    \"otelcol.component.kind\": \"receiver\",\n    \"otelcol.signal\": \"logs\",\n    \"invokedTrigger\": \"CloudWatchEvent\",\n    \"ecs.version\": \"1.6.0\"\n}"
+            },
+            "message": "Lambda triggered",
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-nodejs-json.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-nodejs-json.log-expected.json
@@ -42,7 +42,6 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
-                    "message": "This is a warning message",
                     "request_id": "93f25699-2cbf-4976-8f94-336a0aa98c6f"
                 }
             },
@@ -61,6 +60,7 @@
             "log": {
                 "level": "ERROR"
             },
+            "message": "This is a warning message",
             "tags": [
                 "preserve_original_event"
             ]
@@ -104,7 +104,6 @@
                         "stack_trace": "ReferenceError: some reference error\\n    at Runtime.handler (file:///var/task/index.mjs:3:12)\\n    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)",
                         "type": "ReferenceError"
                     },
-                    "message": "errors logged -  ReferenceError: some reference error\n    at Runtime.handler (file:///var/task/index.mjs:3:12)\n    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29) SyntaxError: some syntax error\n    at Runtime.handler (file:///var/task/index.mjs:4:12)\n    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)",
                     "request_id": "405a4537-9226-4216-ac59-64381ec8654a"
                 }
             },
@@ -123,6 +122,7 @@
             "log": {
                 "level": "INFO"
             },
+            "message": "errors logged -  ReferenceError: some reference error\n    at Runtime.handler (file:///var/task/index.mjs:3:12)\n    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29) SyntaxError: some syntax error\n    at Runtime.handler (file:///var/task/index.mjs:4:12)\n    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-nodejs-json.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-nodejs-json.log-expected.json
@@ -42,6 +42,10 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
+                    "message": {
+                        "message": "This is a warning message",
+                        "timestamp": "2023-11-01T00:21:51.358Z"
+                    },
                     "request_id": "93f25699-2cbf-4976-8f94-336a0aa98c6f"
                 }
             },
@@ -103,6 +107,15 @@
                         "message": "some reference error",
                         "stack_trace": "ReferenceError: some reference error\\n    at Runtime.handler (file:///var/task/index.mjs:3:12)\\n    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)",
                         "type": "ReferenceError"
+                    },
+                    "message": {
+                        "message": "errors logged -  ReferenceError: some reference error\n    at Runtime.handler (file:///var/task/index.mjs:3:12)\n    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29) SyntaxError: some syntax error\n    at Runtime.handler (file:///var/task/index.mjs:4:12)\n    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)",
+                        "stackTrace": [
+                            "ReferenceError: some reference error",
+                            "    at Runtime.handler (file:///var/task/index.mjs:3:12)",
+                            "    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)"
+                        ],
+                        "timestamp": "2023-12-08T23:21:04.646Z"
                     },
                     "request_id": "405a4537-9226-4216-ac59-64381ec8654a"
                 }

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-nodejs-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-nodejs-plain.log-expected.json
@@ -50,7 +50,15 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
-                    "message": "{\n    \"AWS_LAMBDA_FUNCTION_VERSION\": \"$LATEST\",\n    \"AWS_LAMBDA_LOG_GROUP_NAME\": \"/aws/lambda/my-function\",\n    \"AWS_LAMBDA_LOG_STREAM_NAME\": \"2019/06/07/[$LATEST]e6f4a0c4241adcd70c262d34c0bbc85c\",\n    \"AWS_EXECUTION_ENV\": \"AWS_Lambda_nodejs12.x\",\n    \"AWS_LAMBDA_FUNCTION_NAME\": \"my-function\",\n    \"PATH\": \"/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin\",\n    \"NODE_PATH\": \"/opt/nodejs/node10/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules\"\n}"
+                    "message": {
+                        "AWS_EXECUTION_ENV": "AWS_Lambda_nodejs12.x",
+                        "AWS_LAMBDA_FUNCTION_NAME": "my-function",
+                        "AWS_LAMBDA_FUNCTION_VERSION": "$LATEST",
+                        "AWS_LAMBDA_LOG_GROUP_NAME": "/aws/lambda/my-function",
+                        "AWS_LAMBDA_LOG_STREAM_NAME": "2019/06/07/[$LATEST]e6f4a0c4241adcd70c262d34c0bbc85c",
+                        "NODE_PATH": "/opt/nodejs/node10/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules",
+                        "PATH": "/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin"
+                    }
                 }
             },
             "cloud": {
@@ -65,6 +73,7 @@
             "event": {
                 "original": "{\n    \"AWS_LAMBDA_FUNCTION_VERSION\": \"$LATEST\",\n    \"AWS_LAMBDA_LOG_GROUP_NAME\": \"/aws/lambda/my-function\",\n    \"AWS_LAMBDA_LOG_STREAM_NAME\": \"2019/06/07/[$LATEST]e6f4a0c4241adcd70c262d34c0bbc85c\",\n    \"AWS_EXECUTION_ENV\": \"AWS_Lambda_nodejs12.x\",\n    \"AWS_LAMBDA_FUNCTION_NAME\": \"my-function\",\n    \"PATH\": \"/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin\",\n    \"NODE_PATH\": \"/opt/nodejs/node10/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules\"\n}"
             },
+            "message": "{\n    \"AWS_LAMBDA_FUNCTION_VERSION\": \"$LATEST\",\n    \"AWS_LAMBDA_LOG_GROUP_NAME\": \"/aws/lambda/my-function\",\n    \"AWS_LAMBDA_LOG_STREAM_NAME\": \"2019/06/07/[$LATEST]e6f4a0c4241adcd70c262d34c0bbc85c\",\n    \"AWS_EXECUTION_ENV\": \"AWS_Lambda_nodejs12.x\",\n    \"AWS_LAMBDA_FUNCTION_NAME\": \"my-function\",\n    \"PATH\": \"/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin\",\n    \"NODE_PATH\": \"/opt/nodejs/node10/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules\"\n}",
             "tags": [
                 "preserve_original_event"
             ]
@@ -100,7 +109,9 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
-                    "message": "{\n    \"key\": \"value\"\n}"
+                    "message": {
+                        "key": "value"
+                    }
                 }
             },
             "cloud": {
@@ -115,6 +126,7 @@
             "event": {
                 "original": "{\n    \"key\": \"value\"\n}"
             },
+            "message": "{\n    \"key\": \"value\"\n}",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-nodejs-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-nodejs-plain.log-expected.json
@@ -178,6 +178,7 @@
             "event": {
                 "original": "END RequestId: c793869b-ee49-115b-a5b6-4fd21e8dedac"
             },
+            "message": "END RequestId: c793869b-ee49-115b-a5b6-4fd21e8dedac",
             "tags": [
                 "preserve_original_event"
             ]
@@ -209,6 +210,7 @@
             "event": {
                 "original": "REPORT RequestId: c793869b-ee49-115b-a5b6-4fd21e8dedac\tDuration: 128.83 ms\tBilled Duration: 200 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tInit Duration: 166.62 ms\tXRAY TraceId: 1-5d9d007f-0a8c7fd02xmpl480aed55ef0\tSegmentId: 3d752xmpl1bbe37e\tSampled: true"
             },
+            "message": "REPORT RequestId: c793869b-ee49-115b-a5b6-4fd21e8dedac\tDuration: 128.83 ms\tBilled Duration: 200 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tInit Duration: 166.62 ms\tXRAY TraceId: 1-5d9d007f-0a8c7fd02xmpl480aed55ef0\tSegmentId: 3d752xmpl1bbe37e\tSampled: true",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-platform-json.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-platform-json.log-expected.json
@@ -286,7 +286,11 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
-                    "aws_request_id": "aab10ce8-caba-481f-8524-11073604c9ba"
+                    "aws_request_id": "aab10ce8-caba-481f-8524-11073604c9ba",
+                    "message": {
+                        "message": "INFO: Lambda invoked with input: {queryStringParameters: {errorType=runtime},}",
+                        "timestamp": "2025-05-06T11:05:19.955Z"
+                    }
                 }
             },
             "cloud": {

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-platform-json.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-platform-json.log-expected.json
@@ -286,8 +286,7 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
-                    "aws_request_id": "aab10ce8-caba-481f-8524-11073604c9ba",
-                    "message": "INFO: Lambda invoked with input: {queryStringParameters: {errorType=runtime},}"
+                    "aws_request_id": "aab10ce8-caba-481f-8524-11073604c9ba"
                 }
             },
             "cloud": {
@@ -305,6 +304,7 @@
             "log": {
                 "level": "UNDEFINED"
             },
+            "message": "INFO: Lambda invoked with input: {queryStringParameters: {errorType=runtime},}",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-powershell-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-powershell-plain.log-expected.json
@@ -201,7 +201,21 @@
             "@timestamp": "2025-03-20T11:07:58.223Z",
             "aws": {
                 "lambda": {
-                    "message": "{\n  \"Records\": [\n    {\n      \"messageId\": \"19dd0b57-b21e-4ac1-bd88-01bbb068cb78\",\n      \"receiptHandle\": \"MessageReceiptHandle\",\n      \"body\": \"Hello from SQS!\",\n      \"attributes\": {\n        \"ApproximateReceiveCount\": \"1\",\n        \"SentTimestamp\": \"1523232000000\",\n        \"SenderId\": \"123456789012\",\n        \"ApproximateFirstReceiveTimestamp\": \"1523232000001\"\n      }\n    }\n  ]\n}"
+                    "message": {
+                        "Records": [
+                            {
+                                "attributes": {
+                                    "ApproximateFirstReceiveTimestamp": "1523232000001",
+                                    "ApproximateReceiveCount": "1",
+                                    "SenderId": "123456789012",
+                                    "SentTimestamp": "1523232000000"
+                                },
+                                "body": "Hello from SQS!",
+                                "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+                                "receiptHandle": "MessageReceiptHandle"
+                            }
+                        ]
+                    }
                 }
             },
             "cloud": {
@@ -216,6 +230,7 @@
             "event": {
                 "original": "{\n  \"Records\": [\n    {\n      \"messageId\": \"19dd0b57-b21e-4ac1-bd88-01bbb068cb78\",\n      \"receiptHandle\": \"MessageReceiptHandle\",\n      \"body\": \"Hello from SQS!\",\n      \"attributes\": {\n        \"ApproximateReceiveCount\": \"1\",\n        \"SentTimestamp\": \"1523232000000\",\n        \"SenderId\": \"123456789012\",\n        \"ApproximateFirstReceiveTimestamp\": \"1523232000001\"\n      }\n    }\n  ]\n}"
             },
+            "message": "{\n  \"Records\": [\n    {\n      \"messageId\": \"19dd0b57-b21e-4ac1-bd88-01bbb068cb78\",\n      \"receiptHandle\": \"MessageReceiptHandle\",\n      \"body\": \"Hello from SQS!\",\n      \"attributes\": {\n        \"ApproximateReceiveCount\": \"1\",\n        \"SentTimestamp\": \"1523232000000\",\n        \"SenderId\": \"123456789012\",\n        \"ApproximateFirstReceiveTimestamp\": \"1523232000001\"\n      }\n    }\n  ]\n}",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-powershell-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-powershell-plain.log-expected.json
@@ -255,6 +255,7 @@
             "event": {
                 "original": "END RequestId: 56639408-xmpl-435f-9041-ac47ae25ceed"
             },
+            "message": "END RequestId: 56639408-xmpl-435f-9041-ac47ae25ceed",
             "tags": [
                 "preserve_original_event"
             ]
@@ -286,6 +287,7 @@
             "event": {
                 "original": "REPORT RequestId: 56639408-xmpl-435f-9041-ac47ae25ceed\tDuration: 3906.38 ms\tBilled Duration: 4000 ms\tMemory Size: 512 MB\tMax Memory Used: 367 MB\tInit Duration: 5960.19 ms\t"
             },
+            "message": "REPORT RequestId: 56639408-xmpl-435f-9041-ac47ae25ceed\tDuration: 3906.38 ms\tBilled Duration: 4000 ms\tMemory Size: 512 MB\tMax Memory Used: 367 MB\tInit Duration: 5960.19 ms\t",
             "tags": [
                 "preserve_original_event"
             ]
@@ -314,6 +316,7 @@
             "event": {
                 "original": "XRAY TraceId: 1-5e843da6-733cxmple7d0c3c020510040\tSegmentId: 3913xmpl20999446\tSampled: true"
             },
+            "message": "XRAY TraceId: 1-5e843da6-733cxmple7d0c3c020510040\tSegmentId: 3913xmpl20999446\tSampled: true",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-powertools-json.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-powertools-json.log-expected.json
@@ -10,7 +10,6 @@
                     "error": {
                         "location": "hello:32"
                     },
-                    "message": "Hello world API - HTTP 200",
                     "metrics": {
                         "memory_size_mb": 128
                     },
@@ -33,6 +32,7 @@
             "log": {
                 "level": "INFO"
             },
+            "message": "Hello world API - HTTP 200",
             "service": {
                 "name": "PowertoolsHelloWorld"
             },
@@ -50,7 +50,6 @@
                     "error": {
                         "location": "hello_name:19"
                     },
-                    "message": "Request from user received",
                     "metrics": {
                         "memory_size_mb": 128
                     },
@@ -73,6 +72,7 @@
             "log": {
                 "level": "INFO"
             },
+            "message": "Request from user received",
             "service": {
                 "name": "PowertoolsHelloWorld"
             },

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-powertools-json.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-powertools-json.log-expected.json
@@ -10,6 +10,12 @@
                     "error": {
                         "location": "hello:32"
                     },
+                    "message": {
+                        "function_memory_size": "128",
+                        "message": "Hello world API - HTTP 200",
+                        "timestamp": "2025-05-05 04:01:36,154+0000",
+                        "xray_trace_id": "1-68183820-1a7106da2a0a87650e15c2d9"
+                    },
                     "metrics": {
                         "memory_size_mb": 128
                     },
@@ -49,6 +55,12 @@
                     "correlation_id": "aa71551d-c6f5-46e4-a316-740fd7c447c1",
                     "error": {
                         "location": "hello_name:19"
+                    },
+                    "message": {
+                        "function_memory_size": "128",
+                        "message": "Request from user received",
+                        "timestamp": "2025-05-08 14:28:33,173+0000",
+                        "xray_trace_id": "1-681cbf91-2f73e10615dd891f489d7b39"
                     },
                     "metrics": {
                         "memory_size_mb": 128

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-python-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-python-plain.log-expected.json
@@ -47,11 +47,6 @@
         },
         {
             "@timestamp": "2025-03-20T11:07:58.223Z",
-            "aws": {
-                "lambda": {
-                    "message": "{'key': 'value'}"
-                }
-            },
             "cloud": {
                 "provider": "aws",
                 "service": {
@@ -64,6 +59,7 @@
             "event": {
                 "original": "{'key': 'value'}"
             },
+            "message": "{'key': 'value'}",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-python-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-python-plain.log-expected.json
@@ -84,6 +84,7 @@
             "event": {
                 "original": "END RequestId: 8f507cfc-xmpl-4697-b07a-ac58fc914c95"
             },
+            "message": "END RequestId: 8f507cfc-xmpl-4697-b07a-ac58fc914c95",
             "tags": [
                 "preserve_original_event"
             ]
@@ -115,6 +116,7 @@
             "event": {
                 "original": "REPORT RequestId: 8f507cfc-xmpl-4697-b07a-ac58fc914c95  Duration: 15.74 ms  Billed Duration: 16 ms Memory Size: 128 MB Max Memory Used: 56 MB  Init Duration: 130.49 ms"
             },
+            "message": "REPORT RequestId: 8f507cfc-xmpl-4697-b07a-ac58fc914c95  Duration: 15.74 ms  Billed Duration: 16 ms Memory Size: 128 MB Max Memory Used: 56 MB  Init Duration: 130.49 ms",
             "tags": [
                 "preserve_original_event"
             ]
@@ -143,6 +145,7 @@
             "event": {
                 "original": "XRAY TraceId: 1-5e34a614-10bdxmplf1fb44f07bc535a1   SegmentId: 07f5xmpl2d1f6f85 Sampled: true"
             },
+            "message": "XRAY TraceId: 1-5e34a614-10bdxmplf1fb44f07bc535a1   SegmentId: 07f5xmpl2d1f6f85 Sampled: true",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-ruby-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-ruby-plain.log-expected.json
@@ -28,11 +28,6 @@
         },
         {
             "@timestamp": "2025-03-20T11:07:58.223Z",
-            "aws": {
-                "lambda": {
-                    "message": "{'key': 'value'}"
-                }
-            },
             "cloud": {
                 "provider": "aws",
                 "service": {
@@ -45,6 +40,7 @@
             "event": {
                 "original": "{'key': 'value'}"
             },
+            "message": "{'key': 'value'}",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-ruby-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-ruby-plain.log-expected.json
@@ -65,6 +65,7 @@
             "event": {
                 "original": "END RequestId: 8f507cfc-xmpl-4697-b07a-ac58fc914c95"
             },
+            "message": "END RequestId: 8f507cfc-xmpl-4697-b07a-ac58fc914c95",
             "tags": [
                 "preserve_original_event"
             ]
@@ -96,6 +97,7 @@
             "event": {
                 "original": "REPORT RequestId: 8f507cfc-xmpl-4697-b07a-ac58fc914c95  Duration: 15.74 ms  Billed Duration: 16 ms Memory Size: 128 MB Max Memory Used: 56 MB  Init Duration: 130.49 ms"
             },
+            "message": "REPORT RequestId: 8f507cfc-xmpl-4697-b07a-ac58fc914c95  Duration: 15.74 ms  Billed Duration: 16 ms Memory Size: 128 MB Max Memory Used: 56 MB  Init Duration: 130.49 ms",
             "tags": [
                 "preserve_original_event"
             ]
@@ -124,6 +126,7 @@
             "event": {
                 "original": "XRAY TraceId: 1-5e34a614-10bdxmplf1fb44f07bc535a1   SegmentId: 07f5xmpl2d1f6f85 Sampled: true   "
             },
+            "message": "XRAY TraceId: 1-5e34a614-10bdxmplf1fb44f07bc535a1   SegmentId: 07f5xmpl2d1f6f85 Sampled: true   ",
             "tags": [
                 "preserve_original_event"
             ]
@@ -275,6 +278,7 @@
             "event": {
                 "original": "END RequestId: 1c8df7d3-xmpl-46da-9778-518e6eca8125"
             },
+            "message": "END RequestId: 1c8df7d3-xmpl-46da-9778-518e6eca8125",
             "tags": [
                 "preserve_original_event"
             ]
@@ -306,6 +310,7 @@
             "event": {
                 "original": "REPORT RequestId: 1c8df7d3-xmpl-46da-9778-518e6eca8125  Duration: 2.75 ms   Billed Duration: 3 ms Memory Size: 128 MB Max Memory Used: 56 MB  Init Duration: 113.51 ms"
             },
+            "message": "REPORT RequestId: 1c8df7d3-xmpl-46da-9778-518e6eca8125  Duration: 2.75 ms   Billed Duration: 3 ms Memory Size: 128 MB Max Memory Used: 56 MB  Init Duration: 113.51 ms",
             "tags": [
                 "preserve_original_event"
             ]
@@ -334,6 +339,7 @@
             "event": {
                 "original": "XRAY TraceId: 1-5e34a66a-474xmpl7c2534a87870b4370   SegmentId: 073cxmpl3e442861 Sampled: true"
             },
+            "message": "XRAY TraceId: 1-5e34a66a-474xmpl7c2534a87870b4370   SegmentId: 073cxmpl3e442861 Sampled: true",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-typescript-plain.log-expected.json
+++ b/packages/aws/data_stream/lambda_logs/_dev/test/pipeline/test-awslambda-typescript-plain.log-expected.json
@@ -21,6 +21,7 @@
             "event": {
                 "original": "2023/01/31/[$LATEST]2ca67f180dcd4d3e88b5d68576740c8e 2022-08-31T14:48:37.047000 START RequestId: 19ad1007-ff67-40ce-9afe-0af0a9eb512c Version: $LATEST"
             },
+            "message": "2023/01/31/[$LATEST]2ca67f180dcd4d3e88b5d68576740c8e 2022-08-31T14:48:37.047000 START RequestId: 19ad1007-ff67-40ce-9afe-0af0a9eb512c Version: $LATEST",
             "tags": [
                 "preserve_original_event"
             ]
@@ -70,6 +71,7 @@
             "event": {
                 "original": "2023/01/31/[$LATEST]2ca67f180dcd4d3e88b5d68576740c8e 2022-08-31T14:48:37.082000 END RequestId: 19ad1007-ff67-40ce-9afe-0af0a9eb512c"
             },
+            "message": "2023/01/31/[$LATEST]2ca67f180dcd4d3e88b5d68576740c8e 2022-08-31T14:48:37.082000 END RequestId: 19ad1007-ff67-40ce-9afe-0af0a9eb512c",
             "tags": [
                 "preserve_original_event"
             ]
@@ -102,6 +104,7 @@
             "event": {
                 "original": "2023/01/31/[$LATEST]2ca67f180dcd4d3e88b5d68576740c8e 2022-08-31T14:48:37.082000 REPORT RequestId: 19ad1007-ff67-40ce-9afe-0af0a9eb512c Duration: 34.60 ms Billed Duration: 35 ms Memory Size: 128 MB Max Memory Used: 57 MB Init Duration: 173.48 ms"
             },
+            "message": "2023/01/31/[$LATEST]2ca67f180dcd4d3e88b5d68576740c8e 2022-08-31T14:48:37.082000 REPORT RequestId: 19ad1007-ff67-40ce-9afe-0af0a9eb512c Duration: 34.60 ms Billed Duration: 35 ms Memory Size: 128 MB Max Memory Used: 57 MB Init Duration: 173.48 ms",
             "tags": [
                 "preserve_original_event"
             ]
@@ -127,6 +130,7 @@
             "event": {
                 "original": "2023/01/31/[$LATEST]4d53e8d279824834a1ccd35511a4949c 2022-08-31T09:33:10.552000 START RequestId: 70693159-7e94-4102-a2af-98a6343fb8fb Version: $LATEST"
             },
+            "message": "2023/01/31/[$LATEST]4d53e8d279824834a1ccd35511a4949c 2022-08-31T09:33:10.552000 START RequestId: 70693159-7e94-4102-a2af-98a6343fb8fb Version: $LATEST",
             "tags": [
                 "preserve_original_event"
             ]
@@ -224,6 +228,7 @@
             "event": {
                 "original": "2023/01/31/[$LATEST]4d53e8d279824834a1ccd35511a4949c 2022-08-31T09:33:10.754000 END RequestId: 70693159-7e94-4102-a2af-98a6343fb8fb"
             },
+            "message": "2023/01/31/[$LATEST]4d53e8d279824834a1ccd35511a4949c 2022-08-31T09:33:10.754000 END RequestId: 70693159-7e94-4102-a2af-98a6343fb8fb",
             "tags": [
                 "preserve_original_event"
             ]
@@ -256,6 +261,7 @@
             "event": {
                 "original": "2023/01/31/[$LATEST]4d53e8d279824834a1ccd35511a4949c 2022-08-31T09:33:10.754000 REPORT RequestId: 70693159-7e94-4102-a2af-98a6343fb8fb Duration: 201.55 ms Billed Duration: 202 ms Memory Size: 128 MB Max Memory Used: 66 MB Init Duration: 252.42 ms"
             },
+            "message": "2023/01/31/[$LATEST]4d53e8d279824834a1ccd35511a4949c 2022-08-31T09:33:10.754000 REPORT RequestId: 70693159-7e94-4102-a2af-98a6343fb8fb Duration: 201.55 ms Billed Duration: 202 ms Memory Size: 128 MB Max Memory Used: 66 MB Init Duration: 252.42 ms",
             "tags": [
                 "preserve_original_event"
             ]
@@ -284,6 +290,7 @@
             "event": {
                 "original": "XRAY TraceId: 1-630f2ad5-1de22b6d29a658a466e7ecf5 SegmentId: 567c116658fbf11a Sampled: true"
             },
+            "message": "XRAY TraceId: 1-630f2ad5-1de22b6d29a658a466e7ecf5 SegmentId: 567c116658fbf11a Sampled: true",
             "tags": [
                 "preserve_original_event"
             ]

--- a/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-json.yml
+++ b/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-json.yml
@@ -339,6 +339,17 @@ processors:
     target_field: aws.lambda.message
     ignore_missing: true
     ignore_failure: true
+    if: "ctx.parsed?.message instanceof Map"
+
+- set:
+    field: message
+    copy_from: parsed.message
+    if: "ctx.parsed?.message != null && !(ctx.parsed.message instanceof Map)"
+
+- set:
+    field: message
+    copy_from: event.original
+    if: "ctx.message == null && ctx.aws?.lambda?.message == null"
 
 - rename:
     field: parsed.users
@@ -411,12 +422,7 @@ processors:
     target_field: aws.lambda.message
     ignore_missing: true
     ignore_failure: true
-    if: "ctx.parsed instanceof Map && !(ctx.parsed.containsKey('message') || ctx.parsed.containsKey('record') || ctx.parsed.containsKey('_aws') || ctx.parsed.containsKey('time') || ctx.parsed.containsKey('timestamp'))"
-
-- set:
-    field: aws.lambda.message
-    copy_from: event.original
-    if: "ctx.parsed == null"
+    if: "ctx.parsed instanceof Map && !(ctx.parsed.containsKey('record') || ctx.parsed.containsKey('_aws') || ctx.parsed.containsKey('time') || ctx.parsed.containsKey('timestamp'))"
 
 - remove:
     field: parsed

--- a/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-json.yml
+++ b/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-json.yml
@@ -422,7 +422,7 @@ processors:
     target_field: aws.lambda.message
     ignore_missing: true
     ignore_failure: true
-    if: "ctx.parsed instanceof Map && !(ctx.parsed.containsKey('record') || ctx.parsed.containsKey('_aws') || ctx.parsed.containsKey('time') || ctx.parsed.containsKey('timestamp'))"
+    if: "ctx.parsed instanceof Map && !(ctx.parsed.containsKey('record') || ctx.parsed.containsKey('_aws') || ctx.parsed.containsKey('time') )"
 
 - remove:
     field: parsed

--- a/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-json.yml
+++ b/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-json.yml
@@ -358,12 +358,6 @@ processors:
     ignore_failure: true
 
 - rename:
-    field: parsed.timestamp
-    target_field: "@timestamp"
-    ignore_missing: true
-    ignore_failure: true
-
-- rename:
     field: parsed.tracing.xray_trace_id
     target_field: aws.lambda.xray_trace_id
     ignore_missing: true

--- a/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-plaintext.yml
+++ b/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-plaintext.yml
@@ -43,6 +43,12 @@ processors:
       value: "{{_ingest.timestamp}}"
       ignore_failure: true
 
+  - set:
+      field: message
+      copy_from: event.original
+      if: "ctx.message == null || ctx.message == ''"
+      ignore_failure: true
+
   - remove:
       field: timestamp
       ignore_missing: true

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.19.0
+version: 6.19.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

`aws.lambda.message` is defined as a `flattened` field. However, Lambda integration's  JSON pipeline ignore checks to validate this. This causes JSON pipeline to parse but Elastic indexing to fail with `expecting token of type [START_OBJECT] but found [VALUE_STRING] `

See `fields.yaml` of this integration for specific field definition (see extraction below),
```yaml
- name: aws.lambda
  type: group
  fields:
  - name: message
    type: flattened
```

If the payload contains a non-compliant content, then this fix preserve the original message at root level `message` field.

See test changes and newly added tests to understand the change better. 

Additionally, `message` section is now added in plain text mode as well.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
