### PR TITLE
[netbox] Fix flaky system tests and missing default for `disable_keep_alive`

### DIFF
--- a/packages/netbox/_dev/deploy/docker/docker-compose.yml
+++ b/packages/netbox/_dev/deploy/docker/docker-compose.yml
@@ -13,3 +13,9 @@ services:
       - http-server
       - --addr=:8080
       - --config=/config.yml
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 8080"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s

--- a/packages/netbox/changelog.yml
+++ b/packages/netbox/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add default value for `disable_keep_alive` and add healthcheck to mock service used in system tests.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/16025
+      link: https://github.com/elastic/integrations/pull/19298
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/netbox/changelog.yml
+++ b/packages/netbox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Add default value for `disable_keep_alive` and add healthcheck to mock service used in system tests.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/16025
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/netbox/manifest.yml
+++ b/packages/netbox/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.1
 name: netbox
 title: "NetBox"
-version: 0.1.0
+version: 0.1.1
 source:
   license: "Elastic-2.0"
 description: "Collect logs from NetBox with Elastic Agent"
@@ -88,6 +88,7 @@ policy_templates:
             description: Controls whether HTTP keep-alives are disabled.
             type: bool
             multi: false
+            default: false
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Fixes flaky and failing system tests in the NetBox integration:

- Adds a Docker healthcheck (`nc -z 127.0.0.1 8080`) to the `netbox_mock` service so `elastic-package` waits until the mock HTTP server is actually accepting connections before running tests. This addresses the reported flakiness on PRs that trigger the full integration test matrix.
- Adds `default: false` to the `disable_keep_alive` input variable in `manifest.yml`. The variable was declared `required: true` with no default, which caused Kibana Fleet to reject the package policy with `Disable HTTP Keep-Alives is required` and broke system tests deterministically. Matches the convention used by `okta` and `1password` and preserves the standard Beats behavior of HTTP keep-alives enabled.
- Bumps version to `0.1.1` and adds a `bugfix` changelog entry.
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
