### PR TITLE
[o365] Remove redundant filtering logic for non-cursor state

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.1"
+  changes:
+    - description: Remove redundant filtering logic for non-cursor state.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19320
 - version: "3.10.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
@@ -74,7 +74,7 @@ inputs:
                     (existing_todo_types.size() > 0) ?
                       existing_todo_types
                     :
-                      state.base.content_types.split(",").map(t, t.trim_space())
+                      state.base.content_types.split(",").map(t, t.trim_space() != "", t.trim_space())
                   ),
                 }
               )

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
@@ -65,19 +65,16 @@ inputs:
               )
             ).as(state,
               // Initialize the list of types to consider in this sequence of evaluations.
-              // If content types were changed in the config, remove any that are no
-              // longer configured from the in-progress list.
+              // When there are no more types to consider the sequence will end and this
+              // list will be reinitialized on the next evaluation. It's non-cursor data
+              // so it will be cleared by any restart.
               state.with(
                 {
                   "todo_types": state.?todo_types.orValue([]).as(existing_todo_types,
-                    state.base.content_types.split(",").map(t, t.trim_space()).as(configured_types,
-                      existing_todo_types.filter(t, configured_types.exists(c, c == t)).as(filtered,
-                        (filtered.size() > 0) ?
-                          filtered
-                        :
-                          configured_types
-                      )
-                    )
+                    (existing_todo_types.size() > 0) ?
+                      existing_todo_types
+                    :
+                      state.base.content_types.split(",").map(t, t.trim_space())
                   ),
                 }
               )

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
@@ -55,19 +55,16 @@ inputs:
               )
             ).as(state,
               // Initialize the list of types to consider in this sequence of evaluations.
-              // If content types were changed in the config, remove any that are no
-              // longer configured from the in-progress list.
+              // When there are no more types to consider the sequence will end and this
+              // list will be reinitialized on the next evaluation. It's non-cursor data
+              // so it will be cleared by any restart.
               state.with(
                 {
                   "todo_types": state.?todo_types.orValue([]).as(existing_todo_types,
-                    state.base.content_types.split(",").map(t, t.trim_space()).as(configured_types,
-                      existing_todo_types.filter(t, configured_types.exists(c, c == t)).as(filtered,
-                        (filtered.size() > 0) ?
-                          filtered
-                        :
-                          configured_types
-                      )
-                    )
+                    (existing_todo_types.size() > 0) ?
+                      existing_todo_types
+                    :
+                      state.base.content_types.split(",").map(t, t.trim_space())
                   ),
                 }
               )

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
@@ -64,7 +64,7 @@ inputs:
                     (existing_todo_types.size() > 0) ?
                       existing_todo_types
                     :
-                      state.base.content_types.split(",").map(t, t.trim_space())
+                      state.base.content_types.split(",").map(t, t.trim_space() != "", t.trim_space())
                   ),
                 }
               )

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -92,6 +92,7 @@ redact:
 # - Rewrite legacy cursor data if present.
 # - Set a stopping point if absent.
 # - Generate the list of content types to process if empty.
+# - Filter stale cursor data.
 #
 # A check done on every evaluation:
 # - Ensure there is an active content type.
@@ -137,19 +138,16 @@ program: |-
     )
   ).as(state,
     // Initialize the list of types to consider in this sequence of evaluations.
-    // If content types were changed in the config, remove any that are no
-    // longer configured from the in-progress list.
+    // When there are no more types to consider the sequence will end and this
+    // list will be reinitialized on the next evaluation. It's non-cursor data
+    // so it will be cleared by any restart.
     state.with(
       {
         "todo_types": state.?todo_types.orValue([]).as(existing_todo_types,
-          state.base.content_types.split(",").map(t, t.trim_space()).as(configured_types,
-            existing_todo_types.filter(t, configured_types.exists(c, c == t)).as(filtered,
-              (filtered.size() > 0) ?
-                filtered
-              :
-                configured_types
-            )
-          )
+          (existing_todo_types.size() > 0) ?
+            existing_todo_types
+          :
+            state.base.content_types.split(",").map(t, t.trim_space())
         ),
       }
     )

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -147,7 +147,7 @@ program: |-
           (existing_todo_types.size() > 0) ?
             existing_todo_types
           :
-            state.base.content_types.split(",").map(t, t.trim_space())
+            state.base.content_types.split(",").map(t, t.trim_space() != "", t.trim_space())
         ),
       }
     )

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "3.10.0"
+version: "3.10.1"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

```
[o365] Remove redundant filtering logic for non-cursor state

#17540 added logic to filter out data in `state.cursor.todo_links` and
`state.cursor.todo_content` that isn't related to the currently
configured types. That's good. This PR adds an item for that in logic
overview comment at the top.

#17540 added similar filtering of `state.todo_types`, but that is
redundant because each config change or other restart will clear that
data already. This PR reverts that part and adds a comment to clarify.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates #17540
