### PR TITLE
[CI] Improve changelog link check TIP message to mention issue links

### DIFF
--- a/.buildkite/scripts/check_changelog_entries.sh
+++ b/.buildkite/scripts/check_changelog_entries.sh
@@ -174,7 +174,7 @@ main() {
         for f in "${failed_files[@]}"; do
             message+="- \`${f}\`"$'\n'
         done
-        message+=$'\n'"> [!TIP]"$'\n'"> Add the \`${CHANGELOG_SKIP_LABEL}\` label to skip this check."
+        message+=$'\n'"> [!TIP]"$'\n'"> If expected, add the \`${CHANGELOG_SKIP_LABEL}\` label to skip this check. Or, if an issue link was intended, use \`.../issues/<n>\` instead."
         echo "${message}"
         if running_on_buildkite; then
             message+=$'\n\n'"[View Buildkite build](${BUILDKITE_BUILD_URL})"


### PR DESCRIPTION
## Proposed commit message

```
[CI] Improve changelog link check TIP message to mention issue links

When the changelog link check fails, the TIP callout now informs
developers that using an issue link is also a valid alternative to
adding the skip label.
```

**WHAT:**

Update the error TIP callout in `.buildkite/scripts/check_changelog_entries.sh` to mention that an issue link (`.../issues/<n>`) can be used in the `link:` field as an alternative to the current PR link — the check already accepts issue links without validation.

**WHY:**

The original TIP only mentioned the `changelog-link-check:skip` label, leaving developers unaware that they can simply use an issue link if that is their intent. This small addition makes the error message more actionable and self-contained.

## Author's Checklist

- [x] No script or test changes required — message-only update.


## Related issues

- Follows https://github.com/elastic/integrations/pull/19171

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).