### PR TITLE
[AWS Cloudwatch OTEL Input] Update Auth extensions

### DIFF
--- a/packages/aws_cloudwatch_input_otel/_dev/build/docs/README.md
+++ b/packages/aws_cloudwatch_input_otel/_dev/build/docs/README.md
@@ -6,8 +6,6 @@ The AWS CloudWatch OpenTelemetry Input Package for Elastic enables collection of
 ### How it works
 This package configures the AWS region, credentials, and a CloudWatch namespace once per supported AWS service (EC2, RDS, SQS, ELB, Lambda, Fargate). The configuration is applied to the `awscloudwatchmetrics` receiver in the EDOT collector, which polls CloudWatch via the AWS API and forwards metrics to the Elastic Agent. The Elastic Agent enriches the data and ships it to Elasticsearch for indexing and analysis. The receiver runs in autodiscover mode so newly published metrics from AWS are picked up automatically without package changes.
 
-> **Status: blocked on EDOT.** The `awscloudwatchmetrics` receiver is not yet bundled in the EDOT Collector embedded in Elastic Agent (verified against EDOT 9.4.x). The package compiles and lints, but cannot run end-to-end via Elastic Agent until the receiver is included in EDOT. Track [elastic/opentelemetry](https://github.com/elastic/opentelemetry) for inclusion.
-
 ## Supported services
 Each service is exposed as a separate policy template. Add the integration once per service you want to monitor.
 

--- a/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
+++ b/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
@@ -1,17 +1,15 @@
 extensions:
   awscredentialsprovider:
-    region: {{region}}
-{{#if profile}}
-    profile: {{profile}}
+{{#if imds_endpoint}}
+    imds_endpoint: {{imds_endpoint}}
 {{/if}}
 {{#if access_key_id}}
-    access_key_id: {{access_key_id}}
-{{/if}}
-{{#if secret_access_key}}
-    secret_access_key: {{secret_access_key}}
-{{/if}}
+    credentials:
+      access_key_id: {{access_key_id}}
+      secret_access_key: {{secret_access_key}}
 {{#if session_token}}
-    session_token: {{session_token}}
+      session_token: {{session_token}}
+{{/if}}
 {{/if}}
 {{#if role_arn}}
     assume_role:
@@ -25,9 +23,6 @@ receivers:
   awscloudwatch:
     auth: awscredentialsprovider
     region: {{region}}
-{{#if imds_endpoint}}
-    imds_endpoint: {{imds_endpoint}}
-{{/if}}
     metrics:
       collection_interval: {{collection_interval}}
       period: {{period}}

--- a/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
+++ b/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
@@ -1,29 +1,30 @@
-{{#if access_key_id}}
-access_key_id: {{access_key_id}}
-{{/if}}
-{{#if secret_access_key}}
-secret_access_key: {{secret_access_key}}
-{{/if}}
-{{#if session_token}}
-session_token: {{session_token}}
-{{/if}}
-{{#if credential_profile_name}}
-credential_profile_name: {{credential_profile_name}}
-{{/if}}
-{{#if shared_credential_file}}
-shared_credential_file: {{shared_credential_file}}
-{{/if}}
-{{#if role_arn}}
-role_arn: {{role_arn}}
-{{/if}}
-
-
-receivers:
-  awscloudwatch:
+extensions:
+  awscredentialsprovider:
     region: {{region}}
 {{#if profile}}
     profile: {{profile}}
 {{/if}}
+{{#if access_key_id}}
+    access_key_id: {{access_key_id}}
+{{/if}}
+{{#if secret_access_key}}
+    secret_access_key: {{secret_access_key}}
+{{/if}}
+{{#if session_token}}
+    session_token: {{session_token}}
+{{/if}}
+{{#if role_arn}}
+    assume_role:
+      arn: {{role_arn}}
+{{#if external_id}}
+      external_id: {{external_id}}
+{{/if}}
+{{/if}}
+
+receivers:
+  awscloudwatch:
+    auth: awscredentialsprovider
+    region: {{region}}
 {{#if imds_endpoint}}
     imds_endpoint: {{imds_endpoint}}
 {{/if}}
@@ -51,6 +52,7 @@ processors:
     override: false
 
 service:
+  extensions: [awscredentialsprovider]
   pipelines:
     metrics:
       receivers: [awscloudwatch]

--- a/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
+++ b/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
@@ -21,7 +21,7 @@ extensions:
 
 receivers:
   awscloudwatch:
-    auth: awscredentialsprovider
+    credentials_provider: awscredentialsprovider
     region: {{#if service_region}}{{service_region}}{{else}}{{region}}{{/if}}
     metrics:
       collection_interval: {{collection_interval}}

--- a/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
+++ b/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
@@ -1,8 +1,5 @@
 extensions:
   awscredentialsprovider:
-{{#if imds_endpoint}}
-    imds_endpoint: {{imds_endpoint}}
-{{/if}}
 {{#if access_key_id}}
     credentials:
       access_key_id: {{access_key_id}}

--- a/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
+++ b/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
@@ -22,7 +22,7 @@ extensions:
 receivers:
   awscloudwatch:
     auth: awscredentialsprovider
-    region: {{region}}
+    region: {{#if service_region}}{{service_region}}{{else}}{{region}}{{/if}}
     metrics:
       collection_interval: {{collection_interval}}
       period: {{period}}

--- a/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
+++ b/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
@@ -19,7 +19,7 @@ extensions:
 receivers:
   awscloudwatch:
     credentials_provider: awscredentialsprovider
-    region: {{#if service_region}}{{service_region}}{{else}}{{region}}{{/if}}
+    region: {{region}}
     metrics:
       collection_interval: {{collection_interval}}
       period: {{period}}

--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Authenticate via the `awscredentialsprovider` extension (bundled in EDOT through elastic-agent#14933).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: "Make agentless the default deployment mode (`is_default: true`) while keeping the standard agent mode enabled. Add `release: beta` to the agentless block."

--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: "0.3.0"
   changes:
+    - description: Add support for region specific to a service.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19563
     - description: Authenticate via the `awscredentialsprovider` extension (bundled in EDOT through elastic-agent#14933).
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19563

--- a/packages/aws_cloudwatch_input_otel/docs/README.md
+++ b/packages/aws_cloudwatch_input_otel/docs/README.md
@@ -6,8 +6,6 @@ The AWS CloudWatch OpenTelemetry Input Package for Elastic enables collection of
 ### How it works
 This package configures the AWS region, credentials, and a CloudWatch namespace once per supported AWS service (EC2, RDS, SQS, ELB, Lambda, Fargate). The configuration is applied to the `awscloudwatchmetrics` receiver in the EDOT collector, which polls CloudWatch via the AWS API and forwards metrics to the Elastic Agent. The Elastic Agent enriches the data and ships it to Elasticsearch for indexing and analysis. The receiver runs in autodiscover mode so newly published metrics from AWS are picked up automatically without package changes.
 
-> **Status: blocked on EDOT.** The `awscloudwatchmetrics` receiver is not yet bundled in the EDOT Collector embedded in Elastic Agent (verified against EDOT 9.4.x). The package compiles and lints, but cannot run end-to-end via Elastic Agent until the receiver is included in EDOT. Track [elastic/opentelemetry](https://github.com/elastic/opentelemetry) for inclusion.
-
 ## Supported services
 Each service is exposed as a separate policy template. Add the integration once per service you want to monitor.
 

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -32,12 +32,6 @@ vars:
     description: AWS region to query CloudWatch metrics from (for example, `us-east-1`).
     required: true
     show_user: true
-  - name: profile
-    type: text
-    title: AWS Shared Credentials Profile
-    description: The AWS profile used to authenticate.
-    required: false
-    show_user: false
   - name: imds_endpoint
     type: text
     title: IMDS Endpoint
@@ -133,6 +127,7 @@ policy_templates:
         default: 15m
         required: false
         show_user: false
+      # required: true to fetch metrics appropriately as the metrics only needed is fetched.
       - name: autodiscover_aggregation
         type: text
         multi: true
@@ -141,7 +136,7 @@ policy_templates:
         default:
           - Average
           - Sum
-        required: false
+        required: true
         show_user: false
 
   - name: aws.lambda
@@ -196,7 +191,7 @@ policy_templates:
           - Maximum
           - Average
           - Sum
-        required: false
+        required: true
         show_user: false
 
   - name: aws.rds
@@ -249,7 +244,7 @@ policy_templates:
         description: CloudWatch statistics applied to every discovered metric for this namespace.
         default:
           - Average
-        required: false
+        required: true
         show_user: false
 
   - name: aws.sqs
@@ -304,7 +299,7 @@ policy_templates:
           - Maximum
           - Average
           - Sum
-        required: false
+        required: true
         show_user: false
 
   - name: aws.elb
@@ -359,7 +354,7 @@ policy_templates:
           - Maximum
           - Average
           - Sum
-        required: false
+        required: true
         show_user: false
 
   - name: aws.ecs
@@ -412,7 +407,7 @@ policy_templates:
         description: CloudWatch statistics applied to every discovered metric for this namespace.
         default:
           - Average
-        required: false
+        required: true
         show_user: false
 
 owner:

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -32,12 +32,6 @@ vars:
     description: AWS region to query CloudWatch metrics from (for example, `us-east-1`).
     required: true
     show_user: true
-  - name: imds_endpoint
-    type: text
-    title: IMDS Endpoint
-    description: Override the EC2 Instance Metadata Service endpoint. Leave blank to use the AWS SDK default.
-    required: false
-    show_user: false
   # --- Inline AWS credentials (rendered into env vars on the collector process) ---
   - name: access_key_id
     type: password

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -93,12 +93,6 @@ policy_templates:
         default: "AWS/EC2"
         required: true
         show_user: false
-      - name: service_region
-        type: text
-        title: Region
-        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
-        required: false
-        show_user: false
       - name: autodiscover_limit
         type: integer
         title: Autodiscover Limit
@@ -153,12 +147,6 @@ policy_templates:
         description: CloudWatch namespace this template scrapes. Fixed per service.
         default: "AWS/Lambda"
         required: true
-        show_user: false
-      - name: service_region
-        type: text
-        title: Region
-        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
-        required: false
         show_user: false
       - name: autodiscover_limit
         type: integer
@@ -215,12 +203,6 @@ policy_templates:
         default: "AWS/RDS"
         required: true
         show_user: false
-      - name: service_region
-        type: text
-        title: Region
-        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
-        required: false
-        show_user: false
       - name: autodiscover_limit
         type: integer
         title: Autodiscover Limit
@@ -273,12 +255,6 @@ policy_templates:
         description: CloudWatch namespace this template scrapes. Fixed per service.
         default: "AWS/SQS"
         required: true
-        show_user: false
-      - name: service_region
-        type: text
-        title: Region
-        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
-        required: false
         show_user: false
       - name: autodiscover_limit
         type: integer
@@ -335,12 +311,6 @@ policy_templates:
         default: "AWS/ApplicationELB"
         required: true
         show_user: false
-      - name: service_region
-        type: text
-        title: Region
-        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
-        required: false
-        show_user: false
       - name: autodiscover_limit
         type: integer
         title: Autodiscover Limit
@@ -395,12 +365,6 @@ policy_templates:
         description: CloudWatch namespace this template scrapes. Fixed per service.
         default: "AWS/ECS"
         required: true
-        show_user: false
-      - name: service_region
-        type: text
-        title: Region
-        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
-        required: false
         show_user: false
       - name: autodiscover_limit
         type: integer

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_cloudwatch_input_otel
 title: "AWS CloudWatch OpenTelemetry Input Package"
-version: 0.2.0
+version: 0.3.0
 source:
   license: "Elastic-2.0"
 description: "Collect AWS CloudWatch metrics for selected AWS services (EC2, RDS, SQS, ELB, Lambda, Fargate) using the OpenTelemetry Collector awscloudwatchmetrics receiver."

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -13,7 +13,7 @@ categories:
   - opentelemetry
 conditions:
   kibana:
-    version: "~9.4.3 || ^9.5.0"
+    version: "^9.5.0"
   elastic:
     subscription: "basic"
 icons:

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -99,6 +99,12 @@ policy_templates:
         default: "AWS/EC2"
         required: true
         show_user: false
+      - name: service_region
+        type: text
+        title: Region
+        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
+        required: false
+        show_user: false
       - name: autodiscover_limit
         type: integer
         title: Autodiscover Limit
@@ -153,6 +159,12 @@ policy_templates:
         description: CloudWatch namespace this template scrapes. Fixed per service.
         default: "AWS/Lambda"
         required: true
+        show_user: false
+      - name: service_region
+        type: text
+        title: Region
+        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
+        required: false
         show_user: false
       - name: autodiscover_limit
         type: integer
@@ -209,6 +221,12 @@ policy_templates:
         default: "AWS/RDS"
         required: true
         show_user: false
+      - name: service_region
+        type: text
+        title: Region
+        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
+        required: false
+        show_user: false
       - name: autodiscover_limit
         type: integer
         title: Autodiscover Limit
@@ -261,6 +279,12 @@ policy_templates:
         description: CloudWatch namespace this template scrapes. Fixed per service.
         default: "AWS/SQS"
         required: true
+        show_user: false
+      - name: service_region
+        type: text
+        title: Region
+        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
+        required: false
         show_user: false
       - name: autodiscover_limit
         type: integer
@@ -317,6 +341,12 @@ policy_templates:
         default: "AWS/ApplicationELB"
         required: true
         show_user: false
+      - name: service_region
+        type: text
+        title: Region
+        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
+        required: false
+        show_user: false
       - name: autodiscover_limit
         type: integer
         title: Autodiscover Limit
@@ -371,6 +401,12 @@ policy_templates:
         description: CloudWatch namespace this template scrapes. Fixed per service.
         default: "AWS/ECS"
         required: true
+        show_user: false
+      - name: service_region
+        type: text
+        title: Region
+        description: Optional. Overrides the package-level AWS Region for this service only. Leave blank to use the global region.
+        required: false
         show_user: false
       - name: autodiscover_limit
         type: integer

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -13,7 +13,7 @@ categories:
   - opentelemetry
 conditions:
   kibana:
-    version: "^9.5.0"
+    version: "~9.4.3 || ^9.5.0"
   elastic:
     subscription: "basic"
 icons:


### PR DESCRIPTION

- Enhancement

## Proposed commit message

Adds the awscredentialprovider extensions to pass the credentials and adds support for regions per service.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
