### PR TITLE
[Kubernetes Otel] Improvements for Overview, Workloads and Deployment details dashboards

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Improvements to the Overview, Workloads, and Deployment details dashboards.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19516
 - version: 2.1.0-preview8
   changes:
     - description: Improvements to Nodes, Namespaces, Node Detail, and Namespace Detail dashboards

--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.1.0-preview9
+  changes:
+    - description: Improvements to the Overview, Workloads, and Deployment details dashboards.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 2.1.0-preview8
   changes:
     - description: Improvements to Nodes, Namespaces, Node Detail, and Namespace Detail dashboards

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f.json
@@ -3,6 +3,38 @@
         "description": "Workload monitoring with Deployments, DaemonSets, StatefulSets, Jobs, container restart trends, and deployment drilldowns.",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
+                "filter": [
+                    {
+                        "meta": {
+                            "disabled": false,
+                            "field": "data_stream.dataset",
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "params": [
+                                "k8sclusterreceiver.otel",
+                                "kubeletstatsreceiver.otel"
+                            ],
+                            "type": "phrases"
+                        },
+                        "query": {
+                            "bool": {
+                                "minimum_should_match": 1,
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "k8sclusterreceiver.otel"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "kubeletstatsreceiver.otel"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -27,37 +59,37 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_02b16bcb-9073-43a1-a6b7-ca2bd02fe321_dashboard",
+                            "destinationRefName": "link_2a32c1a4-a9e8-497c-a0e2-814de66bf1b5_dashboard",
                             "label": "Overview",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_a0cec3c9-85ce-4486-970c-fc1fd994418a_dashboard",
+                            "destinationRefName": "link_e0b8bc76-1f19-4954-8ca8-b4efaf00b847_dashboard",
                             "label": "Clusters",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_3fa37faf-7e87-42a8-9ede-2a06533d3cc8_dashboard",
+                            "destinationRefName": "link_92cc52e3-c389-4d36-bb02-6c414c13e69e_dashboard",
                             "label": "Nodes",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_a37dc1ba-1855-40e3-b3bc-10aeeaca3f0b_dashboard",
+                            "destinationRefName": "link_83031f55-4a2f-4799-979e-482acf38266f_dashboard",
                             "label": "Namespaces",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_e90f7302-7c8c-4b19-90f4-d5411d1c1dcd_dashboard",
+                            "destinationRefName": "link_71766b7c-7710-4efc-8356-f90cbde9d1eb_dashboard",
                             "label": "Workload resources",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_ea675733-c1d8-43ca-9354-5a7899fb4012_dashboard",
+                            "destinationRefName": "link_a14c8a42-ee85-417e-a61f-b3611d93817c_dashboard",
                             "label": "Pods",
                             "options": {},
                             "type": "dashboardLink"
@@ -80,17 +112,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -98,9 +130,9 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-*"
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
@@ -118,9 +150,9 @@
                                                     }
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.available IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name)\n"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n  AND k8s.deployment.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| WHERE @timestamp == latest_ts\n| STATS count = COUNT(*)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -128,26 +160,27 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.available IS NOT NULL\n| STATS count = COUNT_DISTINCT(k8s.deployment.name)\n"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n  AND k8s.deployment.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| WHERE @timestamp == latest_ts\n| STATS count = COUNT(*)"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
-                                "color": "#61A2FF",
                                 "colorMode": "background",
                                 "layerId": "c069c5ac-dcdc-f1b8-1f4e-2539b0f16301",
                                 "layerType": "data",
                                 "metricAccessor": "9f004cfb-3448-bdfe-58ee-2c77580a9c20",
-                                "showBar": false
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "showBar": false,
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
-                        "type": "lens",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Total deployment count. COUNT_DISTINCT(k8s.deployment.name).",
+                    "description": "Total number of deployments with available replica metrics, based on distinct deployment names observed in the selected time range.",
                     "hide_title": true
                 },
                 "gridData": {
@@ -156,10 +189,10 @@
                     "sectionId": "section-deploy-metrics",
                     "w": 6,
                     "x": 0,
-                    "y": 16
+                    "y": 13
                 },
                 "panelIndex": "v2-workloads-alt-total-deployments",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -167,23 +200,29 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                     "managed": false,
-                                    "name": "metrics-*",
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
                             "datasourceStates": {
                                 "textBased": {
-                                    "indexPatternRefs": [],
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
                                     "layers": {
                                         "f5b1d7b4-0818-809d-e59d-829dcd9c8c7b": {
                                             "columns": [
@@ -196,12 +235,13 @@
                                                     "meta": {
                                                         "esType": "long",
                                                         "type": "number"
-                                                    }
+                                                    },
+                                                    "params": {}
                                                 }
                                             ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts) BY k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.name != \"\"\n| STATS\n    restarts_per = MAX(k8s.container.restarts),\n    last_seen = MAX(@timestamp)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_restarts = SUM(restarts_per)"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -209,12 +249,12 @@
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [],
+                            "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts) BY k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.name != \"\"\n| STATS\n    restarts_per = MAX(k8s.container.restarts),\n    last_seen = MAX(@timestamp)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_restarts = SUM(restarts_per)"
                             },
                             "visualization": {
-                                "applyColorTo": "background",
+                                "applyColorTo": "value",
                                 "colorMode": "background",
                                 "layerId": "f5b1d7b4-0818-809d-e59d-829dcd9c8c7b",
                                 "layerType": "data",
@@ -248,21 +288,23 @@
                                             },
                                             {
                                                 "color": "#F6726A",
-                                                "stop": 3408
+                                                "stop": 394
                                             }
                                         ]
                                     },
                                     "type": "palette"
                                 },
-                                "showBar": false
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "showBar": false,
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
-                        "type": "lens",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Total container restarts. MAX(k8s.container.restarts) per pod+container, then SUM."
+                    "description": "Total container restarts across all pods, summed from the maximum restart count per container observed in the selected time range."
                 },
                 "gridData": {
                     "h": 6,
@@ -270,422 +312,10 @@
                     "sectionId": "section-deploy-metrics",
                     "w": 6,
                     "x": 0,
-                    "y": 22
+                    "y": 19
                 },
                 "panelIndex": "c585ade6-5e12-4a1c-aea7-c2ebc1189e98",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                    "managed": false,
-                                    "name": "metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "fdfad702-0d8c-6690-f73b-71e4e64101a4": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "58394d5d-f244-ac4d-0efc-444da7cb5700",
-                                                    "customLabel": true,
-                                                    "fieldName": "desired",
-                                                    "inMetricDimension": true,
-                                                    "label": "Desired",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1d07e96c-590b-03f1-4108-cbe912c2ac4a",
-                                                    "customLabel": true,
-                                                    "fieldName": "available",
-                                                    "inMetricDimension": true,
-                                                    "label": "Available",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "24258928-91bb-7193-d4df-0329829a7575",
-                                                    "customLabel": false,
-                                                    "fieldName": "timestamp",
-                                                    "label": "timestamp"
-                                                }
-                                            ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                            "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50 , ?_tstart, ?_tend)\n| sort timestamp\n| KEEP timestamp, available, desired\n"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50 , ?_tstart, ?_tend)\n| sort timestamp\n| KEEP timestamp, available, desired\n"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "58394d5d-f244-ac4d-0efc-444da7cb5700",
-                                            "1d07e96c-590b-03f1-4108-cbe912c2ac4a"
-                                        ],
-                                        "layerId": "fdfad702-0d8c-6690-f73b-71e4e64101a4",
-                                        "layerType": "data",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "24258928-91bb-7193-d4df-0329829a7575"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "bottom"
-                                },
-                                "preferredSeriesType": "line",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "Deployment replica trend. SUM(k8s.deployment.available) vs SUM(k8s.deployment.desired) per 1m bucket.",
-                    "title": "Deployment replicas over time"
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "v2-workloads-alt-deploy-trend",
-                    "sectionId": "section-deploy-metrics",
-                    "w": 13,
-                    "x": 6,
-                    "y": 16
-                },
-                "panelIndex": "v2-workloads-alt-deploy-trend",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                    "managed": false,
-                                    "name": "metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "9d698809-25fc-7d1d-9030-db07c457d87b": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "014ea010-d756-94db-97ff-f77ab7e7788f",
-                                                    "customLabel": true,
-                                                    "fieldName": "Desired scheduled",
-                                                    "inMetricDimension": true,
-                                                    "label": "Desired scheduled",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "cc602dc1-bbd6-334b-b4f0-87b9fa141ed1",
-                                                    "customLabel": true,
-                                                    "fieldName": "Current scheduled",
-                                                    "inMetricDimension": true,
-                                                    "label": "Current scheduled",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "3b77cf63-db0d-00a4-1a3e-eb05af4e63d0",
-                                                    "customLabel": true,
-                                                    "fieldName": "Ready",
-                                                    "inMetricDimension": true,
-                                                    "label": "Ready",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "24258928-91bb-7193-d4df-0329829a7575",
-                                                    "customLabel": false,
-                                                    "fieldName": "timestamp",
-                                                    "label": "timestamp"
-                                                }
-                                            ],
-                                            "index": "0e2ef7c055c1cbe93cdfae543c1c67b1578b09d63c8e8b2751d8016d3592c0ed",
-                                            "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.daemonset.name IS NOT NULL\n  AND (k8s.daemonset.current_scheduled_nodes IS NOT NULL OR k8s.daemonset.desired_scheduled_nodes IS NOT NULL)\n| STATS\n    `Current scheduled` = SUM(k8s.daemonset.current_scheduled_nodes),\n    `Desired scheduled` = SUM(k8s.daemonset.desired_scheduled_nodes),\n    Ready = SUM(k8s.daemonset.ready_nodes)\n  BY timestamp = TBUCKET(50 , ?_tstart, ?_tend)\n| sort timestamp\n| KEEP timestamp, `Desired scheduled`, `Current scheduled`, Ready\n"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.daemonset.name IS NOT NULL\n  AND (k8s.daemonset.current_scheduled_nodes IS NOT NULL OR k8s.daemonset.desired_scheduled_nodes IS NOT NULL)\n| STATS\n    `Current scheduled` = SUM(k8s.daemonset.current_scheduled_nodes),\n    `Desired scheduled` = SUM(k8s.daemonset.desired_scheduled_nodes),\n    Ready = SUM(k8s.daemonset.ready_nodes)\n  BY timestamp = TBUCKET(50 , ?_tstart, ?_tend)\n| sort timestamp\n| KEEP timestamp, `Desired scheduled`, `Current scheduled`, Ready\n"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "014ea010-d756-94db-97ff-f77ab7e7788f",
-                                            "cc602dc1-bbd6-334b-b4f0-87b9fa141ed1",
-                                            "3b77cf63-db0d-00a4-1a3e-eb05af4e63d0"
-                                        ],
-                                        "layerId": "9d698809-25fc-7d1d-9030-db07c457d87b",
-                                        "layerType": "data",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "24258928-91bb-7193-d4df-0329829a7575"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "bottom"
-                                },
-                                "preferredSeriesType": "line",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "DaemonSet scheduling trend. SUM of desired, scheduled, and ready nodes per 1m bucket.",
-                    "title": "DaemonSet scheduling over time"
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "v2-workloads-alt-daemonset-trend",
-                    "sectionId": "section-deploy-metrics",
-                    "w": 14,
-                    "x": 19,
-                    "y": 16
-                },
-                "panelIndex": "v2-workloads-alt-daemonset-trend",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
-                                    "managed": false,
-                                    "name": "metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "fa263ac0-f497-434a-84c3-a8310197b0c4": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "total_restarts",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_restarts",
-                                                    "inMetricDimension": true,
-                                                    "label": "Container restarts",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "timestamp",
-                                                    "customLabel": false,
-                                                    "fieldName": "timestamp",
-                                                    "label": "timestamp",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "k8s.deployment.name",
-                                                    "customLabel": false,
-                                                    "fieldName": "k8s.deployment.name",
-                                                    "label": "k8s.deployment.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "84f6ce3ff5709eed7dd3934d32b8aae90586b3a31f0765f56763d26f57372fa6",
-                                            "query": {
-                                                "esql": "TS metrics-*\n| WHERE k8s.container.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.deployment.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n       k8s.deployment.name, k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n    BY timestamp, k8s.deployment.name\n| Where total_restarts > 0\n| SORT total_restarts DESC"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-*\n| WHERE k8s.container.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.deployment.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n       k8s.deployment.name, k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n    BY timestamp, k8s.deployment.name\n| Where total_restarts > 0\n| SORT total_restarts DESC"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "Linear",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "total_restarts"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "elastic_line_optimized",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "fa263ac0-f497-434a-84c3-a8310197b0c4",
-                                        "layerType": "data",
-                                        "seriesType": "line",
-                                        "splitAccessors": [
-                                            "k8s.deployment.name"
-                                        ],
-                                        "xAccessor": "timestamp"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "layout": "list",
-                                    "position": "bottom",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "line",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "Container restarts over time per deployment. max(k8s.container.restarts) broken down by k8s.deployment.name.",
-                    "title": "Top 10 deployments by container restarts"
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "e2adfa82-6921-44da-84fb-609bc7b86e61",
-                    "sectionId": "section-deploy-metrics",
-                    "w": 15,
-                    "x": 33,
-                    "y": 16
-                },
-                "panelIndex": "e2adfa82-6921-44da-84fb-609bc7b86e61",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -718,7 +348,7 @@
                                     ],
                                     "layers": {
                                         "2bc4e7dc-d6e6-470e-b5ea-c6c962d95588": {
-                                            "columns": [
+                                            "allColumns": [
                                                 {
                                                     "columnId": "k8s.deployment.name",
                                                     "fieldName": "k8s.deployment.name",
@@ -796,9 +426,87 @@
                                                     }
                                                 }
                                             ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "availability",
+                                                    "customLabel": true,
+                                                    "fieldName": "availability",
+                                                    "inMetricDimension": true,
+                                                    "label": "Availability",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "available",
+                                                    "customLabel": true,
+                                                    "fieldName": "available",
+                                                    "inMetricDimension": true,
+                                                    "label": "Available replicas",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "desired",
+                                                    "customLabel": true,
+                                                    "fieldName": "desired",
+                                                    "inMetricDimension": true,
+                                                    "label": "Desired replicas",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "restarts",
+                                                    "customLabel": true,
+                                                    "fieldName": "restarts",
+                                                    "inMetricDimension": true,
+                                                    "label": "Container restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL\n    OR k8s.container.restarts IS NOT NULL)\n| EVAL is_deploy_doc = CASE(k8s.deployment.available IS NOT NULL, 1, 0)\n| INLINE STATS latest_deploy_ts = MAX(CASE(is_deploy_doc == 1, @timestamp, NULL))\n    BY k8s.deployment.name\n| EVAL keep_deploy = CASE(\n    is_deploy_doc == 1 AND @timestamp == latest_deploy_ts, 1,\n    is_deploy_doc == 0, 1,\n    0)\n| WHERE keep_deploy == 1\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.deployment.available),\n    desired   = MAX(k8s.deployment.desired),\n    max_restarts = MAX(k8s.container.restarts)\n  BY k8s.namespace.name, k8s.deployment.name, k8s.pod.uid, k8s.container.name\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(available),\n    desired   = MAX(desired),\n    restarts  = SUM(max_restarts)\n  BY k8s.namespace.name, k8s.deployment.name\n| EVAL\n    restarts = COALESCE(restarts, 0),\n    availability = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL)\n| SORT availability ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n  AND (\n    k8s.deployment.available IS NOT NULL\n    OR k8s.container.restarts IS NOT NULL\n  )\n| EVAL is_deploy_doc = CASE(k8s.deployment.available IS NOT NULL, 1, 0)\n| INLINE STATS latest_deploy_ts = MAX(CASE(is_deploy_doc == 1, @timestamp, NULL))\n    BY k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| EVAL keep_deploy = CASE(\n    is_deploy_doc == 1 AND @timestamp == latest_deploy_ts, 1,\n    is_deploy_doc == 0, 1,\n    0)\n| WHERE keep_deploy == 1\n| STATS\n    available = MAX(k8s.deployment.available),\n    desired   = MAX(k8s.deployment.desired),\n    max_restarts = MAX(k8s.container.restarts),\n    last_seen = MAX(@timestamp)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.deployment.name,\n     k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS\n    available = MAX(available),\n    desired   = MAX(desired),\n    restarts  = SUM(max_restarts)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| EVAL\n    restarts = COALESCE(restarts, 0),\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL)\n| SORT availability ASC, restarts DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -808,7 +516,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL\n    OR k8s.container.restarts IS NOT NULL)\n| EVAL is_deploy_doc = CASE(k8s.deployment.available IS NOT NULL, 1, 0)\n| INLINE STATS latest_deploy_ts = MAX(CASE(is_deploy_doc == 1, @timestamp, NULL))\n    BY k8s.deployment.name\n| EVAL keep_deploy = CASE(\n    is_deploy_doc == 1 AND @timestamp == latest_deploy_ts, 1,\n    is_deploy_doc == 0, 1,\n    0)\n| WHERE keep_deploy == 1\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.deployment.available),\n    desired   = MAX(k8s.deployment.desired),\n    max_restarts = MAX(k8s.container.restarts)\n  BY k8s.namespace.name, k8s.deployment.name, k8s.pod.uid, k8s.container.name\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(available),\n    desired   = MAX(desired),\n    restarts  = SUM(max_restarts)\n  BY k8s.namespace.name, k8s.deployment.name\n| EVAL\n    restarts = COALESCE(restarts, 0),\n    availability = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL)\n| SORT availability ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n  AND (\n    k8s.deployment.available IS NOT NULL\n    OR k8s.container.restarts IS NOT NULL\n  )\n| EVAL is_deploy_doc = CASE(k8s.deployment.available IS NOT NULL, 1, 0)\n| INLINE STATS latest_deploy_ts = MAX(CASE(is_deploy_doc == 1, @timestamp, NULL))\n    BY k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| EVAL keep_deploy = CASE(\n    is_deploy_doc == 1 AND @timestamp == latest_deploy_ts, 1,\n    is_deploy_doc == 0, 1,\n    0)\n| WHERE keep_deploy == 1\n| STATS\n    available = MAX(k8s.deployment.available),\n    desired   = MAX(k8s.deployment.desired),\n    max_restarts = MAX(k8s.container.restarts),\n    last_seen = MAX(@timestamp)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.deployment.name,\n     k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS\n    available = MAX(available),\n    desired   = MAX(desired),\n    restarts  = SUM(max_restarts)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| EVAL\n    restarts = COALESCE(restarts, 0),\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL)\n| SORT availability ASC, restarts DESC"
                             },
                             "visualization": {
                                 "columns": [
@@ -824,41 +532,27 @@
                                     },
                                     {
                                         "columnId": "k8s.namespace.name",
-                                        "oneClickFilter": true
+                                        "oneClickFilter": true,
+                                        "width": 327.0238095238095
                                     },
                                     {
                                         "columnId": "k8s.deployment.name",
                                         "oneClickFilter": true
                                     },
                                     {
-                                        "columnId": "restarts"
-                                    },
-                                    {
-                                        "colorMode": "cell",
-                                        "columnId": "availability",
+                                        "colorMode": "badge",
+                                        "columnId": "restarts",
                                         "palette": {
                                             "name": "custom",
                                             "params": {
                                                 "colorStops": [
                                                     {
-                                                        "color": "#f6726a",
+                                                        "color": "#AEE8D2",
                                                         "stop": 0
                                                     },
                                                     {
-                                                        "color": "#ffc9c2",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#fcd883",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#aee8d2",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#24c292",
-                                                        "stop": 80
+                                                        "color": "#FFC9C2",
+                                                        "stop": 11.8
                                                     }
                                                 ],
                                                 "continuity": "above",
@@ -866,38 +560,69 @@
                                                 "progression": "fixed",
                                                 "rangeMax": null,
                                                 "rangeMin": 0,
-                                                "rangeType": "percent",
+                                                "rangeType": "number",
                                                 "reverse": false,
                                                 "steps": 5,
                                                 "stops": [
                                                     {
-                                                        "color": "#f6726a",
-                                                        "stop": 20
+                                                        "color": "#AEE8D2",
+                                                        "stop": 11.8
                                                     },
                                                     {
-                                                        "color": "#ffc9c2",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#fcd883",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#aee8d2",
-                                                        "stop": 80
-                                                    },
-                                                    {
-                                                        "color": "#24c292",
-                                                        "stop": 100
+                                                        "color": "#FFC9C2",
+                                                        "stop": 59
                                                     }
                                                 ]
                                             },
                                             "type": "palette"
                                         }
+                                    },
+                                    {
+                                        "colorMode": "badge",
+                                        "columnId": "availability",
+                                        "palette": {
+                                            "name": "custom",
+                                            "params": {
+                                                "colorStops": [
+                                                    {
+                                                        "color": "#FFC9C2",
+                                                        "stop": 0
+                                                    },
+                                                    {
+                                                        "color": "#AEE8D2",
+                                                        "stop": 1
+                                                    }
+                                                ],
+                                                "continuity": "none",
+                                                "name": "custom",
+                                                "progression": "fixed",
+                                                "rangeMax": 1,
+                                                "rangeMin": 0,
+                                                "rangeType": "number",
+                                                "reverse": false,
+                                                "steps": 5,
+                                                "stops": [
+                                                    {
+                                                        "color": "#FFC9C2",
+                                                        "stop": 1
+                                                    },
+                                                    {
+                                                        "color": "#AEE8D2",
+                                                        "stop": 2
+                                                    }
+                                                ]
+                                            },
+                                            "type": "palette"
+                                        },
+                                        "width": 309.85714285714283
                                     }
                                 ],
                                 "layerId": "2bc4e7dc-d6e6-470e-b5ea-c6c962d95588",
                                 "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
                                 "showRowNumbers": true
                             }
                         },
