### PR TITLE
fix: typos in documentation

### DIFF
--- a/packages/docker/data_stream/healthcheck/fields/fields.yml
+++ b/packages/docker/data_stream/healthcheck/fields/fields.yml
@@ -11,7 +11,7 @@
       type: integer
       metric_type: counter
       description: |
-        concurent failed check
+        concurrent failed check
     - name: status
       type: keyword
       description: |

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -604,7 +604,7 @@ docker `HEALTHCHECK` instruction has been used to build the docker image.
 | docker.healthcheck.event.exit_code | Healthcheck status code | integer |  |
 | docker.healthcheck.event.output | Healthcheck output | keyword |  |
 | docker.healthcheck.event.start_date | Healthcheck start date | date |  |
-| docker.healthcheck.failingstreak | concurent failed check | integer | counter |
+| docker.healthcheck.failingstreak | concurrent failed check | integer | counter |
 | docker.healthcheck.status | Healthcheck status code | keyword |  |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |  |


### PR DESCRIPTION
Fixes:
- `concurent` → `concurrent` in packages/docker/docs/README.md
- `concurent` → `concurrent` in packages/docker/data_stream/healthcheck/fields/fields.yml

Closes #19359