### PR TITLE
[eset_protect, lumos, sophos_central] Add Agentless Deployment

### DIFF
--- a/packages/eset_protect/_dev/build/docs/README.md
+++ b/packages/eset_protect/_dev/build/docs/README.md
@@ -4,6 +4,12 @@ ESET PROTECT enables you to manage ESET products on workstations and servers in 
 
 ## Data streams
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
+
 The ESET PROTECT integration collects three types of logs: Detection, Device Task and Event.
 
 **[Detection](https://help.eset.com/protect_cloud/en-US/admin_ct.html?threats.html)** is used to retrieve detections via the [Incident Management - List detections v1](https://help.eset.com/eset_connect/en-US/incident_management_v1_detections_get.html) endpoint.

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.3.0"
   changes:
     - description: Add device and device_vulnerability data streams. The device stream collects managed device inventory from the Device Management API. The device_vulnerability stream collects per-vulnerability records from the Vulnerability Management API.

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19353
 - version: "2.3.0"
   changes:
     - description: Add device and device_vulnerability data streams. The device stream collects managed device inventory from the Device Management API. The device_vulnerability stream collects per-vulnerability records from the Vulnerability Management API.

--- a/packages/eset_protect/docs/README.md
+++ b/packages/eset_protect/docs/README.md
@@ -4,6 +4,12 @@ ESET PROTECT enables you to manage ESET products on workstations and servers in 
 
 ## Data streams
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
+
 The ESET PROTECT integration collects three types of logs: Detection, Device Task and Event.
 
 **[Detection](https://help.eset.com/protect_cloud/en-US/admin_ct.html?threats.html)** is used to retrieve detections via the [Incident Management - List detections v1](https://help.eset.com/eset_connect/en-US/incident_management_v1_detections_get.html) endpoint.
@@ -231,22 +237,8 @@ An example event for `detection` looks as following:
 | eset_protect.detection.uuid | Universally Unique Identifier of detection. | keyword |
 | event.dataset | Event dataset. | constant_keyword |
 | event.module | Event module. | constant_keyword |
-| host.ip | Host ip addresses. | ip |
-| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.full | Operating system name, including the version or code name. | keyword |
-| host.os.full.text | Multi-field of `host.os.full`. | match_only_text |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. If the OS you're dealing with is not listed as an expected value, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
 | input.type | Type of Filebeat input. | keyword |
 | log.offset | Log offset. | long |
-| observer.product | The product name of the observer. | keyword |
-| observer.type | The type of the observer the data is coming from. There is no predefined list of observer types. Some examples are `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM server`. | keyword |
-| observer.vendor | Vendor name of the observer. | keyword |
-| related.ip | All of the IPs seen on your event. | ip |
 
 
 ### Device Task

--- a/packages/eset_protect/docs/README.md
+++ b/packages/eset_protect/docs/README.md
@@ -237,8 +237,22 @@ An example event for `detection` looks as following:
 | eset_protect.detection.uuid | Universally Unique Identifier of detection. | keyword |
 | event.dataset | Event dataset. | constant_keyword |
 | event.module | Event module. | constant_keyword |
+| host.ip | Host ip addresses. | ip |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
+| host.os.full | Operating system name, including the version or code name. | keyword |
+| host.os.full.text | Multi-field of `host.os.full`. | match_only_text |
+| host.os.name | Operating system name, without the version. | keyword |
+| host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. If the OS you're dealing with is not listed as an expected value, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
+| host.os.version | Operating system version as a raw string. | keyword |
 | input.type | Type of Filebeat input. | keyword |
 | log.offset | Log offset. | long |
+| observer.product | The product name of the observer. | keyword |
+| observer.type | The type of the observer the data is coming from. There is no predefined list of observer types. Some examples are `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM server`. | keyword |
+| observer.vendor | Vendor name of the observer. | keyword |
+| related.ip | All of the IPs seen on your event. | ip |
 
 
 ### Device Task

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: eset_protect
 title: ESET PROTECT
-version: "2.3.0"
+version: "2.4.0"
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - vulnerability_management
 conditions:
   kibana:
-    version: "^8.16.0 || ^9.0.0"
+    version: "^8.19.2 || ^9.0.5"
   elastic:
     subscription: basic
 icons:
@@ -35,6 +35,14 @@ policy_templates:
   - name: eset_protect
     title: ESET PROTECT logs
     description: Collect logs from ESET PROTECT.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: tcp
         title: Collect ESET PROTECT logs via TCP input

--- a/packages/lumos/_dev/build/docs/README.md
+++ b/packages/lumos/_dev/build/docs/README.md
@@ -4,6 +4,11 @@ The Lumos integration uses [Lumos' API](https://www.lumos.com/) to retrieve Acti
 
 The Elastic agent running this integration interacts with Lumos' infrastructure using their APIs to retrieve Activity Logs for a Lumos tenant.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Configuration
 
 ### Enabling the integration in Elastic

--- a/packages/lumos/changelog.yml
+++ b/packages/lumos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.6.0"
   changes:
     - description: Prevent updating fleet health status to degraded.

--- a/packages/lumos/changelog.yml
+++ b/packages/lumos/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19353
 - version: "1.6.0"
   changes:
     - description: Prevent updating fleet health status to degraded.

--- a/packages/lumos/docs/README.md
+++ b/packages/lumos/docs/README.md
@@ -4,6 +4,11 @@ The Lumos integration uses [Lumos' API](https://www.lumos.com/) to retrieve Acti
 
 The Elastic agent running this integration interacts with Lumos' infrastructure using their APIs to retrieve Activity Logs for a Lumos tenant.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Configuration
 
 ### Enabling the integration in Elastic

--- a/packages/lumos/manifest.yml
+++ b/packages/lumos/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.1.2
+format_version: 3.3.2
 name: lumos
 title: "Lumos"
-version: "1.6.0"
+version: "1.7.0"
 description: "An integration with Lumos to ship your Activity logs to your Elastic instance."
 type: integration
 categories:
@@ -29,6 +29,14 @@ policy_templates:
   - name: lumos
     title: Lumos Activity Logs
     description: Collect Activity Logs from Lumos
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: "Collect Activity Logs via API"

--- a/packages/sophos_central/_dev/build/docs/README.md
+++ b/packages/sophos_central/_dev/build/docs/README.md
@@ -5,6 +5,11 @@ The [Sophos Central](https://www.sophos.com/en-us/products/sophos-central) integ
 Use the Sophos Central integration to collect logs across Sophos Central managed by your Sophos account.
 Visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference data when troubleshooting an issue.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The Sophos Central integration collects logs for two types of events: alerts and events.

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19353
 - version: "1.21.0"
   changes:
     - description: Add edr_xdr category.

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.0"
   changes:
     - description: Add edr_xdr category.

--- a/packages/sophos_central/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos_central/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/sophos_central/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sophos_central/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/sophos_central/docs/README.md
+++ b/packages/sophos_central/docs/README.md
@@ -5,6 +5,11 @@ The [Sophos Central](https://www.sophos.com/en-us/products/sophos-central) integ
 Use the Sophos Central integration to collect logs across Sophos Central managed by your Sophos account.
 Visualize that data in Kibana, create alerts to notify you if something goes wrong, and reference data when troubleshooting an issue.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The Sophos Central integration collects logs for two types of events: alerts and events.

--- a/packages/sophos_central/manifest.yml
+++ b/packages/sophos_central/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.2"
+format_version: "3.3.2"
 name: sophos_central
 title: Sophos Central
-version: "1.21.0"
+version: "1.22.0"
 description: This Elastic integration collects logs from Sophos Central with Elastic Agent.
 type: integration
 categories:
@@ -30,6 +30,14 @@ policy_templates:
   - name: sophos_central
     title: Sophos Central logs
     description: Collect logs using HTTP JSON.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: Collect Sophos Central logs via HTTP JSON


### PR DESCRIPTION
## Proposed commit message

```
eset_protect, lumos, sophos_central: add agentless deployment
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/ {integration} directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes https://github.com/elastic/integrations/issues/18983
- Closes https://github.com/elastic/integrations/issues/19207
- Closes https://github.com/elastic/integrations/issues/19349