@@ -905,15 +630,24 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "Deployment listing with available/desired counts, availability percentage, and restarts. Drills down to Deployment Detail.",
+                    "description": "Deployments ranked by availability (lowest first). Click a deployment name to drill into deployment details, a namespace to drill into namespace details, or a cluster to drill into cluster details. Availability = available replicas ÷ desired replicas. Available and desired replica counts are latest values. Container restarts = sum across all pods and containers over the selected time range.",
                     "drilldowns": [
+                        {
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+                            "label": "3. View cluster details",
+                            "open_in_new_tab": false,
+                            "trigger": "on_apply_filter",
+                            "type": "dashboard_drilldown",
+                            "use_filters": false,
+                            "use_time_range": true
+                        },
                         {
                             "dashboardRefName": "dashboard_drilldown_kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
                             "label": "1. View deployment details",
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         },
                         {
@@ -922,23 +656,13 @@
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
-                            "use_time_range": true
-                        },
-                        {
-                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
-                            "label": "3. View cluster details",
-                            "open_in_new_tab": false,
-                            "trigger": "on_apply_filter",
-                            "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         }
-                    ],
-                    "title": "Deployments"
+                    ]
                 },
                 "gridData": {
-                    "h": 16,
+                    "h": 13,
                     "i": "72287a15-e7ee-4918-868e-86e2d58057d6",
                     "sectionId": "section-deploy-metrics",
                     "w": 48,
@@ -946,7 +670,545 @@
                     "y": 0
                 },
                 "panelIndex": "72287a15-e7ee-4918-868e-86e2d58057d6",
-                "type": "lens"
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "fdfad702-0d8c-6690-f73b-71e4e64101a4": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "58394d5d-f244-ac4d-0efc-444da7cb5700",
+                                                    "customLabel": true,
+                                                    "fieldName": "desired",
+                                                    "inMetricDimension": true,
+                                                    "label": "Desired",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "1d07e96c-590b-03f1-4108-cbe912c2ac4a",
+                                                    "customLabel": true,
+                                                    "fieldName": "available",
+                                                    "inMetricDimension": true,
+                                                    "label": "Available",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "24258928-91bb-7193-d4df-0329829a7575",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp"
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n  AND (\n    k8s.deployment.available IS NOT NULL\n    OR k8s.deployment.desired IS NOT NULL\n  )\n| STATS\n    avail_per = MAX(k8s.deployment.available),\n    desired_per = MAX(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name,\n     k8s.namespace.name,\n     k8s.deployment.name\n| STATS\n    available = SUM(avail_per),\n    desired = SUM(desired_per)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, available, desired"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n  AND (\n    k8s.deployment.available IS NOT NULL\n    OR k8s.deployment.desired IS NOT NULL\n  )\n| STATS\n    avail_per = MAX(k8s.deployment.available),\n    desired_per = MAX(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name,\n     k8s.namespace.name,\n     k8s.deployment.name\n| STATS\n    available = SUM(avail_per),\n    desired = SUM(desired_per)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, available, desired"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "58394d5d-f244-ac4d-0efc-444da7cb5700",
+                                            "1d07e96c-590b-03f1-4108-cbe912c2ac4a"
+                                        ],
+                                        "layerId": "fdfad702-0d8c-6690-f73b-71e4e64101a4",
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "24258928-91bb-7193-d4df-0329829a7575"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "bottom"
+                                },
+                                "preferredSeriesType": "line",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Total available and desired deployment replica counts across all clusters, summed per time bucket.",
+                    "title": "Deployment replicas over time"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "v2-workloads-alt-deploy-trend",
+                    "sectionId": "section-deploy-metrics",
+                    "w": 21,
+                    "x": 6,
+                    "y": 13
+                },
+                "panelIndex": "v2-workloads-alt-deploy-trend",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "fa263ac0-f497-434a-84c3-a8310197b0c4": {
+                                            "allColumns": [
+                                                {
+                                                    "columnId": "total_restarts",
+                                                    "customLabel": true,
+                                                    "fieldName": "total_restarts",
+                                                    "inMetricDimension": true,
+                                                    "label": "Container restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "a511dbea-0d53-46b9-9d09-76693cde4680",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "009c62f7-cdad-4324-9ade-dc18379b3a2a",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.namespace.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "deployment_id",
+                                                    "fieldName": "deployment_id",
+                                                    "label": "deployment_id",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "total_restarts",
+                                                    "customLabel": true,
+                                                    "fieldName": "total_restarts",
+                                                    "inMetricDimension": true,
+                                                    "label": "Container restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "009c62f7-cdad-4324-9ade-dc18379b3a2a",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.namespace.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "a511dbea-0d53-46b9-9d09-76693cde4680",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n       k8s.cluster.name,\n       k8s.namespace.name,\n       k8s.deployment.name,\n       k8s.pod.uid,\n       k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n    BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| EVAL deployment_id = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.deployment.name)\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n       k8s.cluster.name,\n       k8s.namespace.name,\n       k8s.deployment.name,\n       k8s.pod.uid,\n       k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n    BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| EVAL deployment_id = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.deployment.name)\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "total_restarts"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "elastic_line_optimized",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "fa263ac0-f497-434a-84c3-a8310197b0c4",
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "splitAccessors": [
+                                            "k8s.deployment.name",
+                                            "009c62f7-cdad-4324-9ade-dc18379b3a2a",
+                                            "a511dbea-0d53-46b9-9d09-76693cde4680"
+                                        ],
+                                        "xAccessor": "timestamp"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 2,
+                                    "position": "bottom",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Top 10 deployments by total container restarts over time (per time bucket). Restarts use the latest count per container in each bucket, summed across all pods and containers for each deployment (by cluster, namespace, and deployment name). Values reflect cumulative restart counts, not new restarts in the interval.",
+                    "title": "Top 10 deployments by container restarts"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "e2adfa82-6921-44da-84fb-609bc7b86e61",
+                    "sectionId": "section-deploy-metrics",
+                    "w": 21,
+                    "x": 27,
+                    "y": 13
+                },
+                "panelIndex": "e2adfa82-6921-44da-84fb-609bc7b86e61",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "9d698809-25fc-7d1d-9030-db07c457d87b": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "014ea010-d756-94db-97ff-f77ab7e7788f",
+                                                    "customLabel": true,
+                                                    "fieldName": "Desired scheduled",
+                                                    "inMetricDimension": true,
+                                                    "label": "Desired scheduled",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "cc602dc1-bbd6-334b-b4f0-87b9fa141ed1",
+                                                    "customLabel": true,
+                                                    "fieldName": "Current scheduled",
+                                                    "inMetricDimension": true,
+                                                    "label": "Current scheduled",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "3b77cf63-db0d-00a4-1a3e-eb05af4e63d0",
+                                                    "customLabel": true,
+                                                    "fieldName": "Ready",
+                                                    "inMetricDimension": true,
+                                                    "label": "Ready",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "24258928-91bb-7193-d4df-0329829a7575",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp"
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.daemonset.name IS NOT NULL\n  AND k8s.daemonset.name != \"\"\n  AND (\n    k8s.daemonset.current_scheduled_nodes IS NOT NULL\n    OR k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n  )\n| STATS\n    current_scheduled = MAX(k8s.daemonset.current_scheduled_nodes),\n    desired_scheduled = MAX(k8s.daemonset.desired_scheduled_nodes),\n    ready = MAX(k8s.daemonset.ready_nodes)\n  BY k8s.cluster.name,\n     k8s.namespace.name,\n     k8s.daemonset.name,\n     timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| STATS\n    `Current scheduled` = SUM(current_scheduled),\n    `Desired scheduled` = SUM(desired_scheduled),\n    Ready = SUM(ready)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, `Desired scheduled`, `Current scheduled`, Ready"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.daemonset.name IS NOT NULL\n  AND k8s.daemonset.name != \"\"\n  AND (\n    k8s.daemonset.current_scheduled_nodes IS NOT NULL\n    OR k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n  )\n| STATS\n    current_scheduled = MAX(k8s.daemonset.current_scheduled_nodes),\n    desired_scheduled = MAX(k8s.daemonset.desired_scheduled_nodes),\n    ready = MAX(k8s.daemonset.ready_nodes)\n  BY k8s.cluster.name,\n     k8s.namespace.name,\n     k8s.daemonset.name,\n     timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| STATS\n    `Current scheduled` = SUM(current_scheduled),\n    `Desired scheduled` = SUM(desired_scheduled),\n    Ready = SUM(ready)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, `Desired scheduled`, `Current scheduled`, Ready"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "014ea010-d756-94db-97ff-f77ab7e7788f",
+                                            "cc602dc1-bbd6-334b-b4f0-87b9fa141ed1",
+                                            "3b77cf63-db0d-00a4-1a3e-eb05af4e63d0"
+                                        ],
+                                        "layerId": "9d698809-25fc-7d1d-9030-db07c457d87b",
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "24258928-91bb-7193-d4df-0329829a7575"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "bottom"
+                                },
+                                "preferredSeriesType": "line",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Total desired and currently scheduled DaemonSet counts, plus ready node counts, across all clusters, summed per time bucket",
+                    "title": "DaemonSet scheduling over time"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "v2-workloads-alt-daemonset-trend",
+                    "sectionId": "section-other-workloads",
+                    "w": 12,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "v2-workloads-alt-daemonset-trend",
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -979,7 +1241,7 @@
                                     ],
                                     "layers": {
                                         "2de5cfb7-f53e-413e-9eef-7700c321f1e0": {
-                                            "columns": [
+                                            "allColumns": [
                                                 {
                                                     "columnId": "k8s.daemonset.name",
                                                     "fieldName": "k8s.daemonset.name",
@@ -1002,6 +1264,25 @@
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "availability",
+                                                    "customLabel": true,
+                                                    "fieldName": "availability",
+                                                    "inMetricDimension": true,
+                                                    "label": "Availability",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
                                                     }
                                                 },
                                                 {
@@ -1047,6 +1328,43 @@
                                                         "esType": "long",
                                                         "type": "number"
                                                     }
+                                                }
+                                            ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "k8s.daemonset.name",
+                                                    "fieldName": "k8s.daemonset.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "misscheduled",
+                                                    "customLabel": true,
+                                                    "fieldName": "misscheduled",
+                                                    "inMetricDimension": true,
+                                                    "label": "Misscheduled",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
                                                 },
                                                 {
                                                     "columnId": "availability",
@@ -1066,11 +1384,44 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "current",
+                                                    "customLabel": true,
+                                                    "fieldName": "current",
+                                                    "inMetricDimension": true,
+                                                    "label": "Scheduled",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "desired",
+                                                    "customLabel": true,
+                                                    "fieldName": "desired",
+                                                    "inMetricDimension": true,
+                                                    "label": "Desired",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "ready",
+                                                    "customLabel": true,
+                                                    "fieldName": "ready",
+                                                    "inMetricDimension": true,
+                                                    "label": "Ready",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
                                                 }
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.daemonset.name IS NOT NULL\n  AND k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.daemonset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name      = MAX(k8s.cluster.name),\n    current      = MAX(k8s.daemonset.current_scheduled_nodes),\n    desired      = MAX(k8s.daemonset.desired_scheduled_nodes),\n    ready        = MAX(k8s.daemonset.ready_nodes),\n    misscheduled = MAX(k8s.daemonset.misscheduled_nodes)\n  BY k8s.namespace.name, k8s.daemonset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(ready) / TO_DOUBLE(desired), 4),\n      NULL)\n| SORT misscheduled DESC\n| LIMIT 100"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.daemonset.name IS NOT NULL\n  AND k8s.daemonset.name != \"\"\n  AND k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp)\n    BY k8s.cluster.name, k8s.namespace.name, k8s.daemonset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    current      = MAX(k8s.daemonset.current_scheduled_nodes),\n    desired      = MAX(k8s.daemonset.desired_scheduled_nodes),\n    ready        = MAX(k8s.daemonset.ready_nodes),\n    misscheduled = MAX(k8s.daemonset.misscheduled_nodes)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.daemonset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(ready) / TO_DOUBLE(desired), 4),\n      NULL)\n| SORT availability asc, misscheduled desc"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1080,7 +1431,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.daemonset.name IS NOT NULL\n  AND k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.daemonset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name      = MAX(k8s.cluster.name),\n    current      = MAX(k8s.daemonset.current_scheduled_nodes),\n    desired      = MAX(k8s.daemonset.desired_scheduled_nodes),\n    ready        = MAX(k8s.daemonset.ready_nodes),\n    misscheduled = MAX(k8s.daemonset.misscheduled_nodes)\n  BY k8s.namespace.name, k8s.daemonset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(ready) / TO_DOUBLE(desired), 4),\n      NULL)\n| SORT misscheduled DESC\n| LIMIT 100"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.daemonset.name IS NOT NULL\n  AND k8s.daemonset.name != \"\"\n  AND k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp)\n    BY k8s.cluster.name, k8s.namespace.name, k8s.daemonset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    current      = MAX(k8s.daemonset.current_scheduled_nodes),\n    desired      = MAX(k8s.daemonset.desired_scheduled_nodes),\n    ready        = MAX(k8s.daemonset.ready_nodes),\n    misscheduled = MAX(k8s.daemonset.misscheduled_nodes)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.daemonset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(ready) / TO_DOUBLE(desired), 4),\n      NULL)\n| SORT availability asc, misscheduled desc"
                             },
                             "visualization": {
                                 "columns": [
@@ -1102,46 +1453,46 @@
                                     },
                                     {
                                         "columnId": "k8s.namespace.name",
-                                        "oneClickFilter": true
+                                        "oneClickFilter": true,
+                                        "width": 335.67857142857144
                                     },
                                     {
                                         "columnId": "k8s.daemonset.name",
-                                        "oneClickFilter": true
+                                        "oneClickFilter": true,
+                                        "width": 295.25
                                     },
                                     {
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "availability",
                                         "palette": {
-                                            "name": "status",
+                                            "name": "custom",
                                             "params": {
+                                                "colorStops": [
+                                                    {
+                                                        "color": "#FFC9C2",
+                                                        "stop": 0
+                                                    },
+                                                    {
+                                                        "color": "#AEE8D2",
+                                                        "stop": 1
+                                                    }
+                                                ],
                                                 "continuity": "above",
-                                                "name": "status",
+                                                "name": "custom",
                                                 "progression": "fixed",
                                                 "rangeMax": null,
                                                 "rangeMin": 0,
-                                                "rangeType": "percent",
+                                                "rangeType": "number",
                                                 "reverse": false,
                                                 "steps": 5,
                                                 "stops": [
                                                     {
-                                                        "color": "#24c292",
-                                                        "stop": 0
+                                                        "color": "#FFC9C2",
+                                                        "stop": 1
                                                     },
                                                     {
-                                                        "color": "#aee8d2",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#fcd883",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#ffc9c2",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#f6726a",
-                                                        "stop": 80
+                                                        "color": "#AEE8D2",
+                                                        "stop": 2
                                                     }
                                                 ]
                                             },
@@ -1151,6 +1502,10 @@
                                 ],
                                 "layerId": "2de5cfb7-f53e-413e-9eef-7700c321f1e0",
                                 "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
                                 "showRowNumbers": true
                             }
                         },
@@ -1158,15 +1513,15 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "DaemonSet listing with scheduled/desired/ready/misscheduled node counts.",
+                    "description": "DaemonSets ranked by misscheduled node count (highest first). Click a DaemonSet name to see its pods, a namespace to drill into namespace details, or a cluster to drill into cluster details. Availability = ready ÷ desired. All counts reflect the latest collected values.",
                     "drilldowns": [
                         {
-                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
-                            "label": "2. View namespace details",
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+                            "label": "3. View cluster details",
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         },
                         {
@@ -1175,31 +1530,31 @@
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         },
                         {
-                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
-                            "label": "3. View cluster details",
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
+                            "label": "2. View namespace details",
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         }
                     ],
