### PR TITLE
[ti_google_threat_intelligence] Clarify "enrichment" in the README

### DIFF
--- a/packages/ti_google_threat_intelligence/_dev/build/docs/README.md
+++ b/packages/ti_google_threat_intelligence/_dev/build/docs/README.md
@@ -159,7 +159,7 @@ These transforms are automatically started to populate `Threat Intelligence`, `A
 ## Limitations
 
 1. If an event contains multiple matching mappings (e.g., two file hash fields within the same event match GTI data), only one alert per detection rule will be generated for that event.
-2. If GTI information is ingested and procesed by a transform, and the GTI source information is updated later, the changes are not reflected in the dashboards because the Elastic detection rules only run on the transformed (destination) data.
+2. If GTI information is ingested and processed by a transform, and the GTI source information is updated later, the changes are not reflected in the dashboards because the Elastic detection rules only run on the transformed (destination) data.
 
 ## Troubleshooting
 

--- a/packages/ti_google_threat_intelligence/_dev/build/docs/README.md
+++ b/packages/ti_google_threat_intelligence/_dev/build/docs/README.md
@@ -6,7 +6,7 @@
 
 Google Threat Intelligence integration offers support for two APIs:
 1. **[Threat List API](https://gtidocs.virustotal.com/reference/get-hourly-threat-list)** to deliver hourly data chunks. The Threat Lists feature allows customers to consume **Indicators of Compromise (IOCs)** categorized by various threat types.
-2. **[IOC Stream API](https://gtidocs.virustotal.com/reference/get-objects-from-the-ioc-stream)** to deliver various types of **Indicators of Compromise (IOCs)** originating from multiple sources. Depending on the source of the notification, different context-specific attributes are added to enrich the IOCs.
+2. **[IOC Stream API](https://gtidocs.virustotal.com/reference/get-objects-from-the-ioc-stream)** to deliver various types of **Indicators of Compromise (IOCs)** originating from multiple sources. Depending on the source of the notification, different context-specific attributes are added to the IOCs.
 
 ## Threat List API Feeds
 
@@ -114,15 +114,15 @@ A **retention policy** is used to remove data older than the default retention p
 
 In this integration, all data streams have a **retention period of 30 days**.
 
-### Enrichment with Detection Rules
+### Customizing Detection Rules
 
-Detection Rules match the user's Elastic environment data with GTI data, generating an alert if a match is found. To access detection rules:
+Detection Rules match the user's data with GTI data, generating an alert if a match is found. To access detection rules:
 
 1. Navigate to **Security > Rules > Detection Rules** and click on **Add Elastic Rules**.
 2. Search for **Google Threat Intelligence** to find prebuilt Elastic detection rules.
 3. Four detection rules are available for **IP, URL, File, and Domain**. Users can install one or more rules as needed.
 
-To tailor a rule based on Elastic environment:
+To customize a rule for your Elastic environment:
 
 1. Click the three dots on the right side of any detection rule.
 2. Select **Duplicate Rule**.
@@ -154,12 +154,12 @@ The following are the names of the eight sample rules:
 - Detected IOC Transform (ID: `logs-ti_google_threat_intelligence.rule`)
 - Detected IOC from IOC stream Transform (ID: `logs-ti_google_threat_intelligence.rule_ioc_st`)
 
-These transforms are automatically started to populate `Threat Intelligence`, `Adversary Intelligence` and `IOC Stream Threat Intelligence` dashboards. The `data_stream.dataset: ti_google_threat_intelligence.enriched_ioc` and `data_stream.dataset: ti_google_threat_intelligence.enriched_ioc_stream` field represents logs for enriched threat intelligence data, which can be analyzed in the **Discover** section.
+These transforms are automatically started to populate `Threat Intelligence`, `Adversary Intelligence` and `IOC Stream Threat Intelligence` dashboards. The `data_stream.dataset: ti_google_threat_intelligence.enriched_ioc` and `data_stream.dataset: ti_google_threat_intelligence.enriched_ioc_stream` field represents logs for current threat intelligence data, which can be analyzed in the **Discover** section.
 
 ## Limitations
 
 1. If an event contains multiple matching mappings (e.g., two file hash fields within the same event match GTI data), only one alert per detection rule will be generated for that event.
-2. If an IOC from the user's Elasticsearch index is enriched with GTI information, and the GTI information is updated later, the changes are not reflected in the dashboards because Elastic detection rules only run on live data.
+2. If GTI information is ingested and procesed by a transform, and the GTI source information is updated later, the changes are not reflected in the dashboards because the Elastic detection rules only run on the transformed (destination) data.
 
 ## Troubleshooting
 

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Clarify "enhanced" in the README.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19411
 - version: "1.0.0"
   changes:
     - description: Fix IOC stream correlation pipeline field mappings for indicator enrichment.

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.1.0"
   changes:
-    - description: Clarify "enhanced" in the README.
+    - description: Clarify "enrichment" in the README.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19411
 - version: "1.0.0"

--- a/packages/ti_google_threat_intelligence/changelog.yml
+++ b/packages/ti_google_threat_intelligence/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.1.0"
   changes:
-    - description: Clarify "enrichment" in the README.
+    - description: Rename detection rules section to avoid confusion with data enrichment.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19411
 - version: "1.0.0"

--- a/packages/ti_google_threat_intelligence/docs/README.md
+++ b/packages/ti_google_threat_intelligence/docs/README.md
@@ -159,7 +159,7 @@ These transforms are automatically started to populate `Threat Intelligence`, `A
 ## Limitations
 
 1. If an event contains multiple matching mappings (e.g., two file hash fields within the same event match GTI data), only one alert per detection rule will be generated for that event.
