### PR TITLE
Armis Integration Transforms - Removing Dynamic Mapping

### DIFF
--- a/packages/armis/changelog.yml
+++ b/packages/armis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.3"
+  changes:
+    - description: Remove dynamic mapping from transform definitions to avoid field type conflicts with standard ECS fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19295
 - version: "0.4.2"
   changes:
     - description: Change page_size/batch_size variable type from text to integer for Fleet input validation.

--- a/packages/armis/elasticsearch/transform/latest_alert/manifest.yml
+++ b/packages/armis/elasticsearch/transform/latest_alert/manifest.yml
@@ -1,11 +1,1 @@
 start: true
-destination_index_template:
-  mappings:
-    dynamic: true
-    dynamic_templates:
-      - strings_as_keyword:
-          match_mapping_type: string
-          mapping:
-            ignore_above: 1024
-            type: keyword
-    date_detection: true

--- a/packages/armis/elasticsearch/transform/latest_device/manifest.yml
+++ b/packages/armis/elasticsearch/transform/latest_device/manifest.yml
@@ -1,11 +1,1 @@
 start: true
-destination_index_template:
-  mappings:
-    dynamic: true
-    dynamic_templates:
-      - strings_as_keyword:
-          match_mapping_type: string
-          mapping:
-            ignore_above: 1024
-            type: keyword
-    date_detection: true

--- a/packages/armis/manifest.yml
+++ b/packages/armis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: armis
 title: Armis
-version: "0.4.2"
+version: "0.4.3"
 description: Collect logs from Armis with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Dynamic mappings in the manifests for Armis transforms were taking precedence over ecs@mappings and causing field conflicts in logs-*

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Updating Armis integration to avoid field type conflicts from transforms.  Removed the dynamic mapping from the manifests in these transforms to allow fields to properly use ecs@mappings.  Specifically, there were fields that should have been mapped as match_only_text that were being set to keyword.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Validate the preview for logs-armis.latest_alert-template that dynamic keyword mappings are not at the top of the template
- [ ] Validate the preview for logs-armis.latest_device-template that dynamic keyword mappings are not at the top of the template