-                    "title": "DaemonSet"
+                    "title": "DaemonSets"
                 },
                 "gridData": {
-                    "h": 13,
+                    "h": 12,
                     "i": "38f010f8-ca9e-4bf0-847f-2f395d39ee5d",
                     "sectionId": "section-other-workloads",
-                    "w": 48,
-                    "x": 0,
+                    "w": 36,
+                    "x": 12,
                     "y": 0
                 },
                 "panelIndex": "38f010f8-ca9e-4bf0-847f-2f395d39ee5d",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1232,7 +1587,7 @@
                                     ],
                                     "layers": {
                                         "eb8d585c-d830-4baf-87fb-fec3369996b6": {
-                                            "columns": [
+                                            "allColumns": [
                                                 {
                                                     "columnId": "current",
                                                     "customLabel": true,
@@ -1339,9 +1694,132 @@
                                                     }
                                                 }
                                             ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "availability",
+                                                    "customLabel": true,
+                                                    "fieldName": "availability",
+                                                    "inMetricDimension": true,
+                                                    "label": "Availability",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "current",
+                                                    "customLabel": true,
+                                                    "fieldName": "current",
+                                                    "inMetricDimension": true,
+                                                    "label": "Current pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "desired",
+                                                    "customLabel": true,
+                                                    "fieldName": "desired",
+                                                    "inMetricDimension": true,
+                                                    "label": "Desired pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "ready",
+                                                    "customLabel": true,
+                                                    "fieldName": "ready",
+                                                    "inMetricDimension": true,
+                                                    "label": "Ready pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "updated",
+                                                    "customLabel": true,
+                                                    "fieldName": "updated",
+                                                    "inMetricDimension": true,
+                                                    "label": "Updated pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.statefulset.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.statefulset.name",
+                                                    "label": "k8s.statefulset.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "not_ready",
+                                                    "customLabel": false,
+                                                    "fieldName": "not_ready",
+                                                    "inMetricDimension": true,
+                                                    "label": "not_ready",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "not_updated",
+                                                    "customLabel": false,
+                                                    "fieldName": "not_updated",
+                                                    "inMetricDimension": true,
+                                                    "label": "not_updated",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "7d656e1e-c894-463e-a61f-dd413001433f",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.statefulset.name IS NOT NULL\n  AND k8s.statefulset.desired_pods IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.statefulset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    current = MAX(k8s.statefulset.current_pods),\n    desired = MAX(k8s.statefulset.desired_pods),\n    ready   = MAX(k8s.statefulset.ready_pods),\n    updated = MAX(k8s.statefulset.updated_pods)\n  BY k8s.namespace.name, k8s.statefulset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(ready) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_ready = COALESCE(desired, 0) - COALESCE(ready, 0),\n    not_updated = COALESCE(desired, 0) - COALESCE(updated, 0)\n| SORT not_ready DESC, availability ASC, not_updated DESC, k8s.statefulset.name ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.statefulset.name IS NOT NULL\n  AND k8s.statefulset.name != \"\"\n  AND k8s.statefulset.desired_pods IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp)\n    BY k8s.cluster.name, k8s.namespace.name, k8s.statefulset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    current = MAX(k8s.statefulset.current_pods),\n    desired = MAX(k8s.statefulset.desired_pods),\n    ready   = MAX(k8s.statefulset.ready_pods),\n    updated = MAX(k8s.statefulset.updated_pods)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.statefulset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(ready) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_ready = COALESCE(desired, 0) - COALESCE(ready, 0),\n    not_updated = COALESCE(desired, 0) - COALESCE(updated, 0)\n| SORT  availability ASC, not_ready DESC,not_updated DESC, k8s.statefulset.name ASC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1351,7 +1829,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.statefulset.name IS NOT NULL\n  AND k8s.statefulset.desired_pods IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.statefulset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    current = MAX(k8s.statefulset.current_pods),\n    desired = MAX(k8s.statefulset.desired_pods),\n    ready   = MAX(k8s.statefulset.ready_pods),\n    updated = MAX(k8s.statefulset.updated_pods)\n  BY k8s.namespace.name, k8s.statefulset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(ready) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_ready = COALESCE(desired, 0) - COALESCE(ready, 0),\n    not_updated = COALESCE(desired, 0) - COALESCE(updated, 0)\n| SORT not_ready DESC, availability ASC, not_updated DESC, k8s.statefulset.name ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.statefulset.name IS NOT NULL\n  AND k8s.statefulset.name != \"\"\n  AND k8s.statefulset.desired_pods IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp)\n    BY k8s.cluster.name, k8s.namespace.name, k8s.statefulset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    current = MAX(k8s.statefulset.current_pods),\n    desired = MAX(k8s.statefulset.desired_pods),\n    ready   = MAX(k8s.statefulset.ready_pods),\n    updated = MAX(k8s.statefulset.updated_pods)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.statefulset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(ready) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_ready = COALESCE(desired, 0) - COALESCE(ready, 0),\n    not_updated = COALESCE(desired, 0) - COALESCE(updated, 0)\n| SORT  availability ASC, not_ready DESC,not_updated DESC, k8s.statefulset.name ASC"
                             },
                             "visualization": {
                                 "columns": [
@@ -1369,47 +1847,46 @@
                                     },
                                     {
                                         "columnId": "k8s.namespace.name",
-                                        "oneClickFilter": true
+                                        "oneClickFilter": true,
+                                        "width": 343.7142857142857
                                     },
                                     {
                                         "columnId": "k8s.statefulset.name",
                                         "oneClickFilter": true,
-                                        "width": 193
+                                        "width": 289
                                     },
                                     {
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "availability",
                                         "palette": {
-                                            "name": "status",
+                                            "name": "custom",
                                             "params": {
-                                                "continuity": "above",
-                                                "name": "status",
-                                                "progression": "fixed",
-                                                "rangeMax": null,
-                                                "rangeMin": 0,
-                                                "rangeType": "percent",
-                                                "reverse": false,
-                                                "steps": 5,
-                                                "stops": [
+                                                "colorStops": [
                                                     {
-                                                        "color": "#24c292",
+                                                        "color": "#FFC9C2",
                                                         "stop": 0
                                                     },
                                                     {
                                                         "color": "#aee8d2",
-                                                        "stop": 20
+                                                        "stop": 1
+                                                    }
+                                                ],
+                                                "continuity": "above",
+                                                "name": "custom",
+                                                "progression": "fixed",
+                                                "rangeMax": null,
+                                                "rangeMin": 0,
+                                                "rangeType": "number",
+                                                "reverse": false,
+                                                "steps": 5,
+                                                "stops": [
+                                                    {
+                                                        "color": "#FFC9C2",
+                                                        "stop": 1
                                                     },
                                                     {
-                                                        "color": "#fcd883",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#ffc9c2",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#f6726a",
-                                                        "stop": 80
+                                                        "color": "#aee8d2",
+                                                        "stop": 2
                                                     }
                                                 ]
                                             },
@@ -1423,10 +1900,20 @@
                                     {
                                         "columnId": "not_updated",
                                         "hidden": true
+                                    },
+                                    {
+                                        "columnId": "7d656e1e-c894-463e-a61f-dd413001433f",
+                                        "isMetric": false,
+                                        "isTransposed": false,
+                                        "oneClickFilter": true
                                     }
                                 ],
                                 "layerId": "eb8d585c-d830-4baf-87fb-fec3369996b6",
                                 "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
                                 "showRowNumbers": true
                             }
                         },
@@ -1434,7 +1921,7 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "StatefulSet listing with current/desired/ready/updated pod counts.",
+                    "description": "ReplicaSets ranked by availability (lowest first). Click a ReplicaSet name to see its pods, a namespace to drill into namespace details, or a cluster to drill into cluster details. Availability = ( available / desired replicas). All counts reflect the latest collected values",
                     "drilldowns": [
                         {
                             "dashboardRefName": "dashboard_drilldown_kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
@@ -1442,7 +1929,7 @@
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         },
                         {
@@ -1451,22 +1938,31 @@
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
+                            "use_time_range": true
+                        },
+                        {
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+                            "label": "3. View cluster details",
+                            "open_in_new_tab": false,
+                            "trigger": "on_apply_filter",
+                            "type": "dashboard_drilldown",
+                            "use_filters": false,
                             "use_time_range": true
                         }
                     ],
                     "title": "StatefulSets"
                 },
                 "gridData": {
-                    "h": 15,
+                    "h": 12,
                     "i": "6efc2bbb-059f-422a-9a2e-09b83f8554f3",
                     "sectionId": "section-other-workloads",
-                    "w": 24,
+                    "w": 48,
                     "x": 0,
-                    "y": 13
+                    "y": 12
                 },
                 "panelIndex": "6efc2bbb-059f-422a-9a2e-09b83f8554f3",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1499,7 +1995,26 @@
                                     ],
                                     "layers": {
                                         "70b6e48d-80db-4ee4-88a6-fd3676937521": {
-                                            "columns": [
+                                            "allColumns": [
+                                                {
+                                                    "columnId": "completion",
+                                                    "customLabel": true,
+                                                    "fieldName": "completion",
+                                                    "inMetricDimension": true,
+                                                    "label": "Completion",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
                                                 {
                                                     "columnId": "active",
                                                     "customLabel": true,
@@ -1565,6 +2080,46 @@
                                                     }
                                                 },
                                                 {
+                                                    "columnId": "remaining",
+                                                    "customLabel": false,
+                                                    "fieldName": "remaining",
+                                                    "inMetricDimension": true,
+                                                    "label": "remaining",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "8d2f4aba-bb28-4734-bd0e-327aa28d4e5c",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "failed",
+                                                    "customLabel": true,
+                                                    "fieldName": "failed",
+                                                    "inMetricDimension": true,
+                                                    "label": "Failed pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
                                                     "columnId": "completion",
                                                     "customLabel": true,
                                                     "fieldName": "completion",
@@ -1584,6 +2139,59 @@
                                                     }
                                                 },
                                                 {
+                                                    "columnId": "active",
+                                                    "customLabel": true,
+                                                    "fieldName": "active",
+                                                    "inMetricDimension": true,
+                                                    "label": "Active pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "successful",
+                                                    "customLabel": true,
+                                                    "fieldName": "successful",
+                                                    "inMetricDimension": true,
+                                                    "label": "Successful pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "desired",
+                                                    "customLabel": true,
+                                                    "fieldName": "desired",
+                                                    "inMetricDimension": true,
+                                                    "label": "Desired pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.job.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.job.name",
+                                                    "label": "k8s.job.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
                                                     "columnId": "remaining",
                                                     "customLabel": false,
                                                     "fieldName": "remaining",
@@ -1593,11 +2201,27 @@
                                                         "esType": "long",
                                                         "type": "number"
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "8d2f4aba-bb28-4734-bd0e-327aa28d4e5c",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
                                                 }
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.job.name IS NOT NULL\n  AND k8s.job.active_pods IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.job.name\n| WHERE @timestamp == latest_ts\n| STATS\n    active     = MAX(k8s.job.active_pods),\n    successful = MAX(k8s.job.successful_pods),\n    failed     = MAX(k8s.job.failed_pods),\n    desired    = MAX(k8s.job.desired_successful_pods)\n  BY k8s.namespace.name, k8s.job.name\n| EVAL\n    completion = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(successful) / TO_DOUBLE(desired), 4),\n      NULL),\n    remaining = COALESCE(desired, 0) - COALESCE(successful, 0)\n| SORT failed DESC, remaining DESC, completion ASC, k8s.job.name ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.job.name IS NOT NULL\n  AND k8s.job.name != \"\"\n  AND k8s.job.active_pods IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp)\n    BY k8s.cluster.name, k8s.namespace.name, k8s.job.name\n| WHERE @timestamp == latest_ts\n| STATS\n    active     = MAX(k8s.job.active_pods),\n    successful = MAX(k8s.job.successful_pods),\n    failed     = MAX(k8s.job.failed_pods),\n    desired    = MAX(k8s.job.desired_successful_pods)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.job.name\n| EVAL\n    completion = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(successful) / TO_DOUBLE(desired), 4),\n      NULL),\n    remaining = COALESCE(desired, 0) - COALESCE(successful, 0)\n| SORT failed DESC, remaining DESC, completion ASC, k8s.job.name ASC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1607,7 +2231,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.job.name IS NOT NULL\n  AND k8s.job.active_pods IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.job.name\n| WHERE @timestamp == latest_ts\n| STATS\n    active     = MAX(k8s.job.active_pods),\n    successful = MAX(k8s.job.successful_pods),\n    failed     = MAX(k8s.job.failed_pods),\n    desired    = MAX(k8s.job.desired_successful_pods)\n  BY k8s.namespace.name, k8s.job.name\n| EVAL\n    completion = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(successful) / TO_DOUBLE(desired), 4),\n      NULL),\n    remaining = COALESCE(desired, 0) - COALESCE(successful, 0)\n| SORT failed DESC, remaining DESC, completion ASC, k8s.job.name ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.job.name IS NOT NULL\n  AND k8s.job.name != \"\"\n  AND k8s.job.active_pods IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp)\n    BY k8s.cluster.name, k8s.namespace.name, k8s.job.name\n| WHERE @timestamp == latest_ts\n| STATS\n    active     = MAX(k8s.job.active_pods),\n    successful = MAX(k8s.job.successful_pods),\n    failed     = MAX(k8s.job.failed_pods),\n    desired    = MAX(k8s.job.desired_successful_pods)\n  BY k8s.cluster.name, k8s.namespace.name, k8s.job.name\n| EVAL\n    completion = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(successful) / TO_DOUBLE(desired), 4),\n      NULL),\n    remaining = COALESCE(desired, 0) - COALESCE(successful, 0)\n| SORT failed DESC, remaining DESC, completion ASC, k8s.job.name ASC"
                             },
                             "visualization": {
                                 "columns": [
@@ -1618,53 +2242,88 @@
                                         "columnId": "successful"
                                     },
                                     {
-                                        "columnId": "failed"
+                                        "colorMode": "badge",
+                                        "columnId": "failed",
+                                        "palette": {
+                                            "name": "custom",
+                                            "params": {
+                                                "colorStops": [
+                                                    {
+                                                        "color": "#AEE8D2",
+                                                        "stop": 0
+                                                    },
+                                                    {
+                                                        "color": "#FFC9C2",
+                                                        "stop": 1
+                                                    }
+                                                ],
+                                                "continuity": "above",
+                                                "name": "custom",
+                                                "progression": "fixed",
+                                                "rangeMax": null,
+                                                "rangeMin": 0,
+                                                "rangeType": "number",
+                                                "reverse": false,
+                                                "steps": 5,
+                                                "stops": [
+                                                    {
+                                                        "color": "#AEE8D2",
+                                                        "stop": 1
+                                                    },
+                                                    {
+                                                        "color": "#FFC9C2",
+                                                        "stop": 7
+                                                    }
+                                                ]
+                                            },
+                                            "type": "palette"
+                                        }
                                     },
                                     {
                                         "columnId": "desired"
                                     },
                                     {
                                         "columnId": "k8s.namespace.name",
-                                        "oneClickFilter": true
+                                        "oneClickFilter": true,
+                                        "width": 340.25
                                     },
                                     {
                                         "columnId": "k8s.job.name",
-                                        "oneClickFilter": true
+                                        "oneClickFilter": true,
+                                        "width": 286.25
                                     },
                                     {
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "completion",
                                         "palette": {
-                                            "name": "status",
+                                            "name": "custom",
                                             "params": {
+                                                "colorStops": [
+                                                    {
+                                                        "color": "#FFC9C2",
+                                                        "stop": 0
+                                                    },
+                                                    {
+                                                        "color": "#AEE8D2",
+                                                        "stop": 1
+                                                    }
+                                                ],
                                                 "continuity": "above",
-                                                "name": "status",
+                                                "name": "custom",
                                                 "progression": "fixed",
                                                 "rangeMax": null,
                                                 "rangeMin": 0,
-                                                "rangeType": "percent",
+                                                "rangeType": "number",
                                                 "reverse": false,
                                                 "steps": 5,
                                                 "stops": [
                                                     {
-                                                        "color": "#24c292",
-                                                        "stop": 0
+                                                        "color": "#FFC9C2",
+                                                        "stop": 1
                                                     },
                                                     {
-                                                        "color": "#aee8d2",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#fcd883",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#ffc9c2",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#f6726a",
-                                                        "stop": 80
+                                                        "color": "#AEE8D2",
+                                                        "stop": 2
                                                     }
                                                 ]
                                             },
@@ -1674,10 +2333,20 @@
                                     {
                                         "columnId": "remaining",
                                         "hidden": true
+                                    },
+                                    {
+                                        "columnId": "8d2f4aba-bb28-4734-bd0e-327aa28d4e5c",
+                                        "isMetric": false,
+                                        "isTransposed": false,
+                                        "oneClickFilter": true
                                     }
                                 ],
                                 "layerId": "70b6e48d-80db-4ee4-88a6-fd3676937521",
                                 "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
                                 "showRowNumbers": true
                             }
                         },
@@ -1685,30 +2354,48 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "Job listing with active/successful/failed/desired pod counts.",
+                    "description": "Jobs ranked by failed pods (highest first), then by remaining completions. Click a Job name to see its pods, a namespace to drill into namespace details, or a cluster to drill into cluster details. Completion = successful ÷ desired pods. All pod counts reflect the latest collected values.",
                     "drilldowns": [
                         {
-                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
-                            "label": "1. View namespace details",
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+                            "label": "2. View cluster details",
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
+                            "use_time_range": true
+                        },
+                        {
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
+                            "label": "2. View namespace details",
+                            "open_in_new_tab": false,
+                            "trigger": "on_apply_filter",
+                            "type": "dashboard_drilldown",
+                            "use_filters": false,
+                            "use_time_range": true
+                        },
+                        {
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
+                            "label": "1. View pods in job",
+                            "open_in_new_tab": false,
+                            "trigger": "on_apply_filter",
+                            "type": "dashboard_drilldown",
+                            "use_filters": false,
                             "use_time_range": true
                         }
                     ],
                     "title": "Jobs"
                 },
                 "gridData": {
-                    "h": 15,
+                    "h": 12,
                     "i": "10464629-43fb-42f8-b36b-0f587c8c342f",
                     "sectionId": "section-other-workloads",
-                    "w": 24,
-                    "x": 24,
-                    "y": 13
+                    "w": 48,
+                    "x": 0,
+                    "y": 24
                 },
                 "panelIndex": "10464629-43fb-42f8-b36b-0f587c8c342f",
-                "type": "lens"
+                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -1741,7 +2428,7 @@
                                     ],
                                     "layers": {
                                         "bdc1e70e-2126-4713-a7e7-537fd05d3f6b": {
-                                            "columns": [
+                                            "allColumns": [
                                                 {
                                                     "columnId": "available",
                                                     "customLabel": true,
@@ -1820,9 +2507,88 @@
                                                     }
                                                 }
                                             ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "availability",
+                                                    "customLabel": true,
+                                                    "fieldName": "availability",
+                                                    "inMetricDimension": true,
+                                                    "label": "Availability",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "available",
+                                                    "customLabel": true,
+                                                    "fieldName": "available",
+                                                    "inMetricDimension": true,
+                                                    "label": "Available replicas",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "desired",
+                                                    "customLabel": true,
+                                                    "fieldName": "desired",
+                                                    "inMetricDimension": true,
+                                                    "label": "Desired replicas",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.replicaset.name",
+                                                    "fieldName": "k8s.replicaset.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "Namespace",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "not_available",
+                                                    "customLabel": false,
+                                                    "fieldName": "not_available",
+                                                    "inMetricDimension": true,
+                                                    "label": "not_available",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.replicaset.name IS NOT NULL\n  AND k8s.replicaset.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.replicaset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.replicaset.available),\n    desired   = MAX(k8s.replicaset.desired)\n  BY k8s.namespace.name, k8s.replicaset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_available = COALESCE(desired, 0) - COALESCE(available, 0)\n| SORT not_available DESC, availability ASC, k8s.replicaset.name ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.replicaset.name IS NOT NULL\n  AND k8s.replicaset.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.replicaset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.replicaset.available),\n    desired   = MAX(k8s.replicaset.desired)\n  BY k8s.namespace.name, k8s.replicaset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_available = COALESCE(desired, 0) - COALESCE(available, 0)\n| SORT not_available DESC, availability ASC, k8s.replicaset.name ASC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1832,7 +2598,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.replicaset.name IS NOT NULL\n  AND k8s.replicaset.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.replicaset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.replicaset.available),\n    desired   = MAX(k8s.replicaset.desired)\n  BY k8s.namespace.name, k8s.replicaset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired > 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_available = COALESCE(desired, 0) - COALESCE(available, 0)\n| SORT not_available DESC, availability ASC, k8s.replicaset.name ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.replicaset.name IS NOT NULL\n  AND k8s.replicaset.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.replicaset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.replicaset.available),\n    desired   = MAX(k8s.replicaset.desired)\n  BY k8s.namespace.name, k8s.replicaset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_available = COALESCE(desired, 0) - COALESCE(available, 0)\n| SORT not_available DESC, availability ASC, k8s.replicaset.name ASC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
@@ -1848,38 +2614,27 @@
                                     },
                                     {
                                         "columnId": "k8s.replicaset.name",
-                                        "oneClickFilter": true
+                                        "oneClickFilter": true,
+                                        "width": 347.6666666666667
                                     },
                                     {
                                         "columnId": "k8s.cluster.name",
                                         "oneClickFilter": true
                                     },
                                     {
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "availability",
                                         "palette": {
                                             "name": "custom",
                                             "params": {
                                                 "colorStops": [
                                                     {
-                                                        "color": "#f6726a",
+                                                        "color": "#FFC9C2",
                                                         "stop": 0
                                                     },
                                                     {
-                                                        "color": "#ffc9c2",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#fcd883",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#aee8d2",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#24c292",
-                                                        "stop": 80
+                                                        "color": "#AEE8D2",
+                                                        "stop": 1
                                                     }
                                                 ],
                                                 "continuity": "above",
@@ -1887,29 +2642,17 @@
                                                 "progression": "fixed",
                                                 "rangeMax": null,
                                                 "rangeMin": 0,
-                                                "rangeType": "percent",
+                                                "rangeType": "number",
                                                 "reverse": false,
                                                 "steps": 5,
                                                 "stops": [
                                                     {
-                                                        "color": "#f6726a",
-                                                        "stop": 20
+                                                        "color": "#FFC9C2",
+                                                        "stop": 1
                                                     },
                                                     {
-                                                        "color": "#ffc9c2",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#fcd883",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#aee8d2",
-                                                        "stop": 80
-                                                    },
-                                                    {
-                                                        "color": "#24c292",
-                                                        "stop": 100
+                                                        "color": "#AEE8D2",
+                                                        "stop": 2
                                                     }
                                                 ]
                                             },
@@ -1923,6 +2666,10 @@
                                 ],
                                 "layerId": "bdc1e70e-2126-4713-a7e7-537fd05d3f6b",
                                 "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
                                 "showRowNumbers": true
                             }
                         },
