### PR TITLE
[otel_collector_internal_telemetry] Clarify that prometheus format is not supported

### DIFF
--- a/packages/otel_collector_internal_telemetry/changelog.yml
+++ b/packages/otel_collector_internal_telemetry/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Doc update: Clarify expected metrics format and explicitly calling out that Prometheus format is not supported. 
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/TODO
+      link: https://github.com/elastic/integrations/pull/19254
 - version: "1.2.1"
   changes:
     - description: Document setting data_stream.dataset to collectortelemetry and fix queries for TBS dashboards.

--- a/packages/otel_collector_internal_telemetry/changelog.yml
+++ b/packages/otel_collector_internal_telemetry/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Doc update: Clarify expected metrics format and explicitly calling out that Prometheus format is not supported. 
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/TODO
 - version: "1.2.1"
   changes:
     - description: Document setting data_stream.dataset to collectortelemetry and fix queries for TBS dashboards.

--- a/packages/otel_collector_internal_telemetry/changelog.yml
+++ b/packages/otel_collector_internal_telemetry/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.2.2"
   changes:
-    - description: Doc update: Clarify expected metrics format and explicitly calling out that Prometheus format is not supported. 
+    - description: Doc update. Clarify expected metrics format and explicitly calling out that Prometheus format is not supported. 
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19254
 - version: "1.2.1"

--- a/packages/otel_collector_internal_telemetry/docs/README.md
+++ b/packages/otel_collector_internal_telemetry/docs/README.md
@@ -12,6 +12,8 @@ Furthermore, the package also contains dashboards to visualize metrics from the 
 
 The dashboards query metrics from the `collectortelemetry` dataset. Set the resource attribute `data_stream.dataset` to `collectortelemetry` on the collector that emits internal telemetry (see below).
 
+**Note**: The dashboards expect metrics without postfixes. In particular, Prometheus-format metrics—which apply unit suffixes by default—are not supported. The dashboards are designed for metrics exported via OTLP. If you use the Prometheus exporter, set `without_type_suffix` and `without_units` to `true`. For more information, see [the upstream documentation](https://opentelemetry.io/docs/collector/internal-telemetry/#metric-views).
+
 ### How it works
 
 The dashboards rely on field names defined in above documentations.

--- a/packages/otel_collector_internal_telemetry/manifest.yml
+++ b/packages/otel_collector_internal_telemetry/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.2
 name: otel_collector_internal_telemetry
 title: "OpenTelemetry Collector Internal Telemetry"
-version: 1.2.1
+version: 1.2.2
 source:
   license: "Apache-2.0"
 description: "This package contains dashboards that visualize the internal telemetry from the OpenTelemetry Collector"


### PR DESCRIPTION
Adding docs clarifying which metric format the dashboards expect. 
