### PR TITLE
entityanalytics_ad: escape special characters in AD credentials

### DIFF
--- a/packages/entityanalytics_ad/_dev/deploy/docker/ldap-mock-service/main.go
+++ b/packages/entityanalytics_ad/_dev/deploy/docker/ldap-mock-service/main.go
@@ -21,7 +21,11 @@ const (
 
 	bindUser = "cn=admin,dc=testserver,dc=local"
 	bindPass = "password"
-	baseDN   = "DC=testserver,DC=local"
+
+	bindUserSpecial = `TESTSERVER\admin#special`
+	bindPassSpecial = `p@ss:word&"quotes'` // YAML-special characters
+
+	baseDN = "DC=testserver,DC=local"
 )
 
 // entry holds the attributes for a single LDAP directory entry.
@@ -317,12 +321,17 @@ func bindHandler(w *gldap.ResponseWriter, r *gldap.Request) {
 		return
 	}
 
-	if m.UserName == bindUser && m.Password == bindPass {
+	switch {
+	case m.UserName == bindUser && m.Password == bindPass:
+		resp.SetResultCode(gldap.ResultSuccess)
+		log.Printf("bind success for %s", m.UserName)
+		return
+	case m.UserName == bindUserSpecial && m.Password == bindPassSpecial:
 		resp.SetResultCode(gldap.ResultSuccess)
 		log.Printf("bind success for %s", m.UserName)
 		return
 	}
-	log.Printf("bind failed for %s", m.UserName)
+	log.Printf("bind failed for %s (password length %d)", m.UserName, len(m.Password))
 }
 
 func searchHandler(w *gldap.ResponseWriter, r *gldap.Request) {

--- a/packages/entityanalytics_ad/changelog.yml
+++ b/packages/entityanalytics_ad/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.20.1"
+  changes:
+    - description: Fix LDAP bind failures caused by special characters in credentials.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "0.20.0"
   changes:
     - description: Add support for ECS entity fields.

--- a/packages/entityanalytics_ad/changelog.yml
+++ b/packages/entityanalytics_ad/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix LDAP bind failures caused by special characters in credentials.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/19390
 - version: "0.20.0"
   changes:
     - description: Add support for ECS entity fields.

--- a/packages/entityanalytics_ad/data_stream/entity/_dev/test/system/test-special-chars-config.yml
+++ b/packages/entityanalytics_ad/data_stream/entity/_dev/test/system/test-special-chars-config.yml
@@ -1,0 +1,15 @@
+input: entity-analytics
+service: ldap-mock-service
+vars: ~
+data_stream:
+  vars:
+    ad_base_dn: "DC=testserver,DC=local"
+    ad_url: "ldap://{{Hostname}}:{{Port}}"
+    ad_user: 'TESTSERVER\admin#special'
+    ad_password: 'p@ss:word&"quotes'''
+    dataset: all
+    include_empty_groups: true
+    sync_interval: 24h
+    update_interval: 15m
+assert:
+  hit_count: 2

--- a/packages/entityanalytics_ad/data_stream/entity/agent/stream/entity-analytics.yml.hbs
+++ b/packages/entityanalytics_ad/data_stream/entity/agent/stream/entity-analytics.yml.hbs
@@ -3,8 +3,8 @@ sync_interval: {{sync_interval}}
 update_interval: {{update_interval}}
 ad_base_dn: {{ad_base_dn}}
 ad_url: {{ad_url}}
-ad_user: {{ad_user}}
-ad_password: {{ad_password}}
+ad_user: {{escape_string ad_user}}
+ad_password: {{escape_string ad_password}}
 dataset: {{dataset}}
 {{#if include_empty_groups}}
 include_empty_groups: {{include_empty_groups}}

--- a/packages/entityanalytics_ad/manifest.yml
+++ b/packages/entityanalytics_ad/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: entityanalytics_ad
 title: Active Directory Entity Analytics
-version: "0.20.0"
+version: "0.20.1"
 description: "Collect User Identities from Active Directory Entity with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
entityanalytics_ad: escape special characters in AD credentials

The Handlebars template rendered ad_user and ad_password as bare
values. When credentials contained YAML-special characters (backslash,
colon, quotes, etc.) the rendered configuration differed from what was
entered, causing LDAP error 49 "Invalid Credentials" on bind.

Wrap both fields with the escape_string helper so the values are
emitted as properly quoted YAML strings regardless of content.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