-2. If GTI information is ingested and procesed by a transform, and the GTI source information is updated later, the changes are not reflected in the dashboards because the Elastic detection rules only run on the transformed (destination) data.
+2. If GTI information is ingested and processed by a transform, and the GTI source information is updated later, the changes are not reflected in the dashboards because the Elastic detection rules only run on the transformed (destination) data.
 
 ## Troubleshooting
 

--- a/packages/ti_google_threat_intelligence/docs/README.md
+++ b/packages/ti_google_threat_intelligence/docs/README.md
@@ -6,7 +6,7 @@
 
 Google Threat Intelligence integration offers support for two APIs:
 1. **[Threat List API](https://gtidocs.virustotal.com/reference/get-hourly-threat-list)** to deliver hourly data chunks. The Threat Lists feature allows customers to consume **Indicators of Compromise (IOCs)** categorized by various threat types.
-2. **[IOC Stream API](https://gtidocs.virustotal.com/reference/get-objects-from-the-ioc-stream)** to deliver various types of **Indicators of Compromise (IOCs)** originating from multiple sources. Depending on the source of the notification, different context-specific attributes are added to enrich the IOCs.
+2. **[IOC Stream API](https://gtidocs.virustotal.com/reference/get-objects-from-the-ioc-stream)** to deliver various types of **Indicators of Compromise (IOCs)** originating from multiple sources. Depending on the source of the notification, different context-specific attributes are added to the IOCs.
 
 ## Threat List API Feeds
 
@@ -114,15 +114,15 @@ A **retention policy** is used to remove data older than the default retention p
 
 In this integration, all data streams have a **retention period of 30 days**.
 
-### Enrichment with Detection Rules
+### Customizing Detection Rules
 
-Detection Rules match the user's Elastic environment data with GTI data, generating an alert if a match is found. To access detection rules:
+Detection Rules match the user's data with GTI data, generating an alert if a match is found. To access detection rules:
 
 1. Navigate to **Security > Rules > Detection Rules** and click on **Add Elastic Rules**.
 2. Search for **Google Threat Intelligence** to find prebuilt Elastic detection rules.
 3. Four detection rules are available for **IP, URL, File, and Domain**. Users can install one or more rules as needed.
 
-To tailor a rule based on Elastic environment:
+To customize a rule for your Elastic environment:
 
 1. Click the three dots on the right side of any detection rule.
 2. Select **Duplicate Rule**.
@@ -154,12 +154,12 @@ The following are the names of the eight sample rules:
 - Detected IOC Transform (ID: `logs-ti_google_threat_intelligence.rule`)
 - Detected IOC from IOC stream Transform (ID: `logs-ti_google_threat_intelligence.rule_ioc_st`)
 
-These transforms are automatically started to populate `Threat Intelligence`, `Adversary Intelligence` and `IOC Stream Threat Intelligence` dashboards. The `data_stream.dataset: ti_google_threat_intelligence.enriched_ioc` and `data_stream.dataset: ti_google_threat_intelligence.enriched_ioc_stream` field represents logs for enriched threat intelligence data, which can be analyzed in the **Discover** section.
+These transforms are automatically started to populate `Threat Intelligence`, `Adversary Intelligence` and `IOC Stream Threat Intelligence` dashboards. The `data_stream.dataset: ti_google_threat_intelligence.enriched_ioc` and `data_stream.dataset: ti_google_threat_intelligence.enriched_ioc_stream` field represents logs for current threat intelligence data, which can be analyzed in the **Discover** section.
 
 ## Limitations
 
 1. If an event contains multiple matching mappings (e.g., two file hash fields within the same event match GTI data), only one alert per detection rule will be generated for that event.
-2. If an IOC from the user's Elasticsearch index is enriched with GTI information, and the GTI information is updated later, the changes are not reflected in the dashboards because Elastic detection rules only run on live data.
+2. If GTI information is ingested and procesed by a transform, and the GTI source information is updated later, the changes are not reflected in the dashboards because the Elastic detection rules only run on the transformed (destination) data.
 
 ## Troubleshooting
 

--- a/packages/ti_google_threat_intelligence/manifest.yml
+++ b/packages/ti_google_threat_intelligence/manifest.yml
@@ -3,7 +3,7 @@ name: ti_google_threat_intelligence
 title: Google Threat Intelligence
 # This version must match the User-Agent version used in CEL code.
 # Remember to update the User-Agent in CEL code when changing this version.
-version: "1.0.0"
+version: "1.1.0"
 description: Collect Threat Intelligence Events from Google Threat Intelligence using Elastic Agent, and perform enrichment on Elasticsearch by correlating Indicators of Compromise (IOCs).
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
ti_google_threat_intelligence: rename detection rules section to avoid confusion with data enrichment

The heading "Enrichment with Detection Rules" led a customer to
expect automatic data enrichment of their existing indices. The
integration actually ingests threat indicators separately; prebuilt
SIEM detection rules then match those indicators against other data
sources and fire alerts.

Rename the section to "Customizing Detection Rules" and reword
surrounding text to remove ambiguity between this detection-rule
workflow and the unrelated ECS event.kind "enrichment" value that
also appears in the integration's data.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 