### PR TITLE
[ti_cybersixgill] Add agentless deployment

### DIFF
--- a/packages/ti_cybersixgill/_dev/build/docs/README.md
+++ b/packages/ti_cybersixgill/_dev/build/docs/README.md
@@ -2,6 +2,11 @@
 
 This integration connects with the commercial [Cybersixgill Darkfeed](https://cybersixgill.com/products/cyber-threat-intelligence/darkfeed) TAXII server.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Logs
 
 ### Threat

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.36.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.35.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19534
 - version: "1.35.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_cybersixgill/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_cybersixgill/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: cybersixgill

--- a/packages/ti_cybersixgill/docs/README.md
+++ b/packages/ti_cybersixgill/docs/README.md
@@ -2,6 +2,11 @@
 
 This integration connects with the commercial [Cybersixgill Darkfeed](https://cybersixgill.com/products/cyber-threat-intelligence/darkfeed) TAXII server.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Logs
 
 ### Threat

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,19 +1,28 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.35.0"
+version: "1.36.0"
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration
-format_version: "3.0.2"
+format_version: 3.3.2
 categories:
   - security
   - threat_intel
 conditions:
   kibana:
-    version: "^8.13.0 || ^9.0.0"
+    version: "^8.19.2 || ^9.0.5"
 policy_templates:
   - name: cybersixgill
     title: Cybersixgill Threat Intel
     description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: "Ingest threat intelligence indicators from Cybersixgill Darkfeed with Elastic Agent."


### PR DESCRIPTION
## Proposed commit message

```
ti_cybersixgill: add agentless support and update kibana version constraint
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/ti_cybersixgill directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #19454