### PR TITLE
[ti_google_threat_intelligence] Make security rules discoverable in the Add Elastic rules UI

### DIFF
--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.10.1"
+  changes:
+    - description: Make security rules discoverable in the Add Elastic rules UI
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19312
 - version: "0.10.0"
   changes:
     - description: Prevent threat list data streams from requesting hourly packages before they are available.

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,7 +1,7 @@
 # later versions go on top
 - version: "0.10.1"
   changes:
-    - description: Make security rules discoverable in the Add Elastic rules UI
+    - description: Make security rules discoverable in the Add Elastic rules UI.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/19312
 - version: "0.10.0"

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,4 +1,4 @@
-# newer versions go on top
+# later versions go on top
 - version: "0.10.1"
   changes:
     - description: Make security rules discoverable in the Add Elastic rules UI

--- a/packages/ti_google_threat_intelligence/kibana/security_rule/05b83871-a7af-494f-b1cf-be4b20ac4a86_1.json
+++ b/packages/ti_google_threat_intelligence/kibana/security_rule/05b83871-a7af-494f-b1cf-be4b20ac4a86_1.json
@@ -1,23 +1,23 @@
 {
   "attributes": {
-    "id": "36b2cd30-34ae-46c4-993e-a370ea059692",
-    "name": "Google Threat Intelligence File IOC Correlation",
+    "id": "05b83871-a7af-494f-b1cf-be4b20ac4a86",
+    "name": "Google Threat Intelligence URL IOC Correlation",
     "tags": [
       "Google Threat Intelligence",
-      "File IOC",
+      "URL IOC",
       "Elastic",
       "Threat Intelligence"
     ],
     "interval": "1h",
-    "revision": 2,
-    "description": "This rule is triggered when File IOC's collected from the Google Threat Intelligence Integration have a match against File hash that were found in the customer environment.",
+    "revision": 0,
+    "description": "This rule is triggered when URL IOC's collected from the Google Threat Intelligence Integration have a match against URL's that were found in the customer environment.",
     "risk_score": 99,
     "severity": "critical",
     "license": "Elastic License v2",
     "author": ["Elastic"],
     "false_positives": [],
     "from": "now-3900s",
-    "rule_id": "36b2cd30-34ae-46c4-993e-a370ea059692",
+    "rule_id": "05b83871-a7af-494f-b1cf-be4b20ac4a86",
     "max_signals": 1000,
     "risk_score_mapping": [],
     "severity_mapping": [],
@@ -32,11 +32,7 @@
       { "package": "ti_google_threat_intelligence", "version": "^0.6.1" }
     ],
     "required_fields": [
-      {
-        "name": "threat.indicator.file.hash.sha256",
-        "type": "keyword",
-        "ecs": true
-      }
+      { "name": "threat.indicator.url.original", "type": "keyword", "ecs": false }
     ],
     "setup": "",
     "type": "threat_match",
@@ -52,7 +48,7 @@
       "winlogbeat-*",
       "-*elastic-cloud-logs-*"
     ],
-    "query": "NOT event.module : \"ti_google_threat_intelligence\" ",
+    "query": "NOT event.module : \"ti_google_threat_intelligence\"",
     "filters": [],
     "threat_filters": [],
     "threat_query": "@timestamp >= \"now-30d/d\"",
@@ -60,29 +56,27 @@
       {
         "entries": [
           {
-            "field": "file.hash.sha256",
+            "field": "url.original",
             "type": "mapping",
-            "value": "threat.indicator.file.hash.sha256"
+            "value": "threat.indicator.url.original"
           }
         ]
       },
       {
         "entries": [
           {
-            "field": "email.attachments.file.hash.sha256",
+            "field": "threat.indicator.url.original",
             "type": "mapping",
-            "value": "threat.indicator.file.hash.sha256"
+            "value": "threat.indicator.url.original"
           }
         ]
       }
     ],
     "threat_language": "kuery",
-    "threat_index": [
-      "logs-ti_google_threat_intelligence_latest.dest_file_ioc-*"
-    ],
+    "threat_index": ["logs-ti_google_threat_intelligence_latest.dest_url_ioc-*"],
     "threat_indicator_path": "gti.threat.indicator",
     "actions": []
   },
-  "type":"security-rule",
-  "id":"36b2cd30-34ae-46c4-993e-a370ea059692"
+  "type": "security-rule",
+  "id": "05b83871-a7af-494f-b1cf-be4b20ac4a86_1"
 }

