### PR TITLE
crowdstrike: make max_executions configurable for CEL data streams

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.24.0"
+  changes:
+    - description: Make max_executions configurable for all CEL data streams to allow high-volume environments to complete pagination within a single interval.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19530
 - version: "3.23.0"
   changes:
     - description: Add categorization pipeline for new events in the FDR data stream.

--- a/packages/crowdstrike/data_stream/alert/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/alert/_dev/test/policy/test-default.expected
@@ -14,6 +14,7 @@ inputs:
           data_stream:
             dataset: crowdstrike.alert
           interval: 24h
+          max_executions: 1000
           program: |-
             state.with(
               (

--- a/packages/crowdstrike/data_stream/alert/_dev/test/policy/test-traced.expected
+++ b/packages/crowdstrike/data_stream/alert/_dev/test/policy/test-traced.expected
@@ -14,6 +14,7 @@ inputs:
           data_stream:
             dataset: crowdstrike.alert
           interval: 24h
+          max_executions: 1000
           program: |-
             state.with(
               (

--- a/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
@@ -1,5 +1,6 @@
 config_version: 2
 interval: {{interval}}
+max_executions: {{max_executions}}
 resource.tracer:
   enabled: {{enable_request_tracer}}
   filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/crowdstrike/data_stream/alert/manifest.yml
+++ b/packages/crowdstrike/data_stream/alert/manifest.yml
@@ -55,6 +55,15 @@ streams:
         show_user: false
         description: >-
           The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. Disabling the request tracer will delete any stored traces. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable) for details.
+      - name: max_executions
+        type: integer
+        title: Maximum Executions
+        description: >-
+          Maximum number of CEL program re-evaluations per collection interval. High-volume environments with large result sets may need a higher value to complete pagination within a single interval. Set to 0 for unlimited.
+        default: 1000
+        multi: false
+        required: true
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/crowdstrike/data_stream/host/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/host/_dev/test/policy/test-default.expected
@@ -14,6 +14,7 @@ inputs:
           data_stream:
             dataset: crowdstrike.host
           interval: 24h
+          max_executions: 1000
           program: |-
             // This logic determines which CrowdStrike devices endpoint to call. The
             // "/devices/combined/devices/v1" endpoint is not supported in GovCloud

--- a/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
@@ -1,5 +1,6 @@
 config_version: 2
 interval: {{interval}}
+max_executions: {{max_executions}}
 resource.tracer:
   enabled: {{enable_request_tracer}}
   filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/crowdstrike/data_stream/host/manifest.yml
+++ b/packages/crowdstrike/data_stream/host/manifest.yml
@@ -71,6 +71,15 @@ streams:
         show_user: false
         description: >-
           The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. Disabling the request tracer will delete any stored traces. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable) for details.
+      - name: max_executions
+        type: integer
+        title: Maximum Executions
+        description: >-
+          Maximum number of CEL program re-evaluations per collection interval. High-volume environments with large result sets may need a higher value to complete pagination within a single interval. Set to 0 for unlimited.
+        default: 1000
+        multi: false
+        required: true
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/crowdstrike/data_stream/identity_protection_assessment/_dev/test/policy/test-data-sources.expected
+++ b/packages/crowdstrike/data_stream/identity_protection_assessment/_dev/test/policy/test-data-sources.expected
@@ -18,6 +18,7 @@ inputs:
                 enable_nested_assessment_factors: false
           fields_under_root: true
           interval: 24h
+          max_executions: 1000
           program: |-
             (
               // If the domains call already filled worklist, skip the domains request until the list is worked off.

--- a/packages/crowdstrike/data_stream/identity_protection_assessment/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/identity_protection_assessment/_dev/test/policy/test-default.expected
@@ -18,6 +18,7 @@ inputs:
                 enable_nested_assessment_factors: false
           fields_under_root: true
           interval: 24h
+          max_executions: 1000
           program: |-
             (
               // If the domains call already filled worklist, skip the domains request until the list is worked off.

--- a/packages/crowdstrike/data_stream/identity_protection_assessment/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/identity_protection_assessment/agent/stream/cel.yml.hbs
@@ -1,5 +1,6 @@
 config_version: 2
 interval: {{interval}}
+max_executions: {{max_executions}}
 resource.tracer:
   enabled: {{enable_request_tracer}}
   filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/crowdstrike/data_stream/identity_protection_assessment/manifest.yml
+++ b/packages/crowdstrike/data_stream/identity_protection_assessment/manifest.yml
@@ -48,6 +48,15 @@ streams:
         show_user: false
         description: >-
           The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. Disabling the request tracer will delete any stored traces. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable) for details.
+      - name: max_executions
+        type: integer
+        title: Maximum Executions
+        description: >-
+          Maximum number of CEL program re-evaluations per collection interval. High-volume environments with large result sets may need a higher value to complete pagination within a single interval. Set to 0 for unlimited.
+        default: 1000
+        multi: false
+        required: true
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/crowdstrike/data_stream/identity_protection_timeline/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/identity_protection_timeline/_dev/test/policy/test-default.expected
@@ -14,6 +14,7 @@ inputs:
           data_stream:
             dataset: crowdstrike.identity_protection_timeline
           interval: 1h
+          max_executions: 1000
           program: |-
             state.with(
               (

--- a/packages/crowdstrike/data_stream/identity_protection_timeline/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/identity_protection_timeline/agent/stream/cel.yml.hbs
@@ -1,5 +1,6 @@
 config_version: 2
 interval: {{interval}}
+max_executions: {{max_executions}}
 resource.tracer:
   enabled: {{enable_request_tracer}}
   filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/crowdstrike/data_stream/identity_protection_timeline/manifest.yml
+++ b/packages/crowdstrike/data_stream/identity_protection_timeline/manifest.yml
@@ -54,6 +54,15 @@ streams:
         show_user: false
         description: >-
           The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. Disabling the request tracer will delete any stored traces. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable) for details.
+      - name: max_executions
+        type: integer
+        title: Maximum Executions
+        description: >-
+          Maximum number of CEL program re-evaluations per collection interval. High-volume environments with large result sets may need a higher value to complete pagination within a single interval. Set to 0 for unlimited.
+        default: 1000
+        multi: false
+        required: true
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/crowdstrike/data_stream/vulnerability/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/vulnerability/_dev/test/policy/test-default.expected
@@ -14,6 +14,7 @@ inputs:
           data_stream:
             dataset: crowdstrike.vulnerability
           interval: 24h
+          max_executions: 1000
           program: |-
             (
               state.?want_more.orValue(false) ?

--- a/packages/crowdstrike/data_stream/vulnerability/_dev/test/policy/test-traced.expected
+++ b/packages/crowdstrike/data_stream/vulnerability/_dev/test/policy/test-traced.expected
@@ -14,6 +14,7 @@ inputs:
           data_stream:
             dataset: crowdstrike.vulnerability
           interval: 24h
+          max_executions: 1000
           program: |-
             (
               state.?want_more.orValue(false) ?

--- a/packages/crowdstrike/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -1,5 +1,6 @@
 config_version: 2
 interval: {{interval}}
+max_executions: {{max_executions}}
 resource.tracer:
   enabled: {{enable_request_tracer}}
   filename: "../../logs/cel/http-request-trace-*.ndjson"

--- a/packages/crowdstrike/data_stream/vulnerability/manifest.yml
+++ b/packages/crowdstrike/data_stream/vulnerability/manifest.yml
@@ -66,6 +66,15 @@ streams:
         required: false
         show_user: false
         description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.
+      - name: max_executions
+        type: integer
+        title: Maximum Executions
+        description: >-
+          Maximum number of CEL program re-evaluations per collection interval. High-volume environments with large result sets may need a higher value to complete pagination within a single interval. Set to 0 for unlimited.
+        default: 1000
+        multi: false
+        required: true
+        show_user: false
       - name: tags
         type: text
         title: Tags

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "3.23.0"
+version: "3.24.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
crowdstrike: make max_executions configurable for CEL data streams

The CEL input's max_executions limit (default 1000) silently caps
pagination. High-volume environments — particularly the vulnerability
stream with a 24h interval and large result sets — can exhaust the
budget before completing, causing data loss with no degraded status.

Expose max_executions as a manifest variable on all five CEL data
streams (alert, host, vulnerability, identity_protection_assessment,
identity_protection_timeline). The default remains 1000, preserving
existing behaviour, but operators can now raise it without a code
change.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
