### PR TITLE
fix(cloud_security_posture): correct 'Seperate' typo in changelog

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -386,7 +386,7 @@
     - description: Added ingest processor to copy cluster_id to orchestrator.cluster.id
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7185
-    - description: Seperate KSPM and CSPM cloudformation templates
+    - description: Separate KSPM and CSPM cloudformation templates
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6899
     - description: Modify CIS GCP config


### PR DESCRIPTION
Fixes a typo in `packages/cloud_security_posture/changelog.yml`: `Seperate` → `Separate`. Addresses part of #19287.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._