@@ -1930,7 +2677,7 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
-                    "description": "Replicaset listing with current/desired/ready/updated pod counts.",
+                    "description": "ReplicaSets sorted by unavailable replicas (desired minus available), then by availability. Shows available and desired pod counts from the latest collected data for each ReplicaSet. Click a row to drill down.",
                     "drilldowns": [
                         {
                             "dashboardRefName": "dashboard_drilldown_kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
@@ -1938,7 +2685,7 @@
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         },
                         {
@@ -1947,36 +2694,33 @@
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         },
                         {
-                            "dashboardRefName": "dashboard_drilldown_",
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
                             "label": "3. View cluster details",
                             "open_in_new_tab": false,
                             "trigger": "on_apply_filter",
                             "type": "dashboard_drilldown",
-                            "use_filters": true,
+                            "use_filters": false,
                             "use_time_range": true
                         }
                     ],
-                    "title": "Replicasets"
+                    "title": "ReplicaSets"
                 },
                 "gridData": {
-                    "h": 11,
+                    "h": 12,
                     "i": "6c961d92-244e-4019-b6d1-4d75f81db4c0",
                     "sectionId": "section-other-workloads",
                     "w": 48,
                     "x": 0,
-                    "y": 28
+                    "y": 36
                 },
                 "panelIndex": "6c961d92-244e-4019-b6d1-4d75f81db4c0",
-                "type": "lens"
+                "type": "vis"
             }
         ],
-        "pinned_panels": {
-            "panels": {}
-        },
         "sections": [
             {
                 "collapsed": false,
@@ -1995,43 +2739,48 @@
                 "title": "Other workload resources"
             }
         ],
-        "timeFrom": "2026-04-04T20:13:59.991Z",
+        "timeFrom": "2026-06-01T06:17:51.162Z",
         "timeRestore": true,
-        "timeTo": "2026-04-05T05:12:18.942Z",
+        "timeTo": "2026-06-01T06:34:34.462Z",
         "title": "[Kubernetes OTel] Workloads"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-04-06T10:52:20.976Z",
+    "created_at": "2026-06-04T10:11:58.136Z",
     "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v2-workloads-alt-nav:link_02b16bcb-9073-43a1-a6b7-ca2bd02fe321_dashboard",
+            "name": "v2-workloads-alt-nav:link_2a32c1a4-a9e8-497c-a0e2-814de66bf1b5_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e",
-            "name": "v2-workloads-alt-nav:link_a0cec3c9-85ce-4486-970c-fc1fd994418a_dashboard",
+            "name": "v2-workloads-alt-nav:link_e0b8bc76-1f19-4954-8ca8-b4efaf00b847_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0c88decf-de83-47a4-a5df-0a79dc8daff5",
-            "name": "v2-workloads-alt-nav:link_3fa37faf-7e87-42a8-9ede-2a06533d3cc8_dashboard",
+            "name": "v2-workloads-alt-nav:link_92cc52e3-c389-4d36-bb02-6c414c13e69e_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-c0765efe-f172-42c4-a2ea-f4552b6f42dc",
-            "name": "v2-workloads-alt-nav:link_a37dc1ba-1855-40e3-b3bc-10aeeaca3f0b_dashboard",
+            "name": "v2-workloads-alt-nav:link_83031f55-4a2f-4799-979e-482acf38266f_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
-            "name": "v2-workloads-alt-nav:link_e90f7302-7c8c-4b19-90f4-d5411d1c1dcd_dashboard",
+            "name": "v2-workloads-alt-nav:link_71766b7c-7710-4efc-8356-f90cbde9d1eb_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
-            "name": "v2-workloads-alt-nav:link_ea675733-c1d8-43ca-9354-5a7899fb4012_dashboard",
+            "name": "v2-workloads-alt-nav:link_a14c8a42-ee85-417e-a61f-b3611d93817c_dashboard",
+            "type": "dashboard"
+        },
+        {
+            "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "name": "72287a15-e7ee-4918-868e-86e2d58057d6:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
             "type": "dashboard"
         },
         {
@@ -2046,12 +2795,7 @@
         },
         {
             "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
-            "name": "72287a15-e7ee-4918-868e-86e2d58057d6:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
-            "type": "dashboard"
-        },
-        {
-            "id": "kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
-            "name": "38f010f8-ca9e-4bf0-847f-2f395d39ee5d:dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
+            "name": "38f010f8-ca9e-4bf0-847f-2f395d39ee5d:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
             "type": "dashboard"
         },
         {
@@ -2060,8 +2804,8 @@
             "type": "dashboard"
         },
         {
-            "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
-            "name": "38f010f8-ca9e-4bf0-847f-2f395d39ee5d:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "id": "kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
+            "name": "38f010f8-ca9e-4bf0-847f-2f395d39ee5d:dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
             "type": "dashboard"
         },
         {
@@ -2075,8 +2819,23 @@
             "type": "dashboard"
         },
         {
+            "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "name": "6efc2bbb-059f-422a-9a2e-09b83f8554f3:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "type": "dashboard"
+        },
+        {
+            "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "name": "10464629-43fb-42f8-b36b-0f587c8c342f:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "type": "dashboard"
+        },
+        {
             "id": "kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
             "name": "10464629-43fb-42f8-b36b-0f587c8c342f:dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
+            "type": "dashboard"
+        },
+        {
+            "id": "kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
+            "name": "10464629-43fb-42f8-b36b-0f587c8c342f:dashboard_drilldown_kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
             "type": "dashboard"
         },
         {
@@ -2088,6 +2847,16 @@
             "id": "kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
             "name": "6c961d92-244e-4019-b6d1-4d75f81db4c0:dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
             "type": "dashboard"
+        },
+        {
+            "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "name": "6c961d92-244e-4019-b6d1-4d75f81db4c0:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "type": "dashboard"
+        },
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
         }
     ],
     "type": "dashboard",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb.json
@@ -57,37 +57,37 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_06c94a5e-5977-4c3f-a0f4-925314def172_dashboard",
+                            "destinationRefName": "link_7fbd38c4-c9be-4e41-80b3-7db7e90ec066_dashboard",
                             "label": "Overview",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_1f389415-5217-49a3-b555-aa18c10967be_dashboard",
+                            "destinationRefName": "link_cfda9589-2459-4989-9c49-49234a4fc666_dashboard",
                             "label": "Clusters",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_86f5e4b3-feaf-4518-a269-62d55e6208ed_dashboard",
+                            "destinationRefName": "link_513807ed-b630-477f-bff9-df5aa33bdb44_dashboard",
                             "label": "Nodes",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_7d9d3deb-7e1f-40f9-bd78-eddf15de3dda_dashboard",
+                            "destinationRefName": "link_57b0545b-92f0-42c0-9a75-25d719af2c7d_dashboard",
                             "label": "Namespaces",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_9c8e40a6-c729-4f12-bd23-c6b9bc021cab_dashboard",
+                            "destinationRefName": "link_8e073bd0-1a62-482f-b5c0-1e4d1fd268da_dashboard",
                             "label": "Workload resources",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_e4d07205-d25f-4c66-b53b-f1f2c16d4521_dashboard",
+                            "destinationRefName": "link_cd0221cb-010c-45a9-86a7-73acb7f4bf5d_dashboard",
                             "label": "Pods",
                             "options": {},
                             "type": "dashboardLink"
