### PR TITLE
ironscales: skip 404/410 on incident details instead of aborting collection

### DIFF
--- a/packages/ironscales/_dev/deploy/docker/files/config.yml
+++ b/packages/ironscales/_dev/deploy/docker/files/config.yml
@@ -156,7 +156,7 @@ rules:
           {
             "page": 1,
             "total_pages": 3,
-            "total_count": 6,
+            "total_count": 7,
             "incidents": [
               {
                 "incidentID": 72302028,
@@ -179,6 +179,28 @@ rules:
                 "commentsCount": 5,
                 "releaseRequestCount": 0,
                 "latestEmailDate": "2025-10-27T11:59:03Z"
+              },
+              {
+                "incidentID": 99999999,
+                "emailSubject": "Deleted incident",
+                "linksCount": 0,
+                "attachmentsCount": 0,
+                "recipientEmail": "john@example.com",
+                "recipientName": null,
+                "classification": "Phishing",
+                "assignee": null,
+                "senderName": "unknown",
+                "senderEmail": "unknown@example.com",
+                "affectedMailboxesCount": 1,
+                "created": "2025-10-27T08:00:00.000000Z",
+                "reportedBy": "Automated Threat Detection",
+                "resolvedBy": null,
+                "challengedType": null,
+                "firstChallengedDate": null,
+                "incidentType": "Email Report",
+                "commentsCount": 0,
+                "releaseRequestCount": 0,
+                "latestEmailDate": "2025-10-27T08:00:00Z"
               },
               {
                 "incidentID": 72407257,

--- a/packages/ironscales/changelog.yml
+++ b/packages/ironscales/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.2"
+  changes:
+    - description: Skip incidents that return 404 or 410 instead of aborting the entire collection.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19464
 - version: "0.2.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/ironscales/data_stream/incident/agent/stream/cel.yml.hbs
+++ b/packages/ironscales/data_stream/incident/agent/stream/cel.yml.hbs
@@ -178,6 +178,18 @@ program: |
               "want_more": tail(work.worklist.incidents)[?0].hasValue() || int(work.worklist.page) != int(work.worklist.total_pages)
             })
           :
+            // Skip incidents that have been deleted or are no longer accessible.
+            resp.StatusCode == 404 || resp.StatusCode == 410 ?
+              {
+                "events": [{"retry": true}],
+                "worklist": (tail(work.worklist.incidents)[?0].hasValue()) ? work.worklist.with({ "incidents": tail(work.worklist.incidents) }) : {},
+                "next": {
+                  "jwt_token": work.next.jwt_token,
+                  ?"page": work.?next.page,
+                },
+                "want_more": tail(work.worklist.incidents)[?0].hasValue() || int(work.worklist.page) != int(work.worklist.total_pages)
+              }
+            :
             // Generate a new token if expired; otherwise, report an error
             resp.StatusCode == 403 ?
               resp.Body.decode_json().as(body,
@@ -251,7 +263,8 @@ tags:
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true
 {{/contains}}
-{{#if processors}}
 processors:
+- drop_event.when.equals.retry: true
+{{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/ironscales/manifest.yml
+++ b/packages/ironscales/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: ironscales
 title: IRONSCALES
-version: 0.2.1
+version: 0.2.2
 description: Collect logs from IRONSCALES with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
ironscales: skip 404/410 on incident details instead of aborting collection

When the IronScales API returns 404 or 410 for a single incident's
details endpoint, the CEL program aborted the entire collection run
and left the unit in a DEGRADED loop retrying the same incident
indefinitely. This happens when an incident is deleted or archived
between the list and details requests.

Handle 404/410 by advancing the worklist past the missing incident
and continuing with the remaining incidents and pages. A drop_event
processor removes the placeholder event at the agent level.

Add a non-existent incident to the system test mock to exercise
the skip path.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
