### PR TITLE
[wiz] Note maximum historical data in setting descriptions

### DIFF
--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.5.0"
+  changes:
+    - description: Note maximum historical data in setting descriptions.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19281
 - version: "4.4.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/wiz/data_stream/audit/manifest.yml
+++ b/packages/wiz/data_stream/audit/manifest.yml
@@ -10,7 +10,7 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: How far back to pull the Audit logs from Wiz. Supported units for this parameter are h/m/s.
+        description: How far back to pull the Audit logs from Wiz. Supported units for this parameter are h/m/s. Maximum `4320h` (180 days).
         multi: false
         required: true
         show_user: true

--- a/packages/wiz/data_stream/cloud_configuration_finding/manifest.yml
+++ b/packages/wiz/data_stream/cloud_configuration_finding/manifest.yml
@@ -10,7 +10,7 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: How far back to pull the Cloud Configuration Finding logs from Wiz. Supported units for this parameter are h/m/s.
+        description: How far back to pull the Cloud Configuration Finding logs from Wiz. Supported units for this parameter are h/m/s. Maximum `2160h` (90 days).
         multi: false
         required: true
         show_user: true

--- a/packages/wiz/data_stream/cloud_configuration_finding/manifest.yml
+++ b/packages/wiz/data_stream/cloud_configuration_finding/manifest.yml
@@ -10,7 +10,7 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: How far back to pull the Cloud Configuration Finding logs from Wiz. Supported units for this parameter are h/m/s. Maximum `2160h` (90 days).
+        description: How far back to pull the Cloud Configuration Finding logs from Wiz. Supported units for this parameter are h/m/s. Maximum `168h` (7 days).
         multi: false
         required: true
         show_user: true

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: wiz
 title: Wiz
-version: "4.4.0"
+version: "4.5.0"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
Note maximum historical data in setting descriptions

The retention limits are 180 days for audit data, 7 days for cloud
data. Other data sources have no limits.

Relevant API documentation: https://docs.wiz.io/dev/limitations
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 