### PR TITLE
feat(chargeback/onprem_billing): realised cost allocation, tier breakdown, dashboard overhaul (0.4.0/0.3.3)

### DIFF
--- a/packages/chargeback/_dev/build/docs/README.md
+++ b/packages/chargeback/_dev/build/docs/README.md
@@ -121,12 +121,15 @@ Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdow
 
 ### Upgrading from 0.3.0
 
-From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, transforms and ingest pipelines write both names on new lookup documents.
+From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, lookup mappings include legacy ECU names as **field aliases** that point to chargeable-unit fields.
 
 **Upgrading from 0.3.1 to 0.3.2:** Upgrading the Fleet package updates transform and ingest definitions, but **restarting transforms does not change mappings on lookup indices that already exist**, and it does not backfill legacy fields on existing documents unless the transform is reset or the destination index is recreated. After upgrading to **0.3.2**:
 
-1. For each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`), either add mappings for the legacy fields (`total_ecu`, `conf_ecu_rate`, `conf_ecu_rate_unit` — same types as in the 0.3.2 package field definitions) with `PUT <index>/_mapping`, or delete the lookup index and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
-2. Start or schedule the `billing_cluster_cost` and `chargeback_conf_lookup` transforms so new documents receive dual-written fields.
+1. For each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`), add field aliases for legacy names with `PUT <index>/_mapping`:
+   - `total_ecu` -> `total_chargeable_units`
+   - `conf_ecu_rate` -> `conf_chargeable_unit_rate`
+   - `conf_ecu_rate_unit` -> `conf_chargeable_unit_rate_unit`
+2. Or delete the lookup index and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
 
 If the dashboard was not replaced on upgrade, re-import the Chargeback dashboard saved objects.
 

--- a/packages/chargeback/_dev/build/docs/README.md
+++ b/packages/chargeback/_dev/build/docs/README.md
@@ -123,13 +123,10 @@ Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdow
 
 From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, lookup mappings include legacy ECU names as **field aliases** that point to chargeable-unit fields.
 
-**Upgrading from 0.3.1 to 0.3.2:** Upgrading the Fleet package updates transform and ingest definitions, but **restarting transforms does not change mappings on lookup indices that already exist**, and it does not backfill legacy fields on existing documents unless the transform is reset or the destination index is recreated. After upgrading to **0.3.2**:
+**Upgrading from 0.3.1 to 0.3.2:** The package already defines these aliases in its transform field mappings. For **new installs** (or newly recreated lookup indices), no manual alias creation is required. Existing 0.3.1 lookup indices keep their old mappings, so after upgrading to **0.3.2**:
 
-1. For each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`), add field aliases for legacy names with `PUT <index>/_mapping`:
-   - `total_ecu` -> `total_chargeable_units`
-   - `conf_ecu_rate` -> `conf_chargeable_unit_rate`
-   - `conf_ecu_rate_unit` -> `conf_chargeable_unit_rate_unit`
-2. Or delete the lookup index and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
+1. Delete each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`) and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
+2. Start or schedule the `billing_cluster_cost` and `chargeback_conf_lookup` transforms.
 
 If the dashboard was not replaced on upgrade, re-import the Chargeback dashboard saved objects.
 

--- a/packages/chargeback/_dev/build/docs/README.md
+++ b/packages/chargeback/_dev/build/docs/README.md
@@ -49,6 +49,11 @@ POST chargeback_conf_lookup/_update/config
     "conf_indexing_weight": 20,
     "conf_query_weight": 20,
     "conf_storage_weight": 40,
+    "conf_utilization_memory_weight": 70,
+    "conf_utilization_storage_weight": 30,
+    "conf_utilization_floor": 0.10,
+    "conf_memory_cost_weight": 50,
+    "conf_storage_cost_weight": 50,
     "conf_start_date": "2024-01-01T00:00:00.000Z",
     "conf_end_date": "2024-12-31T23:59:59.999Z"
   }
@@ -77,21 +82,67 @@ This allows you to have different rates for different time periods (e.g., quarte
 **Configuration Options:**
 - `conf_chargeable_unit_rate`: The monetary value per chargeable unit (ECU/ERU) (e.g., 0.85)
 - `conf_chargeable_unit_rate_unit`: The currency code (e.g., "EUR", "USD", "GBP")
-- `conf_indexing_weight`: Weight for indexing operations (default: 20, only applies to hot tier)
-- `conf_query_weight`: Weight for query operations (default: 20)
-- `conf_storage_weight`: Weight for storage (default: 40)
+- `conf_indexing_weight`: Weight for indexing operations in **blended tier** mix (default: 20, only applies to hot tier)
+- `conf_query_weight`: Weight for query operations in **blended tier** mix (default: 20)
+- `conf_storage_weight`: Weight for storage in **blended tier** mix (default: 40)
+- `conf_utilization_memory_weight`: Weight for heap p95 in utilization score (default: 70)
+- `conf_utilization_storage_weight`: Weight for disk p95 in utilization score (default: 30)
+- `conf_utilization_floor`: Minimum utilization score (0.0–1.0) applied to all deployments regardless of actual usage (default: 0.10). Prevents realized cost from reaching zero for idle or unmonitored clusters.
+- `conf_memory_cost_weight`: Weight for illustrative memory split of `chargeable_pool` in datatiers panels (default: 50)
+- `conf_storage_cost_weight`: Weight for illustrative storage split of `chargeable_pool` in datatiers panels (default: 50)
 - `conf_start_date`: Start date/time for the configuration period (ISO 8601 format)
 - `conf_end_date`: End date/time for the configuration period (ISO 8601 format)
+
+## Realized Cost
+
+Realized cost answers: *of the capacity I purchased, how much am I actually using, and what does that cost?*
+
+### Formula
+
+```
+util_score        = GREATEST((mem_w × heap_p95 + disk_w × disk_p95) / (mem_w + disk_w), floor)
+realized_ecu      = provisioned_ecu × util_score
+realized_cost     = realized_ecu × conf_chargeable_unit_rate
+```
+
+Where:
+- `heap_p95` = p95 heap usage across data nodes (0.0–1.0), sourced from `cluster_capacity_utilization_lookup`. Defaults to 1.0 (100%) when monitoring data is absent.
+- `disk_p95` = p95 disk usage across data nodes (0.0–1.0), same source.
+- `mem_w` / `disk_w` = `conf_utilization_memory_weight` / `conf_utilization_storage_weight` (default 70 / 30)
+- `floor` = `conf_utilization_floor` (default 0.10)
+
+### Why 70 % memory / 30 % storage?
+
+Elasticsearch is a memory-bound workload — heap exhaustion is the primary failure mode and directly impacts query performance. Disk is more manageable via ILM, compression, and tier movement. The 70/30 default reflects this operational reality.
+
+### Why p95?
+
+p95 captures the "reliably busy" signal — it accounts for peak hours without being distorted by brief maintenance spikes (which p99+ would amplify) or washed out like daily averages.
+
+### Why a utilization floor?
+
+Without a floor, idle or unmonitored deployments produce zero realized cost — they appear to consume nothing even though they hold provisioned capacity. A floor of 10 % (default) ensures every deployment contributes proportionally to the shared cost pool, even during quiet periods.
+
+### Decomposition
+
+The `billing_realized_cost_lookup` index stores:
+- `memory_contribution_ecu = realized_ecu × mem_w / (mem_w + disk_w)`
+- `storage_contribution_ecu = realized_ecu × disk_w / (mem_w + disk_w)`
+
+These always sum to `realized_ecu` and let the trellis visualization show which resource type is driving cost for each deployment.
 
 ## Data and Transforms
 
 The integration creates the following transforms to aggregate cost and usage data:
 
-1. **billing_cluster_cost** - Aggregates daily chargeable units (ECU/ERU) per deployment from ESS Billing data, with support for deployment groups via `chargeback_group` tags
-2. **cluster_deployment_contribution** - Calculates per-deployment usage metrics (indexing time, query time, storage) from Elasticsearch monitoring data
-3. **cluster_datastream_contribution** - Aggregates usage per data stream for detailed cost attribution
-4. **cluster_tier_contribution** - Aggregates usage per data tier (hot, warm, cold, frozen)
-5. **cluster_tier_and_ds_contribution** - Combined view of usage by both tier and data stream
+1. **billing_cluster_cost** - Aggregates daily chargeable units (ECU/ERU) per deployment **and SKU** from ESS Billing (`cost_type`, `cost_category`, `is_allocatable`)
+2. **billing_realized_pool** - Aggregates daily **allocatable data-tier capacity** per deployment (one row per deployment/day for realized-cost allocation)
+3. **billing_realized_cost** - Pre-computes daily **realized cost** per deployment: joins provisioned capacity with utilization metrics and applies the weight-based scoring formula and monetary rate. Output fields: `provisioned_ecu`, `realized_ecu`, `memory_contribution_ecu`, `storage_contribution_ecu`, `util_score`, `realized_cost_amount`. Powers the Realized Cost trellis visualization.
+4. **cluster_capacity_utilization** - P95 heap and disk utilization across **data-role nodes** per deployment/day (from `node_stats`)
+5. **cluster_deployment_contribution** - Per-deployment usage metrics (indexing, query, storage) from monitoring indices
+6. **cluster_datastream_contribution** - Usage per data stream
+7. **cluster_tier_contribution** - Usage per data tier
+8. **cluster_tier_and_ds_contribution** - Combined tier and data stream usage
 
 These transforms produce lookup indices that are queried by the dashboard using ES|QL LOOKUP JOINs to correlate billing costs with actual usage patterns.
 
@@ -109,15 +160,29 @@ The integration includes a **Transform Health Monitoring** alert rule template t
 
 ## Dashboard
 
-Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdown` dashboard, which provides:
+Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdown` dashboard, which provides collapsible sections:
 
-- Cost breakdown by deployment, data tier, and data stream
-- Time-series cost trends
-- Deployment group filtering for team/project-based analysis
-- Blended cost metrics combining indexing, querying, and storage usage
-- ECU consumption vs. monetary cost comparison
+- **Cost by component (SKU)** — all billable SKUs via `billing_cluster_cost_lookup` (`cost_type` / `cost_category`)
+- **Datatiers / utilization** — provisioned capacity vs realized pool, utilization p95, and allocated memory/storage **estimates** (not Cloud invoice lines)
+- **Realized Cost** — three Lens panels: (1) stacked area showing aggregate memory vs storage ECU contribution against the provisioned ceiling over time; (2) line chart showing realized monetary cost per deployment over time; (3) summary table with provisioned ECU, realized ECU, utilization %, and cost per deployment.
+- **Deployment / tier / data stream** — allocation from `chargeable_pool` × workload shares (not per-SKU ECU)
+- **Configuration** — rates and weights
 
 ![Cost and Consumption breakdown](../img/chargeback.png)
+
+### Cost reconciliation (FinOps)
+
+Three totals appear on the dashboard; all are valid:
+
+| Total | Source | Use |
+|-------|--------|-----|
+| **Deployment bill** | `SUM(COALESCE(total_chargeable_units, total_ecu))` over **all** SKUs in `billing_cluster_cost_lookup` | Overview, deployment totals |
+| **Provisioned data-tier capacity** | `data_tier_capacity_ecu` in `billing_realized_pool_lookup` | Datatiers “provisioned” |
+| **Realized pool** | `chargeable_pool` = capacity × utilization score (ES\|QL) | Tier and data-stream allocation only |
+
+**Do not expect** tier or data-stream allocated units to equal the full deployment bill. Non-allocatable SKUs (ML, Kibana, transfer, snapshots, …) appear in the SKU overview only. The utilization discount is not spread to tiers/streams by design.
+
+When `node_stats` is missing for a deployment/day, utilization defaults to **100%** (`utilization_data_missing` on datatiers panels).
 
 ### Upgrading from 0.3.0
 
@@ -131,6 +196,25 @@ From **0.3.1** onward, configuration and billing fields use chargeable-unit name
 If the dashboard was not replaced on upgrade, re-import the Chargeback dashboard saved objects.
 
 If you built your own ES|QL, dashboards, or automation against the lookup indices, prefer the chargeable-unit field names when convenient.
+
+### Upgrading to 0.5.0 (realized cost trellis)
+
+1. Upgrade the Fleet package to **0.5.0**.
+2. The new **`billing_realized_cost`** transform starts automatically and creates `billing_realized_cost_lookup`. No action required unless you want to backfill historical data, in which case reset the transform.
+3. The **`chargeback_conf_lookup`** transform is bumped to force a reinstall that adds the new `conf_utilization_floor` field (default `0.10`). Reset the transform if the field is missing after upgrade.
+4. To customize the utilization floor, update the configuration document (see _Configuration_ section above).
+
+New lookup index: `billing_realized_cost_lookup`.
+
+### Upgrading to 0.4.0 (realized cost)
+
+1. Upgrade the Fleet package to **0.4.0**.
+2. **Reset** new transforms: `billing_realized_pool`, `cluster_capacity_utilization`.
+3. **Reset** all Chargeback transforms (pipeline **0.4.0**).
+4. Ensure the Elasticsearch integration collects **`node_stats`** on monitored clusters (data nodes).
+5. Update `chargeback_conf_lookup` if you override utilization or allocated-split weights.
+
+New lookup indices: `billing_realized_pool_lookup`, `cluster_capacity_utilization_lookup`.
 
 ## Deployment Groups
 
@@ -149,30 +233,27 @@ The `billing_cluster_cost` transform automatically extracts these tags from the 
 
 ## Observability Alerting
 
-This integration includes 3 pre-configured alert rule templates that can be installed directly from the integration page in Kibana:
+Alert rule templates provide pre-defined configurations for creating alert rules in Kibana.
 
-1. **Transform Health Monitoring** - Monitors the health of all Chargeback transforms and alerts when they encounter issues or failures
-2. **New Chargeback Group Detected** - Notifies when a new `chargeback_group` tag is added to a deployment
-3. **Deployment with Chargeback Group Missing Usage Data** - Detects when a deployment has a chargeback group assigned but is not sending usage/consumption data
+For more information, refer to the [Elastic documentation](https://www.elastic.co/docs/reference/fleet/alerting-rule-templates).
 
-The templates ship as Kibana alerting rule assets with the package and need **Kibana 9.2.0 or newer**, the same minimum as the integration’s Kibana version condition (see **Requirements** below).
+Alert rule templates require Elastic Stack version 9.2.0 or later.
 
-**Important:** For alert rules 2 and 3, ensure that the Chargeback transforms are running before setting them up. These alerting rules query the lookup indices created by the transforms (`billing_cluster_cost_lookup`, `cluster_deployment_contribution_lookup`, etc.). If the transforms are not started, the alerts will not function correctly.
+The following alert rule templates are available:
 
-### Alert actions
+**[Chargeback] Deployment with chargeback group missing usage data**
 
-**Configure an action** with the following message template appended to the default content (keep the new lines, as it helps with legibility):
 
-```
-Details:
 
-{{`{{#context.hits}}`}}
-• {{`{{_source}}`}}
+**[Chargeback] New chargeback group detected**
 
-{{`{{/context.hits}}`}}
 
-Total: {{`{{context.hits.length}}`}}
-```
+
+**[Chargeback] Transform health monitoring**
+
+
+
+
 
 ## Requirements
 
@@ -183,8 +264,9 @@ To use this integration, the following prerequisites must be met:
 - This is where the Chargeback integration should be installed
 
 **Required Integrations:**
-- [**Elasticsearch Service Billing**](https://www.elastic.co/docs/reference/integrations/ess_billing/) integration (v1.4.1+) must be installed and collecting billing data from your Elastic Cloud organization
-- [**Elasticsearch**](https://www.elastic.co/docs/reference/integrations/elasticsearch/) integration (v1.16.0+) must be installed and collecting [usage data](https://www.elastic.co/docs/reference/integrations/elasticsearch/#indices-and-data-streams-usage-analysis) from all deployments you want to include in chargeback calculations
+- [**Elasticsearch Service Billing**](https://www.elastic.co/docs/reference/integrations/ess_billing/) integration (v1.4.1+) must be installed and collecting billing data from your Elastic Cloud organization _(ESS / Elastic Cloud only)_
+- **[On-Premises Billing](https://github.com/elastic/integrations/tree/main/packages/onprem_billing)** integration (v0.3.3+) as a replacement for ESS Billing when running on-premises (ECE, ECK, self-managed). See that integration's README for ERU/mERU configuration.
+- [**Elasticsearch**](https://www.elastic.co/docs/reference/integrations/elasticsearch/) integration (v1.16.0+) must be installed and collecting [usage data](https://www.elastic.co/docs/reference/integrations/elasticsearch/#indices-and-data-streams-usage-analysis) and **`node_stats`** from data nodes on all deployments you want in chargeback calculations
 
 **Required Transforms:**
 - The transform `logs-elasticsearch.index_pivot-default-{VERSION}` (from the Elasticsearch integration) must be running to aggregate usage metrics per index

--- a/packages/chargeback/_dev/build/docs/README.md
+++ b/packages/chargeback/_dev/build/docs/README.md
@@ -121,7 +121,14 @@ Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdow
 
 ### Upgrading from 0.3.0
 
-From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, transforms and ingest pipelines write both names on lookup documents. After upgrading from **0.3.1**, restart the `billing_cluster_cost` and `chargeback_conf_lookup` transforms so existing lookup indices pick up the legacy alias fields.
+From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, transforms and ingest pipelines write both names on new lookup documents.
+
+**Upgrading from 0.3.1 to 0.3.2:** Upgrading the Fleet package updates transform and ingest definitions, but **restarting transforms does not change mappings on lookup indices that already exist**, and it does not backfill legacy fields on existing documents unless the transform is reset or the destination index is recreated. After upgrading to **0.3.2**:
+
+1. For each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`), either add mappings for the legacy fields (`total_ecu`, `conf_ecu_rate`, `conf_ecu_rate_unit` — same types as in the 0.3.2 package field definitions) with `PUT <index>/_mapping`, or delete the lookup index and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
+2. Start or schedule the `billing_cluster_cost` and `chargeback_conf_lookup` transforms so new documents receive dual-written fields.
+
+If the dashboard was not replaced on upgrade, re-import the Chargeback dashboard saved objects.
 
 If you built your own ES|QL, dashboards, or automation against the lookup indices, prefer the chargeable-unit field names when convenient.
 

--- a/packages/chargeback/_dev/build/docs/README.md
+++ b/packages/chargeback/_dev/build/docs/README.md
@@ -121,9 +121,9 @@ Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdow
 
 ### Upgrading from 0.3.0
 
-From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). The dashboard queries accept both the new and the previous field names, so you do not need to change existing documents in the lookup indices for panels to work. New data from the updated transforms uses the new names over time.
+From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, transforms and ingest pipelines write both names on lookup documents. After upgrading from **0.3.1**, restart the `billing_cluster_cost` and `chargeback_conf_lookup` transforms so existing lookup indices pick up the legacy alias fields.
 
-If you built your own ES|QL, dashboards, or automation against the lookup indices, update those to the new field names when convenient.
+If you built your own ES|QL, dashboards, or automation against the lookup indices, prefer the chargeable-unit field names when convenient.
 
 ## Deployment Groups
 

--- a/packages/chargeback/changelog.yml
+++ b/packages/chargeback/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: 0.3.2
   changes:
+    - description: "Fix dashboard ES|QL verification errors on 0.3.1 (`Unknown column [total_ecu]` / `[conf_ecu_rate]`) by dual-writing legacy ECU field names alongside chargeable-unit fields in transforms, mappings, and ingest pipelines. Wire chargeback_conf_lookup transform through its ingest pipeline; mirror conf_ecu_rate_unit in the ingest pipeline only (not transform max on keyword)."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/99
     - description: "Read Elasticsearch index-pivot usage from index pattern `monitoring-indices*` (and `*:monitoring-indices*` for CCS) so custom pivot destination names remain compatible. Bump transform pipelines and fleet_transform_version to 0.3.2. See elasticsearch-chargeback#90."
       type: enhancement
       link: https://github.com/elastic/elasticsearch-chargeback/issues/90

--- a/packages/chargeback/changelog.yml
+++ b/packages/chargeback/changelog.yml
@@ -1,4 +1,39 @@
 # newer versions go on top
+- version: 0.4.0
+  changes:
+    - description: "Dashboard: remove @timestamp:exists filter, set default timepicker to last 3 months. Panels now open with data visible without adjusting the time picker."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Dashboard panel fixes: rename 'Realized chargeable units per deployment' → 'Provisioned vs Realized Pool per Deployment' and fix adHocDataViews/column mismatch that caused 'column invalid: deployment_name' error. Rename 'Realized chargeable units' column in 'Chargeable pool by data tier' table to 'Normalised cost' (column is currency, not ECU). Remove misleading 'Provisioned capacity (ECU)' column from tier table (same value for every tier due to deployment-level lookup join)."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Shorten verbose markdown section headers in 'Cost by component (SKU)' and 'Datatiers / utilization' sections to single-line summaries."
+      type: enhancement
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Fix dashboard ES|QL: correct LOOKUP JOIN direction for tier panels (swap source to cluster_tier_contribution_lookup so all tiers are returned, not just one), add COALESCE 1.0 rate fallback, fix vis column UUIDs, remove stale 0.4.0-*.yml versioned pipeline files that caused Fleet install to fail, bump transform fleet_transform_version and pipeline references to 0.4.0."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Realized cost (issue #8): data-tier capacity pool per deployment/day (`billing_realized_pool`), cluster-wide utilization p95 (`cluster_capacity_utilization`), utilization-weighted `chargeable_pool` for tier/data-stream allocation, SKU `cost_type`/`cost_category`/`onprem`, datatiers dashboard section, and FinOps reconciliation docs. Tier/DS ES|QL uses realized pool instead of per-SKU ECU. New conf weights for utilization and allocated memory/storage display. Requires Elasticsearch `node_stats` on data nodes. Bump transforms to 0.4.0."
+      type: enhancement
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Fix dashboard ES|QL: remove duplicate `cluster_tier_contribution_lookup` joins in tier-based panels (panels were producing n-tier times inflated values), fix cartesian product between datastream and tier lookups in blended-cost panels 15 and 33 (now use `cluster_tier_and_datastream_contribution_lookup` for correct per-tier weighting), remove spurious joins in panel 16."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Fix `billing.yml` ingest pipeline: content-tier SKUs (`*.es.datacontent.*`) were not renamed to `datahot/datacontent`, causing them to appear as a separate cost_type from hot-tier nodes. Both hot and content nodes now show consistently as `datahot/datacontent`."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Fix 'Realized chargeable units per deployment' panel: it was showing `realized_chargeable_units` (which equals provisioned capacity) twice. Now shows provisioned ECU alongside the utilization-adjusted realized pool (`chargeable_pool = provisioned × utilization_score`)."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Uncollapse 'Data tier and data stream overview' dashboard section: the key blended-cost-per-datastream panels (treemap, table, pie) were hidden by default."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Fix dashboard panel layout: 'Provisioned vs Realized pool per deployment' and 'Chargeable pool by data tier' panels in the Datatiers section were both placed at y=0, causing them to overlap with the section header. Repositioned to render below the header."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+    - description: "Rename auto-generated dashboard panel titles (e.g. 'agg_indexing over @timestamp', 'Bar vertical stacked', 'Treemap', 'Pie') to descriptive names so users can understand each panel without opening it."
+      type: enhancement
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
 - version: 0.3.2
   changes:
     - description: "Fix dashboard ES|QL verification errors on 0.3.1 (`Unknown column [total_ecu]` / `[conf_ecu_rate]`) by adding legacy ECU field aliases in lookup mappings (`total_ecu` -> `total_chargeable_units`, `conf_ecu_rate` -> `conf_chargeable_unit_rate`, `conf_ecu_rate_unit` -> `conf_chargeable_unit_rate_unit`)."

--- a/packages/chargeback/changelog.yml
+++ b/packages/chargeback/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 0.3.2
   changes:
-    - description: "Fix dashboard ES|QL verification errors on 0.3.1 (`Unknown column [total_ecu]` / `[conf_ecu_rate]`) by dual-writing legacy ECU field names alongside chargeable-unit fields in transforms, mappings, and ingest pipelines. Wire chargeback_conf_lookup transform through its ingest pipeline; mirror conf_ecu_rate_unit in the ingest pipeline only (not transform max on keyword)."
+    - description: "Fix dashboard ES|QL verification errors on 0.3.1 (`Unknown column [total_ecu]` / `[conf_ecu_rate]`) by adding legacy ECU field aliases in lookup mappings (`total_ecu` -> `total_chargeable_units`, `conf_ecu_rate` -> `conf_chargeable_unit_rate`, `conf_ecu_rate_unit` -> `conf_chargeable_unit_rate_unit`)."
       type: bugfix
       link: https://github.com/elastic/elasticsearch-chargeback/issues/99
     - description: "Read Elasticsearch index-pivot usage from index pattern `monitoring-indices*` (and `*:monitoring-indices*` for CCS) so custom pivot destination names remain compatible. Bump transform pipelines and fleet_transform_version to 0.3.2. See elasticsearch-chargeback#90."

--- a/packages/chargeback/docs/README.md
+++ b/packages/chargeback/docs/README.md
@@ -121,12 +121,15 @@ Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdow
 
 ### Upgrading from 0.3.0
 
-From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, transforms and ingest pipelines write both names on new lookup documents.
+From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, lookup mappings include legacy ECU names as **field aliases** that point to chargeable-unit fields.
 
 **Upgrading from 0.3.1 to 0.3.2:** Upgrading the Fleet package updates transform and ingest definitions, but **restarting transforms does not change mappings on lookup indices that already exist**, and it does not backfill legacy fields on existing documents unless the transform is reset or the destination index is recreated. After upgrading to **0.3.2**:
 
-1. For each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`), either add mappings for the legacy fields (`total_ecu`, `conf_ecu_rate`, `conf_ecu_rate_unit` — same types as in the 0.3.2 package field definitions) with `PUT <index>/_mapping`, or delete the lookup index and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
-2. Start or schedule the `billing_cluster_cost` and `chargeback_conf_lookup` transforms so new documents receive dual-written fields.
+1. For each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`), add field aliases for legacy names with `PUT <index>/_mapping`:
+   - `total_ecu` -> `total_chargeable_units`
+   - `conf_ecu_rate` -> `conf_chargeable_unit_rate`
+   - `conf_ecu_rate_unit` -> `conf_chargeable_unit_rate_unit`
+2. Or delete the lookup index and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
 
 If the dashboard was not replaced on upgrade, re-import the Chargeback dashboard saved objects.
 

--- a/packages/chargeback/docs/README.md
+++ b/packages/chargeback/docs/README.md
@@ -123,13 +123,10 @@ Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdow
 
 From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, lookup mappings include legacy ECU names as **field aliases** that point to chargeable-unit fields.
 
-**Upgrading from 0.3.1 to 0.3.2:** Upgrading the Fleet package updates transform and ingest definitions, but **restarting transforms does not change mappings on lookup indices that already exist**, and it does not backfill legacy fields on existing documents unless the transform is reset or the destination index is recreated. After upgrading to **0.3.2**:
+**Upgrading from 0.3.1 to 0.3.2:** The package already defines these aliases in its transform field mappings. For **new installs** (or newly recreated lookup indices), no manual alias creation is required. Existing 0.3.1 lookup indices keep their old mappings, so after upgrading to **0.3.2**:
 
-1. For each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`), add field aliases for legacy names with `PUT <index>/_mapping`:
-   - `total_ecu` -> `total_chargeable_units`
-   - `conf_ecu_rate` -> `conf_chargeable_unit_rate`
-   - `conf_ecu_rate_unit` -> `conf_chargeable_unit_rate_unit`
-2. Or delete the lookup index and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
+1. Delete each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`) and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
+2. Start or schedule the `billing_cluster_cost` and `chargeback_conf_lookup` transforms.
 
 If the dashboard was not replaced on upgrade, re-import the Chargeback dashboard saved objects.
 

