### PR TITLE
[AWS Cloudwatch Input] Enable Agentless by default

### DIFF
--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Make agentless the default deployment mode (`is_default: true`) while keeping the standard agent mode enabled. Add `release: beta` to the agentless block."
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19547
 - version: "0.1.0"
   changes:
     - description: Initial release of AWS CloudWatch OpenTelemetry input package.

--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: "Make agentless the default deployment mode (`is_default: true`) while keeping the standard agent mode enabled. Add `release: beta` to the agentless block."
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.0"
   changes:
     - description: Initial release of AWS CloudWatch OpenTelemetry input package.

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_cloudwatch_input_otel
 title: "AWS CloudWatch OpenTelemetry Input Package"
-version: 0.1.0
+version: 0.2.0
 source:
   license: "Elastic-2.0"
 description: "Collect AWS CloudWatch metrics for selected AWS services (EC2, RDS, SQS, ELB, Lambda, Fargate) using the OpenTelemetry Collector awscloudwatchmetrics receiver."
@@ -145,6 +145,8 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        is_default: true
+        release: beta
         organization: observability
         division: engineering
         team: obs-infraobs-integrations


### PR DESCRIPTION

- Enhancement

This PR enables the `agentless` deployment mode by default.

`Setting "agentless:default" so cloud users aren't asked to pick a deployment is controlled by the package manifest in elastic/integrations`

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