@@ -2926,7 +2926,60 @@
                                         }
                                     ],
                                     "layers": {
-                                        "16414e10-c8c5-4fa9-92ed-16bdb548d2a5": {
+                                        "aa77ef08-15ef-49f7-a720-11de56c01a82": {
+                                            "allColumns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "total_restarts",
+                                                    "customLabel": false,
+                                                    "fieldName": "total_restarts",
+                                                    "inMetricDimension": true,
+                                                    "label": "total_restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
                                             "columns": [
                                                 {
                                                     "columnId": "timestamp",
@@ -2939,10 +2992,30 @@
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "deployment",
+                                                    "columnId": "k8s.deployment.name",
                                                     "customLabel": false,
-                                                    "fieldName": "deployment",
-                                                    "label": "deployment",
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -2962,7 +3035,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n| EVAL deployment = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.deployment.name)\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n    deployment, k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, deployment\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, deployment, total_restarts"
+                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name,\n     k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| WHERE total_restarts \u003e 0\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, total_restarts"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2972,7 +3045,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n| EVAL deployment = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.deployment.name)\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n    deployment, k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, deployment\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, deployment, total_restarts"
+                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.name != \"\"\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name,\n     k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| WHERE total_restarts \u003e 0\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, total_restarts"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3016,18 +3089,20 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "16414e10-c8c5-4fa9-92ed-16bdb548d2a5",
+                                        "layerId": "aa77ef08-15ef-49f7-a720-11de56c01a82",
                                         "layerType": "data",
                                         "seriesType": "line",
                                         "splitAccessors": [
-                                            "deployment"
+                                            "k8s.deployment.name",
+                                            "k8s.namespace.name",
+                                            "k8s.cluster.name"
                                         ],
                                         "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "maxLines": 2,
+                                    "maxLines": 3,
                                     "position": "bottom"
                                 },
                                 "preferredSeriesType": "line",
@@ -3854,18 +3929,8 @@
                                         }
                                     ],
                                     "layers": {
-                                        "6c893e00-1d25-4172-99fd-85b9b5332c02": {
+                                        "73ce91be-81bb-43ef-a9fa-841a6c2b1d06": {
                                             "allColumns": [
-                                                {
-                                                    "columnId": "pod",
-                                                    "customLabel": false,
-                                                    "fieldName": "pod",
-                                                    "label": "pod",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
                                                 {
                                                     "columnId": "@timestamp",
                                                     "customLabel": false,
@@ -3874,6 +3939,46 @@
                                                     "meta": {
                                                         "esType": "date",
                                                         "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
                                                     }
                                                 },
                                                 {
@@ -3891,7 +3996,49 @@
                                             "columns": [
                                                 {
                                                     "columnId": "@timestamp",
-                                                    "fieldName": "pod",
+                                                    "customLabel": false,
+                                                    "fieldName": "@timestamp",
+                                                    "label": "@timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -3906,41 +4053,12 @@
                                                     "meta": {
                                                         "esType": "double",
                                                         "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "209f4500-b18d-420e-891e-5bff23a79417",
-                                                    "fieldName": "@timestamp",
-                                                    "label": "@timestamp",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "params": {
-                                                            "id": "date"
-                                                        },
-                                                        "sourceParams": {
-                                                            "appliedTimeRange": {
-                                                                "from": "2026-04-21T15:53:03.093Z",
-                                                                "to": "2026-04-21T16:08:03.093Z"
-                                                            },
-                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
-                                                            "params": {},
-                                                            "sourceField": "@timestamp"
-                                                        },
-                                                        "type": "date"
                                                     }
                                                 }
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.cpu.usage IS NOT NULL\n| EVAL pod = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.pod.name)\n| STATS cpu_usage = MAX(k8s.pod.cpu.usage)\n  BY pod, @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| KEEP pod, @timestamp, cpu_usage\n| SORT @timestamp ASC, cpu_usage DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.pod.cpu.usage IS NOT NULL\n| STATS\n    cpu_usage = MAX(k8s.pod.cpu.usage),\n    k8s.deployment.name = MAX(k8s.deployment.name)\n  BY @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| WHERE cpu_usage \u003e 0\n| SORT @timestamp ASC, cpu_usage DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp\n| KEEP @timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, cpu_usage"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3950,7 +4068,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.cpu.usage IS NOT NULL\n| EVAL pod = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.pod.name)\n| STATS cpu_usage = MAX(k8s.pod.cpu.usage)\n  BY pod, @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| KEEP pod, @timestamp, cpu_usage\n| SORT @timestamp ASC, cpu_usage DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.pod.cpu.usage IS NOT NULL\n| STATS\n    cpu_usage = MAX(k8s.pod.cpu.usage),\n    k8s.deployment.name = MAX(k8s.deployment.name)\n  BY @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| WHERE cpu_usage \u003e 0\n| SORT @timestamp ASC, cpu_usage DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp\n| KEEP @timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, cpu_usage"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3994,13 +4112,16 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "6c893e00-1d25-4172-99fd-85b9b5332c02",
+                                        "layerId": "73ce91be-81bb-43ef-a9fa-841a6c2b1d06",
                                         "layerType": "data",
                                         "seriesType": "line",
                                         "splitAccessors": [
-                                            "@timestamp"
+                                            "k8s.pod.name",
+                                            "k8s.deployment.name",
+                                            "k8s.namespace.name",
+                                            "k8s.cluster.name"
                                         ],
-                                        "xAccessor": "209f4500-b18d-420e-891e-5bff23a79417"
+                                        "xAccessor": "@timestamp"
                                     }
                                 ],
                                 "legend": {
@@ -4065,18 +4186,8 @@
                                         }
                                     ],
                                     "layers": {
-                                        "00b939be-98c8-4540-b7df-006494d28652": {
+                                        "66f10774-326a-4bd0-aa7c-20e137d2d7e0": {
                                             "allColumns": [
-                                                {
-                                                    "columnId": "pod",
-                                                    "customLabel": false,
-                                                    "fieldName": "pod",
-                                                    "label": "pod",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
                                                 {
                                                     "columnId": "@timestamp",
                                                     "customLabel": false,
@@ -4085,6 +4196,46 @@
                                                     "meta": {
                                                         "esType": "date",
                                                         "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
                                                     }
                                                 },
                                                 {
@@ -4102,7 +4253,49 @@
                                             "columns": [
                                                 {
                                                     "columnId": "@timestamp",
-                                                    "fieldName": "pod",
+                                                    "customLabel": false,
+                                                    "fieldName": "@timestamp",
+                                                    "label": "@timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -4122,36 +4315,15 @@
                                                         "format": {
                                                             "id": "bytes",
                                                             "params": {
-                                                                "decimals": 1
+                                                                "decimals": 2
                                                             }
                                                         }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "d5fde19e-d0aa-48a5-96fa-a30c1c2d22ee",
-                                                    "fieldName": "@timestamp",
-                                                    "label": "@timestamp",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "params": {
-                                                            "id": "date"
-                                                        },
-                                                        "sourceParams": {
-                                                            "appliedTimeRange": {
-                                                                "from": "2026-04-21T15:55:17.373Z",
-                                                                "to": "2026-04-21T16:10:17.373Z"
-                                                            },
-                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
-                                                            "params": {},
-                                                            "sourceField": "@timestamp"
-                                                        },
-                                                        "type": "date"
                                                     }
                                                 }
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.memory.working_set IS NOT NULL\n| EVAL pod = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.pod.name)\n| STATS mem_ws = MAX(k8s.pod.memory.working_set)\n  BY pod, @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| KEEP pod, @timestamp, mem_ws\n| SORT @timestamp ASC, mem_ws DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    mem_ws = MAX(k8s.pod.memory.working_set),\n    k8s.deployment.name = MAX(k8s.deployment.name)\n  BY @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| WHERE mem_ws \u003e 0\n| SORT @timestamp ASC, mem_ws DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp\n| KEEP @timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, mem_ws"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -4161,7 +4333,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.memory.working_set IS NOT NULL\n| EVAL pod = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.pod.name)\n| STATS mem_ws = MAX(k8s.pod.memory.working_set)\n  BY pod, @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| KEEP pod, @timestamp, mem_ws\n| SORT @timestamp ASC, mem_ws DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    mem_ws = MAX(k8s.pod.memory.working_set),\n    k8s.deployment.name = MAX(k8s.deployment.name)\n  BY @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| WHERE mem_ws \u003e 0\n| SORT @timestamp ASC, mem_ws DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp\n| KEEP @timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, mem_ws"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -4205,13 +4377,16 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "00b939be-98c8-4540-b7df-006494d28652",
+                                        "layerId": "66f10774-326a-4bd0-aa7c-20e137d2d7e0",
                                         "layerType": "data",
                                         "seriesType": "line",
                                         "splitAccessors": [
-                                            "@timestamp"
+                                            "k8s.pod.name",
+                                            "k8s.deployment.name",
+                                            "k8s.namespace.name",
+                                            "k8s.cluster.name"
                                         ],
-                                        "xAccessor": "d5fde19e-d0aa-48a5-96fa-a30c1c2d22ee"
+                                        "xAccessor": "@timestamp"
                                     }
                                 ],
                                 "legend": {
@@ -5056,18 +5231,8 @@
                                         }
                                     ],
                                     "layers": {
-                                        "8cc28044-41b5-4498-af7c-1980187614be": {
+                                        "6d227a47-dc77-48a0-a394-c78b38444206": {
                                             "allColumns": [
-                                                {
-                                                    "columnId": "pod",
-                                                    "customLabel": false,
-                                                    "fieldName": "pod",
-                                                    "label": "pod",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
                                                 {
                                                     "columnId": "@timestamp",
                                                     "customLabel": false,
@@ -5076,6 +5241,46 @@
                                                     "meta": {
                                                         "esType": "date",
                                                         "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
                                                     }
                                                 },
                                                 {
@@ -5093,7 +5298,49 @@
                                             "columns": [
                                                 {
                                                     "columnId": "@timestamp",
-                                                    "fieldName": "pod",
+                                                    "customLabel": false,
+                                                    "fieldName": "@timestamp",
+                                                    "label": "@timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -5109,32 +5356,11 @@
                                                         "esType": "long",
                                                         "type": "number"
                                                     }
-                                                },
-                                                {
-                                                    "columnId": "5e2865db-dff7-492a-8e13-68d47b242493",
-                                                    "fieldName": "@timestamp",
-                                                    "label": "@timestamp",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "params": {
-                                                            "id": "date"
-                                                        },
-                                                        "sourceParams": {
-                                                            "appliedTimeRange": {
-                                                                "from": "2026-04-21T15:58:12.670Z",
-                                                                "to": "2026-04-21T16:13:12.670Z"
-                                                            },
-                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
-                                                            "params": {},
-                                                            "sourceField": "@timestamp"
-                                                        },
-                                                        "type": "date"
-                                                    }
                                                 }
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.container.name IS NOT NULL AND k8s.container.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n| EVAL pod = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.pod.name)\n| STATS restarts_per_container = MAX(k8s.container.restarts)\n  BY pod, k8s.container.name,\n     @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| STATS restarts = SUM(restarts_per_container)\n  BY pod, @timestamp\n| KEEP pod, @timestamp, restarts\n| SORT @timestamp ASC, restarts DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n| STATS\n    restarts_per_container = MAX(k8s.container.restarts),\n    k8s.deployment.name = MAX(k8s.deployment.name)\n  BY @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.pod.name,\n     k8s.container.name\n| STATS\n    restarts = SUM(restarts_per_container),\n    k8s.deployment.name = MAX(k8s.deployment.name)\n  BY @timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| WHERE restarts \u003e 0\n| SORT @timestamp ASC, restarts DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp\n| KEEP @timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, restarts"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -5144,7 +5370,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.container.name IS NOT NULL AND k8s.container.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n| EVAL pod = CONCAT(k8s.cluster.name, \"/\", k8s.namespace.name, \"/\", k8s.pod.name)\n| STATS restarts_per_container = MAX(k8s.container.restarts)\n  BY pod, k8s.container.name,\n     @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| STATS restarts = SUM(restarts_per_container)\n  BY pod, @timestamp\n| KEEP pod, @timestamp, restarts\n| SORT @timestamp ASC, restarts DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n| STATS\n    restarts_per_container = MAX(k8s.container.restarts),\n    k8s.deployment.name = MAX(k8s.deployment.name)\n  BY @timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.pod.name,\n     k8s.container.name\n| STATS\n    restarts = SUM(restarts_per_container),\n    k8s.deployment.name = MAX(k8s.deployment.name)\n  BY @timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| WHERE restarts \u003e 0\n| SORT @timestamp ASC, restarts DESC\n| LIMIT 10 BY @timestamp\n| SORT @timestamp\n| KEEP @timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, restarts"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -5188,13 +5414,16 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "8cc28044-41b5-4498-af7c-1980187614be",
+                                        "layerId": "6d227a47-dc77-48a0-a394-c78b38444206",
                                         "layerType": "data",
                                         "seriesType": "line",
                                         "splitAccessors": [
-                                            "@timestamp"
+                                            "k8s.pod.name",
+                                            "k8s.deployment.name",
+                                            "k8s.namespace.name",
+                                            "k8s.cluster.name"
                                         ],
-                                        "xAccessor": "5e2865db-dff7-492a-8e13-68d47b242493"
+                                        "xAccessor": "@timestamp"
                                     }
                                 ],
                                 "legend": {
@@ -5272,43 +5501,43 @@
                 "title": "Pods"
             }
         ],
-        "timeFrom": "now-24h/h",
+        "timeFrom": "now-1h",
         "timeRestore": true,
         "timeTo": "now",
         "title": "[Kubernetes OTel] Overview"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-05-27T07:59:34.070Z",
+    "created_at": "2026-06-04T11:33:38.224Z",
     "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v2-co-nav:link_06c94a5e-5977-4c3f-a0f4-925314def172_dashboard",
+            "name": "v2-co-nav:link_7fbd38c4-c9be-4e41-80b3-7db7e90ec066_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e",
-            "name": "v2-co-nav:link_1f389415-5217-49a3-b555-aa18c10967be_dashboard",
+            "name": "v2-co-nav:link_cfda9589-2459-4989-9c49-49234a4fc666_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0c88decf-de83-47a4-a5df-0a79dc8daff5",
-            "name": "v2-co-nav:link_86f5e4b3-feaf-4518-a269-62d55e6208ed_dashboard",
+            "name": "v2-co-nav:link_513807ed-b630-477f-bff9-df5aa33bdb44_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-c0765efe-f172-42c4-a2ea-f4552b6f42dc",
-            "name": "v2-co-nav:link_7d9d3deb-7e1f-40f9-bd78-eddf15de3dda_dashboard",
+            "name": "v2-co-nav:link_57b0545b-92f0-42c0-9a75-25d719af2c7d_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
-            "name": "v2-co-nav:link_9c8e40a6-c729-4f12-bd23-c6b9bc021cab_dashboard",
+            "name": "v2-co-nav:link_8e073bd0-1a62-482f-b5c0-1e4d1fd268da_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
-            "name": "v2-co-nav:link_e4d07205-d25f-4c66-b53b-f1f2c16d4521_dashboard",
+            "name": "v2-co-nav:link_cd0221cb-010c-45a9-86a7-73acb7f4bf5d_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
@@ -33,36 +33,6 @@
                                 ]
                             }
                         }
-                    },
-                    {
-                        "meta": {
-                            "disabled": false,
-                            "field": "data_stream.dataset",
-                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
-                            "key": "data_stream.dataset",
-                            "params": [
-                                "k8sclusterreceiver.otel",
-                                "kubeletstatsreceiver.otel"
-                            ],
-                            "type": "phrases"
-                        },
-                        "query": {
-                            "bool": {
-                                "minimum_should_match": 1,
-                                "should": [
-                                    {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "k8sclusterreceiver.otel"
-                                        }
-                                    },
-                                    {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubeletstatsreceiver.otel"
-                                        }
-                                    }
-                                ]
-                            }
-                        }
                     }
                 ],
                 "query": {
@@ -84,11 +54,12 @@
             {
                 "embeddableConfig": {
                     "description": "",
+                    "hide_border": true,
                     "hide_title": true,
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_243b4837-67bf-42ba-9008-1d6d1726618f_dashboard",
+                            "destinationRefName": "link_2bfaa6d4-7122-4d25-b200-00f7e1ce1dca_dashboard",
                             "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
@@ -108,500 +79,6 @@
                 },
                 "panelIndex": "v3-deployment-back-link",
                 "type": "links"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "d3b7e528216ce7ef65e68e07a803b7ab53e440cafdb52d9d7ee1ef4bbf5d8afa": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "metrics-*",
-                                    "managed": false,
-                                    "name": "metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "metrics-*",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "86f5ee15-9eab-4f50-af6c-61606d984396": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "75f53985-510d-4051-99fc-10fe0c2c49f0",
-                                                    "customLabel": true,
-                                                    "fieldName": "k8s.deployment.name",
-                                                    "inMetricDimension": true,
-                                                    "label": "View deployment logs in Discover",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "params": {
-                                                            "id": "string"
-                                                        },
-                                                        "sourceParams": {
-                                                            "indexPattern": "metrics-*",
-                                                            "sourceField": "k8s.deployment.name"
-                                                        },
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "metrics-*",
-                                            "query": {
-                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n| KEEP k8s.deployment.name\n| LIMIT 1"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n| KEEP k8s.deployment.name\n| LIMIT 1"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "color": "#61A2FF",
-                                "colorMode": "background",
-                                "icon": "popout",
-                                "iconAlign": "left",
-                                "layerId": "86f5ee15-9eab-4f50-af6c-61606d984396",
-                                "layerType": "data",
-                                "metricAccessor": "75f53985-510d-4051-99fc-10fe0c2c49f0",
-                                "primaryAlign": "center",
-                                "primaryPosition": "bottom",
-                                "showBar": false,
-                                "titleWeight": "normal",
-                                "titlesTextAlign": "center",
-                                "titlesTextSize": "xxs",
-                                "valueFontMode": "fit",
-                                "valuesTextSize": "xs"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Click to view deployment logs (opens a new tab)",
-                    "drilldowns": [
-                        {
-                            "encode_url": true,
-                            "label": "View logs in Discover",
-                            "open_in_new_tab": true,
-                            "trigger": "on_click_value",
-                            "type": "url_drilldown",
-                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.deployment.name:\"{{event.value}}\"'))"
-                        }
-                    ],
-                    "hide_title": true
-                },
-                "gridData": {
-                    "h": 3,
-                    "i": "v4-wd-logs-card",
-                    "w": 7,
-                    "x": 41,
-                    "y": 0
-                },
-                "panelIndex": "v4-wd-logs-card",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                    "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "0b0d242c-566c-9ec0-60cd-826f4be37481": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "c7f73801-90bf-8874-6221-73fd6e0566d3",
-                                                    "customLabel": true,
-                                                    "fieldName": "available",
-                                                    "inMetricDimension": true,
-                                                    "label": "Available replicas",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.available IS NOT NULL\n| STATS available = LAST(k8s.deployment.available, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS available = SUM(available)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.available IS NOT NULL\n| STATS available = LAST(k8s.deployment.available, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS available = SUM(available)"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "colorMode": "background",
-                                "layerId": "0b0d242c-566c-9ec0-60cd-826f4be37481",
-                                "layerType": "data",
-                                "metricAccessor": "c7f73801-90bf-8874-6221-73fd6e0566d3",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#BFDBFF",
-                                                "stop": 0
-                                            },
-                                            {
-                                                "color": "#24C292",
-                                                "stop": 1
-                                            }
-                                        ],
-                                        "continuity": "above",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": 0,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#BFDBFF",
-                                                "stop": 1
-                                            },
-                                            {
-                                                "color": "#24C292",
-                                                "stop": 2
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "showBar": false,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Available replicas for this deployment. MAX(k8s.deployment.available).",
-                    "drilldowns": [],
-                    "hide_title": true
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "6fa9715d-bfa4-4dc0-aead-b410aa40c2b6",
-                    "w": 12,
-                    "x": 0,
-                    "y": 3
-                },
-                "panelIndex": "6fa9715d-bfa4-4dc0-aead-b410aa40c2b6",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                    "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "c5786785-92b9-d1a2-111a-dd75d9ba7934": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "7138585c-d40c-b657-cf06-816942450421",
-                                                    "customLabel": true,
-                                                    "fieldName": "desired",
-                                                    "inMetricDimension": true,
-                                                    "label": "Desired replicas",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| STATS desired = LAST(k8s.deployment.desired, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS desired = SUM(desired)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| STATS desired = LAST(k8s.deployment.desired, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS desired = SUM(desired)"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "color": "#61A2FF",
-                                "colorMode": "background",
-                                "layerId": "c5786785-92b9-d1a2-111a-dd75d9ba7934",
-                                "layerType": "data",
-                                "metricAccessor": "7138585c-d40c-b657-cf06-816942450421",
-                                "showBar": false,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Desired replicas for this deployment. MAX(k8s.deployment.desired).",
-                    "drilldowns": [],
-                    "hide_title": true,
-                    "title": ""
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "5fdcf3cd-b110-4042-a8e1-9652813771ce",
-                    "w": 12,
-                    "x": 12,
-                    "y": 3
-                },
-                "panelIndex": "5fdcf3cd-b110-4042-a8e1-9652813771ce",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                    "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "48bf04fd-0ec2-9a2b-b498-bad9c61750cb": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "602bb36a-b2d9-5e22-bbe6-6f8321bf6cf4",
-                                                    "customLabel": true,
-                                                    "fieldName": "pod_count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Pods in deployment",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| STATS desired = LAST(k8s.deployment.desired, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = SUM(desired)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.deployment.desired IS NOT NULL\n| STATS desired = LAST(k8s.deployment.desired, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.deployment.name, k8s.namespace.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = SUM(desired)"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "color": "#61A2FF",
-                                "colorMode": "background",
-                                "layerId": "48bf04fd-0ec2-9a2b-b498-bad9c61750cb",
-                                "layerType": "data",
-                                "metricAccessor": "602bb36a-b2d9-5e22-bbe6-6f8321bf6cf4",
-                                "showBar": false,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Pod count for this deployment. COUNT_DISTINCT(k8s.pod.uid).",
-                    "drilldowns": [],
-                    "hide_title": true
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "v2-deploy-detail-pods",
-                    "w": 12,
-                    "x": 24,
-                    "y": 3
-                },
-                "panelIndex": "v2-deploy-detail-pods",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                    "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "b8e82f89-e3b7-c30e-2126-19983e1fe23b": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "04502b61-dc7e-1c36-d570-d3e1b897a44d",
-                                                    "customLabel": true,
-                                                    "fieldName": "total_restarts",
-                                                    "inMetricDimension": true,
-                                                    "label": "Container restarts",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS restarts = LAST(k8s.container.restarts, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_restarts = SUM(restarts)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS restarts = LAST(k8s.container.restarts, @timestamp),\n       last_seen = MAX(@timestamp)\n  BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_restarts = SUM(restarts)"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "color": "#F6726A",
-                                "colorMode": "background",
-                                "layerId": "b8e82f89-e3b7-c30e-2126-19983e1fe23b",
-                                "layerType": "data",
-                                "metricAccessor": "04502b61-dc7e-1c36-d570-d3e1b897a44d",
-                                "showBar": false,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Total container restarts. MAX(k8s.container.restarts) per pod+container, then SUM.",
-                    "drilldowns": [],
-                    "hide_title": true
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "v2-deploy-detail-restarts",
-                    "w": 12,
-                    "x": 36,
-                    "y": 3
-                },
-                "panelIndex": "v2-deploy-detail-restarts",
-                "type": "vis"
             },
             {
                 "embeddableConfig": {
@@ -696,17 +173,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                "d3b7e528216ce7ef65e68e07a803b7ab53e440cafdb52d9d7ee1ef4bbf5d8afa": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "id": "metrics-*",
                                     "managed": false,
-                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "name": "metrics-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "title": "metrics-*",
                                     "type": "esql"
                                 }
                             },
@@ -714,47 +191,36 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "id": "metrics-*",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                            "title": "metrics-*"
                                         }
                                     ],
                                     "layers": {
-                                        "4af3de89-68a8-8e1f-ccb7-4e6febd43855": {
+                                        "86f5ee15-9eab-4f50-af6c-61606d984396": {
                                             "columns": [
                                                 {
-                                                    "columnId": "2999510e-3669-b52d-dfab-8810af241dd4",
+                                                    "columnId": "75f53985-510d-4051-99fc-10fe0c2c49f0",
                                                     "customLabel": true,
-                                                    "fieldName": "utilization",
+                                                    "fieldName": "k8s.deployment.name",
                                                     "inMetricDimension": true,
-                                                    "label": "CPU utilization",
+                                                    "label": "View deployment logs in Discover",
                                                     "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "gauge-max-col-cpu-utilization",
-                                                    "customLabel": true,
-                                                    "fieldName": "max_val",
-                                                    "label": "Max",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-*",
+                                                            "sourceField": "k8s.deployment.name"
+                                                        },
+                                                        "type": "string"
                                                     }
                                                 }
                                             ],
-                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "index": "metrics-*",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.cpu_limit_utilization, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n| KEEP k8s.deployment.name\n| LIMIT 1"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -764,79 +230,51 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.cpu_limit_utilization, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                "esql": "FROM metrics-*\n| WHERE k8s.deployment.name IS NOT NULL\n| KEEP k8s.deployment.name\n| LIMIT 1"
                             },
                             "visualization": {
-                                "applyColorTo": "bar",
-                                "layerId": "4af3de89-68a8-8e1f-ccb7-4e6febd43855",
+                                "applyColorTo": "background",
+                                "colorMode": "background",
+                                "icon": "popout",
+                                "iconAlign": "left",
+                                "layerId": "86f5ee15-9eab-4f50-af6c-61606d984396",
                                 "layerType": "data",
-                                "maxAccessor": "gauge-max-col-cpu-utilization",
-                                "metricAccessor": "2999510e-3669-b52d-dfab-8810af241dd4",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#24c292",
-                                                "stop": 0
-                                            },
-                                            {
-                                                "color": "#fcd883",
-                                                "stop": 0.6
-                                            },
-                                            {
-                                                "color": "#f6726a",
-                                                "stop": 0.8
-                                            }
-                                        ],
-                                        "continuity": "above",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": 0,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#24c292",
-                                                "stop": 0.6
-                                            },
-                                            {
-                                                "color": "#fcd883",
-                                                "stop": 0.8
-                                            },
-                                            {
-                                                "color": "#f6726a",
-                                                "stop": 1
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "progressDirection": "horizontal",
-                                "showBar": true,
-                                "subtitle": "Last value"
+                                "metricAccessor": "75f53985-510d-4051-99fc-10fe0c2c49f0",
+                                "primaryAlign": "center",
+                                "primaryPosition": "bottom",
+                                "showBar": false,
+                                "titlesTextAlign": "center",
+                                "titlesTextSize": "xxs",
+                                "valueFontMode": "fit",
+                                "valuesTextSize": "xs"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "CPU utilization for this deployment.",
-                    "drilldowns": [],
+                    "description": "Click to view deployment logs (opens a new tab)",
+                    "drilldowns": [
+                        {
+                            "encode_url": true,
+                            "label": "View logs in Discover",
+                            "open_in_new_tab": true,
+                            "trigger": "on_click_value",
+                            "type": "url_drilldown",
+                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'(k8s.deployment.name:\"{{event.value}}\") OR (data_stream.dataset:\"k8seventsreceiver.otel\" AND k8s.object.kind:\"Pod\" AND k8s.object.name:{{event.value}}*)'))"
+                        }
+                    ],
+                    "hide_border": true,
                     "hide_title": true
                 },
                 "gridData": {
-                    "h": 5,
-                    "i": "v3-wd-cpu-card",
-                    "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
-                    "w": 8,
-                    "x": 0,
-                    "y": 5
+                    "h": 3,
+                    "i": "v4-wd-logs-card",
+                    "w": 7,
+                    "x": 41,
+                    "y": 0
                 },
-                "panelIndex": "v3-wd-cpu-card",
+                "panelIndex": "v4-wd-logs-card",
                 "type": "vis"
             },
             {
@@ -845,17 +283,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "id": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                     "managed": false,
-                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -863,195 +301,139 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "id": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
-                                        "4af3de89-68a8-8e1f-ccb7-4e6febd43855": {
-                                            "columns": [
+                                        "84fba3fb-ea58-4c81-8de5-dd7839a83aab": {
+                                            "allColumns": [
                                                 {
-                                                    "columnId": "2999510e-3669-b52d-dfab-8810af241dd4",
-                                                    "customLabel": true,
-                                                    "fieldName": "utilization",
-                                                    "inMetricDimension": true,
-                                                    "label": "Memory utilization",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "gauge-max-col-memory-utilization",
-                                                    "customLabel": true,
-                                                    "fieldName": "max_val",
-                                                    "label": "Max",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                            "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.memory_limit_utilization, @timestamp) BY k8s.pod.name\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.memory_limit_utilization, @timestamp) BY k8s.pod.name\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
-                            },
-                            "visualization": {
-                                "applyColorTo": "bar",
-                                "layerId": "4af3de89-68a8-8e1f-ccb7-4e6febd43855",
-                                "layerType": "data",
-                                "maxAccessor": "gauge-max-col-memory-utilization",
-                                "metricAccessor": "2999510e-3669-b52d-dfab-8810af241dd4",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#24c292",
-                                                "stop": 0
-                                            },
-                                            {
-                                                "color": "#fcd883",
-                                                "stop": 0.6
-                                            },
-                                            {
-                                                "color": "#f6726a",
-                                                "stop": 0.8
-                                            }
-                                        ],
-                                        "continuity": "above",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": 0,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#24c292",
-                                                "stop": 0.6
-                                            },
-                                            {
-                                                "color": "#fcd883",
-                                                "stop": 0.8
-                                            },
-                                            {
-                                                "color": "#f6726a",
-                                                "stop": 1
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "progressDirection": "horizontal",
-                                "showBar": true,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Memory utilization for this deployment.",
-                    "drilldowns": [],
-                    "hide_title": true
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "v3-wd-memory-card",
-                    "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
-                    "w": 8,
-                    "x": 24,
-                    "y": 5
-                },
-                "panelIndex": "v3-wd-memory-card",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                    "managed": false,
-                                    "name": "metrics-kubeletstatsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubeletstatsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-kubeletstatsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "5439a0b4-84a1-4f10-8a67-bd048a72f706": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "7f8deb7b-997e-4f34-82cf-063237fb330a",
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
                                                     "fieldName": "timestamp",
+                                                    "label": "timestamp",
                                                     "meta": {
                                                         "esType": "date",
                                                         "type": "date"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "c4367452-6147-4d99-a960-adca4fccfe88",
-                                                    "customLabel": true,
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "CPU usage",
+                                                    "customLabel": false,
                                                     "fieldName": "CPU usage",
                                                     "inMetricDimension": true,
                                                     "label": "CPU usage",
                                                     "meta": {
                                                         "esType": "double",
                                                         "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 2,
-                                                                "suffix": " Cores"
-                                                            }
-                                                        }
                                                     }
                                                 }
                                             ],
-                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "columns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "CPU usage",
+                                                    "customLabel": false,
+                                                    "fieldName": "CPU usage",
+                                                    "inMetricDimension": true,
+                                                    "label": "CPU usage",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "ebfc8739-ac51-43b2-84d9-e6dd7c050715",
+                                                    "fieldName": "CPU limit",
+                                                    "inMetricDimension": true,
+                                                    "label": "CPU limit",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "CPU limit"
+                                                        },
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `CPU usage`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND (k8s.pod.cpu.usage IS NOT NULL OR k8s.container.cpu_limit IS NOT NULL)\n| STATS pod_cpu = MAX(k8s.pod.cpu.usage),\n        container_limit = MAX(k8s.container.cpu_limit)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name,\n     k8s.pod.uid, k8s.container.name\n| STATS `CPU usage` = MAX(pod_cpu),\n        `CPU limit` = SUM(container_limit)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.uid\n| STATS `CPU usage` = SUM(`CPU usage`),\n        `CPU limit` = SUM(`CPU limit`)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, `CPU usage`, `CPU limit`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1061,22 +443,37 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `CPU usage`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND (k8s.pod.cpu.usage IS NOT NULL OR k8s.container.cpu_limit IS NOT NULL)\n| STATS pod_cpu = MAX(k8s.pod.cpu.usage),\n        container_limit = MAX(k8s.container.cpu_limit)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name,\n     k8s.pod.uid, k8s.container.name\n| STATS `CPU usage` = MAX(pod_cpu),\n        `CPU limit` = SUM(container_limit)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.uid\n| STATS `CPU usage` = SUM(`CPU usage`),\n        `CPU limit` = SUM(`CPU limit`)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, `CPU usage`, `CPU limit`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
                                     "x": false,
                                     "yLeft": false,
-                                    "yRight": false
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
                                 },
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "c4367452-6147-4d99-a960-adca4fccfe88"
+                                            "CPU usage",
+                                            "ebfc8739-ac51-43b2-84d9-e6dd7c050715"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "elastic_line_optimized",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1091,35 +488,48 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "5439a0b4-84a1-4f10-8a67-bd048a72f706",
+                                        "layerId": "84fba3fb-ea58-4c81-8de5-dd7839a83aab",
                                         "layerType": "data",