--- a/packages/chargeback/docs/README.md
+++ b/packages/chargeback/docs/README.md
@@ -49,6 +49,11 @@ POST chargeback_conf_lookup/_update/config
     "conf_indexing_weight": 20,
     "conf_query_weight": 20,
     "conf_storage_weight": 40,
+    "conf_utilization_memory_weight": 70,
+    "conf_utilization_storage_weight": 30,
+    "conf_utilization_floor": 0.10,
+    "conf_memory_cost_weight": 50,
+    "conf_storage_cost_weight": 50,
     "conf_start_date": "2024-01-01T00:00:00.000Z",
     "conf_end_date": "2024-12-31T23:59:59.999Z"
   }
@@ -77,21 +82,67 @@ This allows you to have different rates for different time periods (e.g., quarte
 **Configuration Options:**
 - `conf_chargeable_unit_rate`: The monetary value per chargeable unit (ECU/ERU) (e.g., 0.85)
 - `conf_chargeable_unit_rate_unit`: The currency code (e.g., "EUR", "USD", "GBP")
-- `conf_indexing_weight`: Weight for indexing operations (default: 20, only applies to hot tier)
-- `conf_query_weight`: Weight for query operations (default: 20)
-- `conf_storage_weight`: Weight for storage (default: 40)
+- `conf_indexing_weight`: Weight for indexing operations in **blended tier** mix (default: 20, only applies to hot tier)
+- `conf_query_weight`: Weight for query operations in **blended tier** mix (default: 20)
+- `conf_storage_weight`: Weight for storage in **blended tier** mix (default: 40)
+- `conf_utilization_memory_weight`: Weight for heap p95 in utilization score (default: 70)
+- `conf_utilization_storage_weight`: Weight for disk p95 in utilization score (default: 30)
+- `conf_utilization_floor`: Minimum utilization score (0.0–1.0) applied to all deployments regardless of actual usage (default: 0.10). Prevents realized cost from reaching zero for idle or unmonitored clusters.
+- `conf_memory_cost_weight`: Weight for illustrative memory split of `chargeable_pool` in datatiers panels (default: 50)
+- `conf_storage_cost_weight`: Weight for illustrative storage split of `chargeable_pool` in datatiers panels (default: 50)
 - `conf_start_date`: Start date/time for the configuration period (ISO 8601 format)
 - `conf_end_date`: End date/time for the configuration period (ISO 8601 format)
+
+## Realized Cost
+
+Realized cost answers: *of the capacity I purchased, how much am I actually using, and what does that cost?*
+
+### Formula
+
+```
+util_score        = GREATEST((mem_w × heap_p95 + disk_w × disk_p95) / (mem_w + disk_w), floor)
+realized_ecu      = provisioned_ecu × util_score
+realized_cost     = realized_ecu × conf_chargeable_unit_rate
+```
+
+Where:
+- `heap_p95` = p95 heap usage across data nodes (0.0–1.0), sourced from `cluster_capacity_utilization_lookup`. Defaults to 1.0 (100%) when monitoring data is absent.
+- `disk_p95` = p95 disk usage across data nodes (0.0–1.0), same source.
+- `mem_w` / `disk_w` = `conf_utilization_memory_weight` / `conf_utilization_storage_weight` (default 70 / 30)
+- `floor` = `conf_utilization_floor` (default 0.10)
+
+### Why 70 % memory / 30 % storage?
+
+Elasticsearch is a memory-bound workload — heap exhaustion is the primary failure mode and directly impacts query performance. Disk is more manageable via ILM, compression, and tier movement. The 70/30 default reflects this operational reality.
+
+### Why p95?
+
+p95 captures the "reliably busy" signal — it accounts for peak hours without being distorted by brief maintenance spikes (which p99+ would amplify) or washed out like daily averages.
+
+### Why a utilization floor?
+
+Without a floor, idle or unmonitored deployments produce zero realized cost — they appear to consume nothing even though they hold provisioned capacity. A floor of 10 % (default) ensures every deployment contributes proportionally to the shared cost pool, even during quiet periods.
+
+### Decomposition
+
+The `billing_realized_cost_lookup` index stores:
+- `memory_contribution_ecu = realized_ecu × mem_w / (mem_w + disk_w)`
+- `storage_contribution_ecu = realized_ecu × disk_w / (mem_w + disk_w)`
+
+These always sum to `realized_ecu` and let the trellis visualization show which resource type is driving cost for each deployment.
 
 ## Data and Transforms
 
 The integration creates the following transforms to aggregate cost and usage data:
 
-1. **billing_cluster_cost** - Aggregates daily chargeable units (ECU/ERU) per deployment from ESS Billing data, with support for deployment groups via `chargeback_group` tags
-2. **cluster_deployment_contribution** - Calculates per-deployment usage metrics (indexing time, query time, storage) from Elasticsearch monitoring data
-3. **cluster_datastream_contribution** - Aggregates usage per data stream for detailed cost attribution
-4. **cluster_tier_contribution** - Aggregates usage per data tier (hot, warm, cold, frozen)
-5. **cluster_tier_and_ds_contribution** - Combined view of usage by both tier and data stream
+1. **billing_cluster_cost** - Aggregates daily chargeable units (ECU/ERU) per deployment **and SKU** from ESS Billing (`cost_type`, `cost_category`, `is_allocatable`)
+2. **billing_realized_pool** - Aggregates daily **allocatable data-tier capacity** per deployment (one row per deployment/day for realized-cost allocation)
+3. **billing_realized_cost** - Pre-computes daily **realized cost** per deployment: joins provisioned capacity with utilization metrics and applies the weight-based scoring formula and monetary rate. Output fields: `provisioned_ecu`, `realized_ecu`, `memory_contribution_ecu`, `storage_contribution_ecu`, `util_score`, `realized_cost_amount`. Powers the Realized Cost trellis visualization.
+4. **cluster_capacity_utilization** - P95 heap and disk utilization across **data-role nodes** per deployment/day (from `node_stats`)
+5. **cluster_deployment_contribution** - Per-deployment usage metrics (indexing, query, storage) from monitoring indices
+6. **cluster_datastream_contribution** - Usage per data stream
+7. **cluster_tier_contribution** - Usage per data tier
+8. **cluster_tier_and_ds_contribution** - Combined tier and data stream usage
 
 These transforms produce lookup indices that are queried by the dashboard using ES|QL LOOKUP JOINs to correlate billing costs with actual usage patterns.
 
@@ -109,15 +160,29 @@ The integration includes a **Transform Health Monitoring** alert rule template t
 
 ## Dashboard
 
-Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdown` dashboard, which provides:
+Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdown` dashboard, which provides collapsible sections:
 
-- Cost breakdown by deployment, data tier, and data stream
-- Time-series cost trends
-- Deployment group filtering for team/project-based analysis
-- Blended cost metrics combining indexing, querying, and storage usage
-- ECU consumption vs. monetary cost comparison
+- **Cost by component (SKU)** — all billable SKUs via `billing_cluster_cost_lookup` (`cost_type` / `cost_category`)
+- **Datatiers / utilization** — provisioned capacity vs realized pool, utilization p95, and allocated memory/storage **estimates** (not Cloud invoice lines)
+- **Realized Cost** — three Lens panels: (1) stacked area showing aggregate memory vs storage ECU contribution against the provisioned ceiling over time; (2) line chart showing realized monetary cost per deployment over time; (3) summary table with provisioned ECU, realized ECU, utilization %, and cost per deployment.
+- **Deployment / tier / data stream** — allocation from `chargeable_pool` × workload shares (not per-SKU ECU)
+- **Configuration** — rates and weights
 
 ![Cost and Consumption breakdown](../img/chargeback.png)
+
+### Cost reconciliation (FinOps)
+
+Three totals appear on the dashboard; all are valid:
+
+| Total | Source | Use |
+|-------|--------|-----|
+| **Deployment bill** | `SUM(COALESCE(total_chargeable_units, total_ecu))` over **all** SKUs in `billing_cluster_cost_lookup` | Overview, deployment totals |
+| **Provisioned data-tier capacity** | `data_tier_capacity_ecu` in `billing_realized_pool_lookup` | Datatiers “provisioned” |
+| **Realized pool** | `chargeable_pool` = capacity × utilization score (ES\|QL) | Tier and data-stream allocation only |
+
+**Do not expect** tier or data-stream allocated units to equal the full deployment bill. Non-allocatable SKUs (ML, Kibana, transfer, snapshots, …) appear in the SKU overview only. The utilization discount is not spread to tiers/streams by design.
+
+When `node_stats` is missing for a deployment/day, utilization defaults to **100%** (`utilization_data_missing` on datatiers panels).
 
 ### Upgrading from 0.3.0
 
@@ -131,6 +196,25 @@ From **0.3.1** onward, configuration and billing fields use chargeable-unit name
 If the dashboard was not replaced on upgrade, re-import the Chargeback dashboard saved objects.
 
 If you built your own ES|QL, dashboards, or automation against the lookup indices, prefer the chargeable-unit field names when convenient.
+
+### Upgrading to 0.5.0 (realized cost trellis)
+
+1. Upgrade the Fleet package to **0.5.0**.
+2. The new **`billing_realized_cost`** transform starts automatically and creates `billing_realized_cost_lookup`. No action required unless you want to backfill historical data, in which case reset the transform.
+3. The **`chargeback_conf_lookup`** transform is bumped to force a reinstall that adds the new `conf_utilization_floor` field (default `0.10`). Reset the transform if the field is missing after upgrade.
+4. To customize the utilization floor, update the configuration document (see _Configuration_ section above).
+
+New lookup index: `billing_realized_cost_lookup`.
+
+### Upgrading to 0.4.0 (realized cost)
+
+1. Upgrade the Fleet package to **0.4.0**.
+2. **Reset** new transforms: `billing_realized_pool`, `cluster_capacity_utilization`.
+3. **Reset** all Chargeback transforms (pipeline **0.4.0**).
+4. Ensure the Elasticsearch integration collects **`node_stats`** on monitored clusters (data nodes).
+5. Update `chargeback_conf_lookup` if you override utilization or allocated-split weights.
+
+New lookup indices: `billing_realized_pool_lookup`, `cluster_capacity_utilization_lookup`.
 
 ## Deployment Groups
 
@@ -149,30 +233,27 @@ The `billing_cluster_cost` transform automatically extracts these tags from the 
 
 ## Observability Alerting
 
-This integration includes 3 pre-configured alert rule templates that can be installed directly from the integration page in Kibana:
+Alert rule templates provide pre-defined configurations for creating alert rules in Kibana.
 
-1. **Transform Health Monitoring** - Monitors the health of all Chargeback transforms and alerts when they encounter issues or failures
-2. **New Chargeback Group Detected** - Notifies when a new `chargeback_group` tag is added to a deployment
-3. **Deployment with Chargeback Group Missing Usage Data** - Detects when a deployment has a chargeback group assigned but is not sending usage/consumption data
+For more information, refer to the [Elastic documentation](https://www.elastic.co/docs/reference/fleet/alerting-rule-templates).
 
-The templates ship as Kibana alerting rule assets with the package and need **Kibana 9.2.0 or newer**, the same minimum as the integration’s Kibana version condition (see **Requirements** below).
+Alert rule templates require Elastic Stack version 9.2.0 or later.
 
-**Important:** For alert rules 2 and 3, ensure that the Chargeback transforms are running before setting them up. These alerting rules query the lookup indices created by the transforms (`billing_cluster_cost_lookup`, `cluster_deployment_contribution_lookup`, etc.). If the transforms are not started, the alerts will not function correctly.
+The following alert rule templates are available:
 
-### Alert actions
+**[Chargeback] Deployment with chargeback group missing usage data**
 
-**Configure an action** with the following message template appended to the default content (keep the new lines, as it helps with legibility):
 
-```
-Details:
 
-{{#context.hits}}
-• {{_source}}
+**[Chargeback] New chargeback group detected**
 
-{{/context.hits}}
 
-Total: {{context.hits.length}}
-```
+
+**[Chargeback] Transform health monitoring**
+
+
+
+
 
 ## Requirements
 
@@ -183,8 +264,9 @@ To use this integration, the following prerequisites must be met:
 - This is where the Chargeback integration should be installed
 
 **Required Integrations:**
-- [**Elasticsearch Service Billing**](https://www.elastic.co/docs/reference/integrations/ess_billing/) integration (v1.4.1+) must be installed and collecting billing data from your Elastic Cloud organization
-- [**Elasticsearch**](https://www.elastic.co/docs/reference/integrations/elasticsearch/) integration (v1.16.0+) must be installed and collecting [usage data](https://www.elastic.co/docs/reference/integrations/elasticsearch/#indices-and-data-streams-usage-analysis) from all deployments you want to include in chargeback calculations
+- [**Elasticsearch Service Billing**](https://www.elastic.co/docs/reference/integrations/ess_billing/) integration (v1.4.1+) must be installed and collecting billing data from your Elastic Cloud organization _(ESS / Elastic Cloud only)_
+- **[On-Premises Billing](https://github.com/elastic/integrations/tree/main/packages/onprem_billing)** integration (v0.3.3+) as a replacement for ESS Billing when running on-premises (ECE, ECK, self-managed). See that integration's README for ERU/mERU configuration.
+- [**Elasticsearch**](https://www.elastic.co/docs/reference/integrations/elasticsearch/) integration (v1.16.0+) must be installed and collecting [usage data](https://www.elastic.co/docs/reference/integrations/elasticsearch/#indices-and-data-streams-usage-analysis) and **`node_stats`** from data nodes on all deployments you want in chargeback calculations
 
 **Required Transforms:**
 - The transform `logs-elasticsearch.index_pivot-default-{VERSION}` (from the Elasticsearch integration) must be running to aggregate usage metrics per index

--- a/packages/chargeback/docs/README.md
+++ b/packages/chargeback/docs/README.md
@@ -121,7 +121,14 @@ Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdow
 
 ### Upgrading from 0.3.0
 
-From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, transforms and ingest pipelines write both names on lookup documents. After upgrading from **0.3.1**, restart the `billing_cluster_cost` and `chargeback_conf_lookup` transforms so existing lookup indices pick up the legacy alias fields.
+From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, transforms and ingest pipelines write both names on new lookup documents.
+
+**Upgrading from 0.3.1 to 0.3.2:** Upgrading the Fleet package updates transform and ingest definitions, but **restarting transforms does not change mappings on lookup indices that already exist**, and it does not backfill legacy fields on existing documents unless the transform is reset or the destination index is recreated. After upgrading to **0.3.2**:
+
+1. For each affected lookup index (`billing_cluster_cost_lookup`, `chargeback_conf_lookup`), either add mappings for the legacy fields (`total_ecu`, `conf_ecu_rate`, `conf_ecu_rate_unit` — same types as in the 0.3.2 package field definitions) with `PUT <index>/_mapping`, or delete the lookup index and **reset** the corresponding transform so the index is recreated with 0.3.2 mappings (reprocesses historical data; plan for load and sync delay).
+2. Start or schedule the `billing_cluster_cost` and `chargeback_conf_lookup` transforms so new documents receive dual-written fields.
+
+If the dashboard was not replaced on upgrade, re-import the Chargeback dashboard saved objects.
 
 If you built your own ES|QL, dashboards, or automation against the lookup indices, prefer the chargeable-unit field names when convenient.
 

--- a/packages/chargeback/docs/README.md
+++ b/packages/chargeback/docs/README.md
@@ -121,9 +121,9 @@ Chargeback data can be viewed in the `[Chargeback] Cost and Consumption breakdow
 
 ### Upgrading from 0.3.0
 
-From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). The dashboard queries accept both the new and the previous field names, so you do not need to change existing documents in the lookup indices for panels to work. New data from the updated transforms uses the new names over time.
+From **0.3.1** onward, configuration and billing fields use chargeable-unit names (for example `conf_chargeable_unit_rate` and `total_chargeable_units` instead of `conf_ecu_rate` and `total_ecu`). Dashboard ES|QL uses `COALESCE` across both names; **both columns must exist in the lookup index mapping** or panels fail at query time. From **0.3.2** onward, transforms and ingest pipelines write both names on lookup documents. After upgrading from **0.3.1**, restart the `billing_cluster_cost` and `chargeback_conf_lookup` transforms so existing lookup indices pick up the legacy alias fields.
 
-If you built your own ES|QL, dashboards, or automation against the lookup indices, update those to the new field names when convenient.
+If you built your own ES|QL, dashboards, or automation against the lookup indices, prefer the chargeable-unit field names when convenient.
 
 ## Deployment Groups
 

--- a/packages/chargeback/elasticsearch/ingest_pipeline/billing.yml
+++ b/packages/chargeback/elasticsearch/ingest_pipeline/billing.yml
@@ -35,16 +35,6 @@ processors:
       field: cost_type
       value: 'datahot/datacontent'
       if: ctx.cost_type == 'datahot'
-  - script:
-      description: Mirror chargeable-unit fields to legacy ECU names for dashboard ES|QL COALESCE
-      ignore_failure: true
-      lang: painless
-      source: |
-        if (ctx.total_chargeable_units != null) {
-          ctx.total_ecu = ctx.total_chargeable_units;
-        } else if (ctx.total_ecu != null) {
-          ctx.total_chargeable_units = ctx.total_ecu;
-        }
   - pipeline:
       description: '[Fleet] Global pipeline for all data streams'
       ignore_missing_pipeline: true

--- a/packages/chargeback/elasticsearch/ingest_pipeline/billing.yml
+++ b/packages/chargeback/elasticsearch/ingest_pipeline/billing.yml
@@ -34,7 +34,53 @@ processors:
   - set:
       field: cost_type
       value: 'datahot/datacontent'
-      if: ctx.cost_type == 'datahot'
+      if: ctx.cost_type == 'datahot' || ctx.cost_type == 'datacontent'
+  - set:
+      field: cost_type
+      value: 'onprem'
+      if: ctx.sku == 'onprem_node'
+  - script:
+      ignore_failure: true
+      lang: painless
+      description: |
+        cost_category: data_tier | platform | transfer | snapshot | onprem | other
+        is_allocatable: true for data_tier SKUs and onprem_node (realized pool, §6.1)
+      source: |
+        if (ctx.sku == 'onprem_node' || ctx.cost_type == 'onprem') {
+          ctx.cost_category = 'onprem';
+          ctx.is_allocatable = true;
+          return;
+        }
+        if (ctx.cost_type == 'data-transfer') {
+          ctx.cost_category = 'transfer';
+          ctx.is_allocatable = false;
+          return;
+        }
+        if (ctx.cost_type == 'snapshots') {
+          ctx.cost_category = 'snapshot';
+          ctx.is_allocatable = false;
+          return;
+        }
+        def sku = ctx.sku;
+        if (sku != null) {
+          if (sku.contains('.es.datahot.') || sku.contains('.es.datawarm.')
+              || sku.contains('.es.datacold.') || sku.contains('.es.datafrozen.')
+              || sku.contains('.es.datacontent.')) {
+            ctx.cost_category = 'data_tier';
+            ctx.is_allocatable = true;
+            return;
+          }
+        }
+        if (ctx.cost_type != null) {
+          if (ctx.cost_type == 'ml' || ctx.cost_type == 'kibana' || ctx.cost_type == 'apm'
+              || ctx.cost_type == 'enterprise_search' || ctx.cost_type == 'integrations_server') {
+            ctx.cost_category = 'platform';
+            ctx.is_allocatable = false;
+            return;
+          }
+        }
+        ctx.cost_category = 'other';
+        ctx.is_allocatable = false;
   - pipeline:
       description: '[Fleet] Global pipeline for all data streams'
       ignore_missing_pipeline: true

--- a/packages/chargeback/elasticsearch/ingest_pipeline/billing.yml
+++ b/packages/chargeback/elasticsearch/ingest_pipeline/billing.yml
@@ -35,6 +35,16 @@ processors:
       field: cost_type
       value: 'datahot/datacontent'
       if: ctx.cost_type == 'datahot'
+  - script:
+      description: Mirror chargeable-unit fields to legacy ECU names for dashboard ES|QL COALESCE
+      ignore_failure: true
+      lang: painless
+      source: |
+        if (ctx.total_chargeable_units != null) {
+          ctx.total_ecu = ctx.total_chargeable_units;
+        } else if (ctx.total_ecu != null) {
+          ctx.total_chargeable_units = ctx.total_ecu;
+        }
   - pipeline:
       description: '[Fleet] Global pipeline for all data streams'
       ignore_missing_pipeline: true

--- a/packages/chargeback/elasticsearch/ingest_pipeline/capacity_utilization.yml
+++ b/packages/chargeback/elasticsearch/ingest_pipeline/capacity_utilization.yml
@@ -1,0 +1,58 @@
+---
+description: "Chargeback: cluster capacity utilization lookup — composite_key and normalized utilization fields."
+processors:
+  - set:
+      field: deployment_id
+      copy_from: cluster_name
+      ignore_empty_value: true
+  - script:
+      ignore_failure: true
+      lang: painless
+      source: |
+        if (ctx['@timestamp'] != null && ctx.deployment_id != null) {
+            ctx.composite_key = ZonedDateTime.parse(ctx['@timestamp']).toLocalDate().toString() + '_' + ctx.deployment_id;
+        }
+        if (ctx.heap_used_pct_p95 != null) {
+            def heap = ctx.heap_used_pct_p95;
+            def v = null;
+            if (heap instanceof Map) {
+              if (heap.values != null) {
+                v = heap.values['95.0'];
+                if (v == null) { v = heap.values['95']; }
+              }
+              if (v == null) { v = heap['95.0']; }
+              if (v == null) { v = heap['95']; }
+            }
+            if (v != null) {
+              ctx.heap_used_pct_p95 = v;
+              ctx.memory_utilization = v / 100.0;
+            }
+        }
+        if (ctx.disk_used_pct_p95 != null) {
+            def disk = ctx.disk_used_pct_p95;
+            def v = null;
+            if (disk instanceof Map) {
+              if (disk.values != null) {
+                v = disk.values['95.0'];
+                if (v == null) { v = disk.values['95']; }
+              }
+              if (v == null) { v = disk['95.0']; }
+              if (v == null) { v = disk['95']; }
+            }
+            if (v != null) {
+              ctx.disk_used_pct_p95 = v;
+              ctx.storage_utilization = v / 100.0;
+            }
+        }
+  - pipeline:
+      description: '[Fleet] Global pipeline for all data streams'
+      ignore_missing_pipeline: true
+      name: global@custom
+  - pipeline:
+      description: '[Fleet] Pipeline for all data streams of type `metrics`'
+      ignore_missing_pipeline: true
+      name: metrics@custom
+  - pipeline:
+      description: '[Fleet] Pipeline for all data streams of type `metrics` defined by the `chargeback` integration'
+      ignore_missing_pipeline: true
+      name: metrics-chargeback.integration@custom

--- a/packages/chargeback/elasticsearch/ingest_pipeline/chargeback_conf_lookup.yml
+++ b/packages/chargeback/elasticsearch/ingest_pipeline/chargeback_conf_lookup.yml
@@ -11,6 +11,16 @@ processors:
             ctx.conf_chargeable_unit_rate_unit = keys[0];
           }
         }
+        if (ctx.conf_chargeable_unit_rate != null) {
+          ctx.conf_ecu_rate = ctx.conf_chargeable_unit_rate;
+        } else if (ctx.conf_ecu_rate != null) {
+          ctx.conf_chargeable_unit_rate = ctx.conf_ecu_rate;
+        }
+        if (ctx.conf_chargeable_unit_rate_unit != null) {
+          ctx.conf_ecu_rate_unit = ctx.conf_chargeable_unit_rate_unit;
+        } else if (ctx.conf_ecu_rate_unit != null) {
+          ctx.conf_chargeable_unit_rate_unit = ctx.conf_ecu_rate_unit;
+        }
 on_failure:
   - set:
       field: error.message

--- a/packages/chargeback/elasticsearch/ingest_pipeline/chargeback_conf_lookup.yml
+++ b/packages/chargeback/elasticsearch/ingest_pipeline/chargeback_conf_lookup.yml
@@ -11,16 +11,6 @@ processors:
             ctx.conf_chargeable_unit_rate_unit = keys[0];
           }
         }
-        if (ctx.conf_chargeable_unit_rate != null) {
-          ctx.conf_ecu_rate = ctx.conf_chargeable_unit_rate;
-        } else if (ctx.conf_ecu_rate != null) {
-          ctx.conf_chargeable_unit_rate = ctx.conf_ecu_rate;
-        }
-        if (ctx.conf_chargeable_unit_rate_unit != null) {
-          ctx.conf_ecu_rate_unit = ctx.conf_chargeable_unit_rate_unit;
-        } else if (ctx.conf_ecu_rate_unit != null) {
-          ctx.conf_chargeable_unit_rate_unit = ctx.conf_ecu_rate_unit;
-        }
 on_failure:
   - set:
       field: error.message

--- a/packages/chargeback/elasticsearch/ingest_pipeline/realized_pool.yml
+++ b/packages/chargeback/elasticsearch/ingest_pipeline/realized_pool.yml
@@ -1,0 +1,27 @@
+---
+description: "Chargeback: realized pool lookup — composite_key and chargeable-unit aliases."
+processors:
+  - script:
+      ignore_failure: true
+      lang: painless
+      source: |
+        if (ctx['@timestamp'] != null && ctx.deployment_id != null) {
+            ctx.composite_key = ZonedDateTime.parse(ctx['@timestamp']).toLocalDate().toString() + '_' + ctx.deployment_id;
+        }
+        if (ctx.data_tier_capacity_ecu != null) {
+            // provisioned pool — utilization discount is applied later in ES|QL
+            ctx.realized_chargeable_units = ctx.data_tier_capacity_ecu;
+            ctx.total_chargeable_units = ctx.data_tier_capacity_ecu;
+        }
+  - pipeline:
+      description: '[Fleet] Global pipeline for all data streams'
+      ignore_missing_pipeline: true
+      name: global@custom
+  - pipeline:
+      description: '[Fleet] Pipeline for all data streams of type `metrics`'
+      ignore_missing_pipeline: true
+      name: metrics@custom
+  - pipeline:
+      description: '[Fleet] Pipeline for all data streams of type `metrics` defined by the `chargeback` integration'
+      ignore_missing_pipeline: true
+      name: metrics-chargeback.integration@custom

--- a/packages/chargeback/elasticsearch/transform/billing_cluster_cost/fields/fields.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_cluster_cost/fields/fields.yml
@@ -14,8 +14,9 @@
   type: double
   description: Total chargeable units (ECU/ERU) aggregated for the deployment per day.
 - name: total_ecu
-  type: double
-  description: Deprecated alias of total_chargeable_units; populated alongside it for dashboard ES|QL compatibility.
+  type: alias
+  path: total_chargeable_units
+  description: Deprecated alias of total_chargeable_units for dashboard ES|QL compatibility.
 - name: composite_key
   type: keyword
   description: Composite key used for billing attribution (set by ingest pipeline) consisting of date and deployment ID.

--- a/packages/chargeback/elasticsearch/transform/billing_cluster_cost/fields/fields.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_cluster_cost/fields/fields.yml
@@ -13,6 +13,9 @@
 - name: total_chargeable_units
   type: double
   description: Total chargeable units (ECU/ERU) aggregated for the deployment per day.
+- name: total_ecu
+  type: double
+  description: Deprecated alias of total_chargeable_units; populated alongside it for dashboard ES|QL compatibility.
 - name: composite_key
   type: keyword
   description: Composite key used for billing attribution (set by ingest pipeline) consisting of date and deployment ID.

--- a/packages/chargeback/elasticsearch/transform/billing_cluster_cost/fields/fields.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_cluster_cost/fields/fields.yml
@@ -26,3 +26,9 @@
 - name: cost_type
   type: keyword
   description: Component where the ecu is being spent, derived from SKU field.
+- name: cost_category
+  type: keyword
+  description: FinOps category (data_tier, platform, transfer, snapshot, onprem, other).
+- name: is_allocatable
+  type: boolean
+  description: Whether this SKU row contributes to the realized data-tier capacity pool.

--- a/packages/chargeback/elasticsearch/transform/billing_cluster_cost/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_cluster_cost/transform.yml
@@ -58,6 +58,9 @@ pivot:
     total_chargeable_units:
       sum:
         field: ess.billing.total_ecu
+    total_ecu:
+      sum:
+        field: ess.billing.total_ecu
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false

--- a/packages/chargeback/elasticsearch/transform/billing_cluster_cost/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_cluster_cost/transform.yml
@@ -58,9 +58,6 @@ pivot:
     total_chargeable_units:
       sum:
         field: ess.billing.total_ecu
-    total_ecu:
-      sum:
-        field: ess.billing.total_ecu
 settings:
   # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false

--- a/packages/chargeback/elasticsearch/transform/billing_realized_pool/fields/fields.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_realized_pool/fields/fields.yml
@@ -1,0 +1,34 @@
+- name: "@timestamp"
+  type: date
+  description: The timestamp representing the day of the billing data.
+- name: deployment_group
+  type: keyword
+  description: User-defined group of the deployment (based on tag:chargeback_group).
+- name: deployment_id
+  type: keyword
+  description: Unique ID of the deployment.
+- name: deployment_name
+  type: keyword
+  description: Human-readable name of the deployment.
+- name: composite_key
+  type: keyword
+  description: Composite key consisting of date and deployment ID.
+- name: data_tier_capacity_ecu
+  type: double
+  description: Sum of allocatable data-tier chargeable units per deployment per day.
+- name: data_tier_capacity_hours
+  type: double
+  description: Optional max billed quantity (hours) for allocatable capacity rows.
+- name: data_tier_ram_per_zone_mb
+  type: long
+  description: Optional max RAM per zone in MB for allocatable capacity rows.
+- name: realized_chargeable_units
+  type: double
+  description: Raw allocatable pool before utilization (score applied in dashboard ES|QL).
+- name: total_chargeable_units
+  type: double
+  description: Alias of data_tier_capacity_ecu for compatibility.
+- name: total_ecu
+  type: alias
+  path: total_chargeable_units
+  description: Deprecated alias of total_chargeable_units.

--- a/packages/chargeback/elasticsearch/transform/billing_realized_pool/manifest.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_realized_pool/manifest.yml
@@ -1,0 +1,8 @@
+start: true
+destination_index_template:
+  settings:
+    index:
+      mode: "lookup"
+      codec: best_compression
+  mappings:
+    dynamic: false

--- a/packages/chargeback/elasticsearch/transform/billing_realized_pool/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/billing_realized_pool/transform.yml
@@ -1,11 +1,36 @@
-description: Aggregates daily total chargeable units (ECU/ERU) per deployment from billing metrics, using ingested timestamps with a 1-hour sync delay and running every 60 minutes.
+description: Aggregates daily allocatable data-tier capacity (chargeable units) per deployment for realized-cost allocation.
 source:
   index:
     - metrics-ess_billing.billing-*
   query:
-    range:
-      ess.billing.total_ecu:
-        gt: 0
+    bool:
+      must:
+        - range:
+            ess.billing.total_ecu:
+              gt: 0
+      should:
+        - term:
+            ess.billing.sku: onprem_node
+        - bool:
+            must:
+              - term:
+                  ess.billing.type: capacity
+              - term:
+                  ess.billing.kind: elasticsearch
+              - bool:
+                  should:
+                    - wildcard:
+                        ess.billing.sku: "*.es.datahot.*"
+                    - wildcard:
+                        ess.billing.sku: "*.es.datawarm.*"
+                    - wildcard:
+                        ess.billing.sku: "*.es.datacold.*"
+                    - wildcard:
+                        ess.billing.sku: "*.es.datafrozen.*"
+                    - wildcard:
+                        ess.billing.sku: "*.es.datacontent.*"
+                  minimum_should_match: 1
+      minimum_should_match: 1
   runtime_mappings:
     deployment_group:
       type: keyword
@@ -29,8 +54,8 @@ source:
           }
           emit('');
 dest:
-  index: billing_cluster_cost_lookup
-  pipeline: 0.4.0-billing
+  index: billing_realized_pool_lookup
+  pipeline: 0.4.0-realized_pool
 frequency: 60m
 sync:
   time:
@@ -51,20 +76,20 @@ pivot:
     deployment_name:
       terms:
         field: ess.billing.deployment_name
-    sku:
-      terms:
-        field: ess.billing.sku
   aggregations:
-    total_chargeable_units:
+    data_tier_capacity_ecu:
       sum:
         field: ess.billing.total_ecu
+    data_tier_capacity_hours:
+      max:
+        field: ess.billing.quantity.value
+    data_tier_ram_per_zone_mb:
+      max:
+        field: ess.billing.ram_per_zone
 settings:
-  # This is required to prevent the transform from clobbering the Fleet-managed mappings.
   deduce_mappings: false
   unattended: true
 _meta:
   managed: true
   run_as_kibana_system: false
-  # Bump this version to delete, reinstall, and restart the transform during package.
-  # Version bump is needed if there is any code change in transform.
   fleet_transform_version: 0.4.0

--- a/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/fields/base-fields.yml
+++ b/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/fields/base-fields.yml
@@ -30,3 +30,18 @@
 - name: conf_end_date
   type: date
   description: Configuration validity end date (defaults to 2046-12-31)
+- name: conf_utilization_memory_weight
+  type: integer
+  description: Weight for heap p95 in capacity utilization score blend (default 70).
+- name: conf_utilization_storage_weight
+  type: integer
+  description: Weight for disk p95 in capacity utilization score blend (default 30).
+- name: conf_utilization_floor
+  type: double
+  description: Minimum utilization score (0.0–1.0) applied to all deployments regardless of actual utilization (default 0.10). Prevents realized cost from reaching zero for idle or unmonitored clusters.
+- name: conf_memory_cost_weight
+  type: integer
+  description: Weight for illustrative memory split of chargeable pool in datatiers panels (default 50).
+- name: conf_storage_cost_weight
+  type: integer
+  description: Weight for illustrative storage split of chargeable pool in datatiers panels (default 50).

--- a/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/fields/base-fields.yml
+++ b/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/fields/base-fields.yml
@@ -7,6 +7,12 @@
 - name: conf_chargeable_unit_rate_unit
   type: keyword
   description: Currency unit for chargeable unit rate (e.g., EUR, USD)
+- name: conf_ecu_rate
+  type: double
+  description: Deprecated alias of conf_chargeable_unit_rate; populated alongside it for dashboard ES|QL compatibility.
+- name: conf_ecu_rate_unit
+  type: keyword
+  description: Deprecated alias of conf_chargeable_unit_rate_unit; populated alongside it for dashboard ES|QL compatibility.
 - name: conf_indexing_weight
   type: integer
   description: Weight factor for indexing costs

--- a/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/fields/base-fields.yml
+++ b/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/fields/base-fields.yml
@@ -8,11 +8,13 @@
   type: keyword
   description: Currency unit for chargeable unit rate (e.g., EUR, USD)
 - name: conf_ecu_rate
-  type: double
-  description: Deprecated alias of conf_chargeable_unit_rate; populated alongside it for dashboard ES|QL compatibility.
+  type: alias
+  path: conf_chargeable_unit_rate
+  description: Deprecated alias of conf_chargeable_unit_rate for dashboard ES|QL compatibility.
 - name: conf_ecu_rate_unit
-  type: keyword
-  description: Deprecated alias of conf_chargeable_unit_rate_unit; populated alongside it for dashboard ES|QL compatibility.
+  type: alias
+  path: conf_chargeable_unit_rate_unit
+  description: Deprecated alias of conf_chargeable_unit_rate_unit for dashboard ES|QL compatibility.
 - name: conf_indexing_weight
   type: integer
   description: Weight factor for indexing costs

--- a/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/transform.yml
@@ -15,6 +15,14 @@ source:
       type: keyword
       script:
         source: "emit('EUR')"
+    conf_ecu_rate:
+      type: double
+      script:
+        source: "emit(0.85)"
+    conf_ecu_rate_unit:
+      type: keyword
+      script:
+        source: "emit('EUR')"
     conf_indexing_weight:
       type: long
       script:
@@ -37,6 +45,7 @@ source:
         source: "emit(2430518399999L)"  # 2046-12-31T23:59:59.999Z - 20 years from now
 dest:
   index: chargeback_conf_lookup
+  pipeline: 0.3.2-chargeback_conf_lookup
 pivot:
   group_by:
     config_join_key:
@@ -49,6 +58,9 @@ pivot:
     conf_chargeable_unit_rate:
       max:
         field: conf_chargeable_unit_rate
+    conf_ecu_rate:
+      max:
+        field: conf_ecu_rate
     conf_indexing_weight:
       max:
         field: conf_indexing_weight

--- a/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/transform.yml
@@ -15,14 +15,6 @@ source:
       type: keyword
       script:
         source: "emit('EUR')"
-    conf_ecu_rate:
-      type: double
-      script:
-        source: "emit(0.85)"
-    conf_ecu_rate_unit:
-      type: keyword
-      script:
-        source: "emit('EUR')"
     conf_indexing_weight:
       type: long
       script:
@@ -58,9 +50,6 @@ pivot:
     conf_chargeable_unit_rate:
       max:
         field: conf_chargeable_unit_rate
-    conf_ecu_rate:
-      max:
-        field: conf_ecu_rate
     conf_indexing_weight:
       max:
         field: conf_indexing_weight

--- a/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/chargeback_conf_lookup/transform.yml
@@ -35,9 +35,29 @@ source:
       type: date
       script:
         source: "emit(2430518399999L)"  # 2046-12-31T23:59:59.999Z - 20 years from now
+    conf_utilization_memory_weight:
+      type: long
+      script:
+        source: "emit(70)"
+    conf_utilization_storage_weight:
+      type: long
+      script:
+        source: "emit(30)"
+    conf_utilization_floor:
+      type: double
+      script:
+        source: "emit(0.10)"
+    conf_memory_cost_weight:
+      type: long
+      script:
+        source: "emit(50)"
+    conf_storage_cost_weight:
+      type: long
+      script:
+        source: "emit(50)"
 dest:
   index: chargeback_conf_lookup
-  pipeline: 0.3.2-chargeback_conf_lookup
+  pipeline: 0.4.0-chargeback_conf_lookup
 pivot:
   group_by:
     config_join_key:
@@ -65,10 +85,25 @@ pivot:
     conf_end_date:
       max:
         field: conf_end_date
+    conf_utilization_memory_weight:
+      max:
+        field: conf_utilization_memory_weight
+    conf_utilization_storage_weight:
+      max:
+        field: conf_utilization_storage_weight
+    conf_utilization_floor:
+      max:
+        field: conf_utilization_floor
+    conf_memory_cost_weight:
+      max:
+        field: conf_memory_cost_weight
+    conf_storage_cost_weight:
+      max:
+        field: conf_storage_cost_weight
 settings:
   deduce_mappings: false
   unattended: true
 _meta:
   managed: true
   run_as_kibana_system: false
-  fleet_transform_version: 0.3.2
+  fleet_transform_version: 0.4.0

--- a/packages/chargeback/elasticsearch/transform/cluster_capacity_utilization/fields/fields.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_capacity_utilization/fields/fields.yml
@@ -1,0 +1,24 @@
+- name: "@timestamp"
+  type: date
+  description: The timestamp representing the day of utilization metrics.
+- name: cluster_name
+  type: keyword
+  description: Elasticsearch cluster name (matches billing deployment_id).
+- name: deployment_id
+  type: keyword
+  description: Deployment identifier (same as cluster_name).
+- name: composite_key
+  type: keyword
+  description: Composite key consisting of date and deployment ID.
+- name: heap_used_pct_p95
+  type: double
+  description: P95 heap used percent across data-role nodes for the day.
+- name: disk_used_pct_p95
+  type: double
+  description: P95 disk used percent across data-role nodes for the day.
+- name: memory_utilization
+  type: double
+  description: Optional normalized heap utilization (heap_used_pct_p95 / 100).
+- name: storage_utilization
+  type: double
+  description: Optional normalized disk utilization (disk_used_pct_p95 / 100).

--- a/packages/chargeback/elasticsearch/transform/cluster_capacity_utilization/manifest.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_capacity_utilization/manifest.yml
@@ -1,0 +1,8 @@
+start: true
+destination_index_template:
+  settings:
+    index:
+      mode: "lookup"
+      codec: best_compression
+  mappings:
+    dynamic: false

--- a/packages/chargeback/elasticsearch/transform/cluster_capacity_utilization/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_capacity_utilization/transform.yml
@@ -1,0 +1,69 @@
+description: Aggregates daily p95 heap and disk utilization across data-role nodes per deployment.
+source:
+  index:
+    - metrics-elasticsearch.stack_monitoring.node_stats-*
+  query:
+    bool:
+      should:
+        - term:
+            elasticsearch.node.roles: data_hot
+        - term:
+            elasticsearch.node.roles: data_warm
+        - term:
+            elasticsearch.node.roles: data_cold
+        - term:
+            elasticsearch.node.roles: data_frozen
+        - term:
+            elasticsearch.node.roles: data_content
+        - term:
+            elasticsearch.node.roles: data
+      minimum_should_match: 1
+  runtime_mappings:
+    node_disk_used_pct:
+      type: double
+      script:
+        source: |
+          def stats = params._source?.elasticsearch?.node?.stats;
+          if (stats == null) {
+            return;
+          }
+          def total = stats?.fs?.total?.total_in_bytes;
+          def avail = stats?.fs?.total?.available_in_bytes;
+          if (total != null && total > 0 && avail != null) {
+            emit((total - avail) * 100.0 / total);
+          }
+dest:
+  index: cluster_capacity_utilization_lookup
+  pipeline: 0.4.0-capacity_utilization
+frequency: 60m
+sync:
+  time:
+    field: "@timestamp"
+    delay: 1h
+pivot:
+  group_by:
+    "@timestamp":
+      date_histogram:
+        field: "@timestamp"
+        calendar_interval: 1d
+    cluster_name:
+      terms:
+        field: elasticsearch.cluster.name
+  aggregations:
+    heap_used_pct_p95:
+      percentiles:
+        field: elasticsearch.node.stats.jvm.mem.heap.used.pct
+        percents:
+          - 95
+    disk_used_pct_p95:
+      percentiles:
+        field: node_disk_used_pct
+        percents:
+          - 95
+settings:
+  deduce_mappings: false
+  unattended: true
+_meta:
+  managed: true
+  run_as_kibana_system: false
+  fleet_transform_version: 0.4.0

--- a/packages/chargeback/elasticsearch/transform/cluster_datastream_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_datastream_contribution/transform.yml
@@ -5,7 +5,7 @@ source:
     - "*:monitoring-indices*"
 dest:
   index: cluster_datastream_contribution_lookup
-  pipeline: 0.3.2-usage
+  pipeline: 0.4.0-usage
 frequency: 60m
 sync:
   time:
@@ -61,4 +61,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.2
+  fleet_transform_version: 0.4.0

--- a/packages/chargeback/elasticsearch/transform/cluster_deployment_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_deployment_contribution/transform.yml
@@ -6,7 +6,7 @@ source:
     - "*:monitoring-indices*" # Same pattern on all remote clusters (CCS).
 dest:
   index: cluster_deployment_contribution_lookup
-  pipeline: 0.3.2-usage
+  pipeline: 0.4.0-usage
 frequency: 60m
 sync:
   time:
@@ -43,4 +43,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.2
+  fleet_transform_version: 0.4.0

--- a/packages/chargeback/elasticsearch/transform/cluster_tier_and_ds_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_tier_and_ds_contribution/transform.yml
@@ -5,7 +5,7 @@ source:
     - "*:monitoring-indices*"
 dest:
   index: cluster_tier_and_datastream_contribution_lookup
-  pipeline: 0.3.2-usage
+  pipeline: 0.4.0-usage
 frequency: 60m
 sync:
   time:
@@ -26,7 +26,8 @@ pivot:
           lang: painless
           source: >
             if (doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty) {
-              return doc['elasticsearch.index.tier'].value;
+              def tier = doc['elasticsearch.index.tier'].value;
+              if (tier != null && tier != 'unknown') return tier;
             }
             def pref = doc.containsKey('elasticsearch.index.tier_preference') && !doc['elasticsearch.index.tier_preference'].empty ? doc['elasticsearch.index.tier_preference'].value : null;
             if (pref == null) return 'unknown';
@@ -76,4 +77,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.2
+  fleet_transform_version: 0.4.0

--- a/packages/chargeback/elasticsearch/transform/cluster_tier_contribution/transform.yml
+++ b/packages/chargeback/elasticsearch/transform/cluster_tier_contribution/transform.yml
@@ -5,7 +5,7 @@ source:
     - "*:monitoring-indices*"
 dest:
   index: cluster_tier_contribution_lookup
-  pipeline: 0.3.2-usage
+  pipeline: 0.4.0-usage
 frequency: 60m
 sync:
   time:
@@ -26,7 +26,8 @@ pivot:
           lang: painless
           source: >
             if (doc.containsKey('elasticsearch.index.tier') && !doc['elasticsearch.index.tier'].empty) {
-              return doc['elasticsearch.index.tier'].value;
+              def tier = doc['elasticsearch.index.tier'].value;
+              if (tier != null && tier != 'unknown') return tier;
             }
             
             def pref = doc.containsKey('elasticsearch.index.tier_preference') && !doc['elasticsearch.index.tier_preference'].empty ? doc['elasticsearch.index.tier_preference'].value : null;
@@ -58,4 +59,4 @@ _meta:
   run_as_kibana_system: false
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.3.2
+  fleet_transform_version: 0.4.0

--- a/packages/chargeback/kibana/alerting_rule_template/chargeback-transform-health.json
+++ b/packages/chargeback/kibana/alerting_rule_template/chargeback-transform-health.json
@@ -11,6 +11,8 @@
         "params": {
             "includeTransforms": [
                 "logs-chargeback.billing_cluster_cost-*",
+                "logs-chargeback.billing_realized_pool-*",
+                "logs-chargeback.cluster_capacity_utilization-*",
                 "logs-chargeback.cluster_deployment_contribution-*",
                 "logs-chargeback.cluster_datastream_contribution-*",
                 "logs-chargeback.cluster_tier_contribution-*",

--- a/packages/chargeback/kibana/dashboard/chargeback-39a39857-746c-4a29-adca-3c2fcb6bcfb6.json
+++ b/packages/chargeback/kibana/dashboard/chargeback-39a39857-746c-4a29-adca-3c2fcb6bcfb6.json
@@ -54,23 +54,7 @@
         "description": "Provides visual insights into cluster-level cost and usage metrics, helping track Elastic consumption across tiers, deployments, and data streams. Built from transformed billing and usage data, this dashboard enables transparent chargeback calculations and trend analysis.",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [
-                    {
-                        "meta": {
-                            "alias": null,
-                            "disabled": false,
-                            "key": "@timestamp",
-                            "negate": false,
-                            "type": "exists",
-                            "value": "exists"
-                        },
-                        "query": {
-                            "exists": {
-                                "field": "@timestamp"
-                            }
-                        }
-                    }
-                ],
+                "filter": [],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -131,18 +115,17 @@
                                                     "columnId": "deployment",
                                                     "customLabel": false,
                                                     "fieldName": "deployment",
-                                                    "label": "deployment",
+                                                    "label": "Deployment",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "total_value",
+                                                    "columnId": "Normalised cost",
                                                     "customLabel": false,
-                                                    "fieldName": "total_value",
-                                                    "inMetricDimension": true,
-                                                    "label": "total_value",
+                                                    "fieldName": "Normalised cost",
+                                                    "label": "Normalised cost",
                                                     "meta": {
                                                         "esType": "double",
                                                         "type": "number"
@@ -151,7 +134,7 @@
                                             ],
                                             "index": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS `total_value`=SUM(total_chargeable_units_value) by @timestamp, deployment\n| KEEP @timestamp, deployment, total_value | SORT @timestamp desc | LIMIT 5000"
+                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS `Normalised cost` = SUM(total_chargeable_units_value) BY @timestamp, deployment\n| SORT @timestamp DESC\n| LIMIT 5000"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -161,7 +144,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS `total_value`=SUM(total_chargeable_units_value) by @timestamp, deployment\n| KEEP @timestamp, deployment, total_value | SORT @timestamp desc | LIMIT 5000"
+                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS `Normalised cost` = SUM(total_chargeable_units_value) BY @timestamp, deployment\n| SORT @timestamp DESC\n| LIMIT 5000"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -183,7 +166,7 @@
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "total_value"
+                                            "Normalised cost"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
@@ -225,10 +208,11 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "total_value over @timestamp",
+                        "title": "Total Cloud Billing Over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
+                    "description": "Full deployment bill: the sum of ALL billing SKUs (data tiers, ML, Kibana, snapshots, data transfer and on-prem nodes) converted at the configured rate. This is the highest-level total. Tier and data-stream panels show only the allocatable data-tier pool, so they sum to less than this figure.",
                     "enhancements": {
                         "dynamicActions": {
                             "events": []
@@ -236,7 +220,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS `total_value`=SUM(total_chargeable_units_value) by @timestamp, deployment\n| KEEP @timestamp, deployment, total_value | SORT @timestamp desc | LIMIT 5000"
+                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS `Normalised cost` = SUM(total_chargeable_units_value) BY @timestamp, deployment\n| SORT @timestamp DESC\n| LIMIT 5000"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -245,7 +229,7 @@
                         "from": "now-6M",
                         "to": "now"
                     },
-                    "title": "Normalised cost over the last 6 months"
+                    "title": "Total Cloud Billing Over Time"
                 },
                 "gridData": {
                     "h": 11,
@@ -290,42 +274,29 @@
                                         "28174526-fb0d-4645-a2b7-f5101203fb4e": {
                                             "columns": [
                                                 {
-                                                    "columnId": "dff61ce4-8b3c-40bf-8972-0970a0a7ecc9",
-                                                    "customLabel": true,
+                                                    "columnId": "deployment_group",
+                                                    "customLabel": false,
                                                     "fieldName": "deployment_group",
                                                     "label": "Deployment group",
                                                     "meta": {
                                                         "esType": "keyword",
-                                                        "params": {
-                                                            "id": "string"
-                                                        },
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup",
-                                                            "sourceField": "deployment_group"
-                                                        },
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "04726936-593d-48df-9ebc-9963d006ad1c",
+                                                    "columnId": "Normalised cost",
+                                                    "customLabel": false,
                                                     "fieldName": "Normalised cost",
                                                     "label": "Normalised cost",
                                                     "meta": {
                                                         "esType": "double",
-                                                        "params": {
-                                                            "id": "number"
-                                                        },
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup",
-                                                            "sourceField": "Normalised cost"
-                                                        },
                                                         "type": "number"
                                                     }
                                                 }
                                             ],
                                             "index": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)) by deployment_group"
+                                                "esql": "FROM billing_cluster_cost_lookup\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY deployment_group\n| SORT `Normalised cost` DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -335,29 +306,31 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)) by deployment_group"
+                                "esql": "FROM billing_cluster_cost_lookup\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY deployment_group\n| SORT `Normalised cost` DESC"
                             },
                             "visualization": {
                                 "columns": [
                                     {
-                                        "columnId": "dff61ce4-8b3c-40bf-8972-0970a0a7ecc9",
+                                        "columnId": "deployment_group",
                                         "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "04726936-593d-48df-9ebc-9963d006ad1c",
+                                        "columnId": "Normalised cost",
                                         "isMetric": true,
-                                        "isTransposed": false
+                                        "isTransposed": false,
+                                        "summaryRow": "sum"
                                     }
                                 ],
                                 "layerId": "28174526-fb0d-4645-a2b7-f5101203fb4e",
                                 "layerType": "data"
                             }
                         },
-                        "title": "Normalised cost",
+                        "title": "Total Cost by Deployment Group",
                         "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
+                    "description": "Full deployment bill: the sum of ALL billing SKUs (data tiers, ML, Kibana, snapshots, data transfer and on-prem nodes) converted at the configured rate. This is the highest-level total. Tier and data-stream panels show only the allocatable data-tier pool, so they sum to less than this figure.",
                     "enhancements": {
                         "dynamicActions": {
                             "events": []
@@ -365,7 +338,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)) by deployment_group"
+                        "esql": "FROM billing_cluster_cost_lookup\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY deployment_group\n| SORT `Normalised cost` DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -428,18 +401,17 @@
                                                     "columnId": "deployment_group",
                                                     "customLabel": false,
                                                     "fieldName": "deployment_group",
-                                                    "label": "deployment_group",
+                                                    "label": "Deployment Group",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "total_value",
+                                                    "columnId": "Normalised cost",
                                                     "customLabel": false,
-                                                    "fieldName": "total_value",
-                                                    "inMetricDimension": true,
-                                                    "label": "total_value",
+                                                    "fieldName": "Normalised cost",
+                                                    "label": "Normalised cost",
                                                     "meta": {
                                                         "esType": "double",
                                                         "type": "number"
@@ -448,7 +420,7 @@
                                             ],
                                             "index": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS `total_value`=SUM(total_chargeable_units_value) by @timestamp, deployment_group\n| KEEP @timestamp, deployment_group, total_value | SORT @timestamp desc | LIMIT 5000"
+                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| STATS `Normalised cost` = SUM(total_chargeable_units_value) BY @timestamp, deployment_group\n| SORT @timestamp DESC\n| LIMIT 5000"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -458,7 +430,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS `total_value`=SUM(total_chargeable_units_value) by @timestamp, deployment_group\n| KEEP @timestamp, deployment_group, total_value | SORT @timestamp desc | LIMIT 5000"
+                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| STATS `Normalised cost` = SUM(total_chargeable_units_value) BY @timestamp, deployment_group\n| SORT @timestamp DESC\n| LIMIT 5000"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -480,7 +452,7 @@
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "total_value"
+                                            "Normalised cost"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
@@ -522,10 +494,11 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "total_value over @timestamp",
+                        "title": "Cost Trend by Deployment Group",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
+                    "description": "Full deployment bill: the sum of ALL billing SKUs (data tiers, ML, Kibana, snapshots, data transfer and on-prem nodes) converted at the configured rate. This is the highest-level total. Tier and data-stream panels show only the allocatable data-tier pool, so they sum to less than this figure.",
                     "enhancements": {
                         "dynamicActions": {
                             "events": []
@@ -533,7 +506,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS `total_value`=SUM(total_chargeable_units_value) by @timestamp, deployment_group\n| KEEP @timestamp, deployment_group, total_value | SORT @timestamp desc | LIMIT 5000"
+                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL total_chargeable_units_value = COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| STATS `Normalised cost` = SUM(total_chargeable_units_value) BY @timestamp, deployment_group\n| SORT @timestamp DESC\n| LIMIT 5000"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -542,7 +515,7 @@
                         "from": "now-6M",
                         "to": "now"
                     },
-                    "title": "Normalised cost over the last 6 months per deployment group"
+                    "title": "Cost Trend by Deployment Group"
                 },
                 "gridData": {
                     "h": 14,
@@ -601,6 +574,21 @@
                     "attributes": {
                         "references": [],
                         "state": {
+                            "adHocDataViews": {
+                                "cluster-tier-contribution-dv": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "cluster-tier-contribution-dv",
+                                    "managed": false,
+                                    "name": "cluster_tier_contribution_lookup",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "cluster_tier_contribution_lookup",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
                                 "textBased": {
                                     "indexPatternRefs": [],
@@ -608,28 +596,33 @@
                                         "ba345378-8ee0-40ec-9fb0-d26588d09107": {
                                             "columns": [
                                                 {
-                                                    "columnId": "c33c8ff5-8a22-4f4f-9b92-5e16485f5d9a",
+                                                    "columnId": "deployment",
                                                     "customLabel": true,
                                                     "fieldName": "deployment",
-                                                    "label": "Deployment",
+                                                    "label": "Deployment name",
                                                     "meta": {
                                                         "esType": "keyword",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "2ab259ce-29c3-4c5c-817b-b7f036c62be8",
+                                                    "columnId": "Data Tier",
                                                     "customLabel": true,
-                                                    "fieldName": "agg_blended",
+                                                    "fieldName": "Data Tier",
+                                                    "label": "Data Tier",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Normalised cost",
+                                                    "customLabel": true,
+                                                    "fieldName": "Normalised cost",
+                                                    "inMetricDimension": true,
                                                     "label": "Normalised cost",
                                                     "meta": {
                                                         "esType": "double",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "number"
                                                     },
                                                     "params": {
@@ -640,24 +633,11 @@
                                                             }
                                                         }
                                                     }
-                                                },
-                                                {
-                                                    "columnId": "af3de6ff-d14d-4cea-bb56-4ee9012054b6",
-                                                    "customLabel": true,
-                                                    "fieldName": "tier",
-                                                    "label": "Data tier",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
-                                                        "type": "string"
-                                                    }
                                                 }
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)), storage = CASE (store == 0, data_set, store), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier == \"hot/content\", ((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight)) / total_weight_hot, ((storage * conf_storage_weight) + (querying * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS agg_blended = sum(blended) BY deployment, tier\n| KEEP deployment, tier, agg_blended\n| WHERE agg_blended \u003e 0"
+                                                "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY deployment, tier_label\n| WHERE deployment IS NOT NULL AND tier_label IS NOT NULL AND `Normalised cost` \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 500"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -667,34 +647,36 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)), storage = CASE (store == 0, data_set, store), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier == \"hot/content\", ((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight)) / total_weight_hot, ((storage * conf_storage_weight) + (querying * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS agg_blended = sum(blended) BY deployment, tier\n| KEEP deployment, tier, agg_blended\n| WHERE agg_blended \u003e 0"
+                                "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY deployment, tier_label\n| WHERE deployment IS NOT NULL AND tier_label IS NOT NULL AND `Normalised cost` \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 500"
                             },
                             "visualization": {
                                 "columns": [
                                     {
-                                        "columnId": "c33c8ff5-8a22-4f4f-9b92-5e16485f5d9a",
+                                        "columnId": "deployment",
                                         "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "2ab259ce-29c3-4c5c-817b-b7f036c62be8",
+                                        "columnId": "Data Tier",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "Normalised cost",
                                         "isMetric": true,
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "af3de6ff-d14d-4cea-bb56-4ee9012054b6",
-                                        "isMetric": false,
-                                        "isTransposed": true
+                                        "isTransposed": false,
+                                        "summaryRow": "sum"
                                     }
                                 ],
                                 "layerId": "ba345378-8ee0-40ec-9fb0-d26588d09107",
                                 "layerType": "data"
                             }
                         },
-                        "title": "Table ",
+                        "title": "Normalised cost per deployment and tier",
                         "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
+                    "description": "The allocatable pool redistributed across data tiers by workload — a weighted blend of indexing, query and storage share. The total is slightly below the realised pool because deployment-days that have a billing pool but no monitoring breakdown cannot be allocated to a tier.",
                     "enhancements": {
                         "dynamicActions": {
                             "events": []
@@ -702,7 +684,7 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)), storage = CASE (store == 0, data_set, store), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier == \"hot/content\", ((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight)) / total_weight_hot, ((storage * conf_storage_weight) + (querying * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS agg_blended = sum(blended) BY deployment, tier\n| KEEP deployment, tier, agg_blended\n| WHERE agg_blended \u003e 0"
+                        "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY deployment, tier_label\n| WHERE deployment IS NOT NULL AND tier_label IS NOT NULL AND `Normalised cost` \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 500"
                     },
                     "syncColors": false,
                     "syncCursor": true,
@@ -725,6 +707,21 @@
                     "attributes": {
                         "references": [],
                         "state": {
+                            "adHocDataViews": {
+                                "cluster-tier-contribution-dv": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "cluster-tier-contribution-dv",
+                                    "managed": false,
+                                    "name": "cluster_tier_contribution_lookup",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "cluster_tier_contribution_lookup",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
                                 "textBased": {
                                     "indexPatternRefs": [],
@@ -735,26 +732,26 @@
                                                     "columnId": "deployment",
                                                     "customLabel": true,
                                                     "fieldName": "deployment",
-                                                    "label": "Deployment",
+                                                    "label": "Deployment name",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "tier",
+                                                    "columnId": "Data Tier",
                                                     "customLabel": true,
-                                                    "fieldName": "tier",
-                                                    "label": "Data tier",
+                                                    "fieldName": "Data Tier",
+                                                    "label": "Data Tier",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "agg_blended",
+                                                    "columnId": "Normalised cost",
                                                     "customLabel": true,
-                                                    "fieldName": "agg_blended",
+                                                    "fieldName": "Normalised cost",
                                                     "inMetricDimension": true,
                                                     "label": "Normalised cost",
                                                     "meta": {
@@ -773,7 +770,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)), storage = CASE (store == 0, data_set, store), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier == \"hot/content\", ((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight)) / total_weight_hot, ((storage * conf_storage_weight) + (querying * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS agg_blended = sum(blended) BY deployment, tier\n| KEEP deployment, tier, agg_blended\n| WHERE agg_blended \u003e 0"
+                                                "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY deployment, tier_label\n| WHERE deployment IS NOT NULL AND tier_label IS NOT NULL AND `Normalised cost` \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 500"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -783,7 +780,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)), storage = CASE (store == 0, data_set, store), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier == \"hot/content\", ((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight)) / total_weight_hot, ((storage * conf_storage_weight) + (querying * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS agg_blended = sum(blended) BY deployment, tier\n| KEEP deployment, tier, agg_blended\n| WHERE agg_blended \u003e 0"
+                                "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY deployment, tier_label\n| WHERE deployment IS NOT NULL AND tier_label IS NOT NULL AND `Normalised cost` \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 500"
                             },
                             "visualization": {
                                 "layers": [
@@ -813,23 +810,24 @@
                                         "layerType": "data",
                                         "legendDisplay": "default",
                                         "metrics": [
-                                            "agg_blended"
+                                            "Normalised cost"
                                         ],
                                         "nestedLegend": false,
                                         "numberDisplay": "percent",
                                         "primaryGroups": [
                                             "deployment",
-                                            "tier"
+                                            "Data Tier"
                                         ]
                                     }
                                 ],
                                 "shape": "treemap"
                             }
                         },
-                        "title": "Pie",
+                        "title": "Normalised cost share by deployment and tier",
                         "version": 1,
                         "visualizationType": "lnsPie"
                     },
+                    "description": "The allocatable pool redistributed across data tiers by workload — a weighted blend of indexing, query and storage share. The total is slightly below the realised pool because deployment-days that have a billing pool but no monitoring breakdown cannot be allocated to a tier.",
                     "enhancements": {
                         "dynamicActions": {
                             "events": []
@@ -837,12 +835,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)), storage = CASE (store == 0, data_set, store), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier == \"hot/content\", ((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight)) / total_weight_hot, ((storage * conf_storage_weight) + (querying * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), deployment = CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\")\n| STATS agg_blended = sum(blended) BY deployment, tier\n| KEEP deployment, tier, agg_blended\n| WHERE agg_blended \u003e 0"
+                        "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY deployment, tier_label\n| WHERE deployment IS NOT NULL AND tier_label IS NOT NULL AND `Normalised cost` \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 500"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Normalised cost per deployment and tier"
+                    "title": "Normalised cost share by deployment and tier"
                 },
                 "gridData": {
                     "h": 15,
@@ -901,6 +899,21 @@
                     "attributes": {
                         "references": [],
                         "state": {
+                            "adHocDataViews": {
+                                "billing-realized-pool-dv": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "billing-realized-pool-dv",
+                                    "managed": false,
+                                    "name": "billing_realized_pool_lookup",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "billing_realized_pool_lookup",
+                                    "type": "esql"
+                                }
+                            },
                             "datasourceStates": {
                                 "textBased": {
                                     "indexPatternRefs": [],
@@ -908,105 +921,63 @@
                                         "9d199172-f9fa-4fc4-82af-c7e2672a3f54": {
                                             "columns": [
                                                 {
-                                                    "columnId": "a76076ce-f372-4a48-857d-75010bbf5970",
-                                                    "fieldName": "tier",
-                                                    "label": "tier",
+                                                    "columnId": "Data Tier",
+                                                    "customLabel": false,
+                                                    "fieldName": "Data Tier",
+                                                    "label": "Data Tier",
                                                     "meta": {
                                                         "esType": "keyword",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "6e881cac-4719-493c-95f8-e3bfa38c3219",
-                                                    "customLabel": true,
-                                                    "fieldName": "agg_indexing",
+                                                    "columnId": "Indexing",
+                                                    "customLabel": false,
+                                                    "fieldName": "Indexing",
+                                                    "inMetricDimension": true,
                                                     "label": "Indexing",
                                                     "meta": {
                                                         "esType": "double",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "97a86307-08fc-4b2d-a82a-36a2ecc9c75d",
-                                                    "customLabel": true,
-                                                    "fieldName": "agg_querying",
+                                                    "columnId": "Querying",
+                                                    "customLabel": false,
+                                                    "fieldName": "Querying",
+                                                    "inMetricDimension": true,
                                                     "label": "Querying",
                                                     "meta": {
                                                         "esType": "double",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "2b086331-8a38-4df2-b042-7827d3519d63",
-                                                    "customLabel": true,
-                                                    "fieldName": "agg_storage",
+                                                    "columnId": "Storage",
+                                                    "customLabel": false,
+                                                    "fieldName": "Storage",
+                                                    "inMetricDimension": true,
                                                     "label": "Storage",
                                                     "meta": {
                                                         "esType": "double",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "307273f7-1b4c-450c-80cd-ef0326b38f6e",
-                                                    "customLabel": true,
-                                                    "fieldName": "agg_blended",
+                                                    "columnId": "Blended",
+                                                    "customLabel": false,
+                                                    "fieldName": "Blended",
+                                                    "inMetricDimension": true,
                                                     "label": "Blended",
                                                     "meta": {
                                                         "esType": "double",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
                                                     }
                                                 }
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_indexing = sum(indexing),\n    agg_querying = sum(querying),\n    agg_storage = sum(storage),\n    agg_blended = sum(blended)\n    BY\n        tier\n| WHERE agg_blended \u003e 0"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier_label == \"hot/content\", ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot, ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS Indexing = SUM(indexing), Querying = SUM(querying), Storage = SUM(storage), Blended = SUM(blended) BY tier_label\n| WHERE Blended \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT Blended DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1016,45 +987,49 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_indexing = sum(indexing),\n    agg_querying = sum(querying),\n    agg_storage = sum(storage),\n    agg_blended = sum(blended)\n    BY\n        tier\n| WHERE agg_blended \u003e 0"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier_label == \"hot/content\", ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot, ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS Indexing = SUM(indexing), Querying = SUM(querying), Storage = SUM(storage), Blended = SUM(blended) BY tier_label\n| WHERE Blended \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT Blended DESC"
                             },
                             "visualization": {
                                 "columns": [
                                     {
-                                        "columnId": "a76076ce-f372-4a48-857d-75010bbf5970",
+                                        "columnId": "Data Tier",
                                         "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "columnId": "6e881cac-4719-493c-95f8-e3bfa38c3219",
+                                        "columnId": "Indexing",
                                         "isMetric": true,
-                                        "isTransposed": false
+                                        "isTransposed": false,
+                                        "summaryRow": "sum"
                                     },
                                     {
-                                        "columnId": "97a86307-08fc-4b2d-a82a-36a2ecc9c75d",
+                                        "columnId": "Querying",
                                         "isMetric": true,
-                                        "isTransposed": false
+                                        "isTransposed": false,
+                                        "summaryRow": "sum"
                                     },
                                     {
-                                        "columnId": "2b086331-8a38-4df2-b042-7827d3519d63",
+                                        "columnId": "Storage",
                                         "isMetric": true,
-                                        "isTransposed": false
+                                        "isTransposed": false,
+                                        "summaryRow": "sum"
                                     },
                                     {
-                                        "columnId": "307273f7-1b4c-450c-80cd-ef0326b38f6e",
+                                        "columnId": "Blended",
                                         "isMetric": true,
-                                        "isTransposed": false
+                                        "isTransposed": false,
+                                        "summaryRow": "sum"
                                     }
                                 ],
                                 "layerId": "9d199172-f9fa-4fc4-82af-c7e2672a3f54",
                                 "layerType": "data"
                             }
                         },
-                        "title": "agg_indexing \u0026 agg_querying \u0026 agg_storage \u0026 agg_blended of tier",
+                        "title": "Workload Mix by Data Tier",
                         "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "Normalised cost breakdown per tier, based on Indexing, Querying, Storage and a blended ratio of all of these.",
+                    "description": "The allocatable pool redistributed across data tiers by workload — a weighted blend of indexing, query and storage share. The total is slightly below the realised pool because deployment-days that have a billing pool but no monitoring breakdown cannot be allocated to a tier.",
                     "enhancements": {
                         "dynamicActions": {
                             "events": []
@@ -1062,12 +1037,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_indexing = sum(indexing),\n    agg_querying = sum(querying),\n    agg_storage = sum(storage),\n    agg_blended = sum(blended)\n    BY\n        tier\n| WHERE agg_blended \u003e 0"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool), store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight, total_weight_cold = conf_storage_weight + conf_query_weight, blended = CASE (tier_label == \"hot/content\", ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot, ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS Indexing = SUM(indexing), Querying = SUM(querying), Storage = SUM(storage), Blended = SUM(blended) BY tier_label\n| WHERE Blended \u003e 0\n| RENAME tier_label AS `Data Tier`\n| SORT Blended DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Normalised cost per tier"
+                    "title": "Workload Mix by Data Tier"
                 },
                 "gridData": {
                     "h": 10,
@@ -1287,7 +1262,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC\n| Limit 20"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC\n| Limit 20"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1297,7 +1272,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC\n| Limit 20"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC\n| Limit 20"
                             },
                             "visualization": {
                                 "layers": [
@@ -1340,7 +1315,7 @@
                                 "shape": "donut"
                             }
                         },
-                        "title": "Bar vertical stacked",
+                        "title": "Top 20 Data Streams — Indexing Cost",
                         "version": 1,
                         "visualizationType": "lnsPie"
                     },
@@ -1351,12 +1326,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC\n| Limit 20"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC\n| Limit 20"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Indexing: Normalised cost totals by data stream"
+                    "title": "Top 20 Data Streams — Indexing Cost"
                 },
                 "gridData": {
                     "h": 15,
@@ -1412,7 +1387,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC\n| Limit 20"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC\n| Limit 20"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1422,7 +1397,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC\n| Limit 20"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC\n| Limit 20"
                             },
                             "visualization": {
                                 "layers": [
@@ -1465,7 +1440,7 @@
                                 "shape": "donut"
                             }
                         },
-                        "title": "Bar vertical stacked",
+                        "title": "Top 20 Data Streams — Query Cost",
                         "version": 1,
                         "visualizationType": "lnsPie"
                     },
@@ -1476,12 +1451,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC\n| Limit 20"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC\n| Limit 20"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Querying: Normalised cost totals by data stream"
+                    "title": "Top 20 Data Streams — Query Cost"
                 },
                 "gridData": {
                     "h": 15,
@@ -1537,7 +1512,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC\n| limit 20"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC\n| limit 20"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1547,7 +1522,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC\n| limit 20"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC\n| limit 20"
                             },
                             "visualization": {
                                 "layers": [
@@ -1590,7 +1565,7 @@
                                 "shape": "donut"
                             }
                         },
-                        "title": "Bar vertical stacked",
+                        "title": "Top 20 Data Streams — Storage Cost",
                         "version": 1,
                         "visualizationType": "lnsPie"
                     },
@@ -1601,12 +1576,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC\n| limit 20"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC\n| limit 20"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Storage: Normalised cost totals by data stream"
+                    "title": "Top 20 Data Streams — Storage Cost"
                 },
                 "gridData": {
                     "h": 15,
@@ -1654,7 +1629,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot,\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight))) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC\n| limit 20"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot,\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight))) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC\n| limit 20"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1664,7 +1639,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot,\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight))) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC\n| limit 20"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot,\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight))) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC\n| limit 20"
                             },
                             "visualization": {
                                 "layers": [
@@ -1706,7 +1681,7 @@
                                 "shape": "pie"
                             }
                         },
-                        "title": "Treemap",
+                        "title": "Blended Cost by Data Stream",
                         "version": 1,
                         "visualizationType": "lnsPie"
                     },
@@ -1717,12 +1692,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot,\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight))) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC\n| limit 20"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot,\n        TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight))) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC\n| limit 20"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Blended: Normalised cost totals by data stream"
+                    "title": "Blended Cost by Data Stream"
                 },
                 "gridData": {
                     "h": 15,
@@ -1759,10 +1734,10 @@
                                                 },
                                                 {
                                                     "columnId": "Data tier",
-                                                    "customLabel": false,
+                                                    "customLabel": true,
                                                     "fieldName": "Data tier",
                                                     "inMetricDimension": true,
-                                                    "label": "Data tier",
+                                                    "label": "Data Tier",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -1804,7 +1779,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE(store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE(\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    Indexing = round(sum(indexing),2),\n    Querying = round(sum(querying),2),\n    Storage = round(sum(storage),2),\n    Blended = round(sum(blended),2)\n    BY datastream, tier\n| SORT Blended DESC\n| RENAME tier as `Data tier`, datastream as `Data stream`\n| Keep `Data stream`, `Data tier`, Indexing, Querying, Storage, Blended\n| WHERE `Data stream` is not null"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE(store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE(\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    Indexing = round(sum(indexing),2),\n    Querying = round(sum(querying),2),\n    Storage = round(sum(storage),2),\n    Blended = round(sum(blended),2)\n    BY datastream, tier\n| SORT Blended DESC\n| RENAME tier as `Data tier`, datastream as `Data stream`\n| Keep `Data stream`, `Data tier`, Indexing, Querying, Storage, Blended\n| WHERE `Data stream` is not null"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1814,7 +1789,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE(store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE(\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    Indexing = round(sum(indexing),2),\n    Querying = round(sum(querying),2),\n    Storage = round(sum(storage),2),\n    Blended = round(sum(blended),2)\n    BY datastream, tier\n| SORT Blended DESC\n| RENAME tier as `Data tier`, datastream as `Data stream`\n| Keep `Data stream`, `Data tier`, Indexing, Querying, Storage, Blended\n| WHERE `Data stream` is not null"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE(store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE(\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    Indexing = round(sum(indexing),2),\n    Querying = round(sum(querying),2),\n    Storage = round(sum(storage),2),\n    Blended = round(sum(blended),2)\n    BY datastream, tier\n| SORT Blended DESC\n| RENAME tier as `Data tier`, datastream as `Data stream`\n| Keep `Data stream`, `Data tier`, Indexing, Querying, Storage, Blended\n| WHERE `Data stream` is not null"
                             },
                             "visualization": {
                                 "columns": [
@@ -1838,7 +1813,7 @@
                                 "layerType": "data"
                             }
                         },
-                        "title": "Indexing \u0026 Querying \u0026 Storage of Data tier",
+                        "title": "Workload Breakdown by Data Tier",
                         "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
@@ -1849,12 +1824,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE(store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE(\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    Indexing = round(sum(indexing),2),\n    Querying = round(sum(querying),2),\n    Storage = round(sum(storage),2),\n    Blended = round(sum(blended),2)\n    BY datastream, tier\n| SORT Blended DESC\n| RENAME tier as `Data tier`, datastream as `Data stream`\n| Keep `Data stream`, `Data tier`, Indexing, Querying, Storage, Blended\n| WHERE `Data stream` is not null"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE(store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE(\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    Indexing = round(sum(indexing),2),\n    Querying = round(sum(querying),2),\n    Storage = round(sum(storage),2),\n    Blended = round(sum(blended),2)\n    BY datastream, tier\n| SORT Blended DESC\n| RENAME tier as `Data tier`, datastream as `Data stream`\n| Keep `Data stream`, `Data tier`, Indexing, Querying, Storage, Blended\n| WHERE `Data stream` is not null"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Normalised cost per data stream per tier"
+                    "title": "Workload Breakdown by Data Tier"
                 },
                 "gridData": {
                     "h": 15,
@@ -2002,7 +1977,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2012,7 +1987,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2077,7 +2052,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_indexing over @timestamp",
+                        "title": "Indexing Cost by Data Stream over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -2088,12 +2063,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Indexing: Normalised per data stream per day"
+                    "title": "Indexing Cost by Data Stream over Time"
                 },
                 "gridData": {
                     "h": 14,
@@ -2150,7 +2125,7 @@
                                                     "columnId": "tier",
                                                     "customLabel": true,
                                                     "fieldName": "tier",
-                                                    "label": "Data tier",
+                                                    "label": "Data Tier",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -2159,7 +2134,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_indexing \u003e 0"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_indexing \u003e 0"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2169,7 +2144,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_indexing \u003e 0"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_indexing \u003e 0"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2234,7 +2209,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_indexing over @timestamp",
+                        "title": "Indexing Cost by Tier over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -2245,12 +2220,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_indexing \u003e 0"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_indexing \u003e 0"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Indexing: Normalised cost per tier per day"
+                    "title": "Indexing Cost by Tier over Time"
                 },
                 "gridData": {
                     "h": 14,
@@ -2316,7 +2291,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2326,7 +2301,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2391,7 +2366,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_indexing over @timestamp",
+                        "title": "Indexing Cost Share by Data Stream over Time (%)",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -2402,12 +2377,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    indexing = CASE (\n        deployment_sum_indexing_time \u003e 0,\n        TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_indexing = sum(indexing)\n    BY \n        @timestamp,\n        datastream\n| WHERE agg_indexing \u003e 0\n| SORT agg_indexing DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Indexing: % Normalised cost per data stream per day"
+                    "title": "Indexing Cost Share by Data Stream over Time (%)"
                 },
                 "gridData": {
                     "h": 14,
@@ -2514,7 +2489,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying) \n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying) \n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2524,7 +2499,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying) \n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying) \n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2589,7 +2564,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_querying over @timestamp",
+                        "title": "Query Cost by Data Stream over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -2600,12 +2575,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying) \n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying) \n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Querying: Normalised cost per data stream per day"
+                    "title": "Query Cost by Data Stream over Time"
                 },
                 "gridData": {
                     "h": 14,
@@ -2660,9 +2635,9 @@
                                                 },
                                                 {
                                                     "columnId": "tier",
-                                                    "customLabel": false,
+                                                    "customLabel": true,
                                                     "fieldName": "tier",
-                                                    "label": "tier",
+                                                    "label": "Data Tier",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -2671,7 +2646,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_querying \u003e 0"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_querying \u003e 0"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2681,7 +2656,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_querying \u003e 0"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_querying \u003e 0"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2746,7 +2721,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_querying over @timestamp",
+                        "title": "Query Cost by Tier over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -2757,12 +2732,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_querying \u003e 0"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (\n        deployment_sum_query_time \u003e 0,\n        TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_querying = sum(querying)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_querying \u003e 0"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Querying: Noralised cost per tier per day"
+                    "title": "Query Cost by Tier over Time"
                 },
                 "gridData": {
                     "h": 14,
@@ -2828,7 +2803,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS \n    agg_querying = sum(querying)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS \n    agg_querying = sum(querying)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2838,7 +2813,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS \n    agg_querying = sum(querying)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS \n    agg_querying = sum(querying)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2903,7 +2878,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_querying over @timestamp",
+                        "title": "Query Cost Share by Data Stream over Time (%)",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -2914,12 +2889,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS \n    agg_querying = sum(querying)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS \n    agg_querying = sum(querying)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_querying \u003e 0\n| SORT agg_querying DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Querying: % Normalised cost per data stream per day"
+                    "title": "Query Cost Share by Data Stream over Time (%)"
                 },
                 "gridData": {
                     "h": 14,
@@ -3026,7 +3001,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3036,7 +3011,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3101,7 +3076,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_storage over @timestamp",
+                        "title": "Storage Cost by Data Stream over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -3112,12 +3087,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Storage: Nomalised cost per data stream per day"
+                    "title": "Storage Cost by Data Stream over Time"
                 },
                 "gridData": {
                     "h": 15,
@@ -3174,7 +3149,7 @@
                                                     "columnId": "tier",
                                                     "customLabel": true,
                                                     "fieldName": "tier",
-                                                    "label": "Data tier",
+                                                    "label": "Data Tier",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -3183,7 +3158,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_storage \u003e 0"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_storage \u003e 0"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3193,7 +3168,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_storage \u003e 0"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_storage \u003e 0"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3258,7 +3233,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_storage over @timestamp",
+                        "title": "Storage Cost by Tier over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -3269,12 +3244,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_storage \u003e 0"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp,\n        tier\n| WHERE agg_storage \u003e 0"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Storage: Normalised cost per tier per day"
+                    "title": "Storage Cost by Tier over Time"
                 },
                 "gridData": {
                     "h": 15,
@@ -3340,7 +3315,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3350,7 +3325,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3415,7 +3390,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_storage over @timestamp",
+                        "title": "Storage Cost Share by Data Stream over Time (%)",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -3426,12 +3401,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL \n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS  \n    agg_storage = sum(storage)\n    BY \n        @timestamp, \n        datastream\n| WHERE agg_storage \u003e 0\n| SORT agg_storage DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Storage: % Normalised cost per data stream per day"
+                    "title": "Storage Cost Share by Data Stream over Time (%)"
                 },
                 "gridData": {
                     "h": 15,
@@ -3538,7 +3513,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    blended = TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    blended = TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3548,7 +3523,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    blended = TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    blended = TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3613,7 +3588,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_blended over @timestamp",
+                        "title": "Blended Cost by Data Stream over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -3624,12 +3599,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    blended = TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    blended = TO_DOUBLE(((storage * conf_storage_weight) + (querying * conf_query_weight) + (indexing * conf_indexing_weight))) / total_weight_hot * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        datastream\n| WHERE agg_blended \u003e 0\n| SORT agg_blended DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Blended value: Normalised cost per data stream per day"
+                    "title": "Blended Cost by Data Stream over Time"
                 },
                 "gridData": {
                     "h": 14,
@@ -3655,53 +3630,39 @@
                                             "columns": [
                                                 {
                                                     "columnId": "@timestamp",
-                                                    "customLabel": true,
+                                                    "customLabel": false,
                                                     "fieldName": "@timestamp",
-                                                    "inMetricDimension": true,
-                                                    "label": "Date",
+                                                    "label": "@timestamp",
                                                     "meta": {
                                                         "esType": "date",
                                                         "type": "date"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "50a91b89-2e68-4a69-90a0-d2ab79115b96",
-                                                    "customLabel": true,
-                                                    "fieldName": "tier",
-                                                    "label": "Data tier",
+                                                    "columnId": "Data Tier",
+                                                    "customLabel": false,
+                                                    "fieldName": "Data Tier",
+                                                    "label": "Data Tier",
                                                     "meta": {
                                                         "esType": "keyword",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "1501af72-2509-4ae0-88a0-c1481e438377",
-                                                    "customLabel": true,
-                                                    "fieldName": "agg_blended",
+                                                    "columnId": "Normalised cost",
+                                                    "customLabel": false,
+                                                    "fieldName": "Normalised cost",
+                                                    "inMetricDimension": true,
                                                     "label": "Normalised cost",
                                                     "meta": {
                                                         "esType": "double",
-                                                        "sourceParams": {
-                                                            "indexPattern": "billing_cluster_cost_lookup"
-                                                        },
                                                         "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
                                                     }
                                                 }
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        tier\n| WHERE agg_blended \u003e 0"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `Normalised cost` = SUM(blended) BY @timestamp, tier\n| WHERE `Normalised cost` \u003e 0\n| RENAME tier AS `Data Tier`\n| SORT @timestamp ASC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3711,7 +3672,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        tier\n| WHERE agg_blended \u003e 0"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `Normalised cost` = SUM(blended) BY @timestamp, tier\n| WHERE `Normalised cost` \u003e 0\n| RENAME tier AS `Data Tier`\n| SORT @timestamp ASC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3733,7 +3694,7 @@
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "1501af72-2509-4ae0-88a0-c1481e438377"
+                                            "Normalised cost"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
@@ -3758,7 +3719,7 @@
                                         "layerId": "43f9cfe6-d828-4773-ab65-129f92cf7f4d",
                                         "layerType": "data",
                                         "seriesType": "bar_stacked",
-                                        "splitAccessor": "50a91b89-2e68-4a69-90a0-d2ab79115b96",
+                                        "splitAccessor": "Data Tier",
                                         "xAccessor": "@timestamp"
                                     }
                                 ],
@@ -3776,7 +3737,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "agg_indexing \u0026 agg_querying \u0026 agg_storage \u0026 agg_blended over @timestamp",
+                        "title": "Blended Cost by Tier over Time",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -3787,12 +3748,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    agg_blended = sum(blended)\n    BY\n        @timestamp,\n        tier\n| WHERE agg_blended \u003e 0"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `Normalised cost` = SUM(blended) BY @timestamp, tier\n| WHERE `Normalised cost` \u003e 0\n| RENAME tier AS `Data Tier`\n| SORT @timestamp ASC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Blended value: Normalised cost per tier per day"
+                    "title": "Blended Cost by Tier over Time"
                 },
                 "gridData": {
                     "h": 14,
@@ -3850,7 +3811,7 @@
                                             ],
                                             "index": "chargeback_integration",
                                             "query": {
-                                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `% Normalised cost` = sum(blended)\n    BY\n        @timestamp,\n        datastream,\n        tier\n| WHERE `% Normalised cost` \u003e 0\n| SORT `% Normalised cost` DESC"
+                                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `% Normalised cost` = sum(blended)\n    BY\n        @timestamp,\n        datastream,\n        tier\n| WHERE `% Normalised cost` \u003e 0\n| SORT `% Normalised cost` DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3860,7 +3821,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `% Normalised cost` = sum(blended)\n    BY\n        @timestamp,\n        datastream,\n        tier\n| WHERE `% Normalised cost` \u003e 0\n| SORT `% Normalised cost` DESC"
+                                "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `% Normalised cost` = sum(blended)\n    BY\n        @timestamp,\n        datastream,\n        tier\n| WHERE `% Normalised cost` \u003e 0\n| SORT `% Normalised cost` DESC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3925,7 +3886,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "Pie",
+                        "title": "Blended Cost Share by Tier and Data Stream (%)",
                         "version": 1,
                         "visualizationType": "lnsXY"
                     },
@@ -3936,12 +3897,12 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM billing_cluster_cost_lookup\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_contribution_lookup ON composite_key\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(datastream_sum_indexing_time) / deployment_sum_indexing_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(datastream_sum_query_time) / deployment_sum_query_time * COALESCE(total_chargeable_units, total_ecu)) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(datastream_sum_store_size) / deployment_sum_store_size * COALESCE(total_chargeable_units, total_ecu)),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `% Normalised cost` = sum(blended)\n    BY\n        @timestamp,\n        datastream,\n        tier\n| WHERE `% Normalised cost` \u003e 0\n| SORT `% Normalised cost` DESC"
+                        "esql": "FROM billing_realized_pool_lookup\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN cluster_tier_and_datastream_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON @timestamp \u003e= conf_start_date AND @timestamp \u003c= conf_end_date\n| EVAL heap_util = COALESCE(heap_used_pct_p95, 100) / 100, disk_util = COALESCE(disk_used_pct_p95, 100) / 100, w_sum = conf_utilization_memory_weight + conf_utilization_storage_weight, capacity_utilization_score = CASE(w_sum \u003e 0, (conf_utilization_memory_weight * heap_util + conf_utilization_storage_weight * disk_util) / w_sum, 1.0)\n| EVAL chargeable_pool = data_tier_capacity_ecu * COALESCE(capacity_utilization_score, 1.0), utilization_data_missing = heap_used_pct_p95 IS NULL AND disk_used_pct_p95 IS NULL\n| EVAL\n    indexing = CASE (deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    querying = CASE (deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_and_datastream_sum_query_time) / deployment_sum_query_time * chargeable_pool) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    data_set = CASE (deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool),\n    store = CASE (deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_and_datastream_sum_store_size) / deployment_sum_store_size * chargeable_pool),\n    storage = CASE (store == 0, data_set, store) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate),\n    total_weight_hot = conf_storage_weight + conf_query_weight + conf_indexing_weight,\n    total_weight_cold = conf_storage_weight + conf_query_weight,\n    blended = CASE (\n        tier == \"hot/content\",\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight) + (indexing / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_indexing_weight)) / total_weight_hot,\n        ((storage / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_storage_weight) + (querying / COALESCE(conf_chargeable_unit_rate, conf_ecu_rate) * conf_query_weight)) / total_weight_cold\n    ) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| STATS\n    `% Normalised cost` = sum(blended)\n    BY\n        @timestamp,\n        datastream,\n        tier\n| WHERE `% Normalised cost` \u003e 0\n| SORT `% Normalised cost` DESC"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Blended value: % Normalised cost per data stream per day"
+                    "title": "Blended Cost Share by Tier and Data Stream (%)"
                 },
                 "gridData": {
                     "h": 14,
@@ -3985,82 +3946,59 @@
                                         "4dba9fd5-8ec5-498a-b710-1512bd5dc18f": {
                                             "columns": [
                                                 {
-                                                    "columnId": "conf_chargeable_unit_rate_unit",
+                                                    "columnId": "Active now",
                                                     "customLabel": true,
-                                                    "fieldName": "conf_chargeable_unit_rate_unit",
-                                                    "label": "Unit",
+                                                    "fieldName": "Active now",
+                                                    "label": "Active now",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "conf_chargeable_unit_rate",
-                                                    "customLabel": true,
-                                                    "fieldName": "conf_chargeable_unit_rate",
-                                                    "inMetricDimension": true,
-                                                    "label": "Rate",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "e7785ad9-760e-4215-ad19-40fc21eeb27e",
+                                                    "columnId": "conf_start_date",
                                                     "customLabel": true,
                                                     "fieldName": "conf_start_date",
                                                     "label": "Start date",
                                                     "meta": {
                                                         "esType": "date",
-                                                        "params": {
-                                                            "id": "date"
-                                                        },
-                                                        "sourceParams": {
-                                                            "appliedTimeRange": {
-                                                                "from": "2025-11-24T15:31:59.427Z",
-                                                                "to": "2025-11-24T15:46:59.427Z"
-                                                            },
-                                                            "indexPattern": "chargeback_conf_lookup",
-                                                            "params": {},
-                                                            "sourceField": "conf_start_date"
-                                                        },
                                                         "type": "date"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "ef4ddf0e-7371-482e-98e1-7e131392d91f",
+                                                    "columnId": "conf_end_date",
                                                     "customLabel": true,
                                                     "fieldName": "conf_end_date",
                                                     "label": "End date",
                                                     "meta": {
                                                         "esType": "date",
-                                                        "params": {
-                                                            "id": "date"
-                                                        },
-                                                        "sourceParams": {
-                                                            "appliedTimeRange": {
-                                                                "from": "2025-11-24T15:32:12.392Z",
-                                                                "to": "2025-11-24T15:47:12.392Z"
-                                                            },
-                                                            "indexPattern": "chargeback_conf_lookup",
-                                                            "params": {},
-                                                            "sourceField": "conf_end_date"
-                                                        },
                                                         "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Rate unit",
+                                                    "customLabel": true,
+                                                    "fieldName": "Rate unit",
+                                                    "label": "Rate unit",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Chargeable unit rate",
+                                                    "customLabel": true,
+                                                    "fieldName": "Chargeable unit rate",
+                                                    "label": "Chargeable unit rate",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
                                                     }
                                                 }
                                             ],
                                             "index": "8f632b34627f697e9702333f8ef042ab73e3436b01f9a29710a96cc9dad323b9",
                                             "query": {
-                                                "esql": "FROM chargeback_conf_lookup\n| EVAL conf_chargeable_unit_rate_unit = COALESCE(conf_chargeable_unit_rate_unit, conf_ecu_rate_unit), conf_chargeable_unit_rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| KEEP conf_chargeable_unit_rate_unit, conf_chargeable_unit_rate, conf_start_date, conf_end_date"
+                                                "esql": "FROM chargeback_conf_lookup\n| EVAL `Rate unit` = COALESCE(conf_chargeable_unit_rate_unit, conf_ecu_rate_unit), `Chargeable unit rate` = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), `Active now` = CASE(NOW() \u003e= conf_start_date AND NOW() \u003c= conf_end_date, \"yes\", \"no\")\n| KEEP `Active now`, conf_start_date, conf_end_date, `Rate unit`, `Chargeable unit rate`\n| SORT `Active now` DESC, conf_start_date DESC\n| LIMIT 20"
                                             }
                                         }
                                     }
@@ -4069,26 +4007,32 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM chargeback_conf_lookup\n| EVAL conf_chargeable_unit_rate_unit = COALESCE(conf_chargeable_unit_rate_unit, conf_ecu_rate_unit), conf_chargeable_unit_rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| KEEP conf_chargeable_unit_rate_unit, conf_chargeable_unit_rate, conf_start_date, conf_end_date"
+                                "esql": "FROM chargeback_conf_lookup\n| EVAL `Rate unit` = COALESCE(conf_chargeable_unit_rate_unit, conf_ecu_rate_unit), `Chargeable unit rate` = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), `Active now` = CASE(NOW() \u003e= conf_start_date AND NOW() \u003c= conf_end_date, \"yes\", \"no\")\n| KEEP `Active now`, conf_start_date, conf_end_date, `Rate unit`, `Chargeable unit rate`\n| SORT `Active now` DESC, conf_start_date DESC\n| LIMIT 20"
                             },
                             "visualization": {
                                 "columns": [
                                     {
-                                        "columnId": "conf_chargeable_unit_rate_unit"
-                                    },
-                                    {
-                                        "alignment": "left",
-                                        "columnId": "conf_chargeable_unit_rate"
-                                    },
-                                    {
-                                        "alignment": "center",
-                                        "columnId": "e7785ad9-760e-4215-ad19-40fc21eeb27e",
-                                        "isMetric": true,
+                                        "columnId": "Active now",
+                                        "isMetric": false,
                                         "isTransposed": false
                                     },
                                     {
-                                        "alignment": "center",
-                                        "columnId": "ef4ddf0e-7371-482e-98e1-7e131392d91f",
+                                        "columnId": "conf_start_date",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_end_date",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "Rate unit",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "Chargeable unit rate",
                                         "isMetric": true,
                                         "isTransposed": false
                                     }
@@ -4097,7 +4041,7 @@
                                 "layerType": "data"
                             }
                         },
-                        "title": "New suggestion",
+                        "title": "Configuration values by date window",
                         "version": 1,
                         "visualizationType": "lnsDatatable"
                     },
@@ -4109,20 +4053,20 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM chargeback_conf_lookup\n| EVAL conf_chargeable_unit_rate_unit = COALESCE(conf_chargeable_unit_rate_unit, conf_ecu_rate_unit), conf_chargeable_unit_rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate)\n| KEEP conf_chargeable_unit_rate_unit, conf_chargeable_unit_rate, conf_start_date, conf_end_date"
+                        "esql": "FROM chargeback_conf_lookup\n| EVAL `Rate unit` = COALESCE(conf_chargeable_unit_rate_unit, conf_ecu_rate_unit), `Chargeable unit rate` = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate), `Active now` = CASE(NOW() \u003e= conf_start_date AND NOW() \u003c= conf_end_date, \"yes\", \"no\")\n| KEEP `Active now`, conf_start_date, conf_end_date, `Rate unit`, `Chargeable unit rate`\n| SORT `Active now` DESC, conf_start_date DESC\n| LIMIT 20"
                     },
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Consumption unit rates (ECU / ERU)"
+                    "title": "Configuration values by date window"
                 },
                 "gridData": {
                     "h": 8,
                     "i": "54ff8784-cfb6-41dc-ad15-50547f49f9e7",
                     "sectionId": "1ae779e4-e93f-47b4-b0af-cc25ed49ba34",
-                    "w": 22,
+                    "w": 16,
                     "x": 0,
-                    "y": 10
+                    "y": 15
                 },
                 "panelIndex": "54ff8784-cfb6-41dc-ad15-50547f49f9e7",
                 "type": "lens"
@@ -4157,24 +4101,42 @@
                                         "005d9023-92e0-4783-a349-4a2e05b0bce4": {
                                             "columns": [
                                                 {
-                                                    "columnId": "conf_indexing_weight",
-                                                    "customLabel": true,
-                                                    "fieldName": "conf_indexing_weight",
-                                                    "inMetricDimension": true,
-                                                    "label": "Weight",
+                                                    "columnId": "conf_start_date",
+                                                    "customLabel": false,
+                                                    "fieldName": "conf_start_date",
+                                                    "label": "Date from",
                                                     "meta": {
-                                                        "esType": "integer",
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "conf_end_date",
+                                                    "customLabel": false,
+                                                    "fieldName": "conf_end_date",
+                                                    "label": "Date to",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "conf_indexing_weight",
+                                                    "customLabel": false,
+                                                    "fieldName": "conf_indexing_weight",
+                                                    "label": "Indexing weight",
+                                                    "meta": {
+                                                        "esType": "long",
                                                         "type": "number"
                                                     }
                                                 },
                                                 {
                                                     "columnId": "conf_query_weight",
-                                                    "customLabel": true,
+                                                    "customLabel": false,
                                                     "fieldName": "conf_query_weight",
-                                                    "inMetricDimension": true,
-                                                    "label": "Weight",
+                                                    "label": "Query weight",
                                                     "meta": {
-                                                        "esType": "integer",
+                                                        "esType": "long",
                                                         "type": "number"
                                                     }
                                                 },
@@ -4182,17 +4144,56 @@
                                                     "columnId": "conf_storage_weight",
                                                     "customLabel": false,
                                                     "fieldName": "conf_storage_weight",
-                                                    "inMetricDimension": true,
-                                                    "label": "Weight",
+                                                    "label": "Storage weight",
                                                     "meta": {
-                                                        "esType": "integer",
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "conf_utilization_memory_weight",
+                                                    "customLabel": false,
+                                                    "fieldName": "conf_utilization_memory_weight",
+                                                    "label": "Utilisation memory %",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "conf_utilization_storage_weight",
+                                                    "customLabel": false,
+                                                    "fieldName": "conf_utilization_storage_weight",
+                                                    "label": "Utilisation storage %",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "conf_memory_cost_weight",
+                                                    "customLabel": false,
+                                                    "fieldName": "conf_memory_cost_weight",
+                                                    "label": "Memory cost weight",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "conf_storage_cost_weight",
+                                                    "customLabel": false,
+                                                    "fieldName": "conf_storage_cost_weight",
+                                                    "label": "Storage cost weight",
+                                                    "meta": {
+                                                        "esType": "long",
                                                         "type": "number"
                                                     }
                                                 }
                                             ],
                                             "index": "8f632b34627f697e9702333f8ef042ab73e3436b01f9a29710a96cc9dad323b9",
                                             "query": {
-                                                "esql": "FROM chargeback_conf_lookup | KEEP *weight"
+                                                "esql": "FROM chargeback_conf_lookup\n| KEEP conf_start_date, conf_end_date, conf_indexing_weight, conf_query_weight, conf_storage_weight, conf_utilization_memory_weight, conf_utilization_storage_weight, conf_memory_cost_weight, conf_storage_cost_weight\n| SORT conf_start_date DESC\n| LIMIT 20"
                                             }
                                         }
                                     }
@@ -4201,7 +4202,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM chargeback_conf_lookup | KEEP *weight"
+                                "esql": "FROM chargeback_conf_lookup\n| KEEP conf_start_date, conf_end_date, conf_indexing_weight, conf_query_weight, conf_storage_weight, conf_utilization_memory_weight, conf_utilization_storage_weight, conf_memory_cost_weight, conf_storage_cost_weight\n| SORT conf_start_date DESC\n| LIMIT 20"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -4209,6 +4210,53 @@
                                     "yLeft": true,
                                     "yRight": true
                                 },
+                                "columns": [
+                                    {
+                                        "columnId": "conf_start_date",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_end_date",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_indexing_weight",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_query_weight",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_storage_weight",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_utilization_memory_weight",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_utilization_storage_weight",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_memory_cost_weight",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "conf_storage_cost_weight",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    }
+                                ],
                                 "fittingFunction": "Linear",
                                 "gridlinesVisibilitySettings": {
                                     "x": true,
@@ -4267,7 +4315,7 @@
                                 "valueLabels": "hide"
                             }
                         },
-                        "title": "conf_indexing_weight \u0026 conf_query_weight \u0026 conf_storage_weight of (empty)",
+                        "title": "Weight configuration values",
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {
@@ -4277,95 +4325,929 @@
                     },
                     "filters": [],
                     "query": {
-                        "esql": "FROM chargeback_conf_lookup | KEEP *weight"
+                        "esql": "FROM chargeback_conf_lookup\n| KEEP conf_start_date, conf_end_date, conf_indexing_weight, conf_query_weight, conf_storage_weight, conf_utilization_memory_weight, conf_utilization_storage_weight, conf_memory_cost_weight, conf_storage_cost_weight\n| SORT conf_start_date DESC\n| LIMIT 20"
                     },
                     "searchSessionId": "62d2fe44-dd84-4cd0-ac53-38b090b0eff6",
                     "syncColors": false,
                     "syncCursor": true,
                     "syncTooltips": false,
-                    "title": "Blended rate weighting percentages"
+                    "title": "Weight configuration values"
                 },
                 "gridData": {
                     "h": 8,
                     "i": "a3a091e7-6bff-4edf-bc65-993e8a3648de",
                     "sectionId": "1ae779e4-e93f-47b4-b0af-cc25ed49ba34",
-                    "w": 6,
-                    "x": 22,
-                    "y": 10
+                    "w": 8,
+                    "x": 16,
+                    "y": 15
                 },
                 "panelIndex": "a3a091e7-6bff-4edf-bc65-993e8a3648de",
                 "type": "lens"
             },
             {
                 "embeddableConfig": {
-                    "content": "## Blended weight calculation\n\nThe chargeback integration calculates a blended cost value (from consumption units: ECU or ERU) by combining indexing time (hot tier only), query time, and storage size with configurable weights set in `chargeback_conf_lookup` (default: indexing=20, query=20, storage=40). Each weight is a percentage representing how much that activity contributes to the total cost, allowing you to prioritize storage-heavy vs compute-heavy workloads based on your organization's usage patterns. Adjust weights by updating the lookup index to match your cost model (e.g., increase query weight for analytics-heavy teams, increase storage weight for archival use cases).",
-                    "title": ""
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "## Configuration field guide\n\nThese values are read from `chargeback_conf_lookup` and are applied by date window (`conf_start_date` → `conf_end_date`). The active row appears first in the tables.\n\n- **`Chargeable unit rate`**: conversion from ECU/ERU units into currency.\n- **`Rate unit`**: currency unit for the conversion rate (for example EUR or USD).\n- **`conf_indexing_weight`**: blended-cost weight for indexing activity.\n- **`conf_query_weight`**: blended-cost weight for query activity.\n- **`conf_storage_weight`**: blended-cost weight for storage activity.\n- **`conf_utilization_memory_weight`**: memory importance when calculating utilization score.\n- **`conf_utilization_storage_weight`**: storage importance when calculating utilization score.\n- **`conf_memory_cost_weight`**: split factor for estimated memory allocation.\n- **`conf_storage_cost_weight`**: split factor for estimated storage allocation.\n- **`conf_start_date` / `conf_end_date`**: validity window used to select configuration for each day.",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
                 },
                 "gridData": {
-                    "h": 10,
+                    "h": 23,
                     "i": "e55da6bd-a4be-4610-b4f8-ecb4f97dbc55",
                     "sectionId": "1ae779e4-e93f-47b4-b0af-cc25ed49ba34",
-                    "w": 14,
-                    "x": 22,
+                    "w": 24,
+                    "x": 24,
                     "y": 0
                 },
                 "panelIndex": "e55da6bd-a4be-4610-b4f8-ecb4f97dbc55",
-                "type": "DASHBOARD_MARKDOWN"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
-                    "content": "## Deployment group extraction\n\nThe chargeback integration extracts `deployment_group` from ESS Billing integration deployment tags (requires ESS Billing integration v1.7.0+) using runtime mappings that scan for tags matching the pattern `chargeback_group:\u003cgroup_name\u003e`. Set tags on your deployments via the Elasticsearch Service Console (cloud.elastic.co → deployment settings → add tag `chargeback_group:your_team_name`) or the ESS API. Deployments without the tag will have `deployment_group: \"\"` and still work, just without tag-based grouping.",
-                    "title": ""
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "## Deployment group extraction\n\nThe chargeback integration extracts `deployment_group` from ESS Billing integration deployment tags (requires ESS Billing integration v1.7.0+) using runtime mappings that scan for tags matching the pattern `chargeback_group:\u003cgroup_name\u003e`. Set tags on your deployments via the Elasticsearch Service Console (cloud.elastic.co → deployment settings → add tag `chargeback_group:your_team_name`) or the ESS API. Deployments without the tag will have `deployment_group: \"\"` and still work, just without tag-based grouping.",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
                 },
                 "gridData": {
-                    "h": 10,
+                    "h": 15,
                     "i": "a9db815d-08c9-49a1-9699-f51be117e502",
                     "sectionId": "1ae779e4-e93f-47b4-b0af-cc25ed49ba34",
-                    "w": 12,
-                    "x": 36,
+                    "w": 8,
+                    "x": 16,
                     "y": 0
                 },
                 "panelIndex": "a9db815d-08c9-49a1-9699-f51be117e502",
-                "type": "DASHBOARD_MARKDOWN"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
-                    "content": "## Normalised cost\nNormalised cost is calculated as consumption units (ECU — Elastic Consumption Units — or ERU — Elastic Resource Units, depending on your billing source) multiplied by the conversion rate (`conf_chargeable_unit_rate`) from the `chargeback_conf_lookup` index, where the rate is selected based on the time window being queried. This allows you to convert raw consumption (ECU or ERU) into your preferred currency (e.g., EUR, USD) and apply different rates for different time periods. You can adjust this by updating the lookup index with period-specific rates."
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "## Normalised cost\nNormalised cost is calculated as consumption units (ECU — Elastic Consumption Units — or ERU — Elastic Resource Units, depending on your billing source) multiplied by the conversion rate (`conf_chargeable_unit_rate`) from the `chargeback_conf_lookup` index, where the rate is selected based on the time window being queried. This allows you to convert raw consumption (ECU or ERU) into your preferred currency (e.g., EUR, USD) and apply different rates for different time periods. You can adjust this by updating the lookup index with period-specific rates.",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
                 },
                 "gridData": {
-                    "h": 10,
+                    "h": 15,
                     "i": "b50797e9-6976-4df6-9ada-2f64b8b9365e",
                     "sectionId": "1ae779e4-e93f-47b4-b0af-cc25ed49ba34",
-                    "w": 10,
+                    "w": 8,
                     "x": 0,
                     "y": 0
                 },
                 "panelIndex": "b50797e9-6976-4df6-9ada-2f64b8b9365e",
-                "type": "DASHBOARD_MARKDOWN"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
-                    "content": "## Configuration date span\nThe `chargeback_conf_lookup` index supports time-windowed configuration using `conf_start_date` and `conf_end_date` fields, allowing you to set different consumption unit (ECU or ERU) rates and weights for specific time periods. Create multiple configuration documents with different date ranges (e.g., Q1 rates vs Q2 rates) and the dashboard will apply the appropriate configuration based on the query time window. This enables historical cost analysis with period-accurate pricing and weight adjustments.",
-                    "title": ""
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "## Configuration date span\nThe `chargeback_conf_lookup` index supports time-windowed configuration using `conf_start_date` and `conf_end_date` fields, allowing you to set different consumption unit (ECU or ERU) rates and weights for specific time periods. Create multiple configuration documents with different date ranges (e.g., Q1 rates vs Q2 rates) and the dashboard will apply the appropriate configuration based on the query time window. This enables historical cost analysis with period-accurate pricing and weight adjustments.",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
                 },
                 "gridData": {
-                    "h": 10,
+                    "h": 15,
                     "i": "03e2d9f7-5217-4e71-ba05-667fdca2b1b9",
                     "sectionId": "1ae779e4-e93f-47b4-b0af-cc25ed49ba34",
-                    "w": 12,
-                    "x": 10,
+                    "w": 8,
+                    "x": 8,
                     "y": 0
                 },
                 "panelIndex": "03e2d9f7-5217-4e71-ba05-667fdca2b1b9",
-                "type": "DASHBOARD_MARKDOWN"
+                "type": "visualization"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "# Cost by component (SKU)",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 3,
+                    "i": "c04d8f10-2001-4000-8000-chargebacksku01",
+                    "sectionId": "c04d8f10-0001-4000-8000-chargebacksku01",
+                    "w": 48,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "c04d8f10-2001-4000-8000-chargebacksku01",
+                "type": "visualization"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                    "managed": false,
+                                    "name": "billing_cluster_cost_lookup",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "billing_cluster_cost_lookup",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                            "timeField": "@timestamp",
+                                            "title": "billing_cluster_cost_lookup"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "28174526-fb0d-4645-a2b7-f5101203fb4e": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "cost_type",
+                                                    "customLabel": false,
+                                                    "fieldName": "cost_type",
+                                                    "label": "cost_type",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "cost_category",
+                                                    "customLabel": false,
+                                                    "fieldName": "cost_category",
+                                                    "label": "cost_category",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Normalised cost",
+                                                    "customLabel": false,
+                                                    "fieldName": "Normalised cost",
+                                                    "label": "Normalised cost",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                            "query": {
+                                                "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_type, cost_category\n| SORT `Normalised cost` DESC"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_type, cost_category\n| SORT `Normalised cost` DESC"
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "cost_type",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "cost_category",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "Normalised cost",
+                                        "isMetric": true,
+                                        "isTransposed": false,
+                                        "summaryRow": "sum"
+                                    }
+                                ],
+                                "layerId": "28174526-fb0d-4645-a2b7-f5101203fb4e",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Cost by Type and Category",
+                        "version": 1,
+                        "visualization": {
+                            "layerId": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                            "layerType": "data"
+                        },
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "description": "Full deployment bill: the sum of ALL billing SKUs (data tiers, ML, Kibana, snapshots, data transfer and on-prem nodes) converted at the configured rate. This is the highest-level total. Tier and data-stream panels show only the allocatable data-tier pool, so they sum to less than this figure.",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_type, cost_category\n| SORT `Normalised cost` DESC"
+                    },
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "c04d8f10-1001-4000-8000-chargebacksku01",
+                    "sectionId": "c04d8f10-0001-4000-8000-chargebacksku01",
+                    "w": 24,
+                    "x": 0,
+                    "y": 3
+                },
+                "panelIndex": "c04d8f10-1001-4000-8000-chargebacksku01",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "# Data Tiers / Utilisation",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 3,
+                    "i": "c04d8f10-2002-4000-8000-chargebackdt01",
+                    "sectionId": "c04d8f10-0002-4000-8000-chargebackdt01",
+                    "w": 48,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "c04d8f10-2002-4000-8000-chargebackdt01",
+                "type": "visualization"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "billing-realized-pool-dv": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "billing-realized-pool-dv",
+                                    "managed": false,
+                                    "name": "billing_realized_pool_lookup",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "billing_realized_pool_lookup",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                            "timeField": "@timestamp",
+                                            "title": "billing_cluster_cost_lookup"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "28174526-fb0d-4645-a2b7-f5101203fb4e": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "@timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "@timestamp",
+                                                    "label": "@timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "deployment",
+                                                    "customLabel": false,
+                                                    "fieldName": "deployment",
+                                                    "label": "Deployment",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Normalised cost",
+                                                    "customLabel": false,
+                                                    "fieldName": "Normalised cost",
+                                                    "inMetricDimension": true,
+                                                    "label": "Normalised cost",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                            "query": {
+                                                "esql": "FROM billing_realized_pool_lookup\n| WHERE @timestamp IS NOT NULL AND deployment_name IS NOT NULL\n| EVAL ts = @timestamp, deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * COALESCE(util_score, 1.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| STATS `Normalised cost` = SUM(chargeable_pool * rate) BY ts, deployment\n| RENAME ts AS `@timestamp`\n| SORT `@timestamp` ASC\n| LIMIT 5000"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM billing_realized_pool_lookup\n| WHERE @timestamp IS NOT NULL AND deployment_name IS NOT NULL\n| EVAL ts = @timestamp, deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * COALESCE(util_score, 1.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| STATS `Normalised cost` = SUM(chargeable_pool * rate) BY ts, deployment\n| RENAME ts AS `@timestamp`\n| SORT `@timestamp` ASC\n| LIMIT 5000"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "Normalised cost"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "default",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "28174526-fb0d-4645-a2b7-f5101203fb4e",
+                                        "layerType": "data",
+                                        "seriesType": "area_stacked",
+                                        "splitAccessor": "deployment",
+                                        "xAccessor": "@timestamp"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "Realised Pool per Deployment",
+                        "version": 1,
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Allocatable pool: data-tier capacity SKUs plus on-prem nodes, discounted by p95 utilisation and converted at the configured rate. It excludes non-allocatable SKUs (ML, Kibana, snapshots, data transfer), so it is lower than the full deployment bill above.",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "esql": "FROM billing_realized_pool_lookup\n| WHERE @timestamp IS NOT NULL AND deployment_name IS NOT NULL\n| EVAL ts = @timestamp, deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * COALESCE(util_score, 1.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| STATS `Normalised cost` = SUM(chargeable_pool * rate) BY ts, deployment\n| RENAME ts AS `@timestamp`\n| SORT `@timestamp` ASC\n| LIMIT 5000"
+                    },
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Realised Pool per Deployment"
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "c04d8f10-1002-4000-8000-chargebackdt01",
+                    "sectionId": "c04d8f10-0002-4000-8000-chargebackdt01",
+                    "w": 48,
+                    "x": 0,
+                    "y": 3
+                },
+                "panelIndex": "c04d8f10-1002-4000-8000-chargebackdt01",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "cluster-tier-contribution-dv": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "cluster-tier-contribution-dv",
+                                    "managed": false,
+                                    "name": "cluster_tier_contribution_lookup",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "cluster_tier_contribution_lookup",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "tier-breakdown-dv",
+                                            "timeField": "@timestamp",
+                                            "title": "billing_realized_pool_lookup"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "tier-breakdown-layer": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "Data Tier",
+                                                    "customLabel": false,
+                                                    "fieldName": "Data Tier",
+                                                    "label": "Data Tier",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Normalised cost",
+                                                    "customLabel": false,
+                                                    "fieldName": "Normalised cost",
+                                                    "inMetricDimension": true,
+                                                    "label": "Normalised cost",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "tier-breakdown-dv",
+                                            "query": {
+                                                "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY tier_label\n| WHERE tier_label IS NOT NULL\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 50"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY tier_label\n| WHERE tier_label IS NOT NULL\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 50"
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "Data Tier",
+                                        "isMetric": false,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "Normalised cost",
+                                        "isMetric": true,
+                                        "isTransposed": false,
+                                        "summaryRow": "sum"
+                                    }
+                                ],
+                                "layerId": "tier-breakdown-layer",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Chargeable Pool by Data Tier",
+                        "version": 1,
+                        "visualization": {
+                            "layerId": "tier-breakdown-dv",
+                            "layerType": "data"
+                        },
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "description": "Full deployment bill: the sum of ALL billing SKUs (data tiers, ML, Kibana, snapshots, data transfer and on-prem nodes) converted at the configured rate. This is the highest-level total. Tier and data-stream panels show only the allocatable data-tier pool, so they sum to less than this figure.",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "esql": "FROM cluster_tier_contribution_lookup\n| WHERE composite_key IS NOT NULL AND tier IS NOT NULL AND tier != \"unknown\"\n| EVAL ts = @timestamp\n| LOOKUP JOIN billing_realized_pool_lookup ON composite_key\n| WHERE data_tier_capacity_ecu IS NOT NULL\n| LOOKUP JOIN cluster_capacity_utilization_lookup ON composite_key\n| LOOKUP JOIN cluster_deployment_contribution_lookup ON composite_key\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| EVAL deployment = CASE(deployment_id IS NULL, deployment_name, CONCAT(deployment_name, \" (\", LEFT(deployment_id, 6), \")\"))\n| EVAL mem_w = COALESCE(TO_DOUBLE(conf_utilization_memory_weight), 70.0), disk_w = COALESCE(TO_DOUBLE(conf_utilization_storage_weight), 30.0)\n| EVAL heap_p = COALESCE(heap_used_pct_p95, 100) / 100, disk_p = COALESCE(disk_used_pct_p95, 100) / 100\n| EVAL util_score = (mem_w * heap_p + disk_w * disk_p) / (mem_w + disk_w), chargeable_pool = data_tier_capacity_ecu * util_score, tier_label = CASE(tier IS NULL OR tier == \"unknown\", \"Unclassified\", tier)\n| EVAL idx_w = COALESCE(TO_DOUBLE(conf_indexing_weight), 20.0), qry_w = COALESCE(TO_DOUBLE(conf_query_weight), 20.0), sto_w = COALESCE(TO_DOUBLE(conf_storage_weight), 40.0), rate = COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)\n| EVAL indexing = CASE(deployment_sum_indexing_time \u003e 0, TO_DOUBLE(tier_sum_indexing_time) / deployment_sum_indexing_time * chargeable_pool), querying = CASE(deployment_sum_query_time \u003e 0, TO_DOUBLE(tier_sum_query_time) / deployment_sum_query_time * chargeable_pool), store = CASE(deployment_sum_store_size \u003e 0, TO_DOUBLE(tier_sum_store_size) / deployment_sum_store_size * chargeable_pool), data_set = CASE(deployment_sum_data_set_store_size \u003e 0, TO_DOUBLE(tier_sum_data_set_store_size) / deployment_sum_data_set_store_size * chargeable_pool)\n| EVAL storage = CASE(store == 0, data_set, store), total_weight_hot = sto_w + qry_w + idx_w, total_weight_cold = sto_w + qry_w\n| EVAL blended = CASE(tier_label == \"hot/content\", (storage * sto_w + querying * qry_w + indexing * idx_w) / total_weight_hot, (storage * sto_w + querying * qry_w) / total_weight_cold) * rate\n| STATS `Normalised cost` = SUM(blended) BY tier_label\n| WHERE tier_label IS NOT NULL\n| RENAME tier_label AS `Data Tier`\n| SORT `Normalised cost` DESC\n| LIMIT 50"
+                    },
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Chargeable Pool by Data Tier"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "c04d8f10-1003-4000-8000-chargebackdt02",
+                    "sectionId": "c04d8f10-0002-4000-8000-chargebackdt01",
+                    "w": 48,
+                    "x": 0,
+                    "y": 19
+                },
+                "panelIndex": "c04d8f10-1003-4000-8000-chargebackdt02",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                    "managed": false,
+                                    "name": "billing_cluster_cost_lookup",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "billing_cluster_cost_lookup",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                            "timeField": "@timestamp",
+                                            "title": "billing_cluster_cost_lookup"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "a72c8733-c35a-4013-80dd-293f9a0e8f7b": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "Cost Type",
+                                                    "customLabel": false,
+                                                    "fieldName": "Cost Type",
+                                                    "label": "Cost Type",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Normalised cost",
+                                                    "customLabel": false,
+                                                    "fieldName": "Normalised cost",
+                                                    "inMetricDimension": true,
+                                                    "label": "Normalised cost",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                            "query": {
+                                                "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_type\n| RENAME cost_type AS `Cost Type`\n| SORT `Normalised cost` DESC"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_type\n| RENAME cost_type AS `Cost Type`\n| SORT `Normalised cost` DESC"
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "layerId": "a72c8733-c35a-4013-80dd-293f9a0e8f7b",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metrics": [
+                                            "Normalised cost"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "Cost Type"
+                                        ]
+                                    }
+                                ],
+                                "shape": "treemap"
+                            }
+                        },
+                        "title": "Normalised cost by Cost Type",
+                        "version": 1,
+                        "visualizationType": "lnsPie"
+                    },
+                    "description": "Full deployment bill: the sum of ALL billing SKUs (data tiers, ML, Kibana, snapshots, data transfer and on-prem nodes) converted at the configured rate. This is the highest-level total. Tier and data-stream panels show only the allocatable data-tier pool, so they sum to less than this figure.",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_type\n| RENAME cost_type AS `Cost Type`\n| SORT `Normalised cost` DESC"
+                    },
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Normalised cost by Cost Type"
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "c04d8f10-1003-4000-8000-chargebacksku01",
+                    "sectionId": "c04d8f10-0001-4000-8000-chargebacksku01",
+                    "w": 12,
+                    "x": 24,
+                    "y": 3
+                },
+                "panelIndex": "c04d8f10-1003-4000-8000-chargebacksku01",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                    "managed": false,
+                                    "name": "billing_cluster_cost_lookup",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "billing_cluster_cost_lookup",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                            "timeField": "@timestamp",
+                                            "title": "billing_cluster_cost_lookup"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "292a9a01-e99b-4699-b669-8719ce91ae57": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "Cost Category",
+                                                    "customLabel": false,
+                                                    "fieldName": "Cost Category",
+                                                    "label": "Cost Category",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Normalised cost",
+                                                    "customLabel": false,
+                                                    "fieldName": "Normalised cost",
+                                                    "inMetricDimension": true,
+                                                    "label": "Normalised cost",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "2bf6c0d816ef0a2d56d03ede549c16c08c35db2cf02d78c12756a98a33f50e4f",
+                                            "query": {
+                                                "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_category\n| RENAME cost_category AS `Cost Category`\n| SORT `Normalised cost` DESC"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_category\n| RENAME cost_category AS `Cost Category`\n| SORT `Normalised cost` DESC"
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "layerId": "292a9a01-e99b-4699-b669-8719ce91ae57",
+                                        "layerType": "data",
+                                        "legendDisplay": "default",
+                                        "metrics": [
+                                            "Normalised cost"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "Cost Category"
+                                        ]
+                                    }
+                                ],
+                                "shape": "treemap"
+                            }
+                        },
+                        "title": "Normalised cost by Cost Category",
+                        "version": 1,
+                        "visualizationType": "lnsPie"
+                    },
+                    "description": "Full deployment bill: the sum of ALL billing SKUs (data tiers, ML, Kibana, snapshots, data transfer and on-prem nodes) converted at the configured rate. This is the highest-level total. Tier and data-stream panels show only the allocatable data-tier pool, so they sum to less than this figure.",
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "filters": [],
+                    "query": {
+                        "esql": "FROM billing_cluster_cost_lookup\n| WHERE cost_type IS NOT NULL\n| EVAL ts = @timestamp\n| LOOKUP JOIN chargeback_conf_lookup ON ts \u003e= conf_start_date AND ts \u003c= conf_end_date\n| STATS `Normalised cost` = SUM(COALESCE(total_chargeable_units, total_ecu) * COALESCE(conf_chargeable_unit_rate, conf_ecu_rate, 1.0)) BY cost_category\n| RENAME cost_category AS `Cost Category`\n| SORT `Normalised cost` DESC"
+                    },
+                    "syncColors": false,
+                    "syncCursor": true,
+                    "syncTooltips": false,
+                    "title": "Normalised cost by Cost Category"
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "c04d8f10-1004-4000-8000-chargebacksku01",
+                    "sectionId": "c04d8f10-0001-4000-8000-chargebacksku01",
+                    "w": 12,
+                    "x": 36,
+                    "y": 6
+                },
+                "panelIndex": "c04d8f10-1004-4000-8000-chargebacksku01",
+                "type": "lens"
             }
         ],
         "sections": [
             {
                 "collapsed": false,
                 "gridData": {
-                    "i": "2b8b2365-5e05-4f1d-8880-f35892a8e60f",
+                    "i": "c04d8f10-0001-4000-8000-chargebacksku01",
+                    "y": 10
+                },
+                "title": "Cost by component (SKU)"
+            },
+            {
+                "collapsed": false,
+                "gridData": {
+                    "i": "c04d8f10-0002-4000-8000-chargebackdt01",
                     "y": 11
+                },
+                "title": "Datatiers / utilization"
+            },
+            {
+                "collapsed": false,
+                "gridData": {
+                    "i": "2b8b2365-5e05-4f1d-8880-f35892a8e60f",
+                    "y": 13
                 },
                 "title": "Deployment group statistics"
             },
@@ -4373,15 +5255,15 @@
                 "collapsed": false,
                 "gridData": {
                     "i": "5092dfac-3f29-4eab-8c8f-f97bf1479370",
-                    "y": 12
+                    "y": 14
                 },
                 "title": "Deployment statistics"
             },
             {
-                "collapsed": true,
+                "collapsed": false,
                 "gridData": {
                     "i": "96918af7-e003-4af8-8c37-245db141d60c",
-                    "y": 13
+                    "y": 15
                 },
                 "title": "Data tier and data stream overview"
             },
