### PR TITLE
[cisco_ftd] Parse raw IP protocols in Cisco FTD msg 106010

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "3.13.6"
   changes:
-    - description: Add support for raw IP protocol numbers in message ID 106010 to handle VRRP, OSPF, PIM and other protocols without ports.
+    - description: Add support for raw IP protocol numbers in message ID 106010 to handle protocols without ports.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19498
 - version: "3.13.5"
   changes:
     - description: Parse user authentication rejection reasons

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.6"
+  changes:
+    - description: Add support for raw IP protocol numbers in message ID 106010 to handle VRRP, OSPF, PIM and other protocols without ports.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.13.5"
   changes:
     - description: Parse user authentication rejection reasons

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log
@@ -4,3 +4,5 @@ Apr 15 2013 09:36:50: %ASA-4-106023: Deny tcp src dmz:10.123.123.123/6316 dst ou
 Apr 17 2020 14:16:20 SNL-ASA-VPN-A01 : %ASA-4-106023: Deny udp src Inside:10.123.123.123/57621(LOCAL\Elastic) dst Outside:10.123.123.123/57621 by access-group "Inside_access_in" [0x0, 0x0]
 Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-2-106017: Deny IP due to Land Attack from 10.123.123.123 to 10.123.123.123
 May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 175.16.199.1/0 laddr 192.168.2.2/0 type 3 code 1
+<131>Jun 05 2026 07:15:18 ALHB1FW01 : %FTD-3-106010: Deny inbound protocol 112 src Inside:10.10.10.10 dst Outside:10.133.123.123
+<131>Jun 05 2026 07:15:18 ALHB1FW01 : %FTD-3-106010: Deny inbound tcp src Inside:10.10.10.10/443 dst Outside:10.133.123.123/51325

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -437,6 +437,175 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-06-05T07:15:18.000Z",
+            "cisco": {
+                "ftd": {
+                    "destination_interface": "Outside",
+                    "source_interface": "Inside"
+                }
+            },
+            "destination": {
+                "address": "10.133.123.123",
+                "ip": "10.133.123.123"
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106010",
+                "kind": "event",
+                "original": "<131>Jun 05 2026 07:15:18 ALHB1FW01 : %FTD-3-106010: Deny inbound protocol 112 src Inside:10.10.10.10 dst Outside:10.133.123.123",
+                "outcome": "failure",
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "ALHB1FW01"
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "facility": {
+                        "code": 16
+                    },
+                    "priority": 131,
+                    "severity": {
+                        "code": 3
+                    }
+                }
+            },
+            "network": {
+                "community_id": "1:q6kZ94hT2vu9UloNnjib7bcEreY=",
+                "iana_number": "112"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "Outside"
+                    }
+                },
+                "hostname": "ALHB1FW01",
+                "ingress": {
+                    "interface": {
+                        "name": "Inside"
+                    }
+                },
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "ALHB1FW01"
+                ],
+                "ip": [
+                    "10.10.10.10",
+                    "10.133.123.123"
+                ]
+            },
+            "source": {
+                "address": "10.10.10.10",
+                "ip": "10.10.10.10"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2026-06-05T07:15:18.000Z",
+            "cisco": {
+                "ftd": {
+                    "destination_interface": "Outside",
+                    "source_interface": "Inside"
+                }
+            },
+            "destination": {
+                "address": "10.133.123.123",
+                "ip": "10.133.123.123",
+                "port": 51325
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106010",
+                "kind": "event",
+                "original": "<131>Jun 05 2026 07:15:18 ALHB1FW01 : %FTD-3-106010: Deny inbound tcp src Inside:10.10.10.10/443 dst Outside:10.133.123.123/51325",
+                "outcome": "failure",
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "ALHB1FW01"
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "facility": {
+                        "code": 16
+                    },
+                    "priority": 131,
+                    "severity": {
+                        "code": 3
+                    }
+                }
+            },
+            "network": {
+                "community_id": "1:SqoHphnz9ud727m8/oExCNWL6GU=",
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "Outside"
+                    }
+                },
+                "hostname": "ALHB1FW01",
+                "ingress": {
+                    "interface": {
+                        "name": "Inside"
+                    }
+                },
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "ALHB1FW01"
+                ],
+                "ip": [
+                    "10.10.10.10",
+                    "10.133.123.123"
+                ]
+            },
+            "source": {
+                "address": "10.10.10.10",
+                "ip": "10.10.10.10",
+                "port": 443
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -265,6 +265,7 @@ processors:
       description: "106010"
       patterns:
         - "%{NOTSPACE:event.outcome} %{NOTSPACE} %{NOTSPACE:network.transport} src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address}/%{POSINT:source.port} (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{POSINT:destination.port}(%{GREEDYDATA})?"
+        - "%{NOTSPACE:event.outcome} %{NOTSPACE} protocol %{POSINT:network.iana_number} src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address} dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}(%{GREEDYDATA})?"
   - dissect:
       tag: dissect_message_6a3adcc1
       if: "ctx._temp_.cisco.message_id == '106013'"

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.13.5"
+version: "3.13.6"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - firewall_security
 conditions:
   kibana:
-    version: "^8.11.0 || ^9.0.0"
+    version: "^8.16.0 || ^9.0.0"
 icons:
   - src: /img/cisco.svg
     title: cisco


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
[cisco_ftd] Parse raw IP protocols in Cisco FTD msg 106010

Cisco FTD failed to parse message ID 106010 events containing raw IP
protocol numbers (such as VRRP, OSPF, or PIM). The existing grok
pattern only matched named transport protocols (TCP, UDP, etc.) and
their associated port numbers.

Add a second grok pattern to the message ID 106010 processor to
explicitly match the raw protocol number format: `protocol <number>`
followed by source/destination interface and address pairs without port
fields. The pattern captures the protocol number into the
`network.iana_number` field, aligning with ECS conventions.
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [x] Verify the new grok pattern correctly parses raw protocol numbers and maps to `network.iana_number` field
- [x] Confirm test fixtures for VRRP (112) pass with expected output
- [x] Validate that the original pattern for transport protocols with ports continues to work unchanged

## How to test this PR locally

```bash
elastic-package format packages/cisco_ftd
elastic-package lint packages/cisco_ftd
elastic-package build packages/cisco_ftd
elastic-package test pipeline packages/cisco_ftd/data_stream/log
```

## Related issues


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->