### PR TITLE
[Logstash] Fix status colour mappings in Node and Pipeline Health dashboards

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.1"
+  changes:
+    - description: Fix status colour mappings in Node Health and Pipeline Health dashboards so that red/yellow/green/unknown statuses render with correct colours using the Borealis palette.
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/18627
 - version: "2.11.0"
   changes:
     - description: Update existing batch graphs with 50th and 90th percentiles during last minute. Replace average lifetime metric with last one minute, for both batch's byte size and value, to be coherent with the other graphed percentiles.. Note that these metrics will only show results for Logstash versions 9.4.0 or later.

--- a/packages/logstash/kibana/dashboard/logstash-838aac39-8edd-48b0-95b4-289e42b1e98a.json
+++ b/packages/logstash/kibana/dashboard/logstash-838aac39-8edd-48b0-95b4-289e42b1e98a.json
@@ -376,7 +376,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 9,
+                                                        "colorIndex": 6,
                                                         "paletteId": "eui_amsterdam_color_blind",
                                                         "type": "categorical"
                                                     },
@@ -390,7 +390,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 5,
+                                                        "colorIndex": 8,
                                                         "paletteId": "eui_amsterdam_color_blind",
                                                         "type": "categorical"
                                                     },
@@ -404,7 +404,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 1,
+                                                        "colorIndex": 3,
                                                         "paletteId": "neutral",
                                                         "type": "categorical"
                                                     },
@@ -2680,7 +2680,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 9,
+                                                        "colorIndex": 6,
                                                         "paletteId": "eui_amsterdam_color_blind",
                                                         "type": "categorical"
                                                     },
@@ -2694,7 +2694,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 5,
+                                                        "colorIndex": 8,
                                                         "paletteId": "eui_amsterdam_color_blind",
                                                         "type": "categorical"
                                                     },
@@ -2702,6 +2702,20 @@
                                                         "type": "matchExactly",
                                                         "values": [
                                                             "yellow"
+                                                        ]
+                                                    },
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 3,
+                                                        "paletteId": "neutral",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rule": {
+                                                        "type": "matchExactly",
+                                                        "values": [
+                                                            "unknown"
                                                         ]
                                                     },
                                                     "touched": true

--- a/packages/logstash/kibana/dashboard/logstash-838aac39-8edd-48b0-95b4-289e42b1e98a.json
+++ b/packages/logstash/kibana/dashboard/logstash-838aac39-8edd-48b0-95b4-289e42b1e98a.json
@@ -404,7 +404,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 3,
+                                                        "colorIndex": 2,
                                                         "paletteId": "neutral",
                                                         "type": "categorical"
                                                     },
@@ -2708,7 +2708,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 3,
+                                                        "colorIndex": 2,
                                                         "paletteId": "neutral",
                                                         "type": "categorical"
                                                     },

--- a/packages/logstash/kibana/dashboard/logstash-9a72208d-e446-48b9-8a63-c4256b9aa4e3.json
+++ b/packages/logstash/kibana/dashboard/logstash-9a72208d-e446-48b9-8a63-c4256b9aa4e3.json
@@ -283,7 +283,7 @@
                                             "assignments": [
                                                 {
                                                     "color": {
-                                                        "colorIndex": 9,
+                                                        "colorIndex": 6,
                                                         "paletteId": "eui_amsterdam_color_blind",
                                                         "type": "categorical"
                                                     },
@@ -311,7 +311,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 5,
+                                                        "colorIndex": 8,
                                                         "paletteId": "eui_amsterdam_color_blind",
                                                         "type": "categorical"
                                                     },
@@ -325,7 +325,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 2,
+                                                        "colorIndex": 3,
                                                         "paletteId": "neutral",
                                                         "type": "categorical"
                                                     },
@@ -830,7 +830,7 @@
                                             "assignments": [
                                                 {
                                                     "color": {
-                                                        "colorIndex": 9,
+                                                        "colorIndex": 6,
                                                         "paletteId": "eui_amsterdam_color_blind",
                                                         "type": "categorical"
                                                     },
@@ -844,7 +844,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 5,
+                                                        "colorIndex": 8,
                                                         "paletteId": "eui_amsterdam_color_blind",
                                                         "type": "categorical"
                                                     },
@@ -858,7 +858,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 2,
+                                                        "colorIndex": 3,
                                                         "paletteId": "neutral",
                                                         "type": "categorical"
                                                     },
@@ -866,6 +866,20 @@
                                                         "type": "matchExactly",
                                                         "values": [
                                                             "unknown"
+                                                        ]
+                                                    },
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 0,
+                                                        "paletteId": "eui_amsterdam_color_blind",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rule": {
+                                                        "type": "matchExactly",
+                                                        "values": [
+                                                            "green"
                                                         ]
                                                     },
                                                     "touched": true

--- a/packages/logstash/kibana/dashboard/logstash-9a72208d-e446-48b9-8a63-c4256b9aa4e3.json
+++ b/packages/logstash/kibana/dashboard/logstash-9a72208d-e446-48b9-8a63-c4256b9aa4e3.json
@@ -325,7 +325,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 3,
+                                                        "colorIndex": 2,
                                                         "paletteId": "neutral",
                                                         "type": "categorical"
                                                     },
@@ -858,7 +858,7 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 3,
+                                                        "colorIndex": 2,
                                                         "paletteId": "neutral",
                                                         "type": "categorical"
                                                     },

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.11.0
+version: 2.11.1
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

Closes #18627: [Logstash] Fix status colour mappings in Node Health and Pipeline Health dashboards so that red/yellow/green/unknown statuses render with correct colours using the Borealis palette.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- #18627 
- #19238

## Screenshots

**before**

<img width="1912" height="661" alt="image" src="https://github.com/user-attachments/assets/798eb675-80c0-4226-9abe-d19e827a6075" />


**after**

<img width="1484" height="592" alt="image" src="https://github.com/user-attachments/assets/a160af3e-bd03-476d-a289-b2762f9207bf" />