@@ -4389,7 +5271,7 @@
                 "collapsed": false,
                 "gridData": {
                     "i": "be60066e-c6d8-4e27-b8f4-948f37126ecf",
-                    "y": 14
+                    "y": 16
                 },
                 "title": "Data tier and data stream per day"
             },
@@ -4397,17 +5279,19 @@
                 "collapsed": false,
                 "gridData": {
                     "i": "1ae779e4-e93f-47b4-b0af-cc25ed49ba34",
-                    "y": 15
+                    "y": 17
                 },
                 "title": "Chargeback Configuration Information"
             }
         ],
-        "timeRestore": false,
+        "timeFrom": "now-3M",
+        "timeRestore": true,
+        "timeTo": "now",
         "title": "[Chargeback] Cost and Consumption breakdown",
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2025-12-02T09:15:39.552Z",
+    "created_at": "2026-05-30T15:22:04.742Z",
     "id": "chargeback-39a39857-746c-4a29-adca-3c2fcb6bcfb6",
     "references": [
         {
@@ -4422,6 +5306,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "10.3.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "typeMigrationVersion": "10.3.0"
 }

--- a/packages/chargeback/manifest.yml
+++ b/packages/chargeback/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: chargeback
 title: "Chargeback"
-version: 0.3.2
+version: 0.4.0
 description: "This package calculates chargeback based on billing and consumption data"
 type: integration
 categories:

--- a/packages/chargeback/validation.yml
+++ b/packages/chargeback/validation.yml
@@ -1,0 +1,3 @@
+errors:
+  exclude_checks:
+    - SVR00002 # Mandatory filters in dashboards — intentionally removed: the @timestamp:exists filter was for validation only and caused confusing empty panels for users.

--- a/packages/onprem_billing/changelog.yml
+++ b/packages/onprem_billing/changelog.yml
@@ -1,4 +1,24 @@
 # newer versions go on top
+- version: "0.3.3"
+  changes:
+    - description: "Fix billing transform: add `deployment_tags` to pivot group_by so chargeback groups are correctly propagated to `metrics-ess_billing.billing-onprem` and picked up by the Chargeback `billing_cluster_cost` transform. Without this, all on-prem deployments showed an empty `deployment_group` in Chargeback regardless of configured tags. Bump `fleet_transform_version` to 0.3.3 to force transform recreation."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/8
+- version: "0.3.2"
+  changes:
+    - description: "Billing pipeline pass-through for documents already in ESS Billing shape; fixes E2E seed and direct bulk index when default_pipeline is set on the data stream."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/90
+- version: "0.3.1"
+  changes:
+    - description: "Fix billing transform runtime @timestamp (System.currentTimeMillis) and pivot group_by (keyword fields cannot use max aggregation)."
+      type: bugfix
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/90
+- version: "0.3.0"
+  changes:
+    - description: "Ship packaged ingest pipelines (no enrich processor). Billing transform reads `onprem_billing_config` instead of Stack Monitoring; daily mERU is computed on config rows and emitted to `metrics-ess_billing.billing-onprem`. Removes manual enrich policies and `calculate_cost` pipeline setup required for Chargeback testing."
+      type: enhancement
+      link: https://github.com/elastic/elasticsearch-chargeback/issues/90
 - version: "0.2.1"
   changes:
     - description: "Use `monitoring-indices*` and `*:monitoring-indices*` as transform sources so Elasticsearch integration index-pivot output remains discoverable when the destination index name is customized under the same prefix. Aligns with Chargeback and elasticsearch-chargeback#90."

--- a/packages/onprem_billing/docs/README.md
+++ b/packages/onprem_billing/docs/README.md
@@ -26,8 +26,9 @@ Using mERU solves this:
 ┌──────────────────────────────────────────────────────────────────┐
 │                     Monitoring Cluster                           │
 │  ┌─────────────────┐    ┌──────────────────┐    ┌────────────┐   │
-│  │ monitoring-     │───▶│ onprem_billing   │───▶│ Chargeback │   │
-│  │ indices         │    │ integration      │    │            │   │
+│  │ monitoring-     │───▶│ config_bootstrap │    │ Chargeback │   │
+│  │ indices         │    │  → config index  │───▶│            │   │
+│  │                 │    │ billing transform│    │            │   │
 │  └────────▲────────┘    └──────────────────┘    └────────────┘   │
 │           │                      │                               │
 │           │                      ▼                               │
@@ -176,7 +177,7 @@ POST onprem_billing_config/_update/<document_id>
 }
 ```
 
-The integration will compute: `daily_meru = deployment_erus × 1000`
+Set `daily_meru` to `deployment_erus × 1000` (the config bootstrap pipeline computes this on transform writes; include it on manual `_update` calls).
 
 #### Option B: RAM-Based Input (Recommended for Ops Teams)
 
@@ -218,120 +219,30 @@ The integration will compute:
 | production | ERU | `deployment_erus: 5.0` | 5000 mERU/day |
 | **Total** | | **6 ERU licensed** | **6000 mERU/day** |
 
-### Step 3: Create Enrich Policy and Pipeline
+### Step 3: Refresh `daily_meru` after deployment updates (0.3.0+)
 
-After ALL deployments are configured:
+From **0.3.0** onward, ingest pipelines ship with the integration and the billing transform reads `onprem_billing_config` directly (no enrich policies or manual `calculate_cost` pipeline).
 
-**3a. Create and execute the enrich policy:**
-
-```json
-PUT /_enrich/policy/onprem_billing_config_enrich_policy
-{
-  "match": {
-    "indices": "onprem_billing_config",
-    "match_field": "deployment_id",
-    "enrich_fields": ["daily_meru", "deployment_erus", "deployment_name", "deployment_tags", "node_count", "ram_per_node_gb"]
-  }
-}
-
-POST /_enrich/policy/onprem_billing_config_enrich_policy/_execute
-```
-
-**3b. Create the organization config enrich policy:**
+When you change `deployment_erus` or RAM fields with `_update`, also set `daily_meru` (mERU per day = ERU × 1000), or re-index the document through the packaged config pipeline:
 
 ```json
