### PR TITLE
[ti_opencti] Fix multi-value filter fields rendered as strings instead of YAML lists

### DIFF
--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.14.1"
+  changes:
+    - description: Fix multi-value filter fields rendered as comma-separated strings instead of YAML lists in CEL state.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.14.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix multi-value filter fields rendered as comma-separated strings instead of YAML lists in CEL state.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19527
 - version: "2.14.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-default.expected
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-default.expected
@@ -1,0 +1,548 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: ti_opencti
+      name: test-default-ti_opencti
+      streams:
+        - auth.oauth2: null
+          config_version: 2
+          data_stream:
+            dataset: ti_opencti.indicator
+          fields:
+            _conf:
+                url: https://opencti.example.com
+          fields_under_root: true
+          interval: 5m
+          keep_null: true
+          max_executions: 1000
+          program: |
+            request(
+              "POST",
+              state.url.trim_suffix("graphql").trim_suffix("/") + "/graphql"
+            ).with({
+              "Header": ({
+                "Content-Type": ["application/json"]
+              }).with(
+                has(state.api_key) && size(state.api_key) > 0 ?
+                  { "Authorization": ["Bearer " + state.api_key] }
+                :
+                  {}
+              )
+            }).with({
+              "Body": {
+                "query": state.query,
+                "variables": {
+                  "after": has(state.cursor) && has(state.cursor.value) ? state.cursor.value : null,
+                  "first": state.page_size,
+                  "orderBy": "modified",
+                  "orderMode": "asc",
+                  "filters": {
+                    "mode": "and",
+                    "filters": (
+                      // Define all possible filters with their configurations
+                      [
+                        {
+                          "condition": true,  // Always include entity_type filter
+                          "key": "entity_type",
+                          "values": ["Indicator"],
+                          "operator": "eq"
+                        },
+                        {
+                          "condition": has(state.pattern_types) && size(state.pattern_types) > 0,
+                          "key": "pattern_type",
+                          "values": state.?pattern_types.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.indicator_types) && size(state.indicator_types) > 0,
+                          "key": "indicator_types",
+                          "values": state.?indicator_types.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.revoked) && state.revoked != "",
+                          "key": "revoked",
+                          "values": [string(state.?revoked.orValue(""))],
+                          "operator": "eq"
+                        },
+                        {
+                          "condition": has(state.valid_from_start) && state.valid_from_start != null,
+                          "key": "valid_from",
+                          "values": [state.?valid_from_start.orValue("")],
+                          "operator": "gte"
+                        },
+                        {
+                          "condition": has(state.valid_until_end) && state.valid_until_end != null,
+                          "key": "valid_until",
+                          "values": [state.?valid_until_end.orValue("")],
+                          "operator": "lte"
+                        },
+                        {
+                          "condition": has(state.label_ids) && size(state.label_ids) > 0,
+                          "key": "objectLabel",
+                          "values": state.?label_ids.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.confidence_min) && state.confidence_min != null,
+                          "key": "confidence",
+                          "values": [string(state.?confidence_min.orValue(0))],
+                          "operator": "gte"
+                        },
+                        {
+                          "condition": has(state.author_ids) && size(state.author_ids) > 0,
+                          "key": "createdBy",
+                          "values": state.?author_ids.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.creator_ids) && size(state.creator_ids) > 0,
+                          "key": "creator_id",
+                          "values": state.?creator_ids.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.created_after) && state.created_after != null,
+                          "key": "created",
+                          "values": [state.?created_after.orValue("")],
+                          "operator": "gt"
+                        },
+                        {
+                          "condition": has(state.last_modified) && state.last_modified != null,
+                          "key": "updated_at",
+                          "values": [state.?last_modified.orValue("")],
+                          "operator": "gt"
+                        },
+                        {
+                          "condition": !has(state.last_modified) && has(state.modified_after) && state.modified_after != null,
+                          "key": "updated_at",
+                          "values": [state.?modified_after.orValue("")],
+                          "operator": "gt"
+                        },
+                        {
+                          "condition": has(state.marking_ids) && size(state.marking_ids) > 0,
+                          "key": "objectMarking",
+                          "values": state.?marking_ids.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        }
+                      ]
+                      // Filter to only include filters where condition is true
+                      // and map to create the final filter objects (removing the condition field)
+                      .map(f, f.condition, {
+                        "key": f.key,
+                        "values": f.values,
+                        "operator": f.operator
+                      }.with(has(f.mode) ? {"mode": f.mode} : {}))
+                    ),
+                    "filterGroups": []
+                  }
+                }
+              }.encode_json()
+            }).do_request().as(resp,
+              bytes(resp.Body).decode_json().as(body,
+                has(body.errors) && size(body.errors) > 0 ?
+                  state.with({
+                    "events": [{
+                      "error": { "message": body.errors.map(e, e.message) },
+                      "event": { "original": body.encode_json() }
+                    }],
+                    "last_modified": state.?last_modified.orValue(null)
+                  })
+                :
+                  state.with({
+                    "events": body.data.indicators.edges.map(e, e.node.with(
+                      has(state.preserve_original_event) && state.preserve_original_event ?
+                        { "event": { "original": e.node.encode_json() } }
+                      :
+                        {}
+                    )),
+                    "want_more": body.data.indicators.pageInfo.hasNextPage,
+                    "cursor": { "value": body.data.indicators.pageInfo.endCursor },
+                    "last_modified": has(body.data.indicators.edges) && body.data.indicators.edges.size() > 0 ?
+                      body.data.indicators.edges.map(e, timestamp(e.node.modified)).max()
+                    :
+                      state.?last_modified.orValue(null)
+                  })
+                )
+              )
+          publisher_pipeline.disable_host: true
+          redact:
+            fields:
+                - api_key
+          resource.ssl: null
+          resource.timeout: 30s
+          resource.tracer:
+            enabled: false
+            filename: ../../logs/cel/http-request-trace-*.ndjson
+            maxbackups: 5
+          resource.url: https://opencti.example.com
+          state:
+            api_key: ${SECRET_0}
+            last_modified: null
+            page_size: 50
+            preserve_original_event: false
+            query: |
+                query IndicatorsLinesPaginationQuery(
+                  $search: String
+                  $filters: FilterGroup
+                  $first: Int!
+                  $after: ID
+                  $orderBy: IndicatorsOrdering
+                  $orderMode: OrderingMode
+                ) {
+                  indicators(
+                    search: $search
+                    filters: $filters
+                    first: $first
+                    after: $after
+                    orderBy: $orderBy
+                    orderMode: $orderMode
+                  ) {
+                    edges {
+                      node {
+                        ...IndicatorLine_node
+                      }
+                      cursor
+                    }
+                    pageInfo {
+                      endCursor
+                      hasNextPage
+                      globalCount
+                    }
+                  }
+                }
+                fragment IndicatorLine_node on Indicator {
+                  id
+                  standard_id
+                  is_inferred
+                  revoked
+                  confidence
+                  lang
+                  created
+                  modified
+                  pattern_type
+                  pattern_version
+                  pattern
+                  name
+                  description
+                  valid_from
+                  valid_until
+                  x_opencti_score
+                  x_opencti_detection
+                  x_opencti_main_observable_type
+                  createdBy {
+                    identity_class
+                    name
+                  }
+                  objectMarking {
+                    definition_type
+                    definition
+                  }
+                  objectLabel {
+                    value
+                  }
+                  killChainPhases {
+                    phase_name
+                    kill_chain_name
+                  }
+                  externalReferences(first: 100) {
+                    edges {
+                      node {
+                        external_id
+                        source_name
+                        url
+                        description
+                      }
+                    }
+                  }
+                  observables(first: 100) { # StixCyberObservableConnection
+                    edges {
+                      node {
+                        id
+                        standard_id
+                        entity_type
+                        observable_value
+                        ... on AutonomousSystem {
+                          number # Int!
+                          name # String
+                          rir # String
+                        }
+                        ... on Directory {
+                          path # String!
+                          path_enc # String
+                          ctime # DateTime
+                          mtime # DateTime
+                          atime # DateTime
+                        }
+                        ... on DomainName {
+                          value # String!
+                        }
+                        ... on EmailAddr {
+                          value # String
+                          display_name # String
+                        }
+                        ... on EmailMessage {
+                          is_multipart # Boolean
+                          attribute_date # DateTime
+                          content_type # String
+                          message_id # String
+                          subject # String
+                          received_lines # [String]
+                          body # String
+                        }
+                        ... on EmailMimePartType {
+                          body # String
+                          content_type # String
+                          content_disposition # String
+                        }
+                        ... on Artifact {
+                          hashes { # [Hash]
+                            algorithm
+                            hash
+                          }
+                          mime_type # String
+                          payload_bin # String
+                          url # String
+                          encryption_algorithm # String
+                          decryption_key # String
+                          x_opencti_additional_names # [String]
+                        }
+                        ... on StixFile {
+                          hashes { # [Hash]
+                            algorithm
+                            hash
+                          }
+                          size # Int
+                          name # String
+                          name_enc # String
+                          magic_number_hex # String
+                          mime_type # String
+                          ctime # DateTime
+                          mtime # DateTime
+                          atime # DateTime
+                          x_opencti_additional_names # [String]
+                          obsContent { # Artifact
+                            payload_bin # String
+                            url # String
+                            encryption_algorithm # String
+                            decryption_key # String
+                          }
+                        }
+                        ... on X509Certificate {
+                          hashes { # [Hash]
+                            algorithm
+                            hash
+                          }
+                          is_self_signed # Boolean
+                          version # String
+                          serial_number # String
+                          signature_algorithm # String
+                          issuer # String
+                          subject # String
+                          subject_public_key_algorithm # String
+                          subject_public_key_modulus # String
+                          subject_public_key_exponent # Int
+                          validity_not_before # DateTime
+                          validity_not_after # DateTime
+                          basic_constraints # String
+                          name_constraints # String
+                          policy_constraints # String
+                          key_usage # String
+                          extended_key_usage # String
+                          subject_key_identifier # String
+                          authority_key_identifier # String
+                          subject_alternative_name # String
+                          issuer_alternative_name # String
+                          subject_directory_attributes # String
+                          crl_distribution_points # String
+                          inhibit_any_policy # String
+                          private_key_usage_period_not_before # DateTime
+                          private_key_usage_period_not_after # DateTime
+                          certificate_policies # String
+                          policy_mappings # String
+                        }
+                        ... on IPv4Addr {
+                          value # String
+                        }
+                        ... on IPv6Addr {
+                          value # String
+                        }
+                        ... on MacAddr {
+                          value # String
+                        }
+                        ... on Mutex {
+                          name # String
+                        }
+                        ... on NetworkTraffic {
+                          start # DateTime
+                          end # DateTime
+                          is_active # Boolean
+                          src_port # Int
+                          dst_port # Int
+                          protocols # [String]
+                          src_byte_count # Int
+                          dst_byte_count # Int
+                          src_packets # Int
+                          dst_packets # Int
+                        }
+                        ... on Process {
+                          is_hidden # Boolean
+                          pid # Int
+                          created_time # DateTime
+                          cwd # String
+                          x_opencti_description # String
+                          command_line # String!
+                          environment_variables # [String]
+                          aslr_enabled # Boolean
+                          dep_enabled # Boolean
+                          priority # String
+                          owner_sid # String
+                          window_title # String
+                          startup_info { # [Dictionary]
+                            key
+                            value
+                          }
+                          integrity_level # String
+                          service_name # String
+                          descriptions # [String]
+                          display_name # String
+                          group_name # String
+                          start_type # String
+                          service_type # String
+                          service_status # String
+                          serviceDlls { # StixFileConnection
+                            edges {
+                              node {
+                                hashes { # [Hash]
+                                  algorithm
+                                  hash
+                                }
+                                size # Int
+                                name # String
+                                name_enc # String
+                                magic_number_hex # String
+                                mime_type # String
+                                ctime # DateTime
+                                mtime # DateTime
+                                atime # DateTime
+                                x_opencti_additional_names # [String]
+                                obsContent { # Artifact
+                                  payload_bin # String
+                                  url # String
+                                  encryption_algorithm # String
+                                  decryption_key # String
+                                }
+                              }
+                            }
+                          }
+                        }
+                        ... on Software {
+                          name # String
+                          cpe # String
+                          swid # String
+                          languages # [String]
+                          vendor # String
+                          version # String
+                        }
+                        ... on Url {
+                          value # String
+                        }
+                        ... on UserAccount {
+                          user_id # String
+                          credential # String
+                          account_login # String
+                          account_type # String
+                          display_name # String
+                          is_service_account # Boolean
+                          is_privileged # Boolean
+                          can_escalate_privs # Boolean
+                          is_disabled # Boolean
+                          account_created # DateTime
+                          account_expires # DateTime
+                          credential_last_changed # DateTime
+                          account_first_login # DateTime
+                          account_last_login # DateTime
+                        }
+                        ... on WindowsRegistryKey {
+                          attribute_key # String
+                          modified_time # DateTime
+                          number_of_subkeys # Int
+                        }
+                        ... on WindowsRegistryValueType {
+                          name # String
+                          data # String
+                          data_type # String
+                        }
+                        ... on CryptographicKey {
+                          value # String
+                        }
+                        ... on CryptocurrencyWallet {
+                          value # String
+                        }
+                        ... on Hostname {
+                          value # String
+                        }
+                        ... on Text {
+                          value # String
+                        }
+                        ... on UserAgent {
+                          value # String
+                        }
+                        ... on BankAccount {
+                          iban # String
+                          bic # String
+                          account_number # String
+                        }
+                        ... on PhoneNumber {
+                          value # String
+                        }
+                        ... on PaymentCard {
+                          card_number # String!
+                          expiration_date # DateTime
+                          cvv # Int
+                          holder_name # String
+                        }
+                        ... on MediaContent {
+                          title # String
+                          content # String
+                          media_category # String
+                          url # String!
+                          publication_date # DateTime
+                        }
+                      }
+                    }
+                    pageInfo {
+                      globalCount
+                    }
+                  }
+                }
+            want_more: false
+          tags:
+            - forwarded
+            - opencti-indicator
+      type: cel
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-ti_opencti.indicator-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-default.yml
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-default.yml
@@ -1,0 +1,3 @@
+vars:
+  url: https://opencti.example.com
+  api_key: test-api-key

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-multi-values.expected
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-multi-values.expected
@@ -1,0 +1,572 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            name: ti_opencti
+      name: test-multi-values-ti_opencti
+      streams:
+        - auth.oauth2: null
+          config_version: 2
+          data_stream:
+            dataset: ti_opencti.indicator
+          fields:
+            _conf:
+                url: https://opencti.example.com
+          fields_under_root: true
+          interval: 10m
+          keep_null: true
+          max_executions: 500
+          program: |
+            request(
+              "POST",
+              state.url.trim_suffix("graphql").trim_suffix("/") + "/graphql"
+            ).with({
+              "Header": ({
+                "Content-Type": ["application/json"]
+              }).with(
+                has(state.api_key) && size(state.api_key) > 0 ?
+                  { "Authorization": ["Bearer " + state.api_key] }
+                :
+                  {}
+              )
+            }).with({
+              "Body": {
+                "query": state.query,
+                "variables": {
+                  "after": has(state.cursor) && has(state.cursor.value) ? state.cursor.value : null,
+                  "first": state.page_size,
+                  "orderBy": "modified",
+                  "orderMode": "asc",
+                  "filters": {
+                    "mode": "and",
+                    "filters": (
+                      // Define all possible filters with their configurations
+                      [
+                        {
+                          "condition": true,  // Always include entity_type filter
+                          "key": "entity_type",
+                          "values": ["Indicator"],
+                          "operator": "eq"
+                        },
+                        {
+                          "condition": has(state.pattern_types) && size(state.pattern_types) > 0,
+                          "key": "pattern_type",
+                          "values": state.?pattern_types.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.indicator_types) && size(state.indicator_types) > 0,
+                          "key": "indicator_types",
+                          "values": state.?indicator_types.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.revoked) && state.revoked != "",
+                          "key": "revoked",
+                          "values": [string(state.?revoked.orValue(""))],
+                          "operator": "eq"
+                        },
+                        {
+                          "condition": has(state.valid_from_start) && state.valid_from_start != null,
+                          "key": "valid_from",
+                          "values": [state.?valid_from_start.orValue("")],
+                          "operator": "gte"
+                        },
+                        {
+                          "condition": has(state.valid_until_end) && state.valid_until_end != null,
+                          "key": "valid_until",
+                          "values": [state.?valid_until_end.orValue("")],
+                          "operator": "lte"
+                        },
+                        {
+                          "condition": has(state.label_ids) && size(state.label_ids) > 0,
+                          "key": "objectLabel",
+                          "values": state.?label_ids.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.confidence_min) && state.confidence_min != null,
+                          "key": "confidence",
+                          "values": [string(state.?confidence_min.orValue(0))],
+                          "operator": "gte"
+                        },
+                        {
+                          "condition": has(state.author_ids) && size(state.author_ids) > 0,
+                          "key": "createdBy",
+                          "values": state.?author_ids.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.creator_ids) && size(state.creator_ids) > 0,
+                          "key": "creator_id",
+                          "values": state.?creator_ids.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        },
+                        {
+                          "condition": has(state.created_after) && state.created_after != null,
+                          "key": "created",
+                          "values": [state.?created_after.orValue("")],
+                          "operator": "gt"
+                        },
+                        {
+                          "condition": has(state.last_modified) && state.last_modified != null,
+                          "key": "updated_at",
+                          "values": [state.?last_modified.orValue("")],
+                          "operator": "gt"
+                        },
+                        {
+                          "condition": !has(state.last_modified) && has(state.modified_after) && state.modified_after != null,
+                          "key": "updated_at",
+                          "values": [state.?modified_after.orValue("")],
+                          "operator": "gt"
+                        },
+                        {
+                          "condition": has(state.marking_ids) && size(state.marking_ids) > 0,
+                          "key": "objectMarking",
+                          "values": state.?marking_ids.orValue([]),
+                          "operator": "eq",
+                          "mode": "or"
+                        }
+                      ]
+                      // Filter to only include filters where condition is true
+                      // and map to create the final filter objects (removing the condition field)
+                      .map(f, f.condition, {
+                        "key": f.key,
+                        "values": f.values,
+                        "operator": f.operator
+                      }.with(has(f.mode) ? {"mode": f.mode} : {}))
+                    ),
+                    "filterGroups": []
+                  }
+                }
+              }.encode_json()
+            }).do_request().as(resp,
+              bytes(resp.Body).decode_json().as(body,
+                has(body.errors) && size(body.errors) > 0 ?
+                  state.with({
+                    "events": [{
+                      "error": { "message": body.errors.map(e, e.message) },
+                      "event": { "original": body.encode_json() }
+                    }],
+                    "last_modified": state.?last_modified.orValue(null)
+                  })
+                :
+                  state.with({
+                    "events": body.data.indicators.edges.map(e, e.node.with(
+                      has(state.preserve_original_event) && state.preserve_original_event ?
+                        { "event": { "original": e.node.encode_json() } }
+                      :
+                        {}
+                    )),
+                    "want_more": body.data.indicators.pageInfo.hasNextPage,
+                    "cursor": { "value": body.data.indicators.pageInfo.endCursor },
+                    "last_modified": has(body.data.indicators.edges) && body.data.indicators.edges.size() > 0 ?
+                      body.data.indicators.edges.map(e, timestamp(e.node.modified)).max()
+                    :
+                      state.?last_modified.orValue(null)
+                  })
+                )
+              )
+          publisher_pipeline.disable_host: true
+          redact:
+            fields:
+                - api_key
+          resource.ssl: null
+          resource.timeout: 60s
+          resource.tracer:
+            enabled: true
+            filename: ../../logs/cel/http-request-trace-*.ndjson
+            maxbackups: 5
+          resource.url: https://opencti.example.com
+          state:
+            api_key: ${SECRET_0}
+            author_ids:
+                - 11111111-2222-3333-4444-555555555555
+                - 66666666-7777-8888-9999-000000000000
+            confidence_min: 50
+            created_after: "2024-01-01T00:00:00.000Z"
+            creator_ids:
+                - aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+                - ffffffff-0000-1111-2222-333333333333
+            indicator_types:
+                - malicious-activity
+                - anomalous-activity
+            label_ids:
+                - 4f433e3b-5c34-4b10-9374-724883cbcd92
+                - a1b2c3d4-e5f6-7890-abcd-ef1234567890
+            last_modified: null
+            marking_ids:
+                - marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9
+                - marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da
+            modified_after: "2024-06-01T00:00:00.000Z"
+            page_size: 100
+            pattern_types:
+                - stix
+                - sigma
+            preserve_original_event: true
+            query: |
+                query IndicatorsLinesPaginationQuery(
+                  $search: String
+                  $filters: FilterGroup
+                  $first: Int!
+                  $after: ID
+                  $orderBy: IndicatorsOrdering
+                  $orderMode: OrderingMode
+                ) {
+                  indicators(
+                    search: $search
+                    filters: $filters
+                    first: $first
+                    after: $after
+                    orderBy: $orderBy
+                    orderMode: $orderMode
+                  ) {
+                    edges {
+                      node {
+                        ...IndicatorLine_node
+                      }
+                      cursor
+                    }
+                    pageInfo {
+                      endCursor
+                      hasNextPage
+                      globalCount
+                    }
+                  }
+                }
+                fragment IndicatorLine_node on Indicator {
+                  id
+                  standard_id
+                  is_inferred
+                  revoked
+                  confidence
+                  lang
+                  created
+                  modified
+                  pattern_type
+                  pattern_version
+                  pattern
+                  name
+                  description
+                  valid_from
+                  valid_until
+                  x_opencti_score
+                  x_opencti_detection
+                  x_opencti_main_observable_type
+                  createdBy {
+                    identity_class
+                    name
+                  }
+                  objectMarking {
+                    definition_type
+                    definition
+                  }
+                  objectLabel {
+                    value
+                  }
+                  killChainPhases {
+                    phase_name
+                    kill_chain_name
+                  }
+                  externalReferences(first: 100) {
+                    edges {
+                      node {
+                        external_id
+                        source_name
+                        url
+                        description
+                      }
+                    }
+                  }
+                  observables(first: 100) { # StixCyberObservableConnection
+                    edges {
+                      node {
+                        id
+                        standard_id
+                        entity_type
+                        observable_value
+                        ... on AutonomousSystem {
+                          number # Int!
+                          name # String
+                          rir # String
+                        }
+                        ... on Directory {
+                          path # String!
+                          path_enc # String
+                          ctime # DateTime
+                          mtime # DateTime
+                          atime # DateTime
+                        }
+                        ... on DomainName {
+                          value # String!
+                        }
+                        ... on EmailAddr {
+                          value # String
+                          display_name # String
+                        }
+                        ... on EmailMessage {
+                          is_multipart # Boolean
+                          attribute_date # DateTime
+                          content_type # String
+                          message_id # String
+                          subject # String
+                          received_lines # [String]
+                          body # String
+                        }
+                        ... on EmailMimePartType {
+                          body # String
+                          content_type # String
+                          content_disposition # String
+                        }
+                        ... on Artifact {
+                          hashes { # [Hash]
+                            algorithm
+                            hash
+                          }
+                          mime_type # String
+                          payload_bin # String
+                          url # String
+                          encryption_algorithm # String
+                          decryption_key # String
+                          x_opencti_additional_names # [String]
+                        }
+                        ... on StixFile {
+                          hashes { # [Hash]
+                            algorithm
+                            hash
+                          }
+                          size # Int
+                          name # String
+                          name_enc # String
+                          magic_number_hex # String
+                          mime_type # String
+                          ctime # DateTime
+                          mtime # DateTime
+                          atime # DateTime
+                          x_opencti_additional_names # [String]
+                          obsContent { # Artifact
+                            payload_bin # String
+                            url # String
+                            encryption_algorithm # String
+                            decryption_key # String
+                          }
+                        }
+                        ... on X509Certificate {
+                          hashes { # [Hash]
+                            algorithm
+                            hash
+                          }
+                          is_self_signed # Boolean
+                          version # String
+                          serial_number # String
+                          signature_algorithm # String
+                          issuer # String
+                          subject # String
+                          subject_public_key_algorithm # String
+                          subject_public_key_modulus # String
+                          subject_public_key_exponent # Int
+                          validity_not_before # DateTime
+                          validity_not_after # DateTime
+                          basic_constraints # String
+                          name_constraints # String
+                          policy_constraints # String
+                          key_usage # String
+                          extended_key_usage # String
+                          subject_key_identifier # String
+                          authority_key_identifier # String
+                          subject_alternative_name # String
+                          issuer_alternative_name # String
+                          subject_directory_attributes # String
+                          crl_distribution_points # String
+                          inhibit_any_policy # String
+                          private_key_usage_period_not_before # DateTime
+                          private_key_usage_period_not_after # DateTime
+                          certificate_policies # String
+                          policy_mappings # String
+                        }
+                        ... on IPv4Addr {
+                          value # String
+                        }
+                        ... on IPv6Addr {
+                          value # String
+                        }
+                        ... on MacAddr {
+                          value # String
+                        }
+                        ... on Mutex {
+                          name # String
+                        }
+                        ... on NetworkTraffic {
+                          start # DateTime
+                          end # DateTime
+                          is_active # Boolean
+                          src_port # Int
+                          dst_port # Int
+                          protocols # [String]
+                          src_byte_count # Int
+                          dst_byte_count # Int
+                          src_packets # Int
+                          dst_packets # Int
+                        }
+                        ... on Process {
+                          is_hidden # Boolean
+                          pid # Int
+                          created_time # DateTime
+                          cwd # String
+                          x_opencti_description # String
+                          command_line # String!
+                          environment_variables # [String]
+                          aslr_enabled # Boolean
+                          dep_enabled # Boolean
+                          priority # String
+                          owner_sid # String
+                          window_title # String
+                          startup_info { # [Dictionary]
+                            key
+                            value
+                          }
+                          integrity_level # String
+                          service_name # String
+                          descriptions # [String]
+                          display_name # String
+                          group_name # String
+                          start_type # String
+                          service_type # String
+                          service_status # String
+                          serviceDlls { # StixFileConnection
+                            edges {
+                              node {
+                                hashes { # [Hash]
+                                  algorithm
+                                  hash
+                                }
+                                size # Int
+                                name # String
+                                name_enc # String
+                                magic_number_hex # String
+                                mime_type # String
+                                ctime # DateTime
+                                mtime # DateTime
+                                atime # DateTime
+                                x_opencti_additional_names # [String]
+                                obsContent { # Artifact
+                                  payload_bin # String
+                                  url # String
+                                  encryption_algorithm # String
+                                  decryption_key # String
+                                }
+                              }
+                            }
+                          }
+                        }
+                        ... on Software {
+                          name # String
+                          cpe # String
+                          swid # String
+                          languages # [String]
+                          vendor # String
+                          version # String
+                        }
+                        ... on Url {
+                          value # String
+                        }
+                        ... on UserAccount {
+                          user_id # String
+                          credential # String
+                          account_login # String
+                          account_type # String
+                          display_name # String
+                          is_service_account # Boolean
+                          is_privileged # Boolean
+                          can_escalate_privs # Boolean
+                          is_disabled # Boolean
+                          account_created # DateTime
+                          account_expires # DateTime
+                          credential_last_changed # DateTime
+                          account_first_login # DateTime
+                          account_last_login # DateTime
+                        }
+                        ... on WindowsRegistryKey {
+                          attribute_key # String
+                          modified_time # DateTime
+                          number_of_subkeys # Int
+                        }
+                        ... on WindowsRegistryValueType {
+                          name # String
+                          data # String
+                          data_type # String
+                        }
+                        ... on CryptographicKey {
+                          value # String
+                        }
+                        ... on CryptocurrencyWallet {
+                          value # String
+                        }
+                        ... on Hostname {
+                          value # String
+                        }
+                        ... on Text {
+                          value # String
+                        }
+                        ... on UserAgent {
+                          value # String
+                        }
+                        ... on BankAccount {
+                          iban # String
+                          bic # String
+                          account_number # String
+                        }
+                        ... on PhoneNumber {
+                          value # String
+                        }
+                        ... on PaymentCard {
+                          card_number # String!
+                          expiration_date # DateTime
+                          cvv # Int
+                          holder_name # String
+                        }
+                        ... on MediaContent {
+                          title # String
+                          content # String
+                          media_category # String
+                          url # String!
+                          publication_date # DateTime
+                        }
+                      }
+                    }
+                    pageInfo {
+                      globalCount
+                    }
+                  }
+                }
+            valid_from_start: "2024-01-01T00:00:00.000Z"
+            valid_until_end: "2024-12-31T23:59:59.000Z"
+            want_more: false
+          tags:
+            - preserve_original_event
+            - forwarded
+            - opencti-indicator
+      type: cel
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-ti_opencti.indicator-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-multi-values.yml
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/policy/test-multi-values.yml
@@ -1,0 +1,34 @@
+vars:
+  url: https://opencti.example.com
+  api_key: test-api-key
+data_stream:
+  vars:
+    interval: 10m
+    page_size: 100
+    max_executions: 500
+    http_client_timeout: 60s
+    preserve_original_event: true
+    enable_request_tracer: true
+    pattern_types:
+      - stix
+      - sigma
+    indicator_types:
+      - malicious-activity
+      - anomalous-activity
+    label_ids:
+      - 4f433e3b-5c34-4b10-9374-724883cbcd92
+      - a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    author_ids:
+      - 11111111-2222-3333-4444-555555555555
+      - 66666666-7777-8888-9999-000000000000
+    creator_ids:
+      - aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+      - ffffffff-0000-1111-2222-333333333333
+    marking_ids:
+      - marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9
+      - marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da
+    valid_from_start: "2024-01-01T00:00:00Z"
+    valid_until_end: "2024-12-31T23:59:59Z"
+    confidence_min: 50
+    created_after: "2024-01-01T00:00:00Z"
+    modified_after: "2024-06-01T00:00:00Z"

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -203,10 +203,16 @@ state:
   last_modified: null
   # Filter configuration
 {{#if pattern_types}}
-  pattern_types: {{pattern_types}}
+  pattern_types:
+{{#each pattern_types as |v|}}
+    - "{{v}}"
+{{/each}}
 {{/if}}
 {{#if indicator_types}}
-  indicator_types: {{indicator_types}}
+  indicator_types:
+{{#each indicator_types as |v|}}
+    - "{{v}}"
+{{/each}}
 {{/if}}
 {{#if revoked}}
   revoked: {{revoked}}
@@ -218,16 +224,25 @@ state:
   valid_until_end: {{valid_until_end}}
 {{/if}}
 {{#if label_ids}}
-  label_ids: {{label_ids}}
+  label_ids:
+{{#each label_ids as |v|}}
+    - "{{v}}"
+{{/each}}
 {{/if}}
 {{#if confidence_min}}
   confidence_min: {{confidence_min}}
 {{/if}}
 {{#if author_ids}}
-  author_ids: {{author_ids}}
+  author_ids:
+{{#each author_ids as |v|}}
+    - "{{v}}"
+{{/each}}
 {{/if}}
 {{#if creator_ids}}
-  creator_ids: {{creator_ids}}
+  creator_ids:
+{{#each creator_ids as |v|}}
+    - "{{v}}"
+{{/each}}
 {{/if}}
 {{#if created_after}}
   created_after: {{created_after}}
@@ -236,7 +251,10 @@ state:
   modified_after: {{modified_after}}
 {{/if}}
 {{#if marking_ids}}
-  marking_ids: {{marking_ids}}
+  marking_ids:
+{{#each marking_ids as |v|}}
+    - "{{v}}"
+{{/each}}
 {{/if}}
   # How to work with this API: https://docs.opencti.io/latest/deployment/integrations/#graphql-api
   # Relevant schema source: https://github.com/OpenCTI-Platform/opencti/blob/master/opencti-platform/opencti-graphql/config/schema/opencti.graphql

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: ti_opencti
 title: OpenCTI
-version: "2.14.0"
+version: "2.14.1"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
[ti_opencti] Fix multi-value filter fields rendered as strings instead of YAML lists

The Handlebars template for the indicator data stream used bare
{{var}} substitution for six multi-value filter fields (pattern_types,
indicator_types, label_ids, author_ids, creator_ids, marking_ids).
When Fleet passes multiple values, JavaScript's Array.toString()
serialises them as a comma-separated string, so CEL state receives a
single string instead of a list. This causes the OpenCTI GraphQL API
to silently return zero results.

Replace bare {{var}} with {{#each}} iteration to render each value as
a separate YAML list item, matching the pattern used by other CEL
integrations.

Add policy tests covering both default and multi-value configurations
to prevent regression.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Added policy tests with multi-valued fields pass and render correctly.
```
--- Test results for package: ti_opencti - START ---
╭────────────┬─────────────┬───────────┬───────────────────────┬────────┬───────────────╮
│ PACKAGE    │ DATA STREAM │ TEST TYPE │ TEST NAME             │ RESULT │  TIME ELAPSED │
├────────────┼─────────────┼───────────┼───────────────────────┼────────┼───────────────┤
│ ti_opencti │ indicator   │ policy    │ test-default.yml      │ PASS   │ 12.818391375s │
│ ti_opencti │ indicator   │ policy    │ test-multi-values.yml │ PASS   │ 11.053741417s │
╰────────────┴─────────────┴───────────┴───────────────────────┴────────┴───────────────╯
--- Test results for package: ti_opencti - END   ---
Done
```

Example:
```yaml
            author_ids:
                - 11111111-2222-3333-4444-555555555555
                - 66666666-7777-8888-9999-000000000000
```