### PR TITLE
[cloudflare_logpush] Fix ingestion failure for events collected via the HTTP Endpoint input

### DIFF
--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.46.2"
+  changes:
+    - description: Fix ingestion failure for events collected via the HTTP Endpoint input by only parsing `event.original` when it is present. The input parses the request body into `json` itself, so `event.original` may be absent.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.46.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix ingestion failure for events collected via the HTTP Endpoint input by only parsing `event.original` when it is present. The input parses the request body into `json` itself, so `event.original` may be absent.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19503
 - version: "1.46.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_type
       field: event.type

--- a/packages/cloudflare_logpush/data_stream/casb/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_ba9b1d84
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dlp_forensic_copies/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       field: event.original
       target_field: json
       tag: json_event_original
+      if: ctx.event?.original != null
   - set:
       field: event.kind
       value: event

--- a/packages/cloudflare_logpush/data_stream/email_security_alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/email_security_alerts/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_52cf4ba2
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       field: event.original
       target_field: json
       tag: json_event_original
+      if: ctx.event?.original != null
   - set:
       field: event.kind
       value: event

--- a/packages/cloudflare_logpush/data_stream/nel_report/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/network_analytics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_ed69613e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/page_shield_events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/page_shield_events/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       field: event.original
       target_field: json
       tag: json_event_original
+      if: ctx.event?.original != null
   - set:
       field: event.kind
       value: event

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
+      if: ctx.event?.original != null
   - set:
       tag: set_event_category_dbab8a4e
       field: event.category

--- a/packages/cloudflare_logpush/data_stream/workers_trace/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/elasticsearch/ingest_pipeline/default.yml
@@ -22,6 +22,7 @@ processors:
       field: event.original
       target_field: json
       tag: json_event_original
+      if: ctx.event?.original != null
   - set:
       field: event.category
       value: [web]

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.46.1"
+version: "1.46.2"
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
cloudflare_logpush: fix ingestion failure for HTTP Endpoint input events

The 1.45.0 ingest pipeline rewrite (#18952, #19234) removed the
ignore_failure guard that previously existed on the json processor
parsing event.original (present up to 1.44.2).

With the http_endpoint input, the request body is parsed by the input
itself into the "json" field: there is no "message" field, so
event.original is never populated by the pipeline preamble. The
unguarded json processor then hard-fails with:

  Processor json with tag json_event_original_to_json_cac66847 in
  pipeline logs-cloudflare_logpush.firewall_event-1.46.0 failed with
  message: field [original] not present as part of path [event.original]

Because the processor has no on_failure handler, the failure aborts the
whole pipeline: every event delivered through the HTTP Endpoint input is
indexed unparsed (no ECS fields, no cloudflare_logpush.* fields,
@timestamp set to ingest time) with event.kind: pipeline_error.

Restore the guard by only running the json processor when
event.original is present, across all data streams.
```

## What happened

After upgrading the package from 1.44.x to 1.45.0+/1.46.x, 100% of events collected through the **HTTP Endpoint** input fail the ingest pipeline. Example failed document (firewall_event, Elastic Agent 8.19.15, `input.type: http_endpoint`): the full Cloudflare payload is present under `json.*` (parsed by the input), `message`/`event.original` are absent, and the document carries:

```
error.message: Processor json with tag json_event_original_to_json_cac66847 in pipeline
logs-cloudflare_logpush.firewall_event-1.46.0 failed with message:
field [original] not present as part of path [event.original]
event.kind: pipeline_error
```

Up to 1.44.2 the processor was:

```yaml
- json:
    field: event.original
    target_field: json
    ignore_failure: true
```

so the missing field was tolerated and the pipeline continued with the `json.*` fields provided by the input. The 1.45.0 rewrite dropped the guard.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Send a firewall_event document through the pipeline without `message`/`event.original` but with the payload already under `json` (as produced by the http_endpoint input): before this change the pipeline aborts with `pipeline_error`; after this change the event is parsed normally.

Co-Authored-By: Oz <oz-agent@warp.dev>