### PR TITLE
fix: updated kibana version & enable_request_tracer default set to false

### DIFF
--- a/packages/doppel/changelog.yml
+++ b/packages/doppel/changelog.yml
@@ -1,8 +1,3 @@
-- version: "0.1.0"
-  changes:
-    - description: Initial Integration to fetch Doppel Alerts API in Elastic Security.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/18777
 - version: "0.1.1"
   changes:
     - description: Fix kibana.version constraints to allow v9 stack.
@@ -11,3 +6,8 @@
     - description: Fix default request trace enablement value.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/19251
+- version: "0.1.0"
+  changes:
+    - description: Initial Integration to fetch Doppel Alerts API in Elastic Security.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/18777

--- a/packages/doppel/changelog.yml
+++ b/packages/doppel/changelog.yml
@@ -3,3 +3,11 @@
     - description: Initial Integration to fetch Doppel Alerts API in Elastic Security.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/18777
+- version: "0.1.1"
+  changes:
+    - description: Fix kibana.version constraints to allow v9 stack.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19251
+    - description: Fix default request trace enablement value.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19251

--- a/packages/doppel/data_stream/alerts/manifest.yml
+++ b/packages/doppel/data_stream/alerts/manifest.yml
@@ -63,6 +63,7 @@ streams:
         type: bool
         title: Enable request tracing
         multi: false
+        default: false
         required: false
         show_user: false
         description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enabled) for details.

--- a/packages/doppel/manifest.yml
+++ b/packages/doppel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.7
 name: doppel
 title: "Doppel"
-version: 0.1.0
+version: 0.1.1
 description: "Collects Doppel alerts and sends them to Elastic"
 type: integration
 source:
@@ -20,7 +20,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: "^8.19.0"
+    version: "^8.19.14 || ^9.3.3"
   elastic:
     subscription: "basic"
 policy_templates:
@@ -32,8 +32,6 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
-        # is_default: true          # default agentless mode for directly test as agentless 
-
         organization: security
         division: engineering
         team: security-service-integrations


### PR DESCRIPTION

Change Type

- Bug

## Proposed commit message

In Ref to : https://github.com/elastic/integrations/issues/19246

## Checklist

- [X] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [X] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

