### PR TITLE
[axonius] Updated kibana version to reflect ILM policy delete index feature.

### DIFF
--- a/packages/axonius/changelog.yml
+++ b/packages/axonius/changelog.yml
@@ -1,9 +1,11 @@
 # newer versions go on top
-- version: 0.1.0
+- version: 0.1.1
   changes:
-    - description: Initial release with update in kibana version.
+    - description: Update in kibana version.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19440
+- version: 0.1.0
+  changes:
     - description: Sync all datastreams to follow new best practices.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19335

--- a/packages/axonius/changelog.yml
+++ b/packages/axonius/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: 0.1.0
   changes:
+    - description: Initial release with update in kibana version.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19440
     - description: Sync all datastreams to follow new best practices.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19335

--- a/packages/axonius/manifest.yml
+++ b/packages/axonius/manifest.yml
@@ -15,7 +15,7 @@ categories:
   - vulnerability_management
 conditions:
   kibana:
-    version: ^8.19.10 || ~9.1.10 || ~9.2.4 || ^9.3.1
+    version: ^8.19.17 || ^9.3.6 || ^9.4.3
   elastic:
     subscription: basic
 screenshots:

--- a/packages/axonius/manifest.yml
+++ b/packages/axonius/manifest.yml
@@ -15,7 +15,7 @@ categories:
   - vulnerability_management
 conditions:
   kibana:
-    version: ^8.19.17 || ^9.3.6 || ^9.4.3
+    version: ^8.19.17 || ~9.3.6 || ^9.4.3
   elastic:
     subscription: basic
 screenshots:

--- a/packages/axonius/manifest.yml
+++ b/packages/axonius/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: axonius
 title: Axonius
-version: 0.1.0
+version: 0.1.1
 description: Collect logs from Axonius with Elastic Agent.
 type: integration
 categories:

--- a/packages/axonius/manifest.yml
+++ b/packages/axonius/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: axonius
 title: Axonius
-version: 0.1.1
+version: 0.1.2
 description: Collect logs from Axonius with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

1. Update in kibana version to support the latest release versions to execute the ILM policy delete step.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates https://github.com/elastic/elasticsearch/pull/150846
- Relates https://github.com/elastic/elasticsearch/pull/150609
- Relates https://github.com/elastic/elasticsearch/pull/150605