### PR TITLE
[dev/scripts] Make get_release_commit tests agnostic of real packages

### DIFF
--- a/dev/scripts/test_get_release_commit.sh
+++ b/dev/scripts/test_get_release_commit.sh
@@ -16,11 +16,12 @@ fail=0
 # Helpers: set up / tear down a minimal git repo with two package layouts.
 #
 # Creates:
-#   packages/flat_pkg/manifest.yml            (flat:   packages/<pkg>/)
+#   packages/flat_pkg/manifest.yml            (flat:   packages/<pkg>/, unquoted version)
 #   packages/group/nested_pkg/manifest.yml    (nested: packages/<group>/<pkg>/)
-# Each package gets two commits (1.0.0 then 1.1.0 / 2.0.0 then 2.1.0) so
-# tests can verify the script finds the right commit, not just the latest.
-# Commit hashes for the first versions are stored in .state/ inside the repo.
+#   packages/quoted_pkg/manifest.yml          (flat, version string in quotes)
+#   packages/beta_pkg/manifest.yml            (flat, version promoted from beta)
+# Each package gets multiple commits so tests can verify the script finds the
+# right commit, not just the latest. Commit hashes are stored in .state/.
 # ---------------------------------------------------------------------------
 
 DUMMY_REPO=""
@@ -58,35 +59,33 @@ setup_dummy_repo() {
     git -C "${tmpdir}" add .
     git -C "${tmpdir}" commit -q -m "Release nested_pkg 2.1.0"
 
+    mkdir -p "${tmpdir}/packages/quoted_pkg"
+    printf 'name: quoted_pkg\nversion: "1.0.0"\n' > "${tmpdir}/packages/quoted_pkg/manifest.yml"
+    git -C "${tmpdir}" add .
+    git -C "${tmpdir}" commit -q -m "Release quoted_pkg 1.0.0"
+    git -C "${tmpdir}" rev-parse --short HEAD > "${tmpdir}/.state/quoted_pkg_1.0.0"
+
+    printf 'name: quoted_pkg\nversion: "1.1.0"\n' > "${tmpdir}/packages/quoted_pkg/manifest.yml"
+    git -C "${tmpdir}" add .
+    git -C "${tmpdir}" commit -q -m "Release quoted_pkg 1.1.0"
+
+    mkdir -p "${tmpdir}/packages/beta_pkg"
+    printf 'name: beta_pkg\nversion: 3.0.0-beta.1\n' > "${tmpdir}/packages/beta_pkg/manifest.yml"
+    git -C "${tmpdir}" add .
+    git -C "${tmpdir}" commit -q -m "Release beta_pkg 3.0.0-beta.1"
+
+    printf 'name: beta_pkg\nversion: 3.0.0\n' > "${tmpdir}/packages/beta_pkg/manifest.yml"
+    git -C "${tmpdir}" add .
+    git -C "${tmpdir}" commit -q -m "Release beta_pkg 3.0.0"
+    git -C "${tmpdir}" rev-parse --short HEAD > "${tmpdir}/.state/beta_pkg_3.0.0"
+
     echo "${tmpdir}"
 }
 
 # ---------------------------------------------------------------------------
-# Tests: against real repo packages
+# Tests: flag validation (no package lookup; agnostic of packages on disk)
 # ---------------------------------------------------------------------------
 echo "--- get_release_commit.sh tests"
-
-# Package at packages/<p>/ with unquoted version
-result="$("${SCRIPT}" -p prometheus -v 1.24.2)"
-assert_equals "finds commit for package at packages/<p>/ (unquoted version)" "43bb655db0" "${result}"
-
-# Package at packages/<p>/ with quoted version
-result="$("${SCRIPT}" -p zscaler_zpa -v 1.23.3)"
-assert_equals "finds commit for package at packages/<p>/ (quoted version)" "8b024204a8" "${result}"
-
-# Version previously released as beta (9.3.8-beta.2 -> 9.3.8)
-result="$("${SCRIPT}" -p security_detection_engine -v 9.3.8)"
-assert_equals "finds commit for version promoted from beta" "fd04de398f" "${result}"
-
-# Unknown package
-exit_code=0
-"${SCRIPT}" -p no_such_package -v 1.0.0 > /dev/null 2>&1 || exit_code=$?
-assert_exit_code "exits non-zero for unknown package" "1" "${exit_code}"
-
-# Unknown version
-exit_code=0
-"${SCRIPT}" -p prometheus -v 9.99.99 > /dev/null 2>&1 || exit_code=$?
-assert_exit_code "exits non-zero for unknown version" "1" "${exit_code}"
 
 # Missing -p flag
 exit_code=0
@@ -95,7 +94,7 @@ assert_exit_code "exits non-zero when -p is missing" "1" "${exit_code}"
 
 # Missing -v flag
 exit_code=0