--- a/packages/ti_google_threat_intelligence/kibana/security_rule/1e6b8753-550a-401e-bffd-06f085f3e658_1.json
+++ b/packages/ti_google_threat_intelligence/kibana/security_rule/1e6b8753-550a-401e-bffd-06f085f3e658_1.json
@@ -1,23 +1,23 @@
 {
   "attributes": {
-    "id": "05b83871-a7af-494f-b1cf-be4b20ac4a86",
-    "name": "Google Threat Intelligence URL IOC Correlation",
+    "id": "1e6b8753-550a-401e-bffd-06f085f3e658",
+    "name": "Google Threat Intelligence Domain IOC Correlation",
     "tags": [
       "Google Threat Intelligence",
-      "URL IOC",
+      "Domain IOC",
       "Elastic",
       "Threat Intelligence"
     ],
     "interval": "1h",
-    "revision": 0,
-    "description": "This rule is triggered when URL IOC's collected from the Google Threat Intelligence Integration have a match against URL's that were found in the customer environment.",
+    "revision": 1,
+    "description": "This rule is triggered when Domain IOC's collected from the Google Threat Intelligence Integration have a match against Domain that were found in the customer environment.",
     "risk_score": 99,
     "severity": "critical",
     "license": "Elastic License v2",
     "author": ["Elastic"],
     "false_positives": [],
     "from": "now-3900s",
-    "rule_id": "05b83871-a7af-494f-b1cf-be4b20ac4a86",
+    "rule_id": "1e6b8753-550a-401e-bffd-06f085f3e658",
     "max_signals": 1000,
     "risk_score_mapping": [],
     "severity_mapping": [],
@@ -32,7 +32,7 @@
       { "package": "ti_google_threat_intelligence", "version": "^0.6.1" }
     ],
     "required_fields": [
-      { "name": "threat.indicator.url.original", "type": "keyword", "ecs": false }
+      { "name": "threat.indicator.id", "type": "keyword", "ecs": false }
     ],
     "setup": "",
     "type": "threat_match",
@@ -48,7 +48,7 @@
       "winlogbeat-*",
       "-*elastic-cloud-logs-*"
     ],
-    "query": "NOT event.module : \"ti_google_threat_intelligence\"",
+    "query": "NOT event.module : \"ti_google_threat_intelligence\" ",
     "filters": [],
     "threat_filters": [],
     "threat_query": "@timestamp >= \"now-30d/d\"",
@@ -56,27 +56,29 @@
       {
         "entries": [
           {
-            "field": "url.original",
+            "field": "source.domain",
             "type": "mapping",
-            "value": "threat.indicator.url.original"
+            "value": "threat.indicator.id"
           }
         ]
       },
       {
         "entries": [
           {
-            "field": "threat.indicator.url.original",
+            "field": "destination.domain",
             "type": "mapping",
-            "value": "threat.indicator.url.original"
+            "value": "threat.indicator.id"
           }
         ]
       }
     ],
     "threat_language": "kuery",
-    "threat_index": ["logs-ti_google_threat_intelligence_latest.dest_url_ioc-*"],
+    "threat_index": [
+      "logs-ti_google_threat_intelligence_latest.dest_domain_ioc-*"
+    ],
     "threat_indicator_path": "gti.threat.indicator",
     "actions": []
   },
   "type": "security-rule",
-  "id": "05b83871-a7af-494f-b1cf-be4b20ac4a86"
+  "id": "1e6b8753-550a-401e-bffd-06f085f3e658_1"
 }