-                                        "position": "top",
                                         "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "7f8deb7b-997e-4f34-82cf-063237fb330a"
+                                        "splitAccessors": [
+                                            "k8s.deployment.name",
+                                            "k8s.namespace.name",
+                                            "k8s.cluster.name"
+                                        ],
+                                        "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
-                                    "isVisible": false
+                                    "isVisible": true,
+                                    "maxLines": 2,
+                                    "position": "bottom"
                                 },
-                                "preferredSeriesType": "line"
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "title": "CPU usage over time"
+                    "description": "Tracks CPU usage against configured CPU limits for each deployment over time. ",
+                    "drilldowns": [],
+                    "title": "CPU usage vs limit over time"
                 },
                 "gridData": {
-                    "h": 10,
-                    "i": "v3-wd-cpu-time",
+                    "h": 12,
+                    "i": "620a2b88-e2e2-48ad-9aba-fdf26d4d2560",
                     "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
                     "w": 16,
                     "x": 8,
                     "y": 0
                 },
-                "panelIndex": "v3-wd-cpu-time",
+                "panelIndex": "620a2b88-e2e2-48ad-9aba-fdf26d4d2560",
                 "type": "vis"
             },
             {
@@ -1152,313 +562,116 @@
                                         }
                                     ],
                                     "layers": {
-                                        "12e41ca7-2f8b-4075-b512-9d085e8cb2f0": {
-                                            "columns": [
+                                        "e5a680a3-9856-49ce-835f-fb928a1037ca": {
+                                            "allColumns": [
                                                 {
-                                                    "columnId": "16fe25e3-e40b-4f70-b099-b5bd549892dc",
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
                                                     "fieldName": "timestamp",
+                                                    "label": "timestamp",
                                                     "meta": {
                                                         "esType": "date",
                                                         "type": "date"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "fb03b4c2-d202-4a46-95cd-1749939306f7",
-                                                    "customLabel": true,
-                                                    "fieldName": "Memory working set",
-                                                    "inMetricDimension": true,
-                                                    "label": "Memory working set",
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
                                                     "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                            "query": {
-                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Memory working set`"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Memory working set`"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": false
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "fb03b4c2-d202-4a46-95cd-1749939306f7"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "12e41ca7-2f8b-4075-b512-9d085e8cb2f0",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "16fe25e3-e40b-4f70-b099-b5bd549892dc"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false
-                                },
-                                "preferredSeriesType": "line"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsXY"
-                    },
-                    "title": "Memory working set over time"
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "v3-wd-memory-time",
-                    "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
-                    "w": 16,
-                    "x": 32,
-                    "y": 0
-                },
-                "panelIndex": "v3-wd-memory-time",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                    "managed": false,
-                                    "name": "metrics-kubeletstatsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubeletstatsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-kubeletstatsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "4af3de89-68a8-8e1f-ccb7-4e6febd43855": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "2999510e-3669-b52d-dfab-8810af241dd4",
-                                                    "customLabel": true,
-                                                    "fieldName": "utilization",
-                                                    "inMetricDimension": true,
-                                                    "label": "Volume utilization",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
+                                                        "esType": "keyword",
+                                                        "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "gauge-max-col-volume-utilization",
-                                                    "customLabel": true,
-                                                    "fieldName": "max_val",
-                                                    "label": "Max",
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
                                                     "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                            "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = LAST(k8s.volume.available, @timestamp),\n        cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS avail = SUM(avail_per), cap = SUM(cap_per)\n| EVAL utilization = 1.0 - TO_DOUBLE(avail) / TO_DOUBLE(cap),\n        max_val = 1.0\n| KEEP utilization, max_val"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = LAST(k8s.volume.available, @timestamp),\n        cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS avail = SUM(avail_per), cap = SUM(cap_per)\n| EVAL utilization = 1.0 - TO_DOUBLE(avail) / TO_DOUBLE(cap),\n        max_val = 1.0\n| KEEP utilization, max_val"
-                            },
-                            "visualization": {
-                                "applyColorTo": "bar",
-                                "layerId": "4af3de89-68a8-8e1f-ccb7-4e6febd43855",
-                                "layerType": "data",
-                                "maxAccessor": "gauge-max-col-volume-utilization",
-                                "metricAccessor": "2999510e-3669-b52d-dfab-8810af241dd4",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#24c292",
-                                                "stop": 0
-                                            },
-                                            {
-                                                "color": "#fcd883",
-                                                "stop": 0.6
-                                            },
-                                            {
-                                                "color": "#f6726a",
-                                                "stop": 0.8
-                                            }
-                                        ],
-                                        "continuity": "above",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": 0,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#24c292",
-                                                "stop": 0.6
-                                            },
-                                            {
-                                                "color": "#fcd883",
-                                                "stop": 0.8
-                                            },
-                                            {
-                                                "color": "#f6726a",
-                                                "stop": 1
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "progressDirection": "horizontal",
-                                "showBar": true,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Volume utilization for this deployment.",
-                    "drilldowns": [],
-                    "hide_title": true
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "v3-wd-volume-gauge",
-                    "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
-                    "w": 8,
-                    "x": 0,
-                    "y": 15
-                },
-                "panelIndex": "v3-wd-volume-gauge",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                    "managed": false,
-                                    "name": "metrics-kubeletstatsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubeletstatsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-kubeletstatsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "a81d3669-29bd-4112-af68-fe125dbdf7fb": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "1136e97c-d95d-4a2c-ba49-6be725adbbfd",
-                                                    "fieldName": "timestamp",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
+                                                        "esType": "keyword",
+                                                        "type": "string"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "36952ebb-4f7e-4b0a-ada7-10ed59e3d124",
-                                                    "customLabel": true,
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Volume usage",
+                                                    "customLabel": false,
                                                     "fieldName": "Volume usage",
                                                     "inMetricDimension": true,
                                                     "label": "Volume usage",
                                                     "meta": {
-                                                        "esType": "double",
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Volume usage",
+                                                    "customLabel": false,
+                                                    "fieldName": "Volume usage",
+                                                    "inMetricDimension": true,
+                                                    "label": "Volume usage",
+                                                    "meta": {
+                                                        "esType": "long",
                                                         "type": "number"
                                                     },
                                                     "params": {
                                                         "format": {
                                                             "id": "bytes",
                                                             "params": {
-                                                                "decimals": 0
+                                                                "decimals": 2
                                                             }
                                                         }
                                                     }
@@ -1466,7 +679,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = AVG(k8s.volume.available),\n        cap_per = AVG(k8s.volume.capacity)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid, k8s.volume.name\n| STATS available = SUM(avail_per),\n        capacity = SUM(cap_per)\n    BY timestamp\n| EVAL `Volume usage` = capacity - available\n| SORT timestamp\n| KEEP timestamp, `Volume usage`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.volume.name IS NOT NULL AND k8s.volume.name != \"\"\n  AND k8s.volume.available IS NOT NULL AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = MAX(k8s.volume.available),\n        cap_per = MAX(k8s.volume.capacity)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name,\n     k8s.pod.uid, k8s.volume.name\n| STATS available = SUM(avail_per),\n        capacity = SUM(cap_per)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| EVAL `Volume usage` = capacity - available\n| SORT timestamp ASC, `Volume usage` DESC\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, `Volume usage`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1476,22 +689,36 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.name IS NOT NULL\n    AND k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = AVG(k8s.volume.available),\n        cap_per = AVG(k8s.volume.capacity)\n    BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid, k8s.volume.name\n| STATS available = SUM(avail_per),\n        capacity = SUM(cap_per)\n    BY timestamp\n| EVAL `Volume usage` = capacity - available\n| SORT timestamp\n| KEEP timestamp, `Volume usage`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.volume.name IS NOT NULL AND k8s.volume.name != \"\"\n  AND k8s.volume.available IS NOT NULL AND k8s.volume.capacity IS NOT NULL\n| STATS avail_per = MAX(k8s.volume.available),\n        cap_per = MAX(k8s.volume.capacity)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name,\n     k8s.pod.uid, k8s.volume.name\n| STATS available = SUM(avail_per),\n        capacity = SUM(cap_per)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| EVAL `Volume usage` = capacity - available\n| SORT timestamp ASC, `Volume usage` DESC\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, `Volume usage`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
                                     "x": false,
                                     "yLeft": false,
-                                    "yRight": false
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
                                 },
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "36952ebb-4f7e-4b0a-ada7-10ed59e3d124"
+                                            "Volume usage"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "elastic_line_optimized",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -1506,35 +733,47 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "a81d3669-29bd-4112-af68-fe125dbdf7fb",
+                                        "layerId": "e5a680a3-9856-49ce-835f-fb928a1037ca",
                                         "layerType": "data",
-                                        "position": "top",
                                         "seriesType": "line",
-                                        "showGridlines": false,
-                                        "xAccessor": "1136e97c-d95d-4a2c-ba49-6be725adbbfd"
+                                        "splitAccessors": [
+                                            "k8s.deployment.name",
+                                            "k8s.namespace.name",
+                                            "k8s.cluster.name"
+                                        ],
+                                        "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
-                                    "isVisible": false
+                                    "isVisible": true,
+                                    "maxLines": 3,
+                                    "position": "bottom"
                                 },
-                                "preferredSeriesType": "line"
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
+                    "description": "Total volume usage (capacity minus available) for the deployment over time.",
                     "title": "Volume usage over time"
                 },
                 "gridData": {
-                    "h": 10,
-                    "i": "v3-wd-volume-time",
+                    "h": 12,
+                    "i": "418af2db-a887-4e9c-8140-ffa863b25e0d",
                     "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
                     "w": 16,
                     "x": 8,
-                    "y": 10
+                    "y": 12
                 },
-                "panelIndex": "v3-wd-volume-time",
+                "panelIndex": "418af2db-a887-4e9c-8140-ffa863b25e0d",
                 "type": "vis"
             },
             {
@@ -1597,28 +836,30 @@
                             },
                             "visualization": {
                                 "applyColorTo": "background",
-                                "color": "#61A2FF",
                                 "colorMode": "background",
                                 "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
                                 "layerType": "data",
                                 "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
                                 "showBar": false,
-                                "subtitle": "Last value"
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": []
+                    "description": "Total CPU limit across all containers in the deployment (in cores)"
                 },
                 "gridData": {
-                    "h": 5,
+                    "h": 6,
                     "i": "v4-wd-cpu-limit",
                     "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
                     "w": 8,
                     "x": 0,
-                    "y": 0
+                    "y": 6
                 },
                 "panelIndex": "v4-wd-cpu-limit",
                 "type": "vis"
@@ -1629,17 +870,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1647,37 +888,86 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
-                                        "27c8778d-41d0-47b6-b0da-cb1478a5794f": {
+                                        "37ff86cc-edaa-43f6-9eb7-ebc40ad7c1aa": {
                                             "columns": [
                                                 {
-                                                    "columnId": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
+                                                    "columnId": "utilization",
                                                     "customLabel": true,
-                                                    "fieldName": "total_gb",
+                                                    "fieldName": "utilization_last",
                                                     "inMetricDimension": true,
-                                                    "label": "Memory limit",
+                                                    "label": "CPU utilization",
                                                     "meta": {
-                                                        "esType": "long",
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization_last"
+                                                        },
                                                         "type": "number"
                                                     },
                                                     "params": {
                                                         "format": {
-                                                            "id": "bytes",
+                                                            "id": "percent",
                                                             "params": {
                                                                 "decimals": 2
                                                             }
                                                         }
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "3f76ef1d-b677-40ed-af9d-61171b97e9d0",
+                                                    "customLabel": false,
+                                                    "fieldName": "utilization",
+                                                    "inMetricDimension": true,
+                                                    "label": "utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "7d4fbcd6-3ac9-4b6d-949e-bf0c5371b12b",
+                                                    "fieldName": "max_value",
+                                                    "label": "max_value",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "max_value"
+                                                        },
+                                                        "type": "number"
+                                                    }
                                                 }
                                             ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.memory_limit IS NOT NULL\n| STATS limit_per = LAST(k8s.container.memory_limit, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(limit_per)\n| EVAL total_gb = ROUND(total_limit, 2)\n| KEEP total_gb"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| INLINE STATS pod_last_seen = MAX(@timestamp) BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(pod_last_seen)\n| WHERE DATE_DIFF(\"minute\", pod_last_seen, latest_ts) \u003c= 5\n| STATS pod_util = MAX(k8s.pod.cpu_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| STATS bucket_util = AVG(pod_util)\n  BY timestamp\n| SORT timestamp\n| STATS\n    utilization = ROUND(AVG(bucket_util), 4),\n    utilization_last = ROUND(LAST(bucket_util, timestamp), 4)\n| EVAL max_value = 1.0\n| KEEP utilization, utilization_last, max_value"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1687,34 +977,270 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.memory_limit IS NOT NULL\n| STATS limit_per = LAST(k8s.container.memory_limit, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(limit_per)\n| EVAL total_gb = ROUND(total_limit, 2)\n| KEEP total_gb"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| INLINE STATS pod_last_seen = MAX(@timestamp) BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(pod_last_seen)\n| WHERE DATE_DIFF(\"minute\", pod_last_seen, latest_ts) \u003c= 5\n| STATS pod_util = MAX(k8s.pod.cpu_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| STATS bucket_util = AVG(pod_util)\n  BY timestamp\n| SORT timestamp\n| STATS\n    utilization = ROUND(AVG(bucket_util), 4),\n    utilization_last = ROUND(LAST(bucket_util, timestamp), 4)\n| EVAL max_value = 1.0\n| KEEP utilization, utilization_last, max_value"
                             },
                             "visualization": {
-                                "applyColorTo": "background",
-                                "color": "#61A2FF",
-                                "colorMode": "background",
-                                "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
+                                "layerId": "37ff86cc-edaa-43f6-9eb7-ebc40ad7c1aa",
                                 "layerType": "data",
-                                "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
-                                "showBar": false,
-                                "subtitle": "Last value"
+                                "maxAccessor": "7d4fbcd6-3ac9-4b6d-949e-bf0c5371b12b",
+                                "metricAccessor": "utilization",
+                                "palette": {
+                                    "name": "status",
+                                    "params": {
+                                        "colorStops": [],
+                                        "continuity": "all",
+                                        "maxSteps": 5,
+                                        "name": "status",
+                                        "progression": "fixed",
+                                        "rangeMax": 100,
+                                        "rangeMin": 0,
+                                        "rangeType": "percent",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24c292",
+                                                "stop": 33.33
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "stop": 66.66
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "stop": 100
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "secondaryLabel": "Last value vs Avg",
+                                "secondaryMetricAccessor": "3f76ef1d-b677-40ed-af9d-61171b97e9d0",
+                                "secondaryTrend": {
+                                    "baselineValue": "primary",
+                                    "paletteId": "compare_to",
+                                    "reversed": true,
+                                    "type": "dynamic",
+                                    "visuals": "both"
+                                },
+                                "showBar": true,
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": []
+                    "description": "Last CPU limit utilization value for this deployment in the selected time range.\n\n\"Last value vs Avg\" shows how the most recent reading compares to the time-range average.",
+                    "hide_title": true
                 },
                 "gridData": {
-                    "h": 5,
-                    "i": "v4-wd-mem-limit",
+                    "h": 6,
+                    "i": "v3-wd-cpu-card",
                     "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
                     "w": 8,
-                    "x": 24,
+                    "x": 0,
                     "y": 0
                 },
-                "panelIndex": "v4-wd-mem-limit",
+                "panelIndex": "v3-wd-cpu-card",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "managed": false,
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "b59030fa-1247-4836-bc0b-78338b2fd664": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "utilization",
+                                                    "customLabel": true,
+                                                    "fieldName": "utilization_last",
+                                                    "inMetricDimension": true,
+                                                    "label": "Volume utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization_last"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "a4da336b-b405-4803-8c92-c6dc229443a7",
+                                                    "customLabel": false,
+                                                    "fieldName": "utilization",
+                                                    "inMetricDimension": true,
+                                                    "label": "utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "acd3ad76-ef75-4b39-905a-f9d72ca98b5e",
+                                                    "fieldName": "max_value",
+                                                    "label": "max_value",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "max_value"
+                                                        },
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "query": {
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.volume.name IS NOT NULL\n  AND k8s.volume.name != \"\"\n  AND k8s.volume.available IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| INLINE STATS vol_last_seen = MAX(@timestamp) BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(vol_last_seen)\n| WHERE DATE_DIFF(\"minute\", vol_last_seen, latest_ts) \u003c= 5\n| STATS avail_per = MAX(k8s.volume.available),\n        cap_per = MAX(k8s.volume.capacity)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.uid, k8s.volume.name\n| STATS avail = SUM(avail_per), cap = SUM(cap_per)\n  BY timestamp\n| EVAL bucket_util = CASE(\n    cap \u003e 0,\n    1.0 - TO_DOUBLE(avail) / TO_DOUBLE(cap),\n    NULL\n  )\n| WHERE bucket_util IS NOT NULL\n| SORT timestamp\n| STATS\n    utilization = ROUND(AVG(bucket_util), 4),\n    utilization_last = ROUND(LAST(bucket_util, timestamp), 4)\n| EVAL max_value = 1.0\n| KEEP utilization, utilization_last, max_value"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.volume.name IS NOT NULL\n  AND k8s.volume.name != \"\"\n  AND k8s.volume.available IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| INLINE STATS vol_last_seen = MAX(@timestamp) BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(vol_last_seen)\n| WHERE DATE_DIFF(\"minute\", vol_last_seen, latest_ts) \u003c= 5\n| STATS avail_per = MAX(k8s.volume.available),\n        cap_per = MAX(k8s.volume.capacity)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.uid, k8s.volume.name\n| STATS avail = SUM(avail_per), cap = SUM(cap_per)\n  BY timestamp\n| EVAL bucket_util = CASE(\n    cap \u003e 0,\n    1.0 - TO_DOUBLE(avail) / TO_DOUBLE(cap),\n    NULL\n  )\n| WHERE bucket_util IS NOT NULL\n| SORT timestamp\n| STATS\n    utilization = ROUND(AVG(bucket_util), 4),\n    utilization_last = ROUND(LAST(bucket_util, timestamp), 4)\n| EVAL max_value = 1.0\n| KEEP utilization, utilization_last, max_value"
+                            },
+                            "visualization": {
+                                "layerId": "b59030fa-1247-4836-bc0b-78338b2fd664",
+                                "layerType": "data",
+                                "maxAccessor": "acd3ad76-ef75-4b39-905a-f9d72ca98b5e",
+                                "metricAccessor": "utilization",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#24c292",
+                                                "stop": null
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "stop": 33.33
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "stop": 66.66
+                                            }
+                                        ],
+                                        "continuity": "all",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": null,
+                                        "rangeType": "percent",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24c292",
+                                                "stop": 33.33
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "stop": 66.66
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "stop": 100
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "secondaryLabel": "Last value vs Avg",
+                                "secondaryMetricAccessor": "a4da336b-b405-4803-8c92-c6dc229443a7",
+                                "secondaryTrend": {
+                                    "baselineValue": "primary",
+                                    "paletteId": "compare_to",
+                                    "reversed": true,
+                                    "type": "dynamic",
+                                    "visuals": "both"
+                                },
+                                "showBar": true,
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Last volume utilization value for this deployment in the selected time range.\n\n\"Last value vs Avg\" shows how the most recent reading compares to the time-range average.",
+                    "hide_title": true
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "v3-wd-volume-gauge",
+                    "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
+                    "w": 8,
+                    "x": 0,
+                    "y": 12
+                },
+                "panelIndex": "v3-wd-volume-gauge",
                 "type": "vis"
             },
             {
@@ -1771,7 +1297,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap_per)\n| EVAL total_gb = ROUND(total_cap, 2)\n| KEEP total_gb"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n    AND k8s.volume.name IS NOT NULL\n    AND k8s.volume.name != \"\"\n| STATS cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap_per)\n| EVAL total_gb = ROUND(TO_DOUBLE(total_cap) , 2)\n| KEEP total_gb"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1781,34 +1307,219 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n| STATS cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap_per)\n| EVAL total_gb = ROUND(total_cap, 2)\n| KEEP total_gb"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n    AND k8s.volume.name IS NOT NULL\n    AND k8s.volume.name != \"\"\n| STATS cap_per = LAST(k8s.volume.capacity, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap_per)\n| EVAL total_gb = ROUND(TO_DOUBLE(total_cap) , 2)\n| KEEP total_gb"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
-                                "color": "#61A2FF",
                                 "colorMode": "background",
                                 "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
                                 "layerType": "data",
                                 "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
                                 "showBar": false,