-"${SCRIPT}" -p prometheus > /dev/null 2>&1 || exit_code=$?
+"${SCRIPT}" -p any_pkg > /dev/null 2>&1 || exit_code=$?
 assert_exit_code "exits non-zero when -v is missing" "1" "${exit_code}"
 
 # Invalid flag
@@ -112,6 +111,8 @@ echo "--- get_release_commit.sh tests (dummy repo)"
 DUMMY_REPO="$(setup_dummy_repo)"
 DUMMY_FLAT_COMMIT="$(cat "${DUMMY_REPO}/.state/flat_pkg_1.0.0")"
 DUMMY_NESTED_COMMIT="$(cat "${DUMMY_REPO}/.state/nested_pkg_2.0.0")"
+DUMMY_QUOTED_COMMIT="$(cat "${DUMMY_REPO}/.state/quoted_pkg_1.0.0")"
+DUMMY_BETA_COMMIT="$(cat "${DUMMY_REPO}/.state/beta_pkg_3.0.0")"
 
 # Flat layout: packages/<pkg>/ — queries v1.0.0, not the latest v1.1.0
 result="$(cd "${DUMMY_REPO}" && "${SCRIPT}" -p flat_pkg -v 1.0.0)"
@@ -120,6 +121,24 @@ assert_equals "finds correct commit for packages/<p>/ (not the latest)" "${DUMMY
 # Nested layout: packages/<group>/<pkg>/ — queries v2.0.0, not the latest v2.1.0
 result="$(cd "${DUMMY_REPO}" && "${SCRIPT}" -p nested_pkg -v 2.0.0)"
 assert_equals "finds correct commit for packages/<group>/<p>/ (not the latest)" "${DUMMY_NESTED_COMMIT}" "${result}"
+
+# Quoted version in manifest (version: "1.0.0") — queries v1.0.0, not the latest v1.1.0
+result="$(cd "${DUMMY_REPO}" && "${SCRIPT}" -p quoted_pkg -v 1.0.0)"
+assert_equals "finds correct commit for package with quoted version in manifest" "${DUMMY_QUOTED_COMMIT}" "${result}"
+
+# Version promoted from beta (3.0.0-beta.1 → 3.0.0)
+result="$(cd "${DUMMY_REPO}" && "${SCRIPT}" -p beta_pkg -v 3.0.0)"
+assert_equals "finds commit for version promoted from beta" "${DUMMY_BETA_COMMIT}" "${result}"
+
+# Unknown package
+exit_code=0
+(cd "${DUMMY_REPO}" && "${SCRIPT}" -p no_such_package -v 1.0.0) > /dev/null 2>&1 || exit_code=$?
+assert_exit_code "exits non-zero for unknown package" "1" "${exit_code}"
+
+# Unknown version
+exit_code=0
+(cd "${DUMMY_REPO}" && "${SCRIPT}" -p flat_pkg -v 9.99.99) > /dev/null 2>&1 || exit_code=$?
+assert_exit_code "exits non-zero for unknown version" "1" "${exit_code}"
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
<!-- Label: Bug -->

## Proposed commit message

```
[dev/scripts] Make get_release_commit tests agnostic of real packages

Replace the "real repo" test section in test_get_release_commit.sh —
which referenced prometheus, zscaler_zpa, and security_detection_engine
(absent from this backport branch) — with fully isolated dummy-repo
equivalents:

- Add quoted_pkg and beta_pkg fixtures to setup_dummy_repo() to cover
  quoted-version and beta-to-stable promotion code paths.
- Move unknown-package and unknown-version error cases into the dummy
  repo context.
- Keep the three flag-validation tests (missing -p, missing -v, invalid
  flag) outside the dummy repo since they exit before any package lookup.
- Replace the prometheus placeholder in the missing-v test with any_pkg
  to make the agnostic intent explicit.
```

**WHAT:** The test suite for `dev/scripts/get_release_commit.sh` had a section ("Tests: against real repo packages") that asserted specific commit hashes for packages (`prometheus`, `zscaler_zpa`, `security_detection_engine`) that only exist in the `main` branch. In backport branches containing only a subset of packages, these tests would fail with `Error: package 'prometheus' not found.`

**WHY:** Tests for a generic script should not depend on the presence of specific packages in the repository. The dummy-repo infrastructure (an isolated temporary git repo) was already present in the file and is the correct place to cover all behavioural cases. Two new package fixtures (`quoted_pkg` and `beta_pkg`) were added to `setup_dummy_repo()` to preserve test coverage of the quoted-version and beta-to-stable code paths that the removed real-package tests exercised.

## Author's Checklist

- [x] Run `bash dev/scripts/test_get_release_commit.sh` — 9 passed, 0 failed

## How to test this PR locally

```bash
# From the repo root
bash dev/scripts/test_get_release_commit.sh
# Expected: 9 passed, 0 failed
```

No real packages or network access required — all tests run against a self-contained temporary git repository.

## Related issues

- Relates https://github.com/elastic/integrations/pull/19391
- Relates https://github.com/elastic/integrations/pull/19393

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).