--- a/packages/ti_google_threat_intelligence/kibana/security_rule/36b2cd30-34ae-46c4-993e-a370ea059692_1.json
+++ b/packages/ti_google_threat_intelligence/kibana/security_rule/36b2cd30-34ae-46c4-993e-a370ea059692_1.json
@@ -1,23 +1,23 @@
 {
   "attributes": {
-    "id": "677c4a0c-d433-48c4-b465-4bab3d0b1755",
-    "name": "Google Threat Intelligence IP Address IOC Correlation",
+    "id": "36b2cd30-34ae-46c4-993e-a370ea059692",
+    "name": "Google Threat Intelligence File IOC Correlation",
     "tags": [
       "Google Threat Intelligence",
-      "IP Address IOC",
+      "File IOC",
       "Elastic",
       "Threat Intelligence"
     ],
     "interval": "1h",
-    "revision": 0,
-    "description": "This rule is triggered when IP Address IOC's collected from the Google Threat Intelligence Integration have a match against IP Address   that were found in the customer environment.",
+    "revision": 2,
+    "description": "This rule is triggered when File IOC's collected from the Google Threat Intelligence Integration have a match against File hash that were found in the customer environment.",
     "risk_score": 99,
     "severity": "critical",
     "license": "Elastic License v2",
     "author": ["Elastic"],
     "false_positives": [],
     "from": "now-3900s",
-    "rule_id": "677c4a0c-d433-48c4-b465-4bab3d0b1755",
+    "rule_id": "36b2cd30-34ae-46c4-993e-a370ea059692",
     "max_signals": 1000,
     "risk_score_mapping": [],
     "severity_mapping": [],
@@ -32,7 +32,11 @@
       { "package": "ti_google_threat_intelligence", "version": "^0.6.1" }
     ],
     "required_fields": [
-      { "name": "threat.indicator.ip", "type": "ip", "ecs": false }
+      {
+        "name": "threat.indicator.file.hash.sha256",
+        "type": "keyword",
+        "ecs": true
+      }
     ],
     "setup": "",
     "type": "threat_match",
@@ -56,27 +60,29 @@
       {
         "entries": [
           {
-            "field": "source.ip",
+            "field": "file.hash.sha256",
             "type": "mapping",
-            "value": "threat.indicator.ip"
+            "value": "threat.indicator.file.hash.sha256"
           }
         ]
       },
       {
         "entries": [
           {
-            "field": "destination.ip",
+            "field": "email.attachments.file.hash.sha256",
             "type": "mapping",
-            "value": "threat.indicator.ip"
+            "value": "threat.indicator.file.hash.sha256"
           }
         ]
       }
     ],
     "threat_language": "kuery",
-    "threat_index": ["logs-ti_google_threat_intelligence_latest.dest_ip_ioc-*"],
+    "threat_index": [
+      "logs-ti_google_threat_intelligence_latest.dest_file_ioc-*"
+    ],
     "threat_indicator_path": "gti.threat.indicator",
     "actions": []
   },
-  "type": "security-rule",
-  "id": "677c4a0c-d433-48c4-b465-4bab3d0b1755"
+  "type":"security-rule",
+  "id":"36b2cd30-34ae-46c4-993e-a370ea059692_1"
 }

--- a/packages/ti_google_threat_intelligence/kibana/security_rule/378bd5c1-04ab-4048-a7ba-d25c3e1e3585_1.json
+++ b/packages/ti_google_threat_intelligence/kibana/security_rule/378bd5c1-04ab-4048-a7ba-d25c3e1e3585_1.json
@@ -1,22 +1,22 @@
 {
     "attributes": {
-        "id": "53d4a523-3100-422d-8749-6bf29ebc76e6",
-        "updated_at": "2025-04-01T12:13:38.732Z",
+        "id": "8703c9eb-90fd-48d9-b1c5-2dcfa3787f80",
+        "updated_at": "2025-04-01T12:01:18.572Z",
         "updated_by": "elastic",
-        "created_at": "2025-04-01T11:49:37.254Z",
+        "created_at": "2025-04-01T11:57:56.648Z",
         "created_by": "elastic",
-        "name": "Google Threat Intelligence URL IOC Stream Correlation",
+        "name": "Google Threat Intelligence File IOC Stream Correlation",
         "tags": [
             "Google Threat Intelligence",
-            "URL IOC Stream",
+            "File IOC Stream",
             "Elastic",
             "Threat Intelligence",
             "IOC Stream"
         ],
         "interval": "1h",
         "enabled": false,
-        "revision": 2,
-        "description": "This rule is triggered when URL IOC's collected from the Google Threat Intelligence Integration have a match against URL's that were found in the customer environment.",
+        "revision": 1,
+        "description": "This rule is triggered when File IOC's collected from the Google Threat Intelligence Integration have a match against File hash that were found in the customer environment.",
         "risk_score": 99,
         "severity": "critical",
         "license": "Elastic License v2",
@@ -30,7 +30,7 @@
         ],
         "false_positives": [],
         "from": "now-3900s",
-        "rule_id": "9b852169-e461-453a-b42f-1cf9ca6594bc",
+        "rule_id": "378bd5c1-04ab-4048-a7ba-d25c3e1e3585",
         "max_signals": 1000,
         "risk_score_mapping": [],
         "severity_mapping": [],
@@ -51,9 +51,9 @@
         ],
         "required_fields": [
             {
-                "name": "threat.indicator.url.original",
+                "name": "threat.indicator.file.hash.sha256",
                 "type": "keyword",
-                "ecs": false
+                "ecs": true
             }
         ],
         "setup": "",
