### PR TITLE
mimecast: fix batch SIEM API token loss causing full data re-ingestion

### DIFF
--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.2"
+  changes:
+    - description: Fix siem_logs and cloud_integrated_logs CEL programs to persist batch API page tokens across polling cycles, preventing full re-ingestion of up to 7 days of data on every interval.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "3.4.1"
   changes:
     - description: Fix pipeline error for av events caused by senderDomainInternal being incorrectly mapped to source.domain.

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix siem_logs and cloud_integrated_logs CEL programs to persist batch API page tokens across polling cycles, preventing full re-ingestion of up to 7 days of data on every interval.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/19442
 - version: "3.4.1"
   changes:
     - description: Fix pipeline error for av events caused by senderDomainInternal being incorrectly mapped to source.domain.

--- a/packages/mimecast/data_stream/cloud_integrated_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/cloud_integrated_logs/agent/stream/cel.yml.hbs
@@ -168,8 +168,7 @@ program: |
                 // the API provides one, regardless of whether there
                 // are more pages in this cycle. This ensures the
                 // token survives into the next polling interval.
-                ("@nextPage" in body ? body["@nextPage"] : "").as(page_token,
-                {
+                ("@nextPage" in body ? body["@nextPage"] : "").as(page_token, {
                   "events": [{"message": "want_more"}],
                   "cursor": {
                     "blobs": body.value.map(b, b.url),

--- a/packages/mimecast/data_stream/cloud_integrated_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/cloud_integrated_logs/agent/stream/cel.yml.hbs
@@ -35,6 +35,12 @@ program: |
   // Memory optimization: This program processes ONE batch file per execution
   // cycle to avoid memory pressure. Batch URLs are stored in cursor.blobs
   // and processed one at a time.
+  // cursor.last_tokens persists the last @nextPage token returned by
+  // the batch API for each event type. When the work_list cycle
+  // completes and restarts on the next interval, these tokens seed
+  // the new requests so the API returns only data written since the
+  // previous download instead of replaying the full 7-day window.
+  state.?cursor.last_tokens.orValue({}).as(last_tokens,
   state.with(
     (
       (has(state.?token.expires) && now() < timestamp(state.token.expires)) ?
@@ -72,8 +78,16 @@ program: |
           }
         )
     ).as(token, !has(token.access_token) ? token :
-      state.?cursor.work_list.orValue(state.types.map(t, {"type": t})).as(work_list, size(work_list) == 0 ?
-        state.types.map(t, {"type": t})
+      state.?cursor.work_list.orValue(
+        // Seed a fresh work_list with saved tokens so each type
+        // resumes from its last position rather than the beginning.
+        state.types.map(t,
+          t in last_tokens ? {"type": t, "next": last_tokens[t]} : {"type": t}
+        )
+      ).as(work_list, size(work_list) == 0 ?
+        state.types.map(t,
+          t in last_tokens ? {"type": t, "next": last_tokens[t]} : {"type": t}
+        )
       :
         work_list
       ).as(work_list,
@@ -91,6 +105,7 @@ program: |
                 "cursor": {
                   "blobs": tail(blobs),
                   "work_list": work_list,
+                  "last_tokens": last_tokens,
                 },
                 "token": {
                   "access_token": token.access_token,
@@ -105,6 +120,7 @@ program: |
                 "cursor": {
                   "blobs": tail(blobs),
                   "work_list": work_list,
+                  "last_tokens": last_tokens,
                 },
                 "token": {
                   "access_token": token.access_token,
@@ -148,6 +164,11 @@ program: |
               }
             }).do_request().as(resp, (resp.StatusCode == 200) ?
               bytes(resp.Body).decode_json().as(body,
+                // Save the @nextPage token for this type whenever
+                // the API provides one, regardless of whether there
+                // are more pages in this cycle. This ensures the
+                // token survives into the next polling interval.
+                ("@nextPage" in body ? body["@nextPage"] : "").as(page_token,
                 {
                   "events": [{"message": "want_more"}],
                   "cursor": {
@@ -159,13 +180,19 @@ program: |
                       :
                         []
                     ) + tail(work_list),
+                    "last_tokens": last_tokens.with(
+                      page_token != "" ?
+                        {work_list[0].type: page_token}
+                      :
+                        {}
+                    ),
                   },
                   "token": {
                     "access_token": token.access_token,
                     "expires": token.expires,
                   },
                   "want_more": size(body.value) != 0 || size(tail(work_list)) != 0,
-                }
+                })
               )
             :
               {
@@ -187,7 +214,7 @@ program: |
         )
       )
     )
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/mimecast/data_stream/siem_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/siem_logs/agent/stream/cel.yml.hbs
@@ -168,8 +168,7 @@ program: |
                 // the API provides one, regardless of whether there
                 // are more pages in this cycle. This ensures the
                 // token survives into the next polling interval.
-                ("@nextPage" in body ? body["@nextPage"] : "").as(page_token,
-                {
+                ("@nextPage" in body ? body["@nextPage"] : "").as(page_token, {
                   "events": [{"message": "want_more"}],
                   "cursor": {
                     "blobs": body.value.map(b, b.url),

--- a/packages/mimecast/data_stream/siem_logs/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/siem_logs/agent/stream/cel.yml.hbs
@@ -35,6 +35,12 @@ program: |
   // Memory optimization: This program processes ONE batch file per execution
   // cycle to avoid memory pressure. Batch URLs are stored in cursor.blobs
   // and processed one at a time.
+  // cursor.last_tokens persists the last @nextPage token returned by
+  // the batch API for each event type. When the work_list cycle
+  // completes and restarts on the next interval, these tokens seed
+  // the new requests so the API returns only data written since the
+  // previous download instead of replaying the full 7-day window.
+  state.?cursor.last_tokens.orValue({}).as(last_tokens,
   state.with(
     (
       (has(state.?token.expires) && now() < timestamp(state.token.expires)) ?
@@ -72,8 +78,16 @@ program: |
           }
         )
     ).as(token, !has(token.access_token) ? token :
-      state.?cursor.work_list.orValue(state.types.map(t, {"type": t})).as(work_list, size(work_list) == 0 ?
-        state.types.map(t, {"type": t})
+      state.?cursor.work_list.orValue(
+        // Seed a fresh work_list with saved tokens so each type
+        // resumes from its last position rather than the beginning.
+        state.types.map(t,
+          t in last_tokens ? {"type": t, "next": last_tokens[t]} : {"type": t}
+        )
+      ).as(work_list, size(work_list) == 0 ?
+        state.types.map(t,
+          t in last_tokens ? {"type": t, "next": last_tokens[t]} : {"type": t}
+        )
       :
         work_list
       ).as(work_list,
@@ -91,6 +105,7 @@ program: |
                 "cursor": {
                   "blobs": tail(blobs),
                   "work_list": work_list,
+                  "last_tokens": last_tokens,
                 },
                 "token": {
                   "access_token": token.access_token,
@@ -105,6 +120,7 @@ program: |
                 "cursor": {
                   "blobs": tail(blobs),
                   "work_list": work_list,
+                  "last_tokens": last_tokens,
                 },
                 "token": {
                   "access_token": token.access_token,
@@ -148,6 +164,11 @@ program: |
               }
             }).do_request().as(resp, (resp.StatusCode == 200) ?
               bytes(resp.Body).decode_json().as(body,
+                // Save the @nextPage token for this type whenever
+                // the API provides one, regardless of whether there
+                // are more pages in this cycle. This ensures the
+                // token survives into the next polling interval.
+                ("@nextPage" in body ? body["@nextPage"] : "").as(page_token,
                 {
                   "events": [{"message": "want_more"}],
                   "cursor": {
@@ -159,13 +180,19 @@ program: |
                       :
                         []
                     ) + tail(work_list),
+                    "last_tokens": last_tokens.with(
+                      page_token != "" ?
+                        {work_list[0].type: page_token}
+                      :
+                        {}
+                    ),
                   },
                   "token": {
                     "access_token": token.access_token,
                     "expires": token.expires,
                   },
                   "want_more": size(body.value) != 0 || size(tail(work_list)) != 0,
-                }
+                })
               )
             :
               {
@@ -187,7 +214,7 @@ program: |
         )
       )
     )
-  )
+  ))
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/mimecast/data_stream/siem_logs/sample_event.json
+++ b/packages/mimecast/data_stream/siem_logs/sample_event.json
@@ -1,22 +1,22 @@
 {
     "@timestamp": "2021-11-12T12:15:46.000Z",
     "agent": {
-        "ephemeral_id": "209054e3-c38a-4e5a-bb6c-e771a044eb63",
-        "id": "561734f3-9650-4135-bc74-cf4d379801c5",
-        "name": "elastic-agent-56189",
+        "ephemeral_id": "b9b503e9-092b-4ff9-82d7-5fe035b87cab",
+        "id": "949dd69d-1c58-45d5-8401-dd1500236b54",
+        "name": "elastic-agent-24961",
         "type": "filebeat",
         "version": "8.19.4"
     },
     "data_stream": {
         "dataset": "mimecast.siem_logs",
-        "namespace": "85570",
+        "namespace": "59193",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "561734f3-9650-4135-bc74-cf4d379801c5",
+        "id": "949dd69d-1c58-45d5-8401-dd1500236b54",
         "snapshot": false,
         "version": "8.19.4"
     },
@@ -41,7 +41,7 @@
         ],
         "created": "2021-11-12T12:15:46+0000",
         "dataset": "mimecast.siem_logs",
-        "ingested": "2025-12-16T05:32:04Z",
+        "ingested": "2026-06-08T14:14:21Z",
         "original": "{\"Content-Disposition\":\"attachment; filename=\\\"jrnl_20211018093329655.json\\\"\",\"Dir\":\"Internal\",\"Rcpt\":\"o365_service_account@example.com\",\"RcptActType\":\"Jnl\",\"RcptHdrType\":\"Unknown\",\"Sender\":\"johndoe@example.com\",\"aCode\":\"fjihpfEgM_iRwemxhe3t_w\",\"acc\":\"ABC123\",\"datetime\":\"2021-11-12T12:15:46+0000\"}",
         "outcome": "unknown"
     },

--- a/packages/mimecast/docs/README.md
+++ b/packages/mimecast/docs/README.md
@@ -690,22 +690,22 @@ An example event for `siem` looks as following:
 {
     "@timestamp": "2021-11-12T12:15:46.000Z",
     "agent": {
-        "ephemeral_id": "209054e3-c38a-4e5a-bb6c-e771a044eb63",
-        "id": "561734f3-9650-4135-bc74-cf4d379801c5",
-        "name": "elastic-agent-56189",
+        "ephemeral_id": "b9b503e9-092b-4ff9-82d7-5fe035b87cab",
+        "id": "949dd69d-1c58-45d5-8401-dd1500236b54",
+        "name": "elastic-agent-24961",
         "type": "filebeat",
         "version": "8.19.4"
     },
     "data_stream": {
         "dataset": "mimecast.siem_logs",
-        "namespace": "85570",
+        "namespace": "59193",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "561734f3-9650-4135-bc74-cf4d379801c5",
+        "id": "949dd69d-1c58-45d5-8401-dd1500236b54",
         "snapshot": false,
         "version": "8.19.4"
     },
@@ -730,7 +730,7 @@ An example event for `siem` looks as following:
         ],
         "created": "2021-11-12T12:15:46+0000",
         "dataset": "mimecast.siem_logs",
-        "ingested": "2025-12-16T05:32:04Z",
+        "ingested": "2026-06-08T14:14:21Z",
         "original": "{\"Content-Disposition\":\"attachment; filename=\\\"jrnl_20211018093329655.json\\\"\",\"Dir\":\"Internal\",\"Rcpt\":\"o365_service_account@example.com\",\"RcptActType\":\"Jnl\",\"RcptHdrType\":\"Unknown\",\"Sender\":\"johndoe@example.com\",\"aCode\":\"fjihpfEgM_iRwemxhe3t_w\",\"acc\":\"ABC123\",\"datetime\":\"2021-11-12T12:15:46+0000\"}",
         "outcome": "unknown"
     },

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: mimecast
 title: "Mimecast"
-version: "3.4.1"
+version: "3.4.2"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
mimecast: fix batch SIEM API token loss causing full data re-ingestion

The siem_logs and cloud_integrated_logs CEL programs discard the
@nextPage token when a type's pages are exhausted. On the next polling
interval the work_list resets with no tokens[1][2], so the batch API returns
all available data (up to 7 days) from the beginning. Every previously
indexed document hits the fingerprint dedup and produces a 409
version_conflict_engine_exception.

Introduce cursor.last_tokens — a map keyed by event type that persists
the last @nextPage token from each type across polling cycles. When the
work_list cycle restarts, each type resumes from its saved position
rather than from the beginning.

[1] - https://developer.services.mimecast.com/siem-batch-guidelines
[2] - https://developer.services.mimecast.com/siem-tutorial-cg
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Current system tests are successful and at the end of the cycle, the response state is:
```json
{
...
  "cursor": {
    "blobs": [],
    "last_tokens": {
      "internal email protect": "String",
      "receipt": "String"
    },
    "work_list": []
  },
...
  "want_more": false
}
```

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
