### PR TITLE
[NGINX] Add condition parameter support to logs and metrics data streams 

### DIFF
--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add condition parameter support for logs and metrics inputs.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/11111
+      link: https://github.com/elastic/integrations/pull/19267
 - version: "3.1.0"
   changes:
     - description: Update dockerfile and readme for recent nginx version.

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.2.0"
+  changes:
+    - description: Add condition parameter support for logs and metrics inputs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11111
 - version: "3.1.0"
   changes:
     - description: Update dockerfile and readme for recent nginx version.

--- a/packages/nginx/data_stream/access/agent/stream/stream.yml.hbs
+++ b/packages/nginx/data_stream/access/agent/stream/stream.yml.hbs
@@ -21,3 +21,6 @@ processors:
 {{processors}}
 {{/if}}
 - add_locale: ~
+{{#if condition}}
+condition: {{condition}}
+{{/if}}

--- a/packages/nginx/data_stream/error/agent/stream/stream.yml.hbs
+++ b/packages/nginx/data_stream/error/agent/stream/stream.yml.hbs
@@ -25,3 +25,6 @@ processors:
 {{processors}}
 {{/if}}
 - add_locale: ~
+{{#if condition}}
+condition: {{condition}}
+{{/if}}

--- a/packages/nginx/data_stream/stubstatus/agent/stream/stream.yml.hbs
+++ b/packages/nginx/data_stream/stubstatus/agent/stream/stream.yml.hbs
@@ -15,3 +15,6 @@ server_status_path: {{server_status_path}}
 processors:
 {{processors}}
 {{/if}}
+{{#if condition}}
+condition: {{condition}}
+{{/if}}

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: nginx
 title: Nginx
-version: "3.1.0"
+version: "3.2.0"
 description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -45,7 +45,7 @@ policy_templates:
             type: text
             multi: false
             required: false
-            show_user: true
+            show_user: false
       - type: nginx/metrics
         vars:
           - name: hosts
@@ -62,7 +62,7 @@ policy_templates:
             type: text
             multi: false
             required: false
-            show_user: true
+            show_user: false
         title: Collect metrics from Nginx instances
         description: Collecting Nginx stub status metrics
 owner:

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -38,6 +38,14 @@ policy_templates:
       - type: logfile
         title: Collect logs from Nginx instances
         description: Collecting Nginx access and error logs
+        vars:
+          - name: condition
+            title: Condition
+            description: Condition to filter when to collect this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
+            type: text
+            multi: false
+            required: false
+            show_user: true
       - type: nginx/metrics
         vars:
           - name: hosts
@@ -48,6 +56,13 @@ policy_templates:
             show_user: true
             default:
               - http://127.0.0.1:80
+          - name: condition
+            title: Condition
+            description: Condition to filter when to collect this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
+            type: text
+            multi: false
+            required: false
+            show_user: true
         title: Collect metrics from Nginx instances
         description: Collecting Nginx stub status metrics
 owner:


### PR DESCRIPTION
## Proposed commit message

[NGINX] Add condition parameter support for logs and metrics inputs.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

- Update the integration
- Assign the integration to a host and verfy that is collecting the data
- Add a condition
- Verify that the conditions are reported in the elastic-agent inspect command
- Verify that the components are not running


## Related issues


## Screenshots

<img width="800" height="402" alt="image" src="https://github.com/user-attachments/assets/fe1f2e22-f2ae-4add-a8aa-8025dfaeb666" />

<img width="800" height="402" alt="image" src="https://github.com/user-attachments/assets/36ff9e42-f7ed-4635-bbf0-da1aae868031" />

```yaml
- data_stream:
    namespace: default
  id: logfile-nginx-545475e2-8cec-4c0d-900e-1a6e091c5586
  meta:
    package:
      name: nginx
      policy_template: nginx
      release: ga
      version: 3.2.0
  name: nginx-1
  package_policy_id: 545475e2-8cec-4c0d-900e-1a6e091c5586
  revision: 4
  streams:
  - condition: ${host.name} != "rocky-linux-small" # <----- CONDITION ADDED
    data_stream:
      dataset: nginx.access
      type: logs
    exclude_files:
    - .gz$
    id: logfile-nginx.access-545475e2-8cec-4c0d-900e-1a6e091c5586
    ignore_older: 72h
    paths:
    - /var/log/nginx/access.log*
    processors:
    - add_locale: null
    tags:
    - nginx-access
  - condition: ${host.name} != "rocky-linux-small" # <----- CONDITION ADDED
    data_stream:
      dataset: nginx.error
      type: logs
    exclude_files:
    - .gz$
    id: logfile-nginx.error-545475e2-8cec-4c0d-900e-1a6e091c5586
    ignore_older: 72h
    multiline:
      match: after
      negate: true
      pattern: '^\d{4}\/\d{2}\/\d{2} '
    paths:
    - /var/log/nginx/error.log*
    processors:
    - add_locale: null
    tags:
    - nginx-error
  type: logfile
  use_output: default
- data_stream:
    namespace: default
  id: nginx/metrics-nginx-545475e2-8cec-4c0d-900e-1a6e091c5586
  meta:
    package:
      name: nginx
      policy_template: nginx
      release: ga
      version: 3.2.0
  name: nginx-1
  package_policy_id: 545475e2-8cec-4c0d-900e-1a6e091c5586
  revision: 4
  streams:
  - condition: ${host.name} != "rocky-linux-small" # <----- CONDITION ADDED
    data_stream:
      dataset: nginx.stubstatus
      type: metrics
    hosts:
    - http://127.0.0.1:80
    id: nginx/metrics-nginx.stubstatus-545475e2-8cec-4c0d-900e-1a6e091c5586
    metricsets:
    - stubstatus
    period: 10s
    server_status_path: /nginx_status
    tags:
    - nginx-stubstatus
  type: nginx/metrics
  use_output: default
```