@@ -70,7 +70,7 @@
             "winlogbeat-*",
             "-*elastic-cloud-logs-*"
         ],
-        "query": "NOT event.module : \"ti_google_threat_intelligence\"",
+        "query": "NOT event.module : \"ti_google_threat_intelligence\" ",
         "filters": [],
         "threat_filters": [],
         "threat_query": "@timestamp >= \"now-30d/d\"",
@@ -78,29 +78,29 @@
             {
                 "entries": [
                     {
-                        "field": "url.original",
+                        "field": "file.hash.sha256",
                         "type": "mapping",
-                        "value": "threat.indicator.url.original"
+                        "value": "threat.indicator.file.hash.sha256"
                     }
                 ]
             },
             {
                 "entries": [
                     {
-                        "field": "threat.indicator.url.original",
+                        "field": "email.attachments.file.hash.sha256",
                         "type": "mapping",
-                        "value": "threat.indicator.url.original"
+                        "value": "threat.indicator.file.hash.sha256"
                     }
                 ]
             }
         ],
         "threat_language": "kuery",
         "threat_index": [
-            "logs-ti_google_threat_intelligence_latest.dest_url_ioc_st*"
+            "logs-ti_google_threat_intelligence_latest.dest_file_ioc_st*"
         ],
         "threat_indicator_path": "gti.threat.indicator",
         "actions": []
     },
     "type": "security-rule",
-    "id": "9b852169-e461-453a-b42f-1cf9ca6594bc"
+    "id": "378bd5c1-04ab-4048-a7ba-d25c3e1e3585_1"
 }

--- a/packages/ti_google_threat_intelligence/kibana/security_rule/5bd95a46-10e3-4bb9-9c0e-4d7493e359ac_1.json
+++ b/packages/ti_google_threat_intelligence/kibana/security_rule/5bd95a46-10e3-4bb9-9c0e-4d7493e359ac_1.json
@@ -1,22 +1,22 @@
 {
     "attributes": {
-        "id": "2df930d4-12b2-4e19-99ca-8c11d89d1b2c",
-        "updated_at": "2025-04-01T11:56:46.516Z",
+        "id": "587f604c-51de-47e4-89ec-9318e586d06b",
+        "updated_at": "2025-04-01T12:06:23.647Z",
         "updated_by": "elastic",
-        "created_at": "2025-04-01T11:34:40.221Z",
+        "created_at": "2025-04-01T12:02:26.601Z",
         "created_by": "elastic",
-        "name": "Google Threat Intelligence Domain IOC Stream Correlation",
+        "name": "Google Threat Intelligence IP Address IOC Stream Correlation",
         "tags": [
             "Google Threat Intelligence",
-            "Domain IOC Stream",
+            "IP Address IOC Stream",
             "Elastic",
             "Threat Intelligence",
             "IOC Stream"
         ],
         "interval": "1h",
         "enabled": false,
-        "revision": 3,
-        "description": "This rule is triggered when Domain IOC's collected from the Google Threat Intelligence Integration have a match against Domain that were found in the customer environment.",
+        "revision": 1,
+        "description": "This rule is triggered when IP Address IOC's collected from the Google Threat Intelligence Integration have a match against IP Address   that were found in the customer environment.",
         "risk_score": 99,
         "severity": "critical",
         "license": "Elastic License v2",
@@ -29,9 +29,8 @@
             "Elastic"
         ],
         "false_positives": [],
-        "from": "now-360s",
-        "rule_id": "b31e8055-8985-4a06-a7e0-4c1b650ade87",
         "from": "now-3900s",
+        "rule_id": "5bd95a46-10e3-4bb9-9c0e-4d7493e359ac",
         "max_signals": 1000,
         "risk_score_mapping": [],
         "severity_mapping": [],
@@ -52,9 +51,9 @@
         ],
         "required_fields": [
             {
-                "name": "threat.indicator.id",
-                "type": "keyword",
-                "ecs": false
+                "name": "threat.indicator.ip",
+                "type": "ip",
+                "ecs": true
             }
         ],
         "setup": "",
