### PR TITLE
Use agentless deployment 'release' field to agentless deployment modes

### DIFF
--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.24.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19439
 - version: "1.24.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: auth0
 title: "Auth0"
-version: "1.24.0"
+version: "1.25.0"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:
@@ -29,6 +29,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/entro/changelog.yml
+++ b/packages/entro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/entro/changelog.yml
+++ b/packages/entro/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19439
 - version: "0.3.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/entro/manifest.yml
+++ b/packages/entro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.5
 name: entro
 title: "Entro"
-version: 0.3.0
+version: 0.4.0
 description: "Collect logs from Entro with Elastic Agent."
 type: integration
 categories:
@@ -31,6 +31,7 @@ policy_templates:
        enabled: true
      agentless:
        enabled: true
+       release: beta
        organization: security
        division: engineering
        team: security-service-integrations

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19439
 - version: "2.4.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.4.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: eset_protect
 title: ESET PROTECT
-version: "2.4.0"
+version: "2.5.0"
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:
@@ -40,6 +40,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.14.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19439
 - version: "1.14.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.14.0"
+version: "1.15.0"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:
@@ -30,6 +30,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/lumos/changelog.yml
+++ b/packages/lumos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/lumos/changelog.yml
+++ b/packages/lumos/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19439
 - version: "1.7.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/lumos/manifest.yml
+++ b/packages/lumos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: lumos
 title: "Lumos"
-version: "1.7.0"
+version: "1.8.0"
 description: "An integration with Lumos to ship your Activity logs to your Elastic instance."
 type: integration
 categories:
@@ -34,6 +34,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/miniflux/changelog.yml
+++ b/packages/miniflux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.1.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/miniflux/changelog.yml
+++ b/packages/miniflux/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19439
 - version: "1.1.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/miniflux/manifest.yml
+++ b/packages/miniflux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.5
 name: miniflux
 title: "Miniflux RSS reader"
-version: 1.1.0
+version: 1.2.0
 source:
   license: "Elastic-2.0"
 description: Collect RSS feed content from the Miniflux API with Elastic Agent.
@@ -38,6 +38,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/nextron_thor/changelog.yml
+++ b/packages/nextron_thor/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19439
 - version: "0.2.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/nextron_thor/changelog.yml
+++ b/packages/nextron_thor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/nextron_thor/manifest.yml
+++ b/packages/nextron_thor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: nextron_thor_apt_scanner
 title: "Nextron Thor APT Scanner"
-version: 0.2.0
+version: 0.3.0
 source:
   license: "Elastic-2.0"
 description: "Integration for Nextron Thor APT Scanner"
@@ -32,6 +32,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Use new `release` field for agentless deployment mode to establish as beta.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.22.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19439
 - version: "1.22.0"
   changes:
     - description: Enable Agentless deployment.

--- a/packages/sophos_central/manifest.yml
+++ b/packages/sophos_central/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: sophos_central
 title: Sophos Central
-version: "1.22.0"
+version: "1.23.0"
 description: This Elastic integration collects logs from Sophos Central with Elastic Agent.
 type: integration
 categories:
@@ -35,6 +35,7 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        release: beta
         organization: security
         division: engineering
         team: security-service-integrations


### PR DESCRIPTION
## Proposed commit message

```
Add release field for agentless deployments and mark applicable integrations as Beta.

Introduces a new release field for agentless deployments to explicitly define deployment 
maturity (beta or ga). Updates the following integrations to use release: beta for their agentless
deployment mode:
- auth0
- entro
- eset_protect
- imperva_cloud_waf
- lumos
- miniflux
- nextron_thor_apt_scanner
- sophos_central

```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations directory.
- Run the following command to run tests.

> elastic-package test -v