-                                "subtitle": "Last value"
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": []
+                    "description": "Total volume capacity across all pods and volumes in the deployment"
                 },
                 "gridData": {
-                    "h": 5,
+                    "h": 6,
                     "i": "v4-wd-vol-cap",
                     "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
                     "w": 8,
                     "x": 0,
-                    "y": 10
+                    "y": 18
                 },
                 "panelIndex": "v4-wd-vol-cap",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "managed": false,
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "38938a7d-dc5b-4af0-a560-8e5474eb52d1": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "utilization",
+                                                    "customLabel": true,
+                                                    "fieldName": "utilization_last",
+                                                    "inMetricDimension": true,
+                                                    "label": "Memory utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization_last"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "4c0290f5-2f60-45bc-84a1-6892e5403071",
+                                                    "fieldName": "max_value",
+                                                    "label": "max_value",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "max_value"
+                                                        },
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "e8770b8a-19ab-4bc1-a180-865ce99103f9",
+                                                    "customLabel": false,
+                                                    "fieldName": "utilization",
+                                                    "inMetricDimension": true,
+                                                    "label": "utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "query": {
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| INLINE STATS pod_last_seen = MAX(@timestamp) BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(pod_last_seen)\n| WHERE DATE_DIFF(\"minute\", pod_last_seen, latest_ts) \u003c= 5\n| STATS pod_util = MAX(k8s.pod.memory_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| STATS bucket_util = AVG(pod_util)\n  BY timestamp\n| SORT timestamp\n| STATS\n    utilization = ROUND(AVG(bucket_util), 4),\n    utilization_last = ROUND(LAST(bucket_util, timestamp), 4)\n| EVAL max_value = 1.0\n| KEEP utilization, utilization_last, max_value"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| INLINE STATS pod_last_seen = MAX(@timestamp) BY k8s.pod.name\n| INLINE STATS latest_ts = MAX(pod_last_seen)\n| WHERE DATE_DIFF(\"minute\", pod_last_seen, latest_ts) \u003c= 5\n| STATS pod_util = MAX(k8s.pod.memory_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| STATS bucket_util = AVG(pod_util)\n  BY timestamp\n| SORT timestamp\n| STATS\n    utilization = ROUND(AVG(bucket_util), 4),\n    utilization_last = ROUND(LAST(bucket_util, timestamp), 4)\n| EVAL max_value = 1.0\n| KEEP utilization, utilization_last, max_value"
+                            },
+                            "visualization": {
+                                "layerId": "38938a7d-dc5b-4af0-a560-8e5474eb52d1",
+                                "layerType": "data",
+                                "maxAccessor": "4c0290f5-2f60-45bc-84a1-6892e5403071",
+                                "metricAccessor": "utilization",
+                                "palette": {
+                                    "name": "status",
+                                    "params": {
+                                        "colorStops": [],
+                                        "continuity": "all",
+                                        "maxSteps": 5,
+                                        "name": "status",
+                                        "progression": "fixed",
+                                        "rangeMax": 100,
+                                        "rangeMin": 0,
+                                        "rangeType": "percent",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24c292",
+                                                "stop": 33.33
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "stop": 66.66
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "stop": 100
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "secondaryLabel": "Last value vs Avg",
+                                "secondaryMetricAccessor": "e8770b8a-19ab-4bc1-a180-865ce99103f9",
+                                "secondaryTrend": {
+                                    "baselineValue": "primary",
+                                    "paletteId": "compare_to",
+                                    "reversed": true,
+                                    "type": "dynamic",
+                                    "visuals": "both"
+                                },
+                                "showBar": true,
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Memory limit utilization for this deployment in the selected time range.\n\n\"Last value vs Avg\" shows how the most recent reading compares to the time-range average.",
+                    "hide_title": true
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "v3-wd-memory-card",
+                    "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
+                    "w": 8,
+                    "x": 24,
+                    "y": 0
+                },
+                "panelIndex": "v3-wd-memory-card",
                 "type": "vis"
             },
             {
@@ -1841,7 +1552,156 @@
                                         }
                                     ],
                                     "layers": {
-                                        "e9d8a440-92d9-4be8-aecf-a08372b63cce": {
+                                        "27c8778d-41d0-47b6-b0da-cb1478a5794f": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
+                                                    "customLabel": true,
+                                                    "fieldName": "total_gb",
+                                                    "inMetricDimension": true,
+                                                    "label": "Memory limit",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.memory_limit IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS limit_per = LAST(k8s.container.memory_limit, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(limit_per)\n| EVAL total_gb = ROUND(total_limit, 2)\n| KEEP total_gb"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.memory_limit IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS limit_per = LAST(k8s.container.memory_limit, @timestamp),\n        last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(limit_per)\n| EVAL total_gb = ROUND(total_limit, 2)\n| KEEP total_gb"
+                            },
+                            "visualization": {
+                                "applyColorTo": "background",
+                                "colorMode": "background",
+                                "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
+                                "layerType": "data",
+                                "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "showBar": false,
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Total memory limit across all containers in the deployment"
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "v4-wd-mem-limit",
+                    "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
+                    "w": 8,
+                    "x": 24,
+                    "y": 6
+                },
+                "panelIndex": "v4-wd-mem-limit",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "managed": false,
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "1c2ef488-a80e-4e43-9b97-ccfdf20239f8": {
+                                            "allColumns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Memory working set",
+                                                    "customLabel": false,
+                                                    "fieldName": "Memory working set",
+                                                    "inMetricDimension": true,
+                                                    "label": "Memory working set",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
                                             "columns": [
                                                 {
                                                     "columnId": "timestamp",
@@ -1854,20 +1714,58 @@
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "Pod count",
+                                                    "columnId": "k8s.deployment.name",
                                                     "customLabel": false,
-                                                    "fieldName": "Pod count",
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Memory working set",
+                                                    "customLabel": false,
+                                                    "fieldName": "Memory working set",
                                                     "inMetricDimension": true,
-                                                    "label": "Pod count",
+                                                    "label": "Memory working set",
                                                     "meta": {
                                                         "esType": "long",
                                                         "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS `Pod count` = COUNT_DISTINCT(k8s.pod.uid)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Pod count`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS pod_ws = MAX(k8s.pod.memory.working_set)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.uid\n| STATS `Memory working set` = SUM(pod_ws)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| SORT timestamp ASC, `Memory working set` DESC\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, `Memory working set`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1877,11 +1775,11 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS `Pod count` = COUNT_DISTINCT(k8s.pod.uid)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, `Pod count`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS pod_ws = MAX(k8s.pod.memory.working_set)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.uid\n| STATS `Memory working set` = SUM(pod_ws)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| SORT timestamp ASC, `Memory working set` DESC\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, `Memory working set`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -1899,7 +1797,7 @@
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "Pod count"
+                                            "Memory working set"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
@@ -1921,15 +1819,20 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "e9d8a440-92d9-4be8-aecf-a08372b63cce",
+                                        "layerId": "1c2ef488-a80e-4e43-9b97-ccfdf20239f8",
                                         "layerType": "data",
                                         "seriesType": "line",
+                                        "splitAccessors": [
+                                            "k8s.deployment.name",
+                                            "k8s.namespace.name",
+                                            "k8s.cluster.name"
+                                        ],
                                         "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "layout": "list",
+                                    "maxLines": 2,
                                     "position": "bottom"
                                 },
                                 "preferredSeriesType": "line",
@@ -1945,17 +1848,18 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "title": "Pod count over time"
+                    "description": "Total memory working set for the deployment over time.",
+                    "title": "Memory working set over time"
                 },
                 "gridData": {
-                    "h": 10,
-                    "i": "61ce689b-d715-46cf-a04d-7be064e85854",
+                    "h": 12,
+                    "i": "ea8bf41a-91db-4159-bdc2-760693bfb275",
                     "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
-                    "w": 24,
-                    "x": 24,
-                    "y": 10
+                    "w": 16,
+                    "x": 32,
+                    "y": 0
                 },
-                "panelIndex": "61ce689b-d715-46cf-a04d-7be064e85854",
+                "panelIndex": "ea8bf41a-91db-4159-bdc2-760693bfb275",
                 "type": "vis"
             },
             {
@@ -1964,17 +1868,17 @@
                         "references": [],
                         "state": {
                             "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
                                     "allowHidden": false,
                                     "allowNoIndex": false,
                                     "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                     "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
                                     "runtimeFieldMap": {},
                                     "sourceFilters": [],
                                     "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
                                     "type": "esql"
                                 }
                             },
@@ -1982,54 +1886,16 @@
                                 "textBased": {
                                     "indexPatternRefs": [
                                         {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
                                         }
                                     ],
                                     "layers": {
-                                        "fbb38c39-4993-8a17-aaee-4bff6adb03ba": {
+                                        "9eca61c7-1e77-4149-b1a6-f9266645bf77": {
                                             "columns": [
                                                 {
-                                                    "columnId": "58394d5d-f244-ac4d-0efc-444da7cb5700",
-                                                    "customLabel": true,
-                                                    "fieldName": "desired",
-                                                    "inMetricDimension": true,
-                                                    "label": "Desired",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1d07e96c-590b-03f1-4108-cbe912c2ac4a",
-                                                    "customLabel": true,
-                                                    "fieldName": "available",
-                                                    "inMetricDimension": true,
-                                                    "label": "Available",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "24258928-91bb-7193-d4df-0329829a7575",
+                                                    "columnId": "timestamp",
                                                     "customLabel": false,
                                                     "fieldName": "timestamp",
                                                     "label": "timestamp",
@@ -2037,11 +1903,52 @@
                                                         "esType": "date",
                                                         "type": "date"
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.deployment.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "Pod Count",
+                                                    "customLabel": false,
+                                                    "fieldName": "Pod Count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Pod Count",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
                                                 }
                                             ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, desired, available"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n| STATS `Pod Count` = COUNT_DISTINCT(k8s.pod.uid)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, `Pod Count`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2051,26 +1958,36 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, desired, available"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n| STATS `Pod Count` = COUNT_DISTINCT(k8s.pod.uid)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, `Pod Count`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
                                     "x": false,
-                                    "yLeft": false
+                                    "yLeft": false,
+                                    "yRight": true
                                 },
-                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "58394d5d-f244-ac4d-0efc-444da7cb5700",
-                                            "1d07e96c-590b-03f1-4108-cbe912c2ac4a"
+                                            "Pod Count"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "paletteId": "elastic_line_optimized",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2085,19 +2002,28 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "fbb38c39-4993-8a17-aaee-4bff6adb03ba",
+                                        "layerId": "9eca61c7-1e77-4149-b1a6-f9266645bf77",
                                         "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area",
-                                        "showGridlines": false,
-                                        "xAccessor": "24258928-91bb-7193-d4df-0329829a7575"
+                                        "seriesType": "line",
+                                        "splitAccessors": [
+                                            "k8s.cluster.name",
+                                            "k8s.namespace.name",
+                                            "k8s.deployment.name"
+                                        ],
+                                        "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "maxLines": 3,
                                     "position": "bottom"
                                 },
-                                "preferredSeriesType": "area",
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
                                 "valueLabels": "hide"
                             }
                         },
@@ -2105,17 +2031,18 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "Available vs desired replicas over time. SUM per 1m bucket."
+                    "description": "Number of pods in the deployment over time.",
+                    "title": "Pod count over time"
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "v2-deploy-detail-replica-trend",
-                    "sectionId": "7e17c507-aaf1-4f4e-8b7d-7689ae5dc648",
-                    "w": 16,
-                    "x": 0,
-                    "y": 0
+                    "i": "61ce689b-d715-46cf-a04d-7be064e85854",
+                    "sectionId": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
+                    "w": 24,
+                    "x": 24,
+                    "y": 12
                 },
-                "panelIndex": "v2-deploy-detail-replica-trend",
+                "panelIndex": "61ce689b-d715-46cf-a04d-7be064e85854",
                 "type": "vis"
             },
             {
@@ -2286,7 +2213,7 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "Network I/O over time by direction (transmit/receive). SUM(RATE(k8s.node.network.io)) per 1m bucket.",
+                    "description": "Network throughput over time by direction (Network In / Network Out).",
                     "title": "Network I/O"
                 },
                 "gridData": {
@@ -2370,11 +2297,59 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "1b1eab8f-defb-43d0-afd6-45f48604a111",
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.deployment.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "8321bf01-7e2b-4887-90c4-9b682e109cf8",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.namespace.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "1ea5ad4f-db4e-4fc1-ab0d-e5ad57234539",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
                                                 }
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS `CPU limit utilization` = AVG(k8s.pod.cpu_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `CPU limit utilization`"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n    AND k8s.deployment.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS `CPU limit utilization` = MAX(k8s.pod.cpu_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.uid, k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, `CPU limit utilization`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2384,7 +2359,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS `CPU limit utilization` = AVG(k8s.pod.cpu_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `CPU limit utilization`"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n    AND k8s.deployment.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS `CPU limit utilization` = MAX(k8s.pod.cpu_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.uid, k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, `CPU limit utilization`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2413,7 +2388,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "default",
+                                            "paletteId": "elastic_line_optimized",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2430,19 +2405,22 @@
                                         },
                                         "layerId": "bc73b68b-c796-4d95-8b0f-2b4a91acca42",
                                         "layerType": "data",
-                                        "seriesType": "area_stacked",
+                                        "seriesType": "line",
                                         "splitAccessors": [
-                                            "k8s.pod.name"
+                                            "k8s.pod.name",
+                                            "1b1eab8f-defb-43d0-afd6-45f48604a111",
+                                            "8321bf01-7e2b-4887-90c4-9b682e109cf8",
+                                            "1ea5ad4f-db4e-4fc1-ab0d-e5ad57234539"
                                         ],
                                         "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "layout": "list",
+                                    "maxLines": 4,
                                     "position": "bottom"
                                 },
-                                "preferredSeriesType": "area",
+                                "preferredSeriesType": "line",
                                 "tickLabelsVisibilitySettings": {
                                     "x": true,
                                     "yLeft": true,
@@ -2455,7 +2433,7 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "CPU limit utilization per pod. avg(k8s.pod.cpu_limit_utilization). ",
+                    "description": "CPU limit utilization per pod over time.",
                     "title": "CPU limit utilization by pod"
                 },
                 "gridData": {
@@ -2539,11 +2517,59 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "7e1648b8-14de-4cac-b500-cfa755e76fcb",
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.deployment.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "3649db0f-ff70-416f-93f1-0332731d4ae0",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.namespace.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "cdaa5434-06ee-443f-bd5e-8a094d544128",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
                                                 }
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS `Memory limit utilization` = AVG(k8s.pod.memory_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Memory limit utilization`"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n    AND k8s.deployment.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS `Memory limit utilization` = MAX(k8s.pod.memory_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.uid, k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, `Memory limit utilization`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2553,7 +2579,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS `Memory limit utilization` = AVG(k8s.pod.memory_limit_utilization)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Memory limit utilization`"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n    AND k8s.deployment.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS `Memory limit utilization` = MAX(k8s.pod.memory_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.uid, k8s.pod.name\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, `Memory limit utilization`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2582,7 +2608,7 @@
                                             "colorMode": {
                                                 "type": "categorical"
                                             },
-                                            "paletteId": "default",
+                                            "paletteId": "elastic_line_optimized",
                                             "specialAssignments": [
                                                 {
                                                     "color": {
@@ -2599,19 +2625,22 @@
                                         },
                                         "layerId": "2f656966-ace6-4e73-bed0-866d9fe00b37",
                                         "layerType": "data",
-                                        "seriesType": "area_stacked",
+                                        "seriesType": "line",
                                         "splitAccessors": [
-                                            "k8s.pod.name"
+                                            "k8s.pod.name",
+                                            "7e1648b8-14de-4cac-b500-cfa755e76fcb",
+                                            "3649db0f-ff70-416f-93f1-0332731d4ae0",
+                                            "cdaa5434-06ee-443f-bd5e-8a094d544128"
                                         ],
                                         "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "layout": "list",
+                                    "maxLines": 4,
                                     "position": "bottom"
                                 },
-                                "preferredSeriesType": "area_stacked",
+                                "preferredSeriesType": "line",
                                 "tickLabelsVisibilitySettings": {
                                     "x": true,
                                     "yLeft": true,
@@ -2624,7 +2653,7 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "Memory limit utilization per pod. avg(k8s.pod.memory_limit_utilization). ",
+                    "description": "Memory limit utilization per pod over time.",
                     "title": "Memory limit utilization by pod"
                 },
                 "gridData": {
@@ -2636,6 +2665,167 @@
                     "y": 0
                 },
                 "panelIndex": "1bdbdcf2-9127-41aa-ab09-056b9e0b38f1",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "fbb38c39-4993-8a17-aaee-4bff6adb03ba": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "58394d5d-f244-ac4d-0efc-444da7cb5700",
+                                                    "customLabel": true,
+                                                    "fieldName": "desired",
+                                                    "inMetricDimension": true,
+                                                    "label": "Desired",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "1d07e96c-590b-03f1-4108-cbe912c2ac4a",
+                                                    "customLabel": true,
+                                                    "fieldName": "available",
+                                                    "inMetricDimension": true,
+                                                    "label": "Available",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "24258928-91bb-7193-d4df-0329829a7575",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, desired, available"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n  AND (k8s.deployment.available IS NOT NULL OR k8s.deployment.desired IS NOT NULL)\n| STATS\n    available = SUM(k8s.deployment.available),\n    desired = SUM(k8s.deployment.desired)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend)\n| SORT timestamp\n| KEEP timestamp, desired, available"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false
+                                },
+                                "curveType": "CURVE_MONOTONE_X",
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "58394d5d-f244-ac4d-0efc-444da7cb5700",
+                                            "1d07e96c-590b-03f1-4108-cbe912c2ac4a"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "fbb38c39-4993-8a17-aaee-4bff6adb03ba",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "24258928-91bb-7193-d4df-0329829a7575"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "bottom"
+                                },
+                                "preferredSeriesType": "line",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Available vs desired replicas for the deployment over time",
+                    "title": "Available vs desired replicas"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "v2-deploy-detail-replica-trend",
+                    "sectionId": "7e17c507-aaf1-4f4e-8b7d-7689ae5dc648",
+                    "w": 16,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "v2-deploy-detail-replica-trend",
                 "type": "vis"
             },
             {
@@ -2700,11 +2890,59 @@
                                                         "esType": "long",
                                                         "type": "number"
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "52ff1c19-46a4-41ef-a74d-73feef2a3cff",
+                                                    "fieldName": "k8s.deployment.name",
+                                                    "label": "k8s.deployment.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.deployment.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "ef7cdb12-cfa9-42bf-a467-ca3cd6d981e4",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.namespace.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "690f852e-0b99-4794-bf62-98bb9e71186b",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
                                                 }
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n    AND k8s.deployment.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.cluster.name IS NOT NULL\n| STATS container_restarts = MAX(k8s.container.restarts),\n        k8s.cluster.name = MAX(k8s.cluster.name),\n        k8s.deployment.name = MAX(k8s.deployment.name)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.namespace.name, k8s.pod.uid, k8s.pod.name, k8s.container.name\n| STATS `Restarts` = SUM(container_restarts)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, `Restarts`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2714,12 +2952,12 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.name IS NOT NULL\n    AND k8s.container.restarts IS NOT NULL\n| STATS `Restarts` = MAX(k8s.container.restarts)\n    BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend), k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.pod.name, `Restarts`"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.name != \"\"\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.name != \"\"\n  AND k8s.container.restarts IS NOT NULL\n    AND k8s.deployment.name != \"\"\n  AND k8s.deployment.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.cluster.name IS NOT NULL\n| STATS container_restarts = MAX(k8s.container.restarts),\n        k8s.cluster.name = MAX(k8s.cluster.name),\n        k8s.deployment.name = MAX(k8s.deployment.name)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend),\n     k8s.namespace.name, k8s.pod.uid, k8s.pod.name, k8s.container.name\n| STATS `Restarts` = SUM(container_restarts)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name\n| WHERE `Restarts` \u003e 0\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.deployment.name, k8s.pod.name, `Restarts`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
                                     "x": true,
-                                    "yLeft": true,
+                                    "yLeft": false,
                                     "yRight": true
                                 },
                                 "fittingFunction": "Linear",