@@ -79,29 +78,29 @@
             {
                 "entries": [
                     {
-                        "field": "source.domain",
+                        "field": "source.ip",
                         "type": "mapping",
-                        "value": "threat.indicator.id"
+                        "value": "threat.indicator.ip"
                     }
                 ]
             },
             {
                 "entries": [
                     {
-                        "field": "destination.domain",
+                        "field": "destination.ip",
                         "type": "mapping",
-                        "value": "threat.indicator.id"
+                        "value": "threat.indicator.ip"
                     }
                 ]
             }
         ],
         "threat_language": "kuery",
         "threat_index": [
-            "logs-ti_google_threat_intelligence_latest.dest_domain_ioc_st*"
+            "logs-ti_google_threat_intelligence_latest.dest_ip_ioc_st*"
         ],
         "threat_indicator_path": "gti.threat.indicator",
         "actions": []
     },
     "type": "security-rule",
-    "id": "b31e8055-8985-4a06-a7e0-4c1b650ade87"
+    "id": "5bd95a46-10e3-4bb9-9c0e-4d7493e359ac_1"
 }

--- a/packages/ti_google_threat_intelligence/kibana/security_rule/677c4a0c-d433-48c4-b465-4bab3d0b1755_1.json
+++ b/packages/ti_google_threat_intelligence/kibana/security_rule/677c4a0c-d433-48c4-b465-4bab3d0b1755_1.json
@@ -1,23 +1,23 @@
 {
   "attributes": {
-    "id": "1e6b8753-550a-401e-bffd-06f085f3e658",
-    "name": "Google Threat Intelligence Domain IOC Correlation",
+    "id": "677c4a0c-d433-48c4-b465-4bab3d0b1755",
+    "name": "Google Threat Intelligence IP Address IOC Correlation",
     "tags": [
       "Google Threat Intelligence",
-      "Domain IOC",
+      "IP Address IOC",
       "Elastic",
       "Threat Intelligence"
     ],
     "interval": "1h",
-    "revision": 1,
-    "description": "This rule is triggered when Domain IOC's collected from the Google Threat Intelligence Integration have a match against Domain that were found in the customer environment.",
+    "revision": 0,
+    "description": "This rule is triggered when IP Address IOC's collected from the Google Threat Intelligence Integration have a match against IP Address   that were found in the customer environment.",
     "risk_score": 99,
     "severity": "critical",
     "license": "Elastic License v2",
     "author": ["Elastic"],
     "false_positives": [],
     "from": "now-3900s",
-    "rule_id": "1e6b8753-550a-401e-bffd-06f085f3e658",
+    "rule_id": "677c4a0c-d433-48c4-b465-4bab3d0b1755",
     "max_signals": 1000,
     "risk_score_mapping": [],
     "severity_mapping": [],
@@ -32,7 +32,7 @@
       { "package": "ti_google_threat_intelligence", "version": "^0.6.1" }
     ],
     "required_fields": [
-      { "name": "threat.indicator.id", "type": "keyword", "ecs": false }
+      { "name": "threat.indicator.ip", "type": "ip", "ecs": false }
     ],
     "setup": "",
     "type": "threat_match",
@@ -56,29 +56,27 @@
       {
         "entries": [
           {
-            "field": "source.domain",
+            "field": "source.ip",
             "type": "mapping",
-            "value": "threat.indicator.id"
+            "value": "threat.indicator.ip"
           }
         ]
       },
       {
         "entries": [
           {
-            "field": "destination.domain",
+            "field": "destination.ip",
             "type": "mapping",
-            "value": "threat.indicator.id"
+            "value": "threat.indicator.ip"
           }
         ]
       }
     ],
     "threat_language": "kuery",
-    "threat_index": [
-      "logs-ti_google_threat_intelligence_latest.dest_domain_ioc-*"
-    ],
+    "threat_index": ["logs-ti_google_threat_intelligence_latest.dest_ip_ioc-*"],
     "threat_indicator_path": "gti.threat.indicator",
     "actions": []
   },
   "type": "security-rule",
