### PR TITLE
[Auth0] Fix "Auth0 logs" saved search columns to use ECS fields

### DIFF
--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix the "Auth0 logs" saved search to reference the ECS fields populated by the ingest pipeline (`user.name`, `user_agent.original`) instead of the raw `auth0.logs.data.user_name`/`user_agent` fields the pipeline removes.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/PR_NUMBER
+      link: https://github.com/elastic/integrations/pull/19512
 - version: "1.25.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Fix the "Auth0 logs" saved search to reference the ECS fields populated by the ingest pipeline (`user.name`, `user_agent.original`) instead of the raw `auth0.logs.data.user_name`/`user_agent` fields the pipeline removes.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/PR_NUMBER
 - version: "1.25.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/auth0/kibana/search/auth0-629b19e0-4061-11ec-b18d-ef6bf98b26bf.json
+++ b/packages/auth0/kibana/search/auth0-629b19e0-4061-11ec-b18d-ef6bf98b26bf.json
@@ -2,8 +2,8 @@
     "attributes": {
         "columns": [
             "auth0.logs.data.connection",
-            "auth0.logs.data.user_name",
-            "auth0.logs.data.user_agent"
+            "user.name",
+            "user_agent.original"
         ],
         "description": "",
         "hits": 0,

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: auth0
 title: "Auth0"
-version: "1.25.0"
+version: "1.25.1"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

The "Auth0 logs" saved search bundled with the package lists the columns
`auth0.logs.data.user_name` and `auth0.logs.data.user_agent`. The package ingest pipeline maps
these fields to ECS (`user.name`, `user.email`, `user_agent.*`) and then removes the originals,
so both columns render `(null)` for every document in the table embedded on the Auth0 dashboard.
The data is there, but under the ECS fields.

This does not depend on the ingestion path or configuration:

- The remove processor in `data_stream/logs/elasticsearch/ingest_pipeline/default.yml` drops
  `auth0.logs.data.{ip,user_name,user_id,user_agent,log_id}` with `ignore_missing: true` and no
  condition. There is no setting that preserves these fields.
- No document in `data_stream/logs/_dev/test/pipeline/*-expected.json` carries
  `auth0.logs.data.user_name` or `auth0.logs.data.user_agent` (109 expected docs across 10
  fixtures). `user.name` is present in 55 of them and `user_agent.original` in 108.

This PR points the columns at the fields the pipeline actually populates: `user.name` and
`user_agent.original`. `auth0.logs.data.connection` stays as is because the pipeline preserves
it (Auth0 only sends it on interactive events, so it is legitimately empty on M2M traffic).

Found while validating the integration against a production deployment on 9.2.4: the saved
search table showed null on every row while the values were sitting in the ECS fields.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs. (No changes to data collection, ingest pipeline or mappings in this PR.)
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition). (Unchanged: `^8.19.16 || ~9.3.5 || ^9.4.1`.)
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices). (No dashboard added or changed, only the saved search columns.)

## Author's Checklist

- [ ] Columns reference fields the pipeline outputs. Cross-check with any
  `data_stream/logs/_dev/test/pipeline/*-expected.json`: the old fields are absent from the
  top level of `auth0.logs.data`, `user.name` and `user_agent.original` are present.
- [ ] Patch version bump (1.25.0 to 1.25.1) plus changelog entry, type `bugfix`.
- [ ] No pipeline, mapping, data stream or dashboard changes.

## How to test this PR locally

Static check, no stack needed:

```
cd packages/auth0
elastic-package check
```

Then open any `data_stream/logs/_dev/test/pipeline/*-expected.json` and look for
`auth0.logs.data.user_name` at the top level of `auth0.logs.data`: the key is not there. The
same documents carry `user.name` and `user_agent.original`.

With a running stack: `elastic-package stack up -d`, `elastic-package install`, ingest any of
the fixture events and open the Auth0 dashboard. Before this change the "Auth0 logs" table
renders `(null)` in the `user_name` and `user_agent` columns; after it, the values show up.

## Related issues

None open for this. The bug was found while validating the integration on a production
deployment and confirmed against the package source and its pipeline test fixtures.

## Screenshots

Before, the stock saved search: `auth0.logs.data.user_name` and `auth0.logs.data.user_agent` render null on every row.

![Stock saved search rendering null columns](https://raw.githubusercontent.com/willianantunes-jsm/elastic-integrations/assets-pr19512/pr19512-before-redacted.png)
After, same dataset and time range with the columns from this PR: `user.name` and `user_agent.original` populated (values redacted).

![Fixed columns populated](https://raw.githubusercontent.com/willianantunes-jsm/elastic-integrations/assets-pr19512/pr19512-after-ecs-columns-redacted.png)


