### PR TITLE
[Mysql] Add ability to set condition for logs and metrics

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add ability to set condition for logs and metrics.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/16942
+      link: https://github.com/elastic/integrations/pull/19269
 - version: "1.29.2"
   changes:
     - description: Fix alerting rule templates names.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.0"
+  changes:
+    - description: Add ability to set condition for logs and metrics.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/16942
 - version: "1.29.2"
   changes:
     - description: Fix alerting rule templates names.

--- a/packages/mysql/data_stream/error/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/error/agent/stream/stream.yml.hbs
@@ -23,3 +23,6 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}

--- a/packages/mysql/data_stream/galera_status/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/galera_status/agent/stream/stream.yml.hbs
@@ -20,3 +20,6 @@ username: {{username}}
 processors:
 {{processors}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}

--- a/packages/mysql/data_stream/performance/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/performance/agent/stream/stream.yml.hbs
@@ -20,3 +20,6 @@ username: {{username}}
 processors:
 {{processors}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}

--- a/packages/mysql/data_stream/replica_status/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/replica_status/agent/stream/stream.yml.hbs
@@ -15,6 +15,9 @@ processors:
 {{#if ssl}}
 {{ssl}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 driver: "mysql"
 sql_queries:
   - query: {{replication_status_query}}

--- a/packages/mysql/data_stream/slowlog/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/slowlog/agent/stream/stream.yml.hbs
@@ -23,3 +23,6 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}

--- a/packages/mysql/data_stream/status/agent/stream/stream.yml.hbs
+++ b/packages/mysql/data_stream/status/agent/stream/stream.yml.hbs
@@ -20,3 +20,6 @@ username: {{username}}
 processors:
 {{processors}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -46,7 +46,7 @@ policy_templates:
             type: text
             multi: false
             required: false
-            show_user: true
+            show_user: false
       - type: mysql/metrics
         title: Collect metrics from MySQL hosts
         description: Collecting MySQL status and galera_status metrics
@@ -103,7 +103,7 @@ policy_templates:
             type: text
             multi: false
             required: false
-            show_user: true
+            show_user: false
       - type: sql/metrics
         title: Collect replica status metrics from MySQL hosts
         description: Collecting replica status metrics
@@ -159,7 +159,7 @@ policy_templates:
             type: text
             multi: false
             required: false
-            show_user: true
+            show_user: false
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: mysql
 title: MySQL
-version: "1.29.2"
+version: "1.30.0"
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -39,6 +39,14 @@ policy_templates:
       - type: logfile
         title: Collect logs from MySQL hosts
         description: Collecting MySQL error and slowlog logs
+        vars:
+          - name: condition
+            title: Condition
+            description: Condition to filter when to collect this datastream. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
+            type: text
+            multi: false
+            required: false
+            show_user: true
       - type: mysql/metrics
         title: Collect metrics from MySQL hosts
         description: Collecting MySQL status and galera_status metrics
@@ -89,6 +97,13 @@ policy_templates:
               #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
               #    sxSmbIUfc2SGJGCJD4I=
               #    -----END CERTIFICATE-----
+          - name: condition
+            title: Condition
+            description: Condition to filter when to collect this datastream. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
+            type: text
+            multi: false
+            required: false
+            show_user: true
       - type: sql/metrics
         title: Collect replica status metrics from MySQL hosts
         description: Collecting replica status metrics
@@ -138,6 +153,13 @@ policy_templates:
               #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
               #    sxSmbIUfc2SGJGCJD4I=
               #    -----END CERTIFICATE-----
+          - name: condition
+            title: Condition
+            description: Condition to filter when to collect this datastream. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
+            type: text
+            multi: false
+            required: false
+            show_user: true
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

[Mysql] Add ability to set condition for logs and metrics

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist


## How to test this PR locally

- Update the integration
- Assign the integration to a host and verfy that is collecting the data
- Add a condition
- Verify that the conditions are reported in the elastic-agent inspect command
- Verify that the components are not running

## Related issues

- #19267

## Screenshots

<img width="794" height="188" alt="image" src="https://github.com/user-attachments/assets/091f1c21-38ce-44ec-82e3-acd511c19c04" />

<img width="767" height="287" alt="image" src="https://github.com/user-attachments/assets/b4f62cb2-b50b-4f08-adc6-c633bc44275b" />

<img width="766" height="467" alt="image" src="https://github.com/user-attachments/assets/b4c2b2f9-d91f-4afe-9bff-468070d7df2f" />


Extract from the elastic-agent inspect
```yaml
- data_stream:
    namespace: default
  id: logfile-mysql-b3eec291-aaf2-4c70-9953-ec8aae0e442a
  meta:
    package:
      name: mysql
      policy_template: mysql
      release: ga
      version: 1.30.0
  name: mysql-1
  package_policy_id: b3eec291-aaf2-4c70-9953-ec8aae0e442a
  revision: 4
  streams:
  - condition: ${host.name} != "rocky-linux-small"  # <--- condition added
    data_stream:
      dataset: mysql.error
      type: logs
    exclude_files:
    - .gz$
    id: logfile-mysql.error-b3eec291-aaf2-4c70-9953-ec8aae0e442a
    multiline:
      match: after
      negate: true
      pattern: ^([0-9]{4}-[0-9]{2}-[0-9]{2}|[0-9]{6})
    paths:
    - /var/log/mysql/error.log*
    - /var/log/mysqld.log*
    processors:
    - add_locale: null
    tags:
    - mysql-error
  - condition: ${host.name} != "rocky-linux-small"  # <--- condition added
    data_stream:
      dataset: mysql.slowlog
      type: logs
    exclude_files:
    - .gz$
    exclude_lines:
    - '^[\/\w\.]+, Version: .* started with:.*'
    - ^# Time:.*
    id: logfile-mysql.slowlog-b3eec291-aaf2-4c70-9953-ec8aae0e442a
    multiline:
      match: after
      negate: true
      pattern: '^(# User@Host: |# Time: )'
    paths:
    - /var/log/mysql/*-slow.log*
    - /var/lib/mysql/*-slow.log*
    processors:
    - add_locale: null
    tags:
    - mysql-slowlog
  type: logfile
  use_output: default
- data_stream:
    namespace: default
  id: mysql/metrics-mysql-b3eec291-aaf2-4c70-9953-ec8aae0e442a
  meta:
    package:
      name: mysql
      policy_template: mysql
      release: ga
      version: 1.30.0
  name: mysql-1
  package_policy_id: b3eec291-aaf2-4c70-9953-ec8aae0e442a
  revision: 4
  streams:
  - condition: ${host.name} != "rocky-linux-small"  # <--- condition added
    data_stream:
      dataset: mysql.performance
      type: metrics
    hosts:
    - tcp(127.0.0.1:3306)/
    id: mysql/metrics-mysql.performance-b3eec291-aaf2-4c70-9953-ec8aae0e442a
    metricsets:
    - performance
    password: <REDACTED>
    period: 10s
    username: root
  - condition: ${host.name} != "rocky-linux-small"
    data_stream:
      dataset: mysql.status
      type: metrics
    hosts:
    - tcp(127.0.0.1:3306)/
    id: mysql/metrics-mysql.status-b3eec291-aaf2-4c70-9953-ec8aae0e442a
    metricsets:
    - status
    password: <REDACTED>
    period: 10s
    username: root
  type: mysql/metrics
  use_output: default
- data_stream:
    namespace: default
  id: sql/metrics-mysql-b3eec291-aaf2-4c70-9953-ec8aae0e442a
  meta:
    package:
      name: mysql
      policy_template: mysql
      release: ga
      version: 1.30.0
  name: mysql-1
  package_policy_id: b3eec291-aaf2-4c70-9953-ec8aae0e442a
  revision: 4
  streams:
  - condition: ${host.name} != "rocky-linux-small" # <--- condition added
    data_stream:
      dataset: mysql.replica_status
      type: metrics
    driver: mysql
    hosts:
    - username:password@tcp(localhost:3306)/
    id: sql/metrics-mysql.replica_status-b3eec291-aaf2-4c70-9953-ec8aae0e442a
    metricsets:
    - query
    period: 10m
    sql_queries:
    - query: SHOW REPLICA STATUS;
      response_format: table
    tags:
    - mysql-replica_status
  type: sql/metrics
  use_output: default
```