-  "id": "1e6b8753-550a-401e-bffd-06f085f3e658"
+  "id": "677c4a0c-d433-48c4-b465-4bab3d0b1755_1"
 }

--- a/packages/ti_google_threat_intelligence/kibana/security_rule/9b852169-e461-453a-b42f-1cf9ca6594bc_1.json
+++ b/packages/ti_google_threat_intelligence/kibana/security_rule/9b852169-e461-453a-b42f-1cf9ca6594bc_1.json
@@ -1,22 +1,22 @@
 {
     "attributes": {
-        "id": "8703c9eb-90fd-48d9-b1c5-2dcfa3787f80",
-        "updated_at": "2025-04-01T12:01:18.572Z",
+        "id": "53d4a523-3100-422d-8749-6bf29ebc76e6",
+        "updated_at": "2025-04-01T12:13:38.732Z",
         "updated_by": "elastic",
-        "created_at": "2025-04-01T11:57:56.648Z",
+        "created_at": "2025-04-01T11:49:37.254Z",
         "created_by": "elastic",
-        "name": "Google Threat Intelligence File IOC Stream Correlation",
+        "name": "Google Threat Intelligence URL IOC Stream Correlation",
         "tags": [
             "Google Threat Intelligence",
-            "File IOC Stream",
+            "URL IOC Stream",
             "Elastic",
             "Threat Intelligence",
             "IOC Stream"
         ],
         "interval": "1h",
         "enabled": false,
-        "revision": 1,
-        "description": "This rule is triggered when File IOC's collected from the Google Threat Intelligence Integration have a match against File hash that were found in the customer environment.",
+        "revision": 2,
+        "description": "This rule is triggered when URL IOC's collected from the Google Threat Intelligence Integration have a match against URL's that were found in the customer environment.",
         "risk_score": 99,
         "severity": "critical",
         "license": "Elastic License v2",
@@ -30,7 +30,7 @@
         ],
         "false_positives": [],
         "from": "now-3900s",
-        "rule_id": "378bd5c1-04ab-4048-a7ba-d25c3e1e3585",
+        "rule_id": "9b852169-e461-453a-b42f-1cf9ca6594bc",
         "max_signals": 1000,
         "risk_score_mapping": [],
         "severity_mapping": [],
@@ -51,9 +51,9 @@
         ],
         "required_fields": [
             {
-                "name": "threat.indicator.file.hash.sha256",
+                "name": "threat.indicator.url.original",
                 "type": "keyword",
-                "ecs": true
+                "ecs": false
             }
         ],
         "setup": "",
@@ -70,7 +70,7 @@
             "winlogbeat-*",
             "-*elastic-cloud-logs-*"
         ],
-        "query": "NOT event.module : \"ti_google_threat_intelligence\" ",
+        "query": "NOT event.module : \"ti_google_threat_intelligence\"",
         "filters": [],
         "threat_filters": [],
         "threat_query": "@timestamp >= \"now-30d/d\"",
@@ -78,29 +78,29 @@
             {
                 "entries": [
                     {
-                        "field": "file.hash.sha256",
+                        "field": "url.original",
                         "type": "mapping",
-                        "value": "threat.indicator.file.hash.sha256"
+                        "value": "threat.indicator.url.original"
                     }
                 ]
             },
             {
                 "entries": [
                     {
-                        "field": "email.attachments.file.hash.sha256",
+                        "field": "threat.indicator.url.original",
                         "type": "mapping",
-                        "value": "threat.indicator.file.hash.sha256"
+                        "value": "threat.indicator.url.original"
                     }
                 ]
             }
         ],
         "threat_language": "kuery",
         "threat_index": [
-            "logs-ti_google_threat_intelligence_latest.dest_file_ioc_st*"
+            "logs-ti_google_threat_intelligence_latest.dest_url_ioc_st*"
         ],
         "threat_indicator_path": "gti.threat.indicator",
         "actions": []
     },
     "type": "security-rule",
-    "id": "378bd5c1-04ab-4048-a7ba-d25c3e1e3585"
+    "id": "9b852169-e461-453a-b42f-1cf9ca6594bc_1"
 }