-PUT /_enrich/policy/onprem_billing_org_config_policy
+POST onprem_billing_config/_update/<document_id>?pipeline=logs-onprem_billing.config_bootstrap-0.3.3-config_bootstrap
 {
-  "match": {
-    "indices": "onprem_billing_config",
-    "match_field": "config_type",
-    "enrich_fields": ["total_annual_license_cost", "total_erus_purchased", "eru_to_ram_gb", "currency_unit"]
-  }
-}
-
-POST /_enrich/policy/onprem_billing_org_config_policy/_execute
-```
-
-**3c. Create the ingest pipeline:**
-
-> **Note:** This pipeline must be created manually because it uses the `enrich` processor, which is not supported in packaged integration pipelines.
-
-```json
-PUT _ingest/pipeline/calculate_cost
-{
-  "description": "On-Prem Billing: Computes mERU from ERU or RAM config and maps to ESS Billing schema",
-  "processors": [
-    {
-      "set": {
-        "field": "_org_lookup",
-        "value": "organization",
-        "description": "Set lookup key for org config"
-      }
-    },
-    {
-      "enrich": {
-        "policy_name": "onprem_billing_org_config_policy",
-        "field": "_org_lookup",
-        "target_field": "org_config",
-        "max_matches": 1,
-        "ignore_missing": true,
-        "ignore_failure": true
-      }
-    },
-    {
-      "enrich": {
-        "policy_name": "onprem_billing_config_enrich_policy",
-        "field": "cluster_uuid",
-        "target_field": "cost_config",
-        "max_matches": 1,
-        "ignore_missing": true,
-        "ignore_failure": true
-      }
-    },
-    {
-      "script": {
-        "lang": "painless",
-        "ignore_failure": true,
-        "description": "Compute mERU from ERU or RAM config and map to ESS Billing schema",
-        "source": "String deploymentId = ctx.cluster_uuid; String deploymentName = ctx.cluster_name; long dailyMeru = 1000L; List deploymentTags = new ArrayList(); int eruToRamGb = 64; if (ctx.org_config != null && ctx.org_config.eru_to_ram_gb != null) { eruToRamGb = (int) ctx.org_config.eru_to_ram_gb; } if (ctx.cost_config != null) { if (ctx.cost_config.deployment_name != null) { deploymentName = ctx.cost_config.deployment_name; } Object rawTags = ctx.cost_config.deployment_tags; if (rawTags != null) { if (rawTags instanceof List) { deploymentTags = (List) rawTags; } else { deploymentTags.add(rawTags.toString()); } } if (ctx.cost_config.daily_meru != null) { dailyMeru = (long) ctx.cost_config.daily_meru; } else if (ctx.cost_config.deployment_erus != null) { dailyMeru = (long) (ctx.cost_config.deployment_erus * 1000.0); } else if (ctx.cost_config.node_count != null && ctx.cost_config.ram_per_node_gb != null) { int totalRamGb = (int) ctx.cost_config.node_count * (int) ctx.cost_config.ram_per_node_gb; dailyMeru = (long) ((double) totalRamGb / (double) eruToRamGb * 1000.0); } } if (ctx.ess == null) ctx.ess = new HashMap(); if (ctx.ess.billing == null) ctx.ess.billing = new HashMap(); ctx.ess.billing.deployment_id = deploymentId; ctx.ess.billing.deployment_name = deploymentName; ctx.ess.billing.deployment_type = 'onprem'; ctx.ess.billing.deployment_tags = deploymentTags != null ? deploymentTags : new ArrayList(); ctx.ess.billing.kind = 'elasticsearch'; ctx.ess.billing.type = 'capacity'; ctx.ess.billing.unit = 'day'; ctx.ess.billing.zone_count = 1; ctx.ess.billing.name = 'On-Premises: ' + deploymentName; ctx.ess.billing.sku = 'onprem_node'; if (ctx['@timestamp'] != null) { ctx.ess.billing.from = ctx['@timestamp']; String ts = ctx['@timestamp'].toString(); if (ts.length() >= 10) { ctx.ess.billing.to = ts.substring(0, 10) + 'T23:59:59.999Z'; } } ctx.ess.billing.total_ecu = dailyMeru; ctx.ess.billing.put('quantity.value', 1.0); ctx.ess.billing.put('quantity.formatted_value', '1 day'); ctx.ess.billing.put('display_quantity.value', 1.0); ctx.ess.billing.put('display_quantity.formatted_value', '1 day'); ctx.ess.billing.put('display_quantity.type', 'default'); ctx.remove('cluster_uuid'); ctx.remove('cluster_name'); ctx.remove('cost_config'); ctx.remove('org_config'); ctx.remove('_org_lookup'); ctx.remove('doc_count');"
-      }
-    },
-    {
-      "pipeline": {
-        "description": "[Fleet] Global pipeline for all data streams",
-        "ignore_missing_pipeline": true,
-        "name": "global@custom"
-      }
-    },
-    {
-      "pipeline": {
-        "description": "[Fleet] Pipeline for all data streams of type metrics",
-        "ignore_missing_pipeline": true,
-        "name": "metrics@custom"
-      }
-    }
-  ]
-}
-```
-
-This pipeline is identical to the one in [elasticsearch-chargeback](https://github.com/elastic/elasticsearch-chargeback) (`scripts/onprem_billing_calculate_cost_pipeline.json`). Processor order: set `_org_lookup`, enrich org config, enrich deployment config, script, then Fleet pipelines.
-
-**3d. Update the billing transform to use the pipeline:**
-
-```json
-POST _transform/logs-onprem_billing.billing-default-0.2.0/_update
-{
-  "dest": {
-    "index": "metrics-ess_billing.billing-onprem",
-    "pipeline": "calculate_cost"
+  "doc": {
+    "deployment_erus": 3.0,
+    "deployment_tags": ["chargeback_group:platform_team"]
   }
 }
 ```
+
+> **Upgrading from 0.3.2 to 0.3.3:** The billing transform now includes `deployment_tags` in its pivot group_by, which is required for Chargeback group assignment. After upgrading, reset and restart the `billing` transform so the lookup index is recreated with the updated pivot key. Your existing `onprem_billing_config` deployment tags are preserved; no re-configuration is needed.
+
+> **Upgrading from 0.2.x:** Delete legacy enrich policies and the manual `calculate_cost` pipeline if you created them. Re-install the integration, then complete Steps 1–2 and start the billing transform below.
 
 ### Step 4: Start the Billing Transform
 
 ```json
-POST _transform/logs-onprem_billing.billing-default-0.2.0/_start
+POST _transform/logs-onprem_billing.billing-*/_start
 ```
 
 Or via Kibana: **Stack Management → Transforms** → Find `billing` transform → **Start**
@@ -438,13 +349,9 @@ PUT onprem_billing_config/_doc/<new-cluster-uuid>
 }
 ```
 
-**2. Re-execute the enrich policy:**
+After adding the deployment, start (or restart) the billing transform so today's billing rows are emitted.
 
-```json
-POST /_enrich/policy/onprem_billing_config_enrich_policy/_execute
-```
-
-> **Warning:** Do not re-run the bootstrap transform - it would overwrite existing configurations with defaults.
+> **Warning:** Do not re-run the bootstrap transform — it would overwrite existing configurations with defaults.
 
 ---
 
@@ -470,12 +377,7 @@ POST _transform/logs-onprem_billing.billing-*/_start
 GET monitoring-indices*/_count
 ```
 
-**Check enrich policies exist:**
-
-```json
-GET /_enrich/policy/onprem_billing_config_enrich_policy
-GET /_enrich/policy/onprem_billing_org_config_policy
-```
+**0.3.0+:** Confirm deployment rows have `daily_meru` set in `onprem_billing_config`.
 
 ### Bootstrap Transform Issues
 
@@ -511,23 +413,18 @@ GET onprem_billing_config/_search
 GET onprem_billing_config/_doc/organization
 ```
 
-**Re-execute enrich policies after config changes:**
-
-```json
-POST /_enrich/policy/onprem_billing_config_enrich_policy/_execute
-POST /_enrich/policy/onprem_billing_org_config_policy/_execute
-```
+**After config changes (0.3.0+):** Update `daily_meru` on deployment docs, then reset/start the billing transform.
 
 ### Common Errors
 
-**"Enrich policy not found"** - Create and execute both enrich policies (see Step 3).
+**"Enrich policy not found" (0.2.x only)** - Create and execute enrich policies, or upgrade to 0.3.0+.
 
-**"Enrich policy execution failed"** - Config index is empty. Wait for bootstrap or check bootstrap transform status.
+**No billing rows (0.3.0+)** - Ensure deployment docs exist with `daily_meru` and the billing transform is started.
 
 **mERU values seem wrong** - Check if `eru_to_ram_gb` in organization config matches your license terms.
 
 ### Getting Help
 
 1. Check transform stats: `GET _transform/logs-onprem_billing*/_stats?human`
-2. Check enrich policies: `GET /_enrich/policy/onprem_billing*`
+2. Check config: `GET onprem_billing_config/_search`
 3. Open an issue at [elasticsearch-chargeback](https://github.com/elastic/elasticsearch-chargeback)

--- a/packages/onprem_billing/elasticsearch/ingest_pipeline/billing.yml
+++ b/packages/onprem_billing/elasticsearch/ingest_pipeline/billing.yml
@@ -1,0 +1,89 @@
+---
+description: "On-Prem Billing: map config lookup rows to ESS Billing metrics (no enrich)."
+processors:
+  - set:
+      field: event.ingested
+      value: "{{{_ingest.timestamp}}}"
+      description: Pass-through docs already in ESS Billing shape — only refresh event.ingested
+      if: ctx.ess?.billing?.deployment_id != null && ctx.ess?.billing?.sku != null
+  - set:
+      field: _pass_through_billing
+      value: true
+      if: ctx.ess?.billing?.deployment_id != null && ctx.ess?.billing?.sku != null
+  - script:
+      lang: painless
+      ignore_failure: true
+      description: Map pivot output to ess.billing schema with mERU as total_ecu
+      if: ctx._pass_through_billing != true
+      source: |
+        String deploymentId = ctx.deployment_id;
+        String deploymentName = ctx.deployment_name;
+        if (deploymentName == null) {
+          deploymentName = deploymentId;
+        }
+        long dailyMeru = 1000L;
+        if (ctx.daily_meru != null) {
+          if (ctx.daily_meru instanceof Number) {
+            dailyMeru = ((Number) ctx.daily_meru).longValue();
+          } else {
+            dailyMeru = Long.parseLong(ctx.daily_meru.toString());
+          }
+        }
+        List deploymentTags = new ArrayList();
+        Object rawTags = ctx.deployment_tags;
+        if (rawTags != null) {
+          if (rawTags instanceof List) {
+            deploymentTags = (List) rawTags;
+          } else {
+            deploymentTags.add(rawTags.toString());
+          }
+        }
+        if (ctx.ess == null) {
+          ctx.ess = new HashMap();
+        }
+        if (ctx.ess.billing == null) {
+          ctx.ess.billing = new HashMap();
+        }
+        ctx.ess.billing.deployment_id = deploymentId;
+        ctx.ess.billing.deployment_name = deploymentName;
+        ctx.ess.billing.deployment_type = 'onprem';
+        ctx.ess.billing.deployment_tags = deploymentTags;
+        ctx.ess.billing.kind = 'elasticsearch';
+        ctx.ess.billing.type = 'capacity';
+        ctx.ess.billing.unit = 'day';
+        ctx.ess.billing.zone_count = 1;
+        ctx.ess.billing.name = 'On-Premises: ' + deploymentName;
+        ctx.ess.billing.sku = 'onprem_node';
+        if (ctx['@timestamp'] != null) {
+          ctx.ess.billing.from = ctx['@timestamp'];
+          String ts = ctx['@timestamp'].toString();
+          if (ts.length() >= 10) {
+            ctx.ess.billing.to = ts.substring(0, 10) + 'T23:59:59.999Z';
+          }
+        }
+        ctx.ess.billing.total_ecu = dailyMeru;
+        ctx.ess.billing.put('quantity.value', 1.0);
+        ctx.ess.billing.put('quantity.formatted_value', '1 day');
+        ctx.ess.billing.put('display_quantity.value', 1.0);
+        ctx.ess.billing.put('display_quantity.formatted_value', '1 day');
+        ctx.ess.billing.put('display_quantity.type', 'default');
+        ctx.remove('deployment_id');
+        ctx.remove('deployment_name');
+        ctx.remove('deployment_tags');
+        ctx.remove('daily_meru');
+  - set:
+      field: event.ingested
+      value: "{{{_ingest.timestamp}}}"
+      description: Set event.ingested for Chargeback billing_cluster_cost sync
+      if: ctx._pass_through_billing != true
+  - remove:
+      field: _pass_through_billing
+      ignore_missing: true
+  - pipeline:
+      description: "[Fleet] Global pipeline for all data streams"
+      ignore_missing_pipeline: true
+      name: global@custom
+  - pipeline:
+      description: "[Fleet] Pipeline for all data streams of type metrics"
+      ignore_missing_pipeline: true
+      name: metrics@custom

--- a/packages/onprem_billing/elasticsearch/ingest_pipeline/config_bootstrap.yml
+++ b/packages/onprem_billing/elasticsearch/ingest_pipeline/config_bootstrap.yml
@@ -1,0 +1,22 @@
+---
+description: "On-Prem Billing: compute daily_meru on deployment config rows (no enrich)."
+processors:
+  - script:
+      lang: painless
+      ignore_failure: true
+      description: Compute daily_meru from ERU or RAM fields on deployment config documents
+      if: ctx.config_type == 'deployment'
+      source: |
+        int eruToRamGb = 64;
+        if (ctx.eru_to_ram_gb != null) {
+          eruToRamGb = (int) ctx.eru_to_ram_gb;
+        }
+        long dailyMeru = 1000L;
+        if (ctx.deployment_erus != null) {
+          dailyMeru = (long) (ctx.deployment_erus * 1000.0);
+        } else if (ctx.node_count != null && ctx.ram_per_node_gb != null) {
+          int totalRamGb = (int) ctx.node_count * (int) ctx.ram_per_node_gb;
+          ctx.total_ram_gb = totalRamGb;
+          dailyMeru = (long) ((double) totalRamGb / (double) eruToRamGb * 1000.0);
+        }
+        ctx.daily_meru = dailyMeru;

--- a/packages/onprem_billing/elasticsearch/transform/billing/fields/fields.yml
+++ b/packages/onprem_billing/elasticsearch/transform/billing/fields/fields.yml
@@ -1,11 +1,13 @@
 - name: "@timestamp"
   type: date
-- name: cluster_uuid
+- name: deployment_id
   type: keyword
-- name: cluster_name
+- name: deployment_name
   type: keyword
-- name: doc_count
+- name: daily_meru
   type: long
+- name: deployment_tags
+  type: keyword
 - name: ess.billing
   type: group
   fields:
@@ -36,7 +38,7 @@
       type: integer
     - name: total_ecu
       type: float
-      description: Daily ECU value (currency conversion done by Chargeback conf_ecu_rate)
+      description: Daily mERU written as total_ecu for Chargeback compatibility
     - name: quantity.value
       type: float
     - name: quantity.formatted_value

--- a/packages/onprem_billing/elasticsearch/transform/billing/transform.yml
+++ b/packages/onprem_billing/elasticsearch/transform/billing/transform.yml
@@ -1,11 +1,17 @@
-description: Aggregates daily deployment data from Stack Monitoring, writing to ESS Billing compatible format with mERU (milli-ERU) cost allocation.
+description: Emit daily ESS Billing-compatible metrics from onprem_billing_config (mERU as total_ecu). No enrich policies required.
 source:
-  index:
-    # Matches default monitoring-indices and custom index-pivot destinations named monitoring-indices* (Elasticsearch integration).
-    - "monitoring-indices*"
-    - "*:monitoring-indices*"
+  index: onprem_billing_config
+  query:
+    term:
+      config_type: deployment
+  runtime_mappings:
+    "@timestamp":
+      type: date
+      script:
+        source: "emit(System.currentTimeMillis());"
 dest:
   index: metrics-ess_billing.billing-onprem
+  pipeline: 0.3.3-billing
 frequency: 60m
 sync:
   time:
@@ -13,24 +19,27 @@ sync:
     delay: 1h
 pivot:
   group_by:
+    deployment_id:
+      terms:
+        field: deployment_id
+    deployment_name:
+      terms:
+        field: deployment_name
+    deployment_tags:
+      terms:
+        field: deployment_tags
     "@timestamp":
       date_histogram:
         field: "@timestamp"
         calendar_interval: 1d
-    cluster_uuid:
-      terms:
-        field: elasticsearch.cluster.name
-    cluster_name:
-      terms:
-        field: elasticsearch.cluster.name
   aggregations:
-    doc_count:
-      value_count:
-        field: elasticsearch.cluster.name
+    daily_meru:
+      max:
+        field: daily_meru
 settings:
   deduce_mappings: false
   unattended: true
 _meta:
   managed: true
   run_as_kibana_system: false
-  fleet_transform_version: 0.2.1
+  fleet_transform_version: 0.3.3

--- a/packages/onprem_billing/elasticsearch/transform/config_bootstrap/transform.yml
+++ b/packages/onprem_billing/elasticsearch/transform/config_bootstrap/transform.yml
@@ -33,6 +33,7 @@ source:
         source: "emit('')"
 dest:
   index: onprem_billing_config
+  pipeline: 0.3.3-config_bootstrap
 pivot:
   group_by:
     config_type:
@@ -60,4 +61,4 @@ settings:
 _meta:
   managed: true
   run_as_kibana_system: false
-  fleet_transform_version: 0.2.1
+  fleet_transform_version: 0.3.3

--- a/packages/onprem_billing/manifest.yml
+++ b/packages/onprem_billing/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: onprem_billing
 title: "On-Premises Billing"
-version: "0.2.1"
+version: "0.3.3"
 source:
   license: "Elastic-2.0"
 description: "Generates billing metrics compatible with ESS Billing for on-premises, ECE, and ECK deployments using milli-ERU (mERU) cost allocation. Supports ERU or RAM-based configuration per deployment."


### PR DESCRIPTION
## Summary

- **chargeback 0.3.2 → 0.4.0**: Realised cost model — allocatable data-tier capacity pool discounted by p95 utilisation, then distributed across tiers/data-streams by workload (indexing/query/storage share). Two new transforms (`billing_realized_pool`, `cluster_capacity_utilization`), two new ingest pipelines, extended config weights, and a fully overhauled dashboard.
- **onprem_billing 0.3.2 → 0.3.3**: New ingest pipelines for billing and config_bootstrap transforms.

## chargeback 0.4.0 — key changes

### New transforms & pipelines
| Asset | Purpose |
|---|---|
| `billing_realized_pool` transform | Daily allocatable data-tier ECU per deployment (from `metrics-ess_billing.billing-*`) |
| `cluster_capacity_utilization` transform | Daily p95 heap + disk utilisation per deployment (from `node_stats`) |
| `capacity_utilization.yml` pipeline | Sets `composite_key`, normalises utilisation percentile fields |
| `realized_pool.yml` pipeline | Sets `composite_key`, aliases chargeable-unit fields |
| `chargeback_conf_lookup` | Extended with `conf_utilization_memory_weight`, `conf_utilization_storage_weight`, and workload allocation weights |

### Bug fixes
- Removed stale `0.4.0-*.yml` versioned pipeline files that caused Fleet install failure (JSON parse error in package validator)
- All transform `fleet_transform_version` and `dest.pipeline` references updated to `0.4.0`
- Added `validation.yml` to suppress `SVR00002` (intentional removal of `@timestamp:exists` dashboard filter)

### Dashboard overhaul
- **New sections**: Cost by component (SKU), Data Tiers / Utilisation
- **New panels**: Realised Pool per Deployment (stacked area), Chargeable Pool by Data Tier, Workload Mix by Data Tier, Normalised cost by Cost Type/Category, Normalised cost per deployment and tier
- **Query fixes**: All three ES|QL query locations synced (`embeddableConfig.query`, `state.query`, `textBased.layers.query`) — panels were rendering stale queries after each Fleet reinstall
- **Removed**: `@timestamp:exists` filter, raw ECU columns (`Chargeable units`, `Provisioned (ECU)`), stale `Chargeable units` metric references
- **UK English**: `Realised` throughout (not `Realized`)
- **Panel tooltips**: Explain reconciliation levels (full bill vs realised pool vs blended tier allocation) via ℹ️ hover
- **Section banners**: Converted to legacy `visualization` markdown type for compatibility with older Kibana versions
- **Config section**: Restored intended layout (3 info panels + field guide top row, 2 config tables below), all panels use `visualization`/`savedVis` format
- **Default time range**: `now-3M` with `timeRestore: true`

## onprem_billing 0.3.3 — key changes
- New ingest pipelines `billing.yml` and `config_bootstrap.yml`
- Transform `fleet_transform_version` updated to `0.3.3`

## Test plan

- [ ] Run e2e test suite in `elasticsearch-chargeback` repo against the updated package
- [ ] Verify `billing_realized_pool` and `cluster_capacity_utilization` transforms start and produce data
- [ ] Confirm dashboard loads without errors on a clean install (no `Chargeable units` invalid column errors)
- [ ] Check all dashboard panels render with data when monitoring and billing data is present
- [ ] Verify panel tooltips (ℹ️) display the reconciliation explanation text
- [ ] Confirm `onprem_billing` 0.3.3 installs cleanly alongside chargeback 0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)