@@ -2762,14 +3000,17 @@
                                         "layerType": "data",
                                         "seriesType": "line",
                                         "splitAccessors": [
-                                            "k8s.pod.name"
+                                            "k8s.pod.name",
+                                            "52ff1c19-46a4-41ef-a74d-73feef2a3cff",
+                                            "ef7cdb12-cfa9-42bf-a467-ca3cd6d981e4",
+                                            "690f852e-0b99-4794-bf62-98bb9e71186b"
                                         ],
                                         "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "layout": "list",
+                                    "maxLines": 4,
                                     "position": "bottom"
                                 },
                                 "preferredSeriesType": "line",
@@ -2785,7 +3026,7 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "Container restarts over time per pod. max(k8s.container.restarts) broken down by k8s.pod.name.",
+                    "description": "Container restarts per pod over time. Only pods with restarts greater than zero are shown.",
                     "title": "Container restarts by pod"
                 },
                 "gridData": {
@@ -2830,7 +3071,7 @@
                                     ],
                                     "layers": {
                                         "c329de2e-8aea-4a95-ac22-b3fcc0140f02": {
-                                            "columns": [
+                                            "allColumns": [
                                                 {
                                                     "columnId": "phase",
                                                     "customLabel": true,
@@ -2949,11 +3190,173 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "50bb1f98-8f65-4eed-be91-4416bd4b242f",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "restarts",
+                                                    "customLabel": true,
+                                                    "fieldName": "restarts",
+                                                    "inMetricDimension": true,
+                                                    "label": "Restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "phase",
+                                                    "customLabel": true,
+                                                    "fieldName": "phase",
+                                                    "inMetricDimension": true,
+                                                    "label": "Phase",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "cpu_usage",
+                                                    "customLabel": true,
+                                                    "fieldName": "cpu_usage",
+                                                    "inMetricDimension": true,
+                                                    "label": "CPU utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "memory_ws",
+                                                    "customLabel": true,
+                                                    "fieldName": "memory_ws",
+                                                    "inMetricDimension": true,
+                                                    "label": "Memory working set",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "mem_limit_util",
+                                                    "customLabel": true,
+                                                    "fieldName": "mem_limit_util",
+                                                    "inMetricDimension": true,
+                                                    "label": "Memory limit utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "fieldName": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.node.name",
+                                                    "fieldName": "k8s.node.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "50bb1f98-8f65-4eed-be91-4416bd4b242f",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
                                                 }
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = MAX(k8s.pod.cpu.usage),\n    memory_ws      = MAX(k8s.pod.memory.working_set),\n    mem_limit_util = MAX(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      phase_num == 5, \"Unknown\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2963,108 +3366,50 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n    AND k8s.deployment.name IS NOT NULL\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = AVG(k8s.pod.cpu.usage),\n    memory_ws      = AVG(k8s.pod.memory.working_set),\n    mem_limit_util = AVG(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = MAX(k8s.pod.cpu.usage),\n    memory_ws      = MAX(k8s.pod.memory.working_set),\n    mem_limit_util = MAX(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      phase_num == 5, \"Unknown\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
                             },
                             "visualization": {
                                 "columns": [
                                     {
-                                        "colorMapping": {
-                                            "assignments": [
-                                                {
-                                                    "color": {
-                                                        "colorIndex": 0,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                        "colorMode": "badge",
+                                        "columnId": "phase",
+                                        "palette": {
+                                            "name": "positive",
+                                            "params": {
+                                                "colorStops": [],
+                                                "continuity": "above",
+                                                "name": "positive",
+                                                "progression": "fixed",
+                                                "rangeMax": 100,
+                                                "rangeMin": 0,
+                                                "rangeType": "percent",
+                                                "reverse": false,
+                                                "steps": 5,
+                                                "stops": [
+                                                    {
+                                                        "color": "#d4efe6",
+                                                        "stop": 20
                                                     },
-                                                    "rules": [
-                                                        {
-                                                            "type": "raw",
-                                                            "value": "Running"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                },
-                                                {
-                                                    "color": {
-                                                        "colorIndex": 2,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                                    {
+                                                        "color": "#b1e4d1",
+                                                        "stop": 40
                                                     },
-                                                    "rules": [
-                                                        {
-                                                            "type": "raw",
-                                                            "value": "Succeeded"
-                                                        }
-                                                    ],
-                                                    "touched": true
-                                                },
-                                                {
-                                                    "color": {
-                                                        "colorIndex": 9,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                                    {
+                                                        "color": "#8cd9bb",
+                                                        "stop": 60
                                                     },
-                                                    "rules": [
-                                                        {
-                                                            "type": "raw",
-                                                            "value": "Pending"
-                                                        }
-                                                    ],
-                                                    "touched": true
-                                                },
-                                                {
-                                                    "color": {
-                                                        "colorIndex": 6,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                                    {
+                                                        "color": "#62cea6",
+                                                        "stop": 80
                                                     },
-                                                    "rules": [
-                                                        {
-                                                            "matchCase": true,
-                                                            "matchEntireWord": true,
-                                                            "pattern": "Failed",
-                                                            "type": "match"
-                                                        }
-                                                    ],
-                                                    "touched": true
-                                                },
-                                                {
-                                                    "color": {
-                                                        "colorIndex": 1,
-                                                        "paletteId": "neutral",
-                                                        "type": "categorical"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "matchCase": true,
-                                                            "matchEntireWord": true,
-                                                            "pattern": "Unknown",
-                                                            "type": "match"
-                                                        }
-                                                    ],
-                                                    "touched": true
-                                                }
-                                            ],
-                                            "colorMode": {
-                                                "type": "categorical"
+                                                    {
+                                                        "color": "#24c292",
+                                                        "stop": 100
+                                                    }
+                                                ]
                                             },
-                                            "paletteId": "default",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": true
-                                                }
-                                            ]
-                                        },
-                                        "colorMode": "cell",
-                                        "columnId": "phase"
+                                            "type": "palette"
+                                        }
                                     },
                                     {
                                         "columnId": "cpu_usage"
@@ -3088,18 +3433,18 @@
                                         "oneClickFilter": true
                                     },
                                     {
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "restarts",
                                         "palette": {
                                             "name": "custom",
                                             "params": {
                                                 "colorStops": [
                                                     {
-                                                        "color": "#24c292",
+                                                        "color": "#AEE8D2",
                                                         "stop": 0
                                                     },
                                                     {
-                                                        "color": "#F6726A",
+                                                        "color": "#FFC9C2",
                                                         "stop": 1
                                                     }
                                                 ],
@@ -3113,21 +3458,31 @@
                                                 "steps": 5,
                                                 "stops": [
                                                     {
-                                                        "color": "#24c292",
+                                                        "color": "#AEE8D2",
                                                         "stop": 1
                                                     },
                                                     {
-                                                        "color": "#F6726A",
-                                                        "stop": 1289
+                                                        "color": "#FFC9C2",
+                                                        "stop": 87
                                                     }
                                                 ]
                                             },
                                             "type": "palette"
                                         }
+                                    },
+                                    {
+                                        "columnId": "50bb1f98-8f65-4eed-be91-4416bd4b242f",
+                                        "isMetric": false,
+                                        "isTransposed": false,
+                                        "oneClickFilter": true
                                     }
                                 ],
                                 "layerId": "c329de2e-8aea-4a95-ac22-b3fcc0140f02",
                                 "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
                                 "showRowNumbers": true
                             }
                         },
@@ -3163,19 +3518,612 @@
                             "type": "dashboard_drilldown",
                             "use_filters": true,
                             "use_time_range": true
+                        },
+                        {
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+                            "label": "4. View cluster details",
+                            "open_in_new_tab": false,
+                            "trigger": "on_apply_filter",
+                            "type": "dashboard_drilldown",
+                            "use_filters": false,
+                            "use_time_range": true
                         }
                     ],
                     "title": "Pods"
                 },
                 "gridData": {
-                    "h": 13,
+                    "h": 12,
                     "i": "d4f41df0-258f-4758-96a0-69a880eeedef",
                     "sectionId": "61a3d034-f398-4c63-8dc4-e194c1804df8",
                     "w": 48,
                     "x": 0,
-                    "y": 0
+                    "y": 4
                 },
                 "panelIndex": "d4f41df0-258f-4758-96a0-69a880eeedef",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "cb765bf7-dc2e-49b8-9942-caa8e99152d8": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "pod_count",
+                                                    "customLabel": true,
+                                                    "fieldName": "pod_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Total pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "layerId": "cb765bf7-dc2e-49b8-9942-caa8e99152d8",
+                                "layerType": "data",
+                                "metricAccessor": "pod_count",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Total number of pods in the deployment."
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "ff6316b8-5d85-4073-a133-3a81563f1562",
+                    "sectionId": "61a3d034-f398-4c63-8dc4-e194c1804df8",
+                    "w": 8,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "ff6316b8-5d85-4073-a133-3a81563f1562",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "3bc2770a-3a71-4a1d-b98e-0ee0fec11fa3": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "running_count",
+                                                    "customLabel": true,
+                                                    "fieldName": "running_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Running pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 2\n| STATS running_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 2\n| STATS running_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "layerId": "3bc2770a-3a71-4a1d-b98e-0ee0fec11fa3",
+                                "layerType": "data",
+                                "metricAccessor": "running_count",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Total number of running pods in this deployment"
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "a8deba30-e932-4c60-8276-68b79421ef5b",
+                    "sectionId": "61a3d034-f398-4c63-8dc4-e194c1804df8",
+                    "w": 8,
+                    "x": 8,
+                    "y": 0
+                },
+                "panelIndex": "a8deba30-e932-4c60-8276-68b79421ef5b",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "9e43d473-7d6a-4a98-9ff7-3e5c01ee326a": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "pending_count",
+                                                    "customLabel": true,
+                                                    "fieldName": "pending_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Pending pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 1\n| STATS pending_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 1\n| STATS pending_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "value",
+                                "layerId": "9e43d473-7d6a-4a98-9ff7-3e5c01ee326a",
+                                "layerType": "data",
+                                "metricAccessor": "pending_count",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#24C292",
+                                                "stop": null
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "stop": 1
+                                            }
+                                        ],
+                                        "continuity": "all",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": null,
+                                        "rangeType": "number",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24C292",
+                                                "stop": 1
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "stop": 4
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of pending pods in the deployment"
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "61e1e7ab-90c2-41ac-b3d4-7e5cf3b2ee3f",
+                    "sectionId": "61a3d034-f398-4c63-8dc4-e194c1804df8",
+                    "w": 8,
+                    "x": 16,
+                    "y": 0
+                },
+                "panelIndex": "61e1e7ab-90c2-41ac-b3d4-7e5cf3b2ee3f",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "b57dea83-bc89-4237-bc1b-7addaec74af5": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "failed_count",
+                                                    "customLabel": true,
+                                                    "fieldName": "failed_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Failed pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 4\n| STATS failed_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 4\n| STATS failed_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "value",
+                                "layerId": "b57dea83-bc89-4237-bc1b-7addaec74af5",
+                                "layerType": "data",
+                                "metricAccessor": "failed_count",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#24C292",
+                                                "stop": null
+                                            },
+                                            {
+                                                "color": "#F6726A",
+                                                "stop": 1
+                                            }
+                                        ],
+                                        "continuity": "all",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": null,
+                                        "rangeType": "number",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24C292",
+                                                "stop": 1
+                                            },
+                                            {
+                                                "color": "#F6726A",
+                                                "stop": 18
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of failed pods in the deployment"
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "38b6524e-6dbd-4856-9e6a-f1072bbebafa",
+                    "sectionId": "61a3d034-f398-4c63-8dc4-e194c1804df8",
+                    "w": 8,
+                    "x": 24,
+                    "y": 0
+                },
+                "panelIndex": "38b6524e-6dbd-4856-9e6a-f1072bbebafa",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "c567806f-2484-4e2f-b8de-12bdd9fd78c8": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "succeeded_count",
+                                                    "customLabel": true,
+                                                    "fieldName": "succeeded_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Succeeded pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 3\n| STATS succeeded_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 3\n| STATS succeeded_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "background",
+                                "layerId": "c567806f-2484-4e2f-b8de-12bdd9fd78c8",
+                                "layerType": "data",
+                                "metricAccessor": "succeeded_count",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of succeeded pods in the deployment"
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "c3365a55-f4ed-43b7-84f5-cade02b68efc",
+                    "sectionId": "61a3d034-f398-4c63-8dc4-e194c1804df8",
+                    "w": 8,
+                    "x": 32,
+                    "y": 0
+                },
+                "panelIndex": "c3365a55-f4ed-43b7-84f5-cade02b68efc",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "6bd31e56-3ab5-40a2-a35b-8a91812fbe8b": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "unknown_count",
+                                                    "customLabel": true,
+                                                    "fieldName": "unknown_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Unknown",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 5\n| STATS unknown_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 5\n| STATS unknown_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "background",
+                                "layerId": "6bd31e56-3ab5-40a2-a35b-8a91812fbe8b",
+                                "layerType": "data",
+                                "metricAccessor": "unknown_count",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of pods with unknown phase in the deployment"
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "91f6447a-eb0a-4a8a-bb9d-17e872543abd",
+                    "sectionId": "61a3d034-f398-4c63-8dc4-e194c1804df8",
+                    "w": 8,
+                    "x": 40,
+                    "y": 0
+                },
+                "panelIndex": "91f6447a-eb0a-4a8a-bb9d-17e872543abd",
                 "type": "vis"
             }
         ],
@@ -3184,7 +4132,7 @@
                 "collapsed": false,
                 "gridData": {
                     "i": "57d2fdcc-67bf-4bfb-8da1-bf56753fd8bd",
-                    "y": 7
+                    "y": 3
                 },
                 "title": "Deployment capacity"
             },
@@ -3192,7 +4140,7 @@
                 "collapsed": false,
                 "gridData": {
                     "i": "7e17c507-aaf1-4f4e-8b7d-7689ae5dc648",
-                    "y": 8
+                    "y": 4
                 },
                 "title": "Deployment metrics"
             },
@@ -3200,23 +4148,23 @@
                 "collapsed": false,
                 "gridData": {
                     "i": "61a3d034-f398-4c63-8dc4-e194c1804df8",
-                    "y": 9
+                    "y": 5
                 },
                 "title": "Pods in deployment"
             }
         ],
-        "timeFrom": "now-30d/d",
+        "timeFrom": "2026-06-01T06:17:51.162Z",
         "timeRestore": true,
-        "timeTo": "now",
+        "timeTo": "2026-06-01T06:34:34.462Z",
         "title": "[Kubernetes OTel] Deployment Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-05-04T03:38:32.518Z",
+    "created_at": "2026-06-04T10:17:25.466Z",
     "id": "kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-deployment-back-link:link_243b4837-67bf-42ba-9008-1d6d1726618f_dashboard",
+            "name": "v3-deployment-back-link:link_2bfaa6d4-7122-4d25-b200-00f7e1ce1dca_dashboard",
             "type": "dashboard"
         },
         {
@@ -3235,13 +4183,13 @@
             "type": "dashboard"
         },
         {
-            "id": "metrics-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
+            "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "name": "d4f41df0-258f-4758-96a0-69a880eeedef:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "type": "dashboard"
         },
         {
             "id": "metrics-*",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[1].meta.index",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
             "type": "index-pattern"
         }
     ],

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
@@ -59,7 +59,7 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_2bfaa6d4-7122-4d25-b200-00f7e1ce1dca_dashboard",
+                            "destinationRefName": "link_4d10bd0a-70ef-4bc6-88ba-f8aada18ccdd_dashboard",
                             "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
@@ -518,7 +518,6 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Tracks CPU usage against configured CPU limits for each deployment over time. ",
-                    "drilldowns": [],
                     "title": "CPU usage vs limit over time"
                 },
                 "gridData": {
@@ -3371,45 +3370,97 @@
                             "visualization": {
                                 "columns": [
                                     {
-                                        "colorMode": "badge",
-                                        "columnId": "phase",
-                                        "palette": {
-                                            "name": "positive",
-                                            "params": {
-                                                "colorStops": [],
-                                                "continuity": "above",
-                                                "name": "positive",
-                                                "progression": "fixed",
-                                                "rangeMax": 100,
-                                                "rangeMin": 0,
-                                                "rangeType": "percent",
-                                                "reverse": false,
-                                                "steps": 5,
-                                                "stops": [
-                                                    {
-                                                        "color": "#d4efe6",
-                                                        "stop": 20
+                                        "colorMapping": {
+                                            "assignments": [
+                                                {
+                                                    "color": {
+                                                        "colorCode": "#AEE8D2",
+                                                        "type": "colorCode"
                                                     },
-                                                    {
-                                                        "color": "#b1e4d1",
-                                                        "stop": 40
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Running"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorCode": "#FFC9C2",
+                                                        "type": "colorCode"
                                                     },
-                                                    {
-                                                        "color": "#8cd9bb",
-                                                        "stop": 60
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Failed"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 3,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
                                                     },
-                                                    {
-                                                        "color": "#62cea6",
-                                                        "stop": 80
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Succeeded"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 9,
+                                                        "paletteId": "default",
+                                                        "type": "categorical"
                                                     },
-                                                    {
-                                                        "color": "#24c292",
-                                                        "stop": 100
-                                                    }
-                                                ]
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Pending"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                },
+                                                {
+                                                    "color": {
+                                                        "colorIndex": 0,
+                                                        "paletteId": "neutral",
+                                                        "type": "categorical"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "raw",
+                                                            "value": "Unknown"
+                                                        }
+                                                    ],
+                                                    "touched": true
+                                                }
+                                            ],
+                                            "colorMode": {
+                                                "type": "categorical"
                                             },
-                                            "type": "palette"
-                                        }
+                                            "paletteId": "default",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "colorMode": "badge",
+                                        "columnId": "phase"
                                     },
                                     {
                                         "columnId": "cpu_usage"
@@ -4153,18 +4204,18 @@
                 "title": "Pods in deployment"
             }
         ],
-        "timeFrom": "2026-06-01T06:17:51.162Z",
+        "timeFrom": "now-1h",
         "timeRestore": true,
-        "timeTo": "2026-06-01T06:34:34.462Z",
+        "timeTo": "now",
         "title": "[Kubernetes OTel] Deployment Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-06-04T10:17:25.466Z",
+    "created_at": "2026-06-15T05:59:56.666Z",
     "id": "kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-deployment-back-link:link_2bfaa6d4-7122-4d25-b200-00f7e1ce1dca_dashboard",
+            "name": "v3-deployment-back-link:link_4d10bd0a-70ef-4bc6-88ba-f8aada18ccdd_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 2.1.0-preview8
+version: 2.1.0-preview9
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:


### PR DESCRIPTION

- Enhancement


## Proposed commit message

- Improvements to the Overview, Workloads, and Deployment details dashboards

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Package upgrade testing 

## How to test this PR locally

- `elastic-package build && elastic-package stack up -v -d --services package-registry`

## Screenshots

#### Deployment details
<img width="1920" height="2237" alt="screencapture-localhost-5601-app-dashboards-2026-06-15-10_59_19" src="https://github.com/user-attachments/assets/235843ca-60b0-4ee5-aa9f-114154206b92" />

#### Workloads
<img width="1920" height="2405" alt="screencapture-localhost-5601-app-dashboards-2026-06-15-11_00_08" src="https://github.com/user-attachments/assets/dc2fe3ec-340b-49c4-8edd-e8ccb408e1ee" />

#### Deployment details
<img width="1920" height="2237" alt="screencapture-localhost-5601-app-dashboards-2026-06-15-11_01_05" src="https://github.com/user-attachments/assets/62328fc9-5fe8-404e-8281-fa5ab25279c0" />