--- a/packages/ti_google_threat_intelligence/kibana/security_rule/b31e8055-8985-4a06-a7e0-4c1b650ade87_1.json
+++ b/packages/ti_google_threat_intelligence/kibana/security_rule/b31e8055-8985-4a06-a7e0-4c1b650ade87_1.json
@@ -1,22 +1,22 @@
 {
     "attributes": {
-        "id": "587f604c-51de-47e4-89ec-9318e586d06b",
-        "updated_at": "2025-04-01T12:06:23.647Z",
+        "id": "2df930d4-12b2-4e19-99ca-8c11d89d1b2c",
+        "updated_at": "2025-04-01T11:56:46.516Z",
         "updated_by": "elastic",
-        "created_at": "2025-04-01T12:02:26.601Z",
+        "created_at": "2025-04-01T11:34:40.221Z",
         "created_by": "elastic",
-        "name": "Google Threat Intelligence IP Address IOC Stream Correlation",
+        "name": "Google Threat Intelligence Domain IOC Stream Correlation",
         "tags": [
             "Google Threat Intelligence",
-            "IP Address IOC Stream",
+            "Domain IOC Stream",
             "Elastic",
             "Threat Intelligence",
             "IOC Stream"
         ],
         "interval": "1h",
         "enabled": false,
-        "revision": 1,
-        "description": "This rule is triggered when IP Address IOC's collected from the Google Threat Intelligence Integration have a match against IP Address   that were found in the customer environment.",
+        "revision": 3,
+        "description": "This rule is triggered when Domain IOC's collected from the Google Threat Intelligence Integration have a match against Domain that were found in the customer environment.",
         "risk_score": 99,
         "severity": "critical",
         "license": "Elastic License v2",
@@ -29,8 +29,9 @@
             "Elastic"
         ],
         "false_positives": [],
+        "from": "now-360s",
+        "rule_id": "b31e8055-8985-4a06-a7e0-4c1b650ade87",
         "from": "now-3900s",
-        "rule_id": "5bd95a46-10e3-4bb9-9c0e-4d7493e359ac",
         "max_signals": 1000,
         "risk_score_mapping": [],
         "severity_mapping": [],
@@ -51,9 +52,9 @@
         ],
         "required_fields": [
             {
-                "name": "threat.indicator.ip",
-                "type": "ip",
-                "ecs": true
+                "name": "threat.indicator.id",
+                "type": "keyword",
+                "ecs": false
             }
         ],
         "setup": "",
@@ -78,29 +79,29 @@
             {
                 "entries": [
                     {
-                        "field": "source.ip",
+                        "field": "source.domain",
                         "type": "mapping",
-                        "value": "threat.indicator.ip"
+                        "value": "threat.indicator.id"
                     }
                 ]
             },
             {
                 "entries": [
                     {
-                        "field": "destination.ip",
+                        "field": "destination.domain",
                         "type": "mapping",
-                        "value": "threat.indicator.ip"
+                        "value": "threat.indicator.id"
                     }
                 ]
             }
         ],
         "threat_language": "kuery",
         "threat_index": [
-            "logs-ti_google_threat_intelligence_latest.dest_ip_ioc_st*"
+            "logs-ti_google_threat_intelligence_latest.dest_domain_ioc_st*"
         ],
         "threat_indicator_path": "gti.threat.indicator",
         "actions": []
     },
     "type": "security-rule",
-    "id": "5bd95a46-10e3-4bb9-9c0e-4d7493e359ac"
+    "id": "b31e8055-8985-4a06-a7e0-4c1b650ade87_1"
 }

--- a/packages/ti_google_threat_intelligence/manifest.yml
+++ b/packages/ti_google_threat_intelligence/manifest.yml
@@ -3,7 +3,7 @@ name: ti_google_threat_intelligence
 title: Google Threat Intelligence
 # This version must match the User-Agent version used in CEL code.
 # Remember to update the User-Agent in CEL code when changing this version.
-version: "0.10.0"
+version: "0.10.1"
 description: Collect Threat Intelligence Events from Google Threat Intelligence using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[ti_google_threat_intelligence] Make security rules discoverable in the Add Elastic rules UI

Change security rule SO IDs to the `<rule_id>_<version>` format.
This is a workaround for an issue[1] that was introduced in 9.4.0.

[1]: https://github.com/elastic/kibana/issues/272095
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

Install this package on 9.4.0, 9.4.1 or 9.4.2.
Search for "Google Threat Intelligence" in _Security > Rules > Detection Rules (SIEM) > Add Elastic rules_.
The rules from this PR will be found.

## Related issues

- Relates https://github.com/elastic/kibana/issues/272095