### PR TITLE
[Kubernetes OTel] Add Pod and Pod details improvements

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+
+- version: 2.2.0-preview1
+  changes:
+    - description: Improvements to the Pod and Pod details dashboards.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 2.1.0-preview9
   changes:
     - description: Improvements to the Overview, Workloads, and Deployment details dashboards.

--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -4,7 +4,7 @@
   changes:
     - description: Improvements to the Pod and Pod details dashboards.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19606
 - version: 2.1.0-preview9
   changes:
     - description: Improvements to the Overview, Workloads, and Deployment details dashboards.

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f.json
@@ -59,37 +59,37 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_2a32c1a4-a9e8-497c-a0e2-814de66bf1b5_dashboard",
+                            "destinationRefName": "link_1e3ff145-06a4-4e59-854f-ff2f39628055_dashboard",
                             "label": "Overview",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_e0b8bc76-1f19-4954-8ca8-b4efaf00b847_dashboard",
+                            "destinationRefName": "link_f6993d94-47ac-4e0f-8d02-dcf54f7324c1_dashboard",
                             "label": "Clusters",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_92cc52e3-c389-4d36-bb02-6c414c13e69e_dashboard",
+                            "destinationRefName": "link_1c421e35-9935-49af-8e37-5f6071f2b00f_dashboard",
                             "label": "Nodes",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_83031f55-4a2f-4799-979e-482acf38266f_dashboard",
+                            "destinationRefName": "link_d834b852-779e-414f-83d7-0ce113cd080a_dashboard",
                             "label": "Namespaces",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_71766b7c-7710-4efc-8356-f90cbde9d1eb_dashboard",
+                            "destinationRefName": "link_603244df-834f-4c79-8a62-ad5e3f805822_dashboard",
                             "label": "Workload resources",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_a14c8a42-ee85-417e-a61f-b3611d93817c_dashboard",
+                            "destinationRefName": "link_86e9a898-e3f0-409c-b761-a5a741d9574b_dashboard",
                             "label": "Pods",
                             "options": {},
                             "type": "dashboardLink"
@@ -2588,7 +2588,7 @@
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.replicaset.name IS NOT NULL\n  AND k8s.replicaset.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.replicaset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.replicaset.available),\n    desired   = MAX(k8s.replicaset.desired)\n  BY k8s.namespace.name, k8s.replicaset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_available = COALESCE(desired, 0) - COALESCE(available, 0)\n| SORT not_available DESC, availability ASC, k8s.replicaset.name ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.replicaset.name IS NOT NULL\n  AND k8s.replicaset.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.replicaset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.replicaset.available),\n    desired   = MAX(k8s.replicaset.desired)\n  BY k8s.namespace.name, k8s.replicaset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_available = COALESCE(desired, 0) - COALESCE(available, 0)\n| SORT not_available DESC, availability ASC, k8s.replicaset.name ASC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2598,7 +2598,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.replicaset.name IS NOT NULL\n  AND k8s.replicaset.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.replicaset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.replicaset.available),\n    desired   = MAX(k8s.replicaset.desired)\n  BY k8s.namespace.name, k8s.replicaset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_available = COALESCE(desired, 0) - COALESCE(available, 0)\n| SORT not_available DESC, availability ASC, k8s.replicaset.name ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.replicaset.name IS NOT NULL\n  AND k8s.replicaset.available IS NOT NULL\n| INLINE STATS latest_ts = MAX(@timestamp) BY k8s.replicaset.name\n| WHERE @timestamp == latest_ts\n| STATS\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    available = MAX(k8s.replicaset.available),\n    desired   = MAX(k8s.replicaset.desired)\n  BY k8s.namespace.name, k8s.replicaset.name\n| EVAL\n    availability = CASE(\n      desired IS NOT NULL AND desired \u003e 0,\n        ROUND(TO_DOUBLE(available) / TO_DOUBLE(desired), 4),\n      NULL),\n    not_available = COALESCE(desired, 0) - COALESCE(available, 0)\n| SORT not_available DESC, availability ASC, k8s.replicaset.name ASC"
                             },
                             "visualization": {
                                 "columns": [
@@ -2739,43 +2739,43 @@
                 "title": "Other workload resources"
             }
         ],
-        "timeFrom": "2026-06-01T06:17:51.162Z",
+        "timeFrom": "now-24h/h",
         "timeRestore": true,
-        "timeTo": "2026-06-01T06:34:34.462Z",
+        "timeTo": "now",
         "title": "[Kubernetes OTel] Workloads"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-06-04T10:11:58.136Z",
+    "created_at": "2026-06-17T05:39:44.087Z",
     "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v2-workloads-alt-nav:link_2a32c1a4-a9e8-497c-a0e2-814de66bf1b5_dashboard",
+            "name": "v2-workloads-alt-nav:link_1e3ff145-06a4-4e59-854f-ff2f39628055_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e",
-            "name": "v2-workloads-alt-nav:link_e0b8bc76-1f19-4954-8ca8-b4efaf00b847_dashboard",
+            "name": "v2-workloads-alt-nav:link_f6993d94-47ac-4e0f-8d02-dcf54f7324c1_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0c88decf-de83-47a4-a5df-0a79dc8daff5",
-            "name": "v2-workloads-alt-nav:link_92cc52e3-c389-4d36-bb02-6c414c13e69e_dashboard",
+            "name": "v2-workloads-alt-nav:link_1c421e35-9935-49af-8e37-5f6071f2b00f_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-c0765efe-f172-42c4-a2ea-f4552b6f42dc",
-            "name": "v2-workloads-alt-nav:link_83031f55-4a2f-4799-979e-482acf38266f_dashboard",
+            "name": "v2-workloads-alt-nav:link_d834b852-779e-414f-83d7-0ce113cd080a_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
-            "name": "v2-workloads-alt-nav:link_71766b7c-7710-4efc-8356-f90cbde9d1eb_dashboard",
+            "name": "v2-workloads-alt-nav:link_603244df-834f-4c79-8a62-ad5e3f805822_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
-            "name": "v2-workloads-alt-nav:link_a14c8a42-ee85-417e-a61f-b3611d93817c_dashboard",
+            "name": "v2-workloads-alt-nav:link_86e9a898-e3f0-409c-b761-a5a741d9574b_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd.json
@@ -54,11 +54,12 @@
             {
                 "embeddableConfig": {
                     "description": "",
+                    "hide_border": true,
                     "hide_title": true,
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_72995b34-850a-4aec-bcb7-2cf694d13086_dashboard",
+                            "destinationRefName": "link_eb1f6dfc-acd5-47d9-8e11-e34a852e42bf_dashboard",
                             "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
@@ -167,12 +168,13 @@
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
-                    }
+                    },
+                    "description": "Name of the pod being inspected."
                 },
                 "gridData": {
                     "h": 3,
                     "i": "v3-pd-header-name",
-                    "w": 21,
+                    "w": 19,
                     "x": 4,
                     "y": 0
                 },
@@ -267,13 +269,13 @@
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Pod phase: Pending/Running/Succeeded/Failed/Unknown."
+                    "description": "Current lifecycle phase of this pod (Pending, Running, Succeeded, Failed, or Unknown). Displays the phase from the most recently scraped document."
                 },
                 "gridData": {
                     "h": 3,
                     "i": "v3-pd-header-status",
-                    "w": 7,
-                    "x": 25,
+                    "w": 6,
+                    "x": 23,
                     "y": 0
                 },
                 "panelIndex": "v3-pd-header-status",
@@ -367,31 +369,187 @@
                                 "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.container.restarts IS NOT NULL\n    AND k8s.pod.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts),\n    last_seen = MAX(@timestamp)\n    BY k8s.pod.uid, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS restarts = SUM(max_restarts)"
                             },
                             "visualization": {
-                                "applyColorTo": "background",
-                                "color": "#F6726A",
+                                "applyColorTo": "value",
                                 "colorMode": "background",
                                 "layerId": "4af3de89-68a8-8e1f-ccb7-4e6febd43855",
                                 "layerType": "data",
                                 "metricAccessor": "2999510e-3669-b52d-dfab-8810af241dd4",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#24c292",
+                                                "stop": 0
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "stop": 1
+                                            }
+                                        ],
+                                        "continuity": "above",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": 0,
+                                        "rangeType": "number",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24c292",
+                                                "stop": 1
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "stop": 2
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "bottom",
                                 "showBar": false,
-                                "subtitle": "Last value"
+                                "subtitle": "Last value",
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "description": "Total container restarts for this pod. MAX(k8s.container.restarts).",
-                    "drilldowns": []
+                    "description": "Total container restarts for this pod. MAX(k8s.container.restarts)."
                 },
                 "gridData": {
                     "h": 3,
                     "i": "v2-pod-detail-restarts",
-                    "w": 11,
-                    "x": 32,
+                    "w": 5,
+                    "x": 29,
                     "y": 0
                 },
                 "panelIndex": "v2-pod-detail-restarts",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "d3b7e528216ce7ef65e68e07a803b7ab53e440cafdb52d9d7ee1ef4bbf5d8afa": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "metrics-*",
+                                    "managed": false,
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "metrics-*",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "9a5aa79b-5205-4e0d-811d-6f59fabdc1c6": {
+                                            "allColumns": [
+                                                {
+                                                    "columnId": "80d9ffc2-9aec-4511-8ef6-9f03fa2c13f7",
+                                                    "customLabel": true,
+                                                    "fieldName": "name",
+                                                    "inMetricDimension": true,
+                                                    "label": "View logs in Discover for pod:",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "80d9ffc2-9aec-4511-8ef6-9f03fa2c13f7",
+                                                    "customLabel": true,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "inMetricDimension": true,
+                                                    "label": "View pod traces in APM",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-*",
+                                                            "sourceField": "k8s.pod.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "metrics-*",
+                                            "query": {
+                                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n| KEEP k8s.pod.name\n| LIMIT 1"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-*\n| WHERE k8s.pod.name IS NOT NULL\n| KEEP k8s.pod.name\n| LIMIT 1"
+                            },
+                            "visualization": {
+                                "applyColorTo": "background",
+                                "colorMode": "background",
+                                "icon": "popout",
+                                "iconAlign": "left",
+                                "layerId": "9a5aa79b-5205-4e0d-811d-6f59fabdc1c6",
+                                "layerType": "data",
+                                "metricAccessor": "80d9ffc2-9aec-4511-8ef6-9f03fa2c13f7",
+                                "primaryAlign": "center",
+                                "showBar": false,
+                                "titlesTextAlign": "center",
+                                "titlesTextSize": "xxs",
+                                "valueFontMode": "fit",
+                                "valuesTextSize": "xs"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "drilldowns": [
+                        {
+                            "encode_url": true,
+                            "label": "View pod traces in APM",
+                            "open_in_new_tab": true,
+                            "trigger": "on_click_value",
+                            "type": "url_drilldown",
+                            "url": "{{kibanaUrl}}/app/apm/traces?rangeFrom={{context.panel.timeRange.from}}\u0026rangeTo={{context.panel.timeRange.to}}\u0026kuery=host.name:\"{{event.value}}\" OR k8s.pod.name:\"{{event.value}}\""
+                        }
+                    ],
+                    "hide_border": true
+                },
+                "gridData": {
+                    "h": 3,
+                    "i": "6fa51571-a6e1-468f-8c5c-71750a609f79",
+                    "w": 7,
+                    "x": 34,
+                    "y": 0
+                },
+                "panelIndex": "6fa51571-a6e1-468f-8c5c-71750a609f79",
                 "type": "vis"
             },
             {
@@ -474,7 +632,6 @@
                             },
                             "visualization": {
                                 "applyColorTo": "background",
-                                "color": "#61A2FF",
                                 "colorMode": "background",
                                 "icon": "popout",
                                 "iconAlign": "left",
@@ -483,7 +640,6 @@
                                 "metricAccessor": "80d9ffc2-9aec-4511-8ef6-9f03fa2c13f7",
                                 "primaryAlign": "center",
                                 "showBar": false,
-                                "titleWeight": "normal",
                                 "titlesTextAlign": "center",
                                 "titlesTextSize": "xxs",
                                 "valueFontMode": "fit",
@@ -503,13 +659,15 @@
                             "type": "url_drilldown",
                             "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.pod.name:\"{{event.value}}\"'))"
                         }
-                    ]
+                    ],
+                    "hide_border": true,
+                    "hide_title": false
                 },
                 "gridData": {
                     "h": 3,
                     "i": "v4-pd-logs-card",
-                    "w": 5,
-                    "x": 43,
+                    "w": 7,
+                    "x": 41,
                     "y": 0
                 },
                 "panelIndex": "v4-pd-logs-card",
@@ -545,72 +703,80 @@
                                         }
                                     ],
                                     "layers": {
-                                        "5324aeda-31bb-49b8-8383-1e41599ce41f": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "fce422fc-c20d-4469-804b-4a5042fe2864",
-                                                    "customLabel": true,
-                                                    "fieldName": "utilization",
-                                                    "inMetricDimension": true,
-                                                    "label": "CPU utilization (vs limits)",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "9c5960a8-831a-4a00-ae2a-3a31a4a64c9c",
-                                                    "customLabel": true,
-                                                    "fieldName": "max_val",
-                                                    "label": "Max",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
+                                        "6924f94d-741a-4219-accb-4dd2272cdc19": {
                                             "columns": [
                                                 {
-                                                    "columnId": "fce422fc-c20d-4469-804b-4a5042fe2864",
+                                                    "columnId": "utilization",
                                                     "customLabel": true,
-                                                    "fieldName": "utilization",
+                                                    "fieldName": "utilization_last",
                                                     "inMetricDimension": true,
-                                                    "label": "CPU utilization (vs limits)",
+                                                    "label": "CPU utilization",
                                                     "meta": {
                                                         "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization_last"
+                                                        },
                                                         "type": "number"
                                                     },
                                                     "params": {
                                                         "format": {
                                                             "id": "percent",
                                                             "params": {
-                                                                "decimals": 1
+                                                                "decimals": 2
                                                             }
                                                         }
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "9c5960a8-831a-4a00-ae2a-3a31a4a64c9c",
-                                                    "customLabel": true,
-                                                    "fieldName": "max_val",
-                                                    "label": "Max",
+                                                    "columnId": "f630716d-66cb-42b0-b631-53940a695ec6",
+                                                    "fieldName": "max_value",
+                                                    "label": "max_value",
                                                     "meta": {
                                                         "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "max_value"
+                                                        },
                                                         "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "94487da3-eb07-436a-a8d3-9633ee8a2d86",
+                                                    "customLabel": false,
+                                                    "fieldName": "utilization",
+                                                    "inMetricDimension": true,
+                                                    "label": "utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.cpu_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS bucket_util = AVG(k8s.pod.cpu_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| STATS\n    utilization = ROUND(AVG(bucket_util), 4),\n    utilization_last = ROUND(LAST(bucket_util, timestamp), 4)\n| EVAL max_value = 1.00\n| KEEP utilization, utilization_last, max_value"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -620,67 +786,78 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS utilization = AVG(k8s.pod.cpu_limit_utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.cpu_limit_utilization IS NOT NULL\n| STATS bucket_util = AVG(k8s.pod.cpu_limit_utilization)\n  BY timestamp = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| SORT timestamp\n| STATS\n    utilization = ROUND(AVG(bucket_util), 4),\n    utilization_last = ROUND(LAST(bucket_util, timestamp), 4)\n| EVAL max_value = 1.00\n| KEEP utilization, utilization_last, max_value"
                             },
                             "visualization": {
-                                "applyColorTo": "bar",
-                                "layerId": "5324aeda-31bb-49b8-8383-1e41599ce41f",
+                                "applyColorTo": "value",
+                                "layerId": "6924f94d-741a-4219-accb-4dd2272cdc19",
                                 "layerType": "data",
-                                "maxAccessor": "9c5960a8-831a-4a00-ae2a-3a31a4a64c9c",
-                                "metricAccessor": "fce422fc-c20d-4469-804b-4a5042fe2864",
+                                "maxAccessor": "f630716d-66cb-42b0-b631-53940a695ec6",
+                                "metricAccessor": "utilization",
                                 "palette": {
                                     "name": "custom",
                                     "params": {
                                         "colorStops": [
                                             {
-                                                "color": "#24C292",
-                                                "stop": 0
+                                                "color": "#24c292",
+                                                "stop": null
                                             },
                                             {
-                                                "color": "#D6BF57",
+                                                "color": "#fcd883",
                                                 "stop": 0.6
                                             },
                                             {
-                                                "color": "#E7664C",
+                                                "color": "#f6726a",
                                                 "stop": 0.8
                                             }
                                         ],
-                                        "continuity": "above",
+                                        "continuity": "all",
                                         "maxSteps": 5,
                                         "name": "custom",
                                         "progression": "fixed",
                                         "rangeMax": null,
-                                        "rangeMin": 0,
+                                        "rangeMin": null,
                                         "rangeType": "number",
                                         "reverse": false,
                                         "steps": 3,
                                         "stops": [
                                             {
-                                                "color": "#24C292",
+                                                "color": "#24c292",
                                                 "stop": 0.6
                                             },
                                             {
-                                                "color": "#D6BF57",
+                                                "color": "#fcd883",
                                                 "stop": 0.8
                                             },
                                             {
-                                                "color": "#E7664C",
+                                                "color": "#f6726a",
                                                 "stop": 1
                                             }
                                         ]
                                     },
                                     "type": "palette"
                                 },
-                                "progressDirection": "horizontal",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "secondaryAlign": "left",
+                                "secondaryLabel": "Last value vs Avg",
+                                "secondaryMetricAccessor": "94487da3-eb07-436a-a8d3-9633ee8a2d86",
+                                "secondaryTrend": {
+                                    "baselineValue": "primary",
+                                    "paletteId": "compare_to",
+                                    "reversed": true,
+                                    "type": "dynamic",
+                                    "visuals": "both"
+                                },
                                 "showBar": true,
-                                "subtitle": "Last value"
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": [],
+                    "description": "Last CPU limit utilization value for the selected time range. Shows what fraction of the pod's CPU limit is being consumed.\n\n\"Last value vs Avg\" shows how the most recent reading compares to the time range average. Pods without a CPU limit are excluded (cpu_limit_utilization is only emitted when a limit is set).",
                     "hide_title": true
                 },
                 "gridData": {
@@ -786,7 +963,7 @@
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -831,12 +1008,27 @@
                                         "layerId": "27bf8c37-9bb7-44e1-926e-6dad56f2272e",
                                         "layerType": "data",
                                         "seriesType": "line",
-                                        "xAccessor": "timestamp"
+                                        "xAccessor": "timestamp",
+                                        "yConfig": [
+                                            {
+                                                "color": "#f6726a",
+                                                "forAccessor": "CPU limits"
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "forAccessor": "CPU requests"
+                                            }
+                                        ]
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "position": "right"
+                                    "legendStats": [
+                                        "currentAndLastValue",
+                                        "max"
+                                    ],
+                                    "position": "bottom",
+                                    "showSingleSeries": true
                                 },
                                 "preferredSeriesType": "line",
                                 "tickLabelsVisibilitySettings": {
@@ -851,7 +1043,7 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "CPU usage over time with request (dashed yellow) and limit (dashed red) reference lines.",
+                    "description": "CPU usage over time with request (yellow) and limit (red) reference lines.",
                     "title": "CPU usage vs requests \u0026 limits"
                 },
                 "gridData": {
@@ -895,72 +1087,80 @@
                                         }
                                     ],
                                     "layers": {
-                                        "72938f7c-f5ca-480b-bcdd-bce4a68d676a": {
-                                            "allColumns": [
-                                                {
-                                                    "columnId": "0f876480-bcac-420d-ae57-75f55ea646dd",
-                                                    "customLabel": true,
-                                                    "fieldName": "utilization",
-                                                    "inMetricDimension": true,
-                                                    "label": "Memory utilization (vs limits)",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    },
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "decimals": 1
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "1904a784-6ec9-43e9-b486-844c5498dc01",
-                                                    "customLabel": true,
-                                                    "fieldName": "max_val",
-                                                    "label": "Max",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
+                                        "52e5f154-e122-4a54-afef-ff4f252e113c": {
                                             "columns": [
                                                 {
-                                                    "columnId": "0f876480-bcac-420d-ae57-75f55ea646dd",
+                                                    "columnId": "utilization",
                                                     "customLabel": true,
-                                                    "fieldName": "utilization",
+                                                    "fieldName": "utilization_last",
                                                     "inMetricDimension": true,
-                                                    "label": "Memory utilization (vs limits)",
+                                                    "label": "Memory utilization",
                                                     "meta": {
                                                         "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization_last"
+                                                        },
                                                         "type": "number"
                                                     },
                                                     "params": {
                                                         "format": {
                                                             "id": "percent",
                                                             "params": {
-                                                                "decimals": 1
+                                                                "decimals": 2
                                                             }
                                                         }
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "1904a784-6ec9-43e9-b486-844c5498dc01",
-                                                    "customLabel": true,
-                                                    "fieldName": "max_val",
-                                                    "label": "Max",
+                                                    "columnId": "d5a753d0-46d4-4afd-a2e4-a6b5f10064a5",
+                                                    "fieldName": "max_value",
+                                                    "label": "max_value",
                                                     "meta": {
                                                         "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "max_value"
+                                                        },
                                                         "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "8645ca5a-f83d-4d2c-ab66-aae2df54b78b",
+                                                    "customLabel": false,
+                                                    "fieldName": "utilization",
+                                                    "inMetricDimension": true,
+                                                    "label": "utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.memory_limit_utilization, @timestamp)\n  BY k8s.pod.name\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS\n    utilization = ROUND(AVG(k8s.pod.memory_limit_utilization), 4),\n    utilization_last = ROUND(LAST(k8s.pod.memory_limit_utilization, @timestamp), 4)\n| EVAL max_value = 1.00\n| KEEP utilization, utilization_last, max_value"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -970,67 +1170,34 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS utilization = LAST(k8s.pod.memory_limit_utilization, @timestamp)\n  BY k8s.pod.name\n| STATS utilization = AVG(utilization)\n| EVAL max_val = 1.0\n| KEEP utilization, max_val"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory_limit_utilization IS NOT NULL\n| STATS\n    utilization = ROUND(AVG(k8s.pod.memory_limit_utilization), 4),\n    utilization_last = ROUND(LAST(k8s.pod.memory_limit_utilization, @timestamp), 4)\n| EVAL max_value = 1.00\n| KEEP utilization, utilization_last, max_value"
                             },
                             "visualization": {
-                                "applyColorTo": "bar",
-                                "layerId": "72938f7c-f5ca-480b-bcdd-bce4a68d676a",
+                                "layerId": "52e5f154-e122-4a54-afef-ff4f252e113c",
                                 "layerType": "data",
-                                "maxAccessor": "1904a784-6ec9-43e9-b486-844c5498dc01",
-                                "metricAccessor": "0f876480-bcac-420d-ae57-75f55ea646dd",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#24C292",
-                                                "stop": 0
-                                            },
-                                            {
-                                                "color": "#D6BF57",
-                                                "stop": 0.6
-                                            },
-                                            {
-                                                "color": "#E7664C",
-                                                "stop": 0.8
-                                            }
-                                        ],
-                                        "continuity": "above",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": 0,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#24C292",
-                                                "stop": 0.6
-                                            },
-                                            {
-                                                "color": "#D6BF57",
-                                                "stop": 0.8
-                                            },
-                                            {
-                                                "color": "#E7664C",
-                                                "stop": 1
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
+                                "maxAccessor": "d5a753d0-46d4-4afd-a2e4-a6b5f10064a5",
+                                "metricAccessor": "utilization",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "secondaryAlign": "left",
+                                "secondaryLabel": "Last value vs Avg",
+                                "secondaryLabelPosition": "before",
+                                "secondaryMetricAccessor": "8645ca5a-f83d-4d2c-ab66-aae2df54b78b",
+                                "secondaryTrend": {
+                                    "baselineValue": "primary",
+                                    "paletteId": "compare_to",
+                                    "reversed": true,
+                                    "type": "dynamic",
+                                    "visuals": "both"
                                 },
-                                "progressDirection": "horizontal",
                                 "showBar": true,
-                                "subtitle": "Last value"
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": [],
                     "hide_title": true
                 },
                 "gridData": {
@@ -1160,7 +1327,7 @@
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -1205,13 +1372,27 @@
                                         "layerId": "de172800-660e-4eb3-86ca-a8fc9c09185b",
                                         "layerType": "data",
                                         "seriesType": "line",
-                                        "xAccessor": "timestamp"
+                                        "xAccessor": "timestamp",
+                                        "yConfig": [
+                                            {
+                                                "color": "#f6726a",
+                                                "forAccessor": "Memory limits"
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "forAccessor": "Memory requests"
+                                            }
+                                        ]
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "layout": "list",
-                                    "position": "bottom"
+                                    "legendStats": [
+                                        "currentAndLastValue",
+                                        "max"
+                                    ],
+                                    "position": "bottom",
+                                    "showSingleSeries": true
                                 },
                                 "preferredSeriesType": "line",
                                 "tickLabelsVisibilitySettings": {
@@ -1226,7 +1407,7 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "Memory working set over time. Yellow dashed = requests, solid red = limits (OOMKill threshold).",
+                    "description": "Memory working set over time. Yellow = requests, solid red = limits (OOMKill threshold).",
                     "title": "Memory working set vs requests \u0026 limits"
                 },
                 "gridData": {
@@ -1313,20 +1494,22 @@
                             },
                             "visualization": {
                                 "applyColorTo": "background",
-                                "color": "#61A2FF",
                                 "colorMode": "background",
                                 "layerId": "27c8778d-41d0-47b6-b0da-cb1478a5794f",
                                 "layerType": "data",
                                 "metricAccessor": "69cbd6aa-7904-4d5e-a9eb-90232c49ca11",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
                                 "showBar": false,
-                                "subtitle": "Last value"
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": []
+                    "description": "Total CPU limit (in cores) across all containers in this pod."
                 },
                 "gridData": {
                     "h": 5,
@@ -1417,7 +1600,7 @@
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -1459,7 +1642,7 @@
                                         },
                                         "layerId": "4be2e9b4-17b0-4048-9a2f-03f268456293",
                                         "layerType": "data",
-                                        "seriesType": "line",
+                                        "seriesType": "area",
                                         "xAccessor": "timestamp"
                                     }
                                 ],
@@ -1467,7 +1650,7 @@
                                     "isVisible": true,
                                     "position": "right"
                                 },
-                                "preferredSeriesType": "line",
+                                "preferredSeriesType": "area",
                                 "tickLabelsVisibilitySettings": {
                                     "x": true,
                                     "yLeft": true,
@@ -1480,6 +1663,7 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
+                    "description": "Volume usage (in bytes) over time for this pod, calculated as total capacity minus total available across all attached volumes.",
                     "title": "Volume usage over time"
                 },
                 "gridData": {
@@ -1563,7 +1747,7 @@
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -1626,6 +1810,7 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
+                    "description": "Number of distinct containers over time, identified by pod name and container name. ",
                     "title": "Container count over time"
                 },
                 "gridData": {
@@ -1674,11 +1859,60 @@
                                                 {
                                                     "columnId": "utilization",
                                                     "customLabel": true,
-                                                    "fieldName": "utilization",
+                                                    "fieldName": "utilization_last",
                                                     "inMetricDimension": true,
                                                     "label": "Volume utilization",
                                                     "meta": {
                                                         "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization_last"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "9a37a19a-e2ff-46dc-a9ae-73a104847352",
+                                                    "fieldName": "max_value",
+                                                    "label": "max_value",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "max_value"
+                                                        },
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "fed1a1b6-cee5-4afb-ba2c-35fa7fb57c26",
+                                                    "customLabel": false,
+                                                    "fieldName": "utilization",
+                                                    "inMetricDimension": true,
+                                                    "label": "utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "utilization"
+                                                        },
                                                         "type": "number"
                                                     },
                                                     "params": {
@@ -1693,7 +1927,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n  AND k8s.volume.available IS NOT NULL\n| STATS avail = LAST(k8s.volume.available, @timestamp),\n    cap = LAST(k8s.volume.capacity, @timestamp),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_avail = SUM(avail),\n    total_cap = SUM(cap)\n| EVAL utilization = ROUND(1.0 - TO_DOUBLE(total_avail) / TO_DOUBLE(total_cap), 4)\n| KEEP utilization"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.volume.name IS NOT NULL\n  AND k8s.volume.name != \"\"\n  AND k8s.volume.capacity IS NOT NULL\n  AND k8s.volume.available IS NOT NULL\n| STATS avail_avg = AVG(k8s.volume.available),\n    cap_avg = AVG(k8s.volume.capacity),\n    avail_last = LAST(k8s.volume.available, @timestamp),\n    cap_last = LAST(k8s.volume.capacity, @timestamp),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_avail_avg = SUM(avail_avg),\n    total_cap_avg = SUM(cap_avg),\n    total_avail_last = SUM(avail_last),\n    total_cap_last = SUM(cap_last)\n| EVAL utilization = ROUND(1.0 - TO_DOUBLE(total_avail_avg) / TO_DOUBLE(total_cap_avg), 4),\n    utilization_last = ROUND(1.0 - TO_DOUBLE(total_avail_last) / TO_DOUBLE(total_cap_last), 4),\n    max_value = 1.00\n| KEEP utilization, utilization_last, max_value"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1703,22 +1937,78 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n  AND k8s.volume.available IS NOT NULL\n| STATS avail = LAST(k8s.volume.available, @timestamp),\n    cap = LAST(k8s.volume.capacity, @timestamp),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_avail = SUM(avail),\n    total_cap = SUM(cap)\n| EVAL utilization = ROUND(1.0 - TO_DOUBLE(total_avail) / TO_DOUBLE(total_cap), 4)\n| KEEP utilization"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.volume.name IS NOT NULL\n  AND k8s.volume.name != \"\"\n  AND k8s.volume.capacity IS NOT NULL\n  AND k8s.volume.available IS NOT NULL\n| STATS avail_avg = AVG(k8s.volume.available),\n    cap_avg = AVG(k8s.volume.capacity),\n    avail_last = LAST(k8s.volume.available, @timestamp),\n    cap_last = LAST(k8s.volume.capacity, @timestamp),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.uid, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_avail_avg = SUM(avail_avg),\n    total_cap_avg = SUM(cap_avg),\n    total_avail_last = SUM(avail_last),\n    total_cap_last = SUM(cap_last)\n| EVAL utilization = ROUND(1.0 - TO_DOUBLE(total_avail_avg) / TO_DOUBLE(total_cap_avg), 4),\n    utilization_last = ROUND(1.0 - TO_DOUBLE(total_avail_last) / TO_DOUBLE(total_cap_last), 4),\n    max_value = 1.00\n| KEEP utilization, utilization_last, max_value"
                             },
                             "visualization": {
                                 "applyColorTo": "background",
-                                "color": "#61A2FF",
                                 "layerId": "ca04349e-a75e-4404-87ae-a78f02decc60",
                                 "layerType": "data",
+                                "maxAccessor": "9a37a19a-e2ff-46dc-a9ae-73a104847352",
                                 "metricAccessor": "utilization",
-                                "subtitle": "Last value"
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#24c292",
+                                                "stop": null
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "stop": 60
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "stop": 80
+                                            }
+                                        ],
+                                        "continuity": "all",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": null,
+                                        "rangeType": "percent",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24c292",
+                                                "stop": 60
+                                            },
+                                            {
+                                                "color": "#fcd883",
+                                                "stop": 80
+                                            },
+                                            {
+                                                "color": "#f6726a",
+                                                "stop": 100
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "secondaryLabel": "Last value vs Avg",
+                                "secondaryMetricAccessor": "fed1a1b6-cee5-4afb-ba2c-35fa7fb57c26",
+                                "secondaryTrend": {
+                                    "baselineValue": "primary",
+                                    "paletteId": "compare_to",
+                                    "reversed": true,
+                                    "type": "dynamic",
+                                    "visuals": "both"
+                                },
+                                "showBar": true,
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": [],
+                    "description": "Last disk utilization value for the selected time range. Shows what fraction of the pod's total volume capacity is in use, calculated as (capacity - available) / capacity across all attached volumes.\n\n\"Last value vs Avg\" shows how the most recent reading compares to the time range average. Stale volumes are excluded using a 5-minute freshness threshold. ",
                     "hide_title": true,
                     "title": "Volume utilization"
                 },
@@ -1800,18 +2090,19 @@
                                 "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.memory_limit IS NOT NULL\n| STATS mem_limit = MAX(k8s.container.memory_limit),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_limit = SUM(mem_limit)\n| KEEP total_limit"
                             },
                             "visualization": {
-                                "color": "#61A2FF",
                                 "layerId": "0de1cb25-05bc-46e8-91bc-acbe36433638",
                                 "layerType": "data",
                                 "metricAccessor": "total_limit",
-                                "subtitle": "Last value"
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": [],
                     "title": ""
                 },
                 "gridData": {
@@ -1892,19 +2183,20 @@
                                 "esql": "FROM metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.volume.capacity IS NOT NULL\n| STATS cap = MAX(k8s.volume.capacity),\n    last_seen = MAX(@timestamp)\n  BY k8s.pod.name, k8s.volume.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS total_cap = SUM(cap)\n| KEEP total_cap"
                             },
                             "visualization": {
-                                "color": "#61A2FF",
                                 "layerId": "e9cbf807-725a-496c-95ea-4462c11f6ebb",
                                 "layerType": "data",
                                 "metricAccessor": "total_cap",
-                                "subtitle": "Last value"
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
                             }
                         },
                         "title": "",
                         "version": 2,
                         "visualizationType": "lnsMetric"
                     },
-                    "drilldowns": [],
-                    "title": ""
+                    "description": "Total volume capacity (in bytes) across all volumes attached to this pod."
                 },
                 "gridData": {
                     "h": 5,
@@ -2473,43 +2765,59 @@
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "memory_ws",
-                                                    "customLabel": false,
-                                                    "fieldName": "memory_ws",
+                                                    "columnId": "cpu_limit",
+                                                    "customLabel": true,
+                                                    "fieldName": "cpu_limit",
                                                     "inMetricDimension": true,
-                                                    "label": "memory_ws",
+                                                    "label": "CPU limit",
                                                     "meta": {
                                                         "esType": "double",
                                                         "type": "number"
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "cpu_limit",
-                                                    "customLabel": false,
-                                                    "fieldName": "cpu_limit",
+                                                    "columnId": "memory_ws",
+                                                    "customLabel": true,
+                                                    "fieldName": "memory_ws",
                                                     "inMetricDimension": true,
-                                                    "label": "cpu_limit",
+                                                    "label": "Memory working set",
                                                     "meta": {
                                                         "esType": "double",
                                                         "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
                                                     }
                                                 },
                                                 {
                                                     "columnId": "memory_limit",
-                                                    "customLabel": false,
+                                                    "customLabel": true,
                                                     "fieldName": "memory_limit",
                                                     "inMetricDimension": true,
-                                                    "label": "memory_limit",
+                                                    "label": "Memory limit",
                                                     "meta": {
                                                         "esType": "long",
                                                         "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
                                                     }
                                                 },
                                                 {
                                                     "columnId": "k8s.container.name",
-                                                    "customLabel": true,
+                                                    "customLabel": false,
                                                     "fieldName": "k8s.container.name",
-                                                    "label": "Container",
+                                                    "label": "k8s.container.name",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -2517,9 +2825,9 @@
                                                 },
                                                 {
                                                     "columnId": "k8s.pod.name",
-                                                    "customLabel": true,
+                                                    "customLabel": false,
                                                     "fieldName": "k8s.pod.name",
-                                                    "label": "Pod",
+                                                    "label": "k8s.pod.name",
                                                     "meta": {
                                                         "esType": "keyword",
                                                         "type": "string"
@@ -2527,23 +2835,31 @@
                                                 },
                                                 {
                                                     "columnId": "mem_limit_util",
-                                                    "customLabel": false,
+                                                    "customLabel": true,
                                                     "fieldName": "mem_limit_util",
                                                     "inMetricDimension": true,
-                                                    "label": "mem_limit_util",
+                                                    "label": "Memory limit utilization",
                                                     "meta": {
                                                         "esType": "double",
                                                         "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             ],
                                             "columns": [
                                                 {
-                                                    "columnId": "ready",
+                                                    "columnId": "restarts",
                                                     "customLabel": true,
-                                                    "fieldName": "ready",
+                                                    "fieldName": "restarts",
                                                     "inMetricDimension": true,
-                                                    "label": "Ready",
+                                                    "label": "Restarts",
                                                     "meta": {
                                                         "esType": "long",
                                                         "type": "number"
@@ -2558,11 +2874,11 @@
                                                     }
                                                 },
                                                 {
-                                                    "columnId": "restarts",
+                                                    "columnId": "ready",
                                                     "customLabel": true,
-                                                    "fieldName": "restarts",
+                                                    "fieldName": "ready",
                                                     "inMetricDimension": true,
-                                                    "label": "Restarts",
+                                                    "label": "Ready",
                                                     "meta": {
                                                         "esType": "long",
                                                         "type": "number"
@@ -2686,7 +3002,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS\n    ready_num    = LAST(k8s.container.ready, CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL)),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit),\n    last_seen    = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS\n    ready_num    = LAST(k8s.container.ready, CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL)),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit),\n    last_seen    = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -2696,7 +3012,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS\n    ready_num    = LAST(k8s.container.ready, CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL)),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit),\n    last_seen    = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS\n    ready_num    = LAST(k8s.container.ready, CASE(k8s.container.ready IS NOT NULL, @timestamp, NULL)),\n    restarts     = MAX(k8s.container.restarts),\n    cpu_usage    = AVG(container.cpu.usage),\n    memory_ws    = AVG(container.memory.working_set),\n    cpu_limit    = MAX(k8s.container.cpu_limit),\n    memory_limit = MAX(k8s.container.memory_limit),\n    last_seen    = MAX(@timestamp)\n  BY k8s.pod.name, k8s.container.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    ready = CASE(\n      ready_num == 1, \"Ready\",\n      ready_num == 0, \"Not Ready\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      memory_limit IS NOT NULL AND memory_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(memory_limit), 4),\n      NULL)\n| KEEP k8s.pod.name, k8s.container.name, ready, restarts, cpu_usage, memory_ws, cpu_limit, memory_limit, mem_limit_util\n| SORT restarts DESC"
                             },
                             "visualization": {
                                 "columns": [
@@ -2705,9 +3021,8 @@
                                             "assignments": [
                                                 {
                                                     "color": {
-                                                        "colorIndex": 0,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                                        "colorCode": "#AEE8D2",
+                                                        "type": "colorCode"
                                                     },
                                                     "rules": [
                                                         {
@@ -2719,9 +3034,8 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 6,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                                        "colorCode": "#ffc9c2",
+                                                        "type": "colorCode"
                                                     },
                                                     "rules": [
                                                         {
@@ -2764,7 +3078,7 @@
                                                 }
                                             ]
                                         },
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "ready"
                                     },
                                     {
@@ -2788,18 +3102,14 @@
                                         "oneClickFilter": true
                                     },
                                     {
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "restarts",
                                         "palette": {
                                             "name": "custom",
                                             "params": {
                                                 "colorStops": [
                                                     {
-                                                        "color": "#24c292",
-                                                        "stop": 0
-                                                    },
-                                                    {
-                                                        "color": "#f6726a",
+                                                        "color": "#FFC9C2",
                                                         "stop": 1
                                                     }
                                                 ],
@@ -2807,18 +3117,14 @@
                                                 "name": "custom",
                                                 "progression": "fixed",
                                                 "rangeMax": null,
-                                                "rangeMin": 0,
+                                                "rangeMin": 1,
                                                 "rangeType": "number",
                                                 "reverse": false,
                                                 "steps": 5,
                                                 "stops": [
                                                     {
-                                                        "color": "#24c292",
-                                                        "stop": 1
-                                                    },
-                                                    {
-                                                        "color": "#f6726a",
-                                                        "stop": 1170
+                                                        "color": "#FFC9C2",
+                                                        "stop": 497
                                                     }
                                                 ]
                                             },
@@ -2831,6 +3137,10 @@
                                 ],
                                 "layerId": "0407c8d7-cd96-4436-8a14-6f4bb354f8e8",
                                 "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
                                 "showRowNumbers": true
                             }
                         },
@@ -2852,7 +3162,7 @@
                     "title": "Containers"
                 },
                 "gridData": {
-                    "h": 15,
+                    "h": 12,
                     "i": "7dad193d-fd5e-416d-8e59-63301bc8f9da",
                     "sectionId": "9fe62ff0-38d4-4caa-93e1-19f45f16f06f",
                     "w": 33,
@@ -2942,8 +3252,8 @@
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
+                                    "x": false,
+                                    "yLeft": false,
                                     "yRight": true
                                 },
                                 "fittingFunction": "Linear",
@@ -2993,7 +3303,8 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "position": "right"
+                                    "layout": "list",
+                                    "position": "bottom"
                                 },
                                 "preferredSeriesType": "line",
                                 "tickLabelsVisibilitySettings": {
@@ -3012,7 +3323,7 @@
                     "title": "CPU usage by container"
                 },
                 "gridData": {
-                    "h": 15,
+                    "h": 12,
                     "i": "be254895-5146-4aa9-8def-d8854fb01d6a",
                     "sectionId": "9fe62ff0-38d4-4caa-93e1-19f45f16f06f",
                     "w": 15,
@@ -3049,18 +3360,18 @@
                 "title": "Containers in pod"
             }
         ],
-        "timeFrom": "2026-05-03T16:31:34.018Z",
+        "timeFrom": "now-24h/h",
         "timeRestore": true,
-        "timeTo": "2026-05-07T09:11:15.618Z",
+        "timeTo": "now",
         "title": "[Kubernetes OTel] Pod Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-05-04T03:38:22.097Z",
+    "created_at": "2026-06-17T05:41:43.358Z",
     "id": "kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-pod-back-link:link_72995b34-850a-4aec-bcb7-2cf694d13086_dashboard",
+            "name": "v3-pod-back-link:link_eb1f6dfc-acd5-47d9-8e11-e34a852e42bf_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13.json
@@ -4785,11 +4785,6 @@
             "id": "kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
             "name": "b0b51832-ae56-4de8-bf14-8d289d67b773:dashboard_drilldown_kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
             "type": "dashboard"
-        },
-        {
-            "id": "dfda744ccd3f15f368e5ca0651b982fbd425ed6a9c51b7def7d79bd513cc5bb3",
-            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
         }
     ],
     "type": "dashboard",

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236.json
@@ -59,7 +59,7 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_4d10bd0a-70ef-4bc6-88ba-f8aada18ccdd_dashboard",
+                            "destinationRefName": "link_a802043b-30bc-421f-a41b-635866189068_dashboard",
                             "label": "\u003c Overview",
                             "options": {
                                 "open_in_new_tab": false,
@@ -2362,7 +2362,7 @@
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -2433,6 +2433,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "CPU limit utilization per pod over time.",
+                    "drilldowns": [],
                     "title": "CPU limit utilization by pod"
                 },
                 "gridData": {
@@ -2582,7 +2583,7 @@
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -2653,6 +2654,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Memory limit utilization per pod over time.",
+                    "drilldowns": [],
                     "title": "Memory limit utilization by pod"
                 },
                 "gridData": {
@@ -2955,7 +2957,7 @@
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -3026,6 +3028,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "description": "Container restarts per pod over time. Only pods with restarts greater than zero are shown.",
+                    "drilldowns": [],
                     "title": "Container restarts by pod"
                 },
                 "gridData": {
@@ -3355,7 +3358,7 @@
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = MAX(k8s.pod.cpu.usage),\n    memory_ws      = MAX(k8s.pod.memory.working_set),\n    mem_limit_util = MAX(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      phase_num == 5, \"Unknown\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = MAX(k8s.pod.cpu.usage),\n    memory_ws      = MAX(k8s.pod.memory.working_set),\n    mem_limit_util = MAX(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      phase_num == 5, \"Unknown\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -3365,7 +3368,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = MAX(k8s.pod.cpu.usage),\n    memory_ws      = MAX(k8s.pod.memory.working_set),\n    mem_limit_util = MAX(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      phase_num == 5, \"Unknown\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL AND k8s.pod.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.namespace.name IS NOT NULL AND k8s.namespace.name != \"\"\n| STATS\n    phase_num      = MAX(k8s.pod.phase),\n    cpu_usage      = MAX(k8s.pod.cpu.usage),\n    memory_ws      = MAX(k8s.pod.memory.working_set),\n    mem_limit_util = MAX(k8s.pod.memory_limit_utilization),\n    restarts       = MAX(k8s.container.restarts),\n    k8s.node.name  = MAX(k8s.node.name),\n    k8s.cluster.name = MAX(k8s.cluster.name),\n    last_seen      = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.uid, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      phase_num == 5, \"Unknown\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT restarts DESC"
                             },
                             "visualization": {
                                 "columns": [
@@ -4204,18 +4207,18 @@
                 "title": "Pods in deployment"
             }
         ],
-        "timeFrom": "now-1h",
+        "timeFrom": "now-24h/h",
         "timeRestore": true,
         "timeTo": "now",
         "title": "[Kubernetes OTel] Deployment Detail"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-06-15T05:59:56.666Z",
+    "created_at": "2026-06-17T05:44:16.016Z",
     "id": "kubernetes_otel-8cf34def-60de-4bf3-9b06-d4ffc6cb4236",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v3-deployment-back-link:link_4d10bd0a-70ef-4bc6-88ba-f8aada18ccdd_dashboard",
+            "name": "v3-deployment-back-link:link_a802043b-30bc-421f-a41b-635866189068_dashboard",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
+++ b/packages/kubernetes_otel/kibana/dashboard/kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d.json
@@ -59,37 +59,37 @@
                     "layout": "horizontal",
                     "links": [
                         {
-                            "destinationRefName": "link_b716e95e-38bd-46f5-a4b9-86e2bef5d9a9_dashboard",
+                            "destinationRefName": "link_471e0694-5d5b-46db-abe1-256aa8c1c8e5_dashboard",
                             "label": "Overview",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_0e2908a4-4b83-4c99-b10d-88a345a61a5e_dashboard",
+                            "destinationRefName": "link_f027319d-e4ac-4138-a59b-053aaa296083_dashboard",
                             "label": "Clusters",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_482fd898-9655-4bfa-803a-a7fb5e1a2099_dashboard",
+                            "destinationRefName": "link_e2511d70-c333-4e94-b94b-8f2da06e7ba0_dashboard",
                             "label": "Nodes",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_2b6f6b33-9a22-46c9-ad1b-9b21e8fb3626_dashboard",
+                            "destinationRefName": "link_e701f90f-32c8-4746-b315-cf960c9bd1b5_dashboard",
                             "label": "Namespaces",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_dc931af3-f804-4def-bfd1-372f4224af2a_dashboard",
+                            "destinationRefName": "link_1ff0f486-1ecb-49ba-a63a-3f8290575bc5_dashboard",
                             "label": "Workload resources",
                             "options": {},
                             "type": "dashboardLink"
                         },
                         {
-                            "destinationRefName": "link_7e2f1926-8938-4099-81cb-a54638b5bae4_dashboard",
+                            "destinationRefName": "link_f0d76b3e-1834-41e2-a73a-86995ec36af6_dashboard",
                             "label": "Pods",
                             "options": {},
                             "type": "dashboardLink"
@@ -138,142 +138,6 @@
                                     "layers": {
                                         "e6f98a1a-9e38-4e5b-a32d-a1fc0d3984c9": {
                                             "allColumns": [
-                                                {
-                                                    "columnId": "cpu_usage",
-                                                    "customLabel": false,
-                                                    "fieldName": "cpu_usage",
-                                                    "inMetricDimension": true,
-                                                    "label": "cpu_usage",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "33ee79af-253e-457f-9021-9705c18d3cdb",
-                                                    "fieldName": "k8s.pod.name",
-                                                    "label": "k8s.pod.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "params": {
-                                                            "id": "string"
-                                                        },
-                                                        "sourceParams": {
-                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
-                                                            "sourceField": "k8s.pod.name"
-                                                        },
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "k8s.namespace.name",
-                                                    "customLabel": false,
-                                                    "fieldName": "k8s.namespace.name",
-                                                    "label": "k8s.namespace.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "93ec0dc8-ba7c-4b8a-a182-07b09408bcf3",
-                                                    "fieldName": "k8s.node.name",
-                                                    "label": "k8s.node.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "params": {
-                                                            "id": "string"
-                                                        },
-                                                        "sourceParams": {
-                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
-                                                            "sourceField": "k8s.node.name"
-                                                        },
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "k8s.cluster.name",
-                                                    "customLabel": false,
-                                                    "fieldName": "k8s.cluster.name",
-                                                    "label": "k8s.cluster.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "440d2f21-bada-4923-b09e-94a9d4cd11cb",
-                                                    "fieldName": "phase",
-                                                    "inMetricDimension": true,
-                                                    "label": "phase",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "params": {
-                                                            "id": "string"
-                                                        },
-                                                        "sourceParams": {
-                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
-                                                            "sourceField": "phase"
-                                                        },
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "k8s.pod.name",
-                                                    "fieldName": "k8s.pod.name",
-                                                    "label": "k8s.pod.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "phase",
-                                                    "fieldName": "phase",
-                                                    "label": "phase",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "memory_ws",
-                                                    "fieldName": "memory_ws",
-                                                    "label": "memory_ws",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "mem_limit_util",
-                                                    "fieldName": "mem_limit_util",
-                                                    "label": "mem_limit_util",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "restarts",
-                                                    "fieldName": "restarts",
-                                                    "label": "restarts",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "k8s.node.name",
-                                                    "fieldName": "k8s.node.name",
-                                                    "label": "k8s.node.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            ],
-                                            "columns": [
                                                 {
                                                     "columnId": "440d2f21-bada-4923-b09e-94a9d4cd11cb",
                                                     "customLabel": true,
@@ -440,11 +304,234 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "phase",
+                                                    "fieldName": "phase",
+                                                    "label": "phase",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "memory_ws",
+                                                    "fieldName": "memory_ws",
+                                                    "label": "memory_ws",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "mem_limit_util",
+                                                    "fieldName": "mem_limit_util",
+                                                    "label": "mem_limit_util",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "restarts",
+                                                    "fieldName": "restarts",
+                                                    "label": "restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.node.name",
+                                                    "fieldName": "k8s.node.name",
+                                                    "label": "k8s.node.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "columns": [
+                                                {
+                                                    "columnId": "89fe5d77-19b2-4be3-bd78-65c7899fe627",
+                                                    "customLabel": true,
+                                                    "fieldName": "restarts",
+                                                    "inMetricDimension": true,
+                                                    "label": "Container restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "restarts"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "440d2f21-bada-4923-b09e-94a9d4cd11cb",
+                                                    "customLabel": true,
+                                                    "fieldName": "phase",
+                                                    "inMetricDimension": true,
+                                                    "label": "Phase",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "phase"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "cpu_usage",
+                                                    "customLabel": true,
+                                                    "fieldName": "cpu_usage",
+                                                    "inMetricDimension": true,
+                                                    "label": "Avg CPU utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "33ee79af-253e-457f-9021-9705c18d3cdb",
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.pod.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.namespace.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "93ec0dc8-ba7c-4b8a-a182-07b09408bcf3",
+                                                    "fieldName": "k8s.node.name",
+                                                    "label": "k8s.node.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.node.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.cluster.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "e2647caf-aee8-421d-adc3-027cc1290c28",
+                                                    "customLabel": true,
+                                                    "fieldName": "memory_ws",
+                                                    "inMetricDimension": true,
+                                                    "label": "Avg memory working set",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "memory_ws"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "dc0bd21c-2bb1-4d08-952e-1af545162b18",
+                                                    "customLabel": true,
+                                                    "fieldName": "mem_limit_util",
+                                                    "inMetricDimension": true,
+                                                    "label": "Memory utilization",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "params": {
+                                                            "id": "number"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*,metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "mem_limit_util"
+                                                        },
+                                                        "type": "number"
+                                                    },
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             ],
                                             "index": "940e9622ed5a553d64d70de28a6d22ade679d741e867ed5246ccd555c690adf4",
                                             "query": {
-                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND @timestamp \u003e ?_tend - 5 minutes\n| STATS\n    cpu_usage        = MAX(k8s.pod.cpu.usage),\n    memory_ws        = MAX(k8s.pod.memory.working_set),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
+                                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND @timestamp \u003e ?_tend - 5 minutes\n| STATS\n    cpu_usage        = AVG(k8s.pod.cpu.usage),\n    memory_ws        = AVG(k8s.pod.memory.working_set),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -454,7 +541,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND @timestamp \u003e ?_tend - 5 minutes\n| STATS\n    cpu_usage        = MAX(k8s.pod.cpu.usage),\n    memory_ws        = MAX(k8s.pod.memory.working_set),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC\n| LIMIT 100"
+                                "esql": "FROM metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND @timestamp \u003e ?_tend - 5 minutes\n| STATS\n    cpu_usage        = AVG(k8s.pod.cpu.usage),\n    memory_ws        = AVG(k8s.pod.memory.working_set),\n    phase_num        = LAST(k8s.pod.phase, CASE(k8s.pod.phase IS NOT NULL, @timestamp, NULL)),\n    restarts         = MAX(k8s.container.restarts),\n    k8s.node.name    = MV_FIRST(VALUES(k8s.node.name)),\n    k8s.cluster.name = MV_FIRST(VALUES(k8s.cluster.name)),\n    mem_limit        = MAX(k8s.container.memory_limit),\n    last_seen        = MAX(@timestamp)\n  BY k8s.namespace.name, k8s.pod.name\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| EVAL\n    phase = CASE(\n      phase_num == 1, \"Pending\",\n      phase_num == 2, \"Running\",\n      phase_num == 3, \"Succeeded\",\n      phase_num == 4, \"Failed\",\n      \"Unknown\"),\n    restarts = COALESCE(restarts, 0),\n    mem_limit_util = CASE(\n      mem_limit IS NOT NULL AND mem_limit \u003e 0,\n        ROUND(TO_DOUBLE(memory_ws) / TO_DOUBLE(mem_limit), 4),\n      NULL)\n| KEEP k8s.cluster.name, k8s.namespace.name, k8s.pod.name, phase, cpu_usage, memory_ws, mem_limit_util, restarts, k8s.node.name\n| SORT cpu_usage DESC NULLS LAST, k8s.pod.name ASC"
                             },
                             "visualization": {
                                 "columns": [
@@ -486,9 +573,8 @@
                                             "assignments": [
                                                 {
                                                     "color": {
-                                                        "colorIndex": 0,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                                        "colorCode": "#AEE8D2",
+                                                        "type": "colorCode"
                                                     },
                                                     "rules": [
                                                         {
@@ -496,13 +582,12 @@
                                                             "value": "Running"
                                                         }
                                                     ],
-                                                    "touched": false
+                                                    "touched": true
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 2,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                                        "colorCode": "#bfdbff",
+                                                        "type": "colorCode"
                                                     },
                                                     "rules": [
                                                         {
@@ -528,9 +613,8 @@
                                                 },
                                                 {
                                                     "color": {
-                                                        "colorIndex": 6,
-                                                        "paletteId": "default",
-                                                        "type": "categorical"
+                                                        "colorCode": "#ffc9c2",
+                                                        "type": "colorCode"
                                                     },
                                                     "rules": [
                                                         {
@@ -577,7 +661,7 @@
                                                 }
                                             ]
                                         },
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "440d2f21-bada-4923-b09e-94a9d4cd11cb",
                                         "isMetric": true,
                                         "isTransposed": false
@@ -588,7 +672,7 @@
                                         "isTransposed": false
                                     },
                                     {
-                                        "colorMode": "cell",
+                                        "colorMode": "badge",
                                         "columnId": "89fe5d77-19b2-4be3-bd78-65c7899fe627",
                                         "isMetric": true,
                                         "isTransposed": false,
@@ -597,11 +681,7 @@
                                             "params": {
                                                 "colorStops": [
                                                     {
-                                                        "color": "#24c292",
-                                                        "stop": 0
-                                                    },
-                                                    {
-                                                        "color": "#F6726A",
+                                                        "color": "#FFC9C2",
                                                         "stop": 1
                                                     }
                                                 ],
@@ -609,18 +689,14 @@
                                                 "name": "custom",
                                                 "progression": "fixed",
                                                 "rangeMax": null,
-                                                "rangeMin": 0,
+                                                "rangeMin": 1,
                                                 "rangeType": "number",
                                                 "reverse": false,
                                                 "steps": 5,
                                                 "stops": [
                                                     {
-                                                        "color": "#24c292",
-                                                        "stop": 1
-                                                    },
-                                                    {
-                                                        "color": "#F6726A",
-                                                        "stop": 4131
+                                                        "color": "#FFC9C2",
+                                                        "stop": 237
                                                     }
                                                 ]
                                             },
@@ -635,6 +711,10 @@
                                 ],
                                 "layerId": "e6f98a1a-9e38-4e5b-a32d-a1fc0d3984c9",
                                 "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
                                 "showRowNumbers": true
                             }
                         },
@@ -642,16 +722,8 @@
                         "version": 2,
                         "visualizationType": "lnsDatatable"
                     },
+                    "description": "All pods across all clusters, ranked by container restarts (highest first). \n\nClick a pod name to drill into pod details, a namespace to drill into namespace details, a node to drill into node details, or a cluster to drill into cluster details. \n\nPhase reflects the latest collected value. CPU utilization, memory working set and memory utilization are averaged over the selected time range. \n\nContainer restarts = sum across all containers over the selected time range.",
                     "drilldowns": [
-                        {
-                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
-                            "label": "1. View pod details",
-                            "open_in_new_tab": false,
-                            "trigger": "on_apply_filter",
-                            "type": "dashboard_drilldown",
-                            "use_filters": true,
-                            "use_time_range": true
-                        },
                         {
                             "dashboardRefName": "dashboard_drilldown_kubernetes_otel-286af595-d3df-4b11-a127-bb096d86db62",
                             "label": "2. View namespace details",
@@ -678,17 +750,1040 @@
                             "type": "dashboard_drilldown",
                             "use_filters": true,
                             "use_time_range": true
+                        },
+                        {
+                            "encode_url": true,
+                            "label": "5. View pod logs in Discover",
+                            "open_in_new_tab": true,
+                            "trigger": "on_click_value",
+                            "type": "url_drilldown",
+                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'logs-*',type:dataView),query:(language:kuery,query:'k8s.pod.name:\"{{event.value}}\"'))"
+                        },
+                        {
+                            "encode_url": true,
+                            "label": "6. View pod traces in Discover",
+                            "open_in_new_tab": true,
+                            "trigger": "on_click_value",
+                            "type": "url_drilldown",
+                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'traces-*',type:dataView),query:(language:kuery,query:'k8s.pod.name:\"{{event.value}}\"'))"
+                        },
+                        {
+                            "encode_url": true,
+                            "label": "7. View pod traces in APM",
+                            "open_in_new_tab": true,
+                            "trigger": "on_click_value",
+                            "type": "url_drilldown",
+                            "url": "{{kibanaUrl}}/app/apm/traces?rangeFrom={{context.panel.timeRange.from}}\u0026rangeTo={{context.panel.timeRange.to}}\u0026kuery=host.name:\"{{event.value}}\" OR k8s.pod.name:\"{{event.value}}\""
+                        },
+                        {
+                            "encode_url": true,
+                            "label": "8. View pod metrics in Discover",
+                            "open_in_new_tab": true,
+                            "trigger": "on_click_value",
+                            "type": "url_drilldown",
+                            "url": "{{kibanaUrl}}/app/discover#/?_g=(time:(from:'{{context.panel.timeRange.from}}',to:'{{context.panel.timeRange.to}}'))\u0026_a=(dataSource:(dataViewId:'metrics-*',type:dataView),query:(language:kuery,query:'k8s.pod.name:\"{{event.value}}\"'))"
+                        },
+                        {
+                            "dashboardRefName": "dashboard_drilldown_kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
+                            "label": "1. View pod details",
+                            "open_in_new_tab": false,
+                            "trigger": "on_apply_filter",
+                            "type": "dashboard_drilldown",
+                            "use_filters": false,
+                            "use_time_range": true
                         }
                     ]
                 },
                 "gridData": {
-                    "h": 20,
+                    "h": 13,
                     "i": "37c11d30-5003-4f4b-ba20-06cdad3441c7",
                     "w": 48,
                     "x": 0,
                     "y": 2
                 },
                 "panelIndex": "37c11d30-5003-4f4b-ba20-06cdad3441c7",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "d2b1c7a4-12c4-4163-8356-9fb68be35302": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "35dbcc0a-ac9f-4b99-89a8-e4efa05fad92",
+                                                    "customLabel": true,
+                                                    "fieldName": "pod_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Total pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "background",
+                                "colorMode": "background",
+                                "layerId": "d2b1c7a4-12c4-4163-8356-9fb68be35302",
+                                "layerType": "data",
+                                "metricAccessor": "35dbcc0a-ac9f-4b99-89a8-e4efa05fad92",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Total number of pods, based on distinct pod UIDs in the latest collected data for the selected time range."
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "v3-pods-health-total",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 4,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "v3-pods-health-total",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "1584f8c0-f752-faf4-db13-b154044a3596": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "90f68402-9f74-4e9b-cc31-d8ed5fb8a06f",
+                                                    "customLabel": true,
+                                                    "fieldName": "running_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Running pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 2\n| STATS running_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 2\n| STATS running_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "background",
+                                "colorMode": "background",
+                                "layerId": "1584f8c0-f752-faf4-db13-b154044a3596",
+                                "layerType": "data",
+                                "metricAccessor": "90f68402-9f74-4e9b-cc31-d8ed5fb8a06f",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "showBar": false,
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of running pods, based on distinct pod UIDs where the latest pod phase is Running (phase=2) in the most recent collected data for the selected time range."
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "61c96cc1-a2d5-4575-a0d4-a9d1c3e364b7",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 4,
+                    "x": 4,
+                    "y": 0
+                },
+                "panelIndex": "61c96cc1-a2d5-4575-a0d4-a9d1c3e364b7",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "5d1dd94c-747f-b8e3-fae6-1270d0306ec0": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "c023f2be-0769-f5f0-1cb2-0b164a453dba",
+                                                    "customLabel": true,
+                                                    "fieldName": "pending_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Pending pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 1\n| STATS pending_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 1\n| STATS pending_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "value",
+                                "colorMode": "background",
+                                "layerId": "5d1dd94c-747f-b8e3-fae6-1270d0306ec0",
+                                "layerType": "data",
+                                "metricAccessor": "c023f2be-0769-f5f0-1cb2-0b164a453dba",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#24C292",
+                                                "stop": 0
+                                            },
+                                            {
+                                                "color": "#FCD883",
+                                                "stop": 1
+                                            }
+                                        ],
+                                        "continuity": "above",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": 0,
+                                        "rangeType": "number",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24C292",
+                                                "stop": 1
+                                            },
+                                            {
+                                                "color": "#FCD883",
+                                                "stop": 2
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "showBar": false,
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of pending pods, based on distinct pod UIDs where the latest pod phase is Pending (phase=1) in the most recent collected data for the selected time range."
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "592fd6a5-5450-49bb-ba05-44307c0ae776",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 4,
+                    "x": 0,
+                    "y": 4
+                },
+                "panelIndex": "592fd6a5-5450-49bb-ba05-44307c0ae776",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "c1fc9697-b165-ea4d-cfee-1d9db3364b92": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "1025cb37-0d1e-c1ee-02ed-c1b868370a2d",
+                                                    "customLabel": true,
+                                                    "fieldName": "failed_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Failed pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 4\n| STATS failed_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 4\n| STATS failed_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "value",
+                                "colorMode": "background",
+                                "layerId": "c1fc9697-b165-ea4d-cfee-1d9db3364b92",
+                                "layerType": "data",
+                                "metricAccessor": "1025cb37-0d1e-c1ee-02ed-c1b868370a2d",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#24C292",
+                                                "stop": 0
+                                            },
+                                            {
+                                                "color": "#F6726A",
+                                                "stop": 1
+                                            }
+                                        ],
+                                        "continuity": "above",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": 0,
+                                        "rangeType": "number",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#24C292",
+                                                "stop": 1
+                                            },
+                                            {
+                                                "color": "#F6726A",
+                                                "stop": 2
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "showBar": false,
+                                "subtitle": "",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of failed pods, based on distinct pod UIDs where the latest pod phase is Failed (phase=4) in the most recent collected data for the selected time range."
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "0a6c7edb-c74a-45d5-8aef-7508a1125879",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 4,
+                    "x": 4,
+                    "y": 4
+                },
+                "panelIndex": "0a6c7edb-c74a-45d5-8aef-7508a1125879",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "bacf7e7d-5aac-48a6-9424-c51297b5d2a9": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "unknown_count",
+                                                    "customLabel": true,
+                                                    "fieldName": "unknown_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Unknown",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 5\n| STATS unknown_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 5\n| STATS unknown_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "background",
+                                "layerId": "bacf7e7d-5aac-48a6-9424-c51297b5d2a9",
+                                "layerType": "data",
+                                "metricAccessor": "unknown_count",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of pods in unknown state, based on distinct pod UIDs where the latest pod phase is Unknown (phase=5) in the most recent collected data for the selected time range. "
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "de2935f0-e8fe-4c14-ba74-332632b901a5",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 4,
+                    "x": 4,
+                    "y": 8
+                },
+                "panelIndex": "de2935f0-e8fe-4c14-ba74-332632b901a5",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "2b3f54e3-c879-45f2-8f05-74bd23929a76": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "succeeded_count",
+                                                    "customLabel": true,
+                                                    "fieldName": "succeeded_count",
+                                                    "inMetricDimension": true,
+                                                    "label": "Succeeded pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 3\n| STATS succeeded_count = COUNT(*)"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 3\n| STATS succeeded_count = COUNT(*)"
+                            },
+                            "visualization": {
+                                "applyColorTo": "background",
+                                "layerId": "2b3f54e3-c879-45f2-8f05-74bd23929a76",
+                                "layerType": "data",
+                                "metricAccessor": "succeeded_count",
+                                "primaryAlign": "left",
+                                "primaryPosition": "top",
+                                "titlesTextAlign": "left"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsMetric"
+                    },
+                    "description": "Number of succeeded pods, based on distinct pod UIDs where the latest pod phase is Succeeded (phase=3) in the most recent collected data for the selected time range."
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "40920ad2-812a-41a9-9fc1-58bb3bba3a2e",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 4,
+                    "x": 0,
+                    "y": 8
+                },
+                "panelIndex": "40920ad2-812a-41a9-9fc1-58bb3bba3a2e",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                    "managed": false,
+                                    "name": "metrics-kubeletstatsreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-kubeletstatsreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-kubeletstatsreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "a9390c0b-daa3-4ca8-893d-6b6775b34bb5": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "CPU usage",
+                                                    "customLabel": false,
+                                                    "fieldName": "CPU usage",
+                                                    "inMetricDimension": true,
+                                                    "label": "CPU usage",
+                                                    "meta": {
+                                                        "esType": "double",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "be898663-8465-4a0b-bcad-22cbae93b9f2",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.namespace.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "2d494a92-9198-42a4-a3d0-91ad7aa7a760",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
+                                            "query": {
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = MAX(k8s.pod.cpu.usage)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.name\n| SORT timestamp ASC, `CPU usage` DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.name, `CPU usage`"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = MAX(k8s.pod.cpu.usage)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.name\n| SORT timestamp ASC, `CPU usage` DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.name, `CPU usage`"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "CPU usage"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "elastic_line_optimized",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "a9390c0b-daa3-4ca8-893d-6b6775b34bb5",
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "splitAccessors": [
+                                            "k8s.pod.name",
+                                            "be898663-8465-4a0b-bcad-22cbae93b9f2",
+                                            "2d494a92-9198-42a4-a3d0-91ad7aa7a760"
+                                        ],
+                                        "xAccessor": "timestamp"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 2,
+                                    "position": "bottom",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "CPU usage per namespace (cores).\n\nShows the 10 namespaces consuming the most CPU.",
+                    "title": "Top 10 pods by CPU usage"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "d3e5c442-b7c7-4291-8c4d-d0f7a0d99111",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 16,
+                    "x": 0,
+                    "y": 12
+                },
+                "panelIndex": "d3e5c442-b7c7-4291-8c4d-d0f7a0d99111",
+                "type": "vis"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
+                                    "allowHidden": false,
+                                    "allowNoIndex": false,
+                                    "fieldFormats": {},
+                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                    "managed": false,
+                                    "name": "metrics-k8sclusterreceiver.otel-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-k8sclusterreceiver.otel-*",
+                                    "type": "esql"
+                                }
+                            },
+                            "datasourceStates": {
+                                "textBased": {
+                                    "indexPatternRefs": [
+                                        {
+                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "timeField": "@timestamp",
+                                            "title": "metrics-k8sclusterreceiver.otel-*"
+                                        }
+                                    ],
+                                    "layers": {
+                                        "c907c7dd-5808-4280-9edf-1c709a95093f": {
+                                            "columns": [
+                                                {
+                                                    "columnId": "timestamp",
+                                                    "customLabel": false,
+                                                    "fieldName": "timestamp",
+                                                    "label": "timestamp",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "k8s.pod.name",
+                                                    "customLabel": false,
+                                                    "fieldName": "k8s.pod.name",
+                                                    "label": "k8s.pod.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "total_restarts",
+                                                    "customLabel": false,
+                                                    "fieldName": "total_restarts",
+                                                    "inMetricDimension": true,
+                                                    "label": "total_restarts",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "08d12508-81f7-437c-9a89-592ec8b37d15",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.namespace.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "e1ba354d-950e-4f58-a7d5-3d33ebe79c8d",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-k8sclusterreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ],
+                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
+                                            "query": {
+                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.name,\n     k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.name\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.name, total_restarts"
+                                            },
+                                            "timeField": "@timestamp"
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [],
+                            "needsRefresh": false,
+                            "query": {
+                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.name,\n     k8s.pod.uid, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.name\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.name, total_restarts"
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "total_restarts"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "elastic_line_optimized",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rules": [
+                                                        {
+                                                            "type": "other"
+                                                        }
+                                                    ],
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "c907c7dd-5808-4280-9edf-1c709a95093f",
+                                        "layerType": "data",
+                                        "seriesType": "line",
+                                        "splitAccessors": [
+                                            "k8s.pod.name",
+                                            "08d12508-81f7-437c-9a89-592ec8b37d15",
+                                            "e1ba354d-950e-4f58-a7d5-3d33ebe79c8d"
+                                        ],
+                                        "xAccessor": "timestamp"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 2,
+                                    "position": "bottom"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "version": 2,
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "Container restarts per pod.\n\nShows the 10 pods with the most container restarts.",
+                    "title": "Top 10 pods by container restarts"
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "6da0c918-ddda-4d63-990b-c64ec4798c18",
+                    "sectionId": "v3-pods-per-pod-metrics",
+                    "w": 16,
+                    "x": 16,
+                    "y": 12
+                },
+                "panelIndex": "6da0c918-ddda-4d63-990b-c64ec4798c18",
                 "type": "vis"
             },
             {
@@ -793,7 +1888,7 @@
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    rss = AVG(k8s.pod.memory.rss),\n    working_set = AVG(k8s.pod.memory.working_set),\n    available = AVG(k8s.pod.memory.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid\n| STATS\n    rss = SUM(rss),\n    working_set = SUM(working_set),\n    available = SUM(available)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, rss, working_set, available"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    rss = MAX(k8s.pod.memory.rss),\n    working_set = MAX(k8s.pod.memory.working_set),\n    available = MAX(k8s.pod.memory.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.uid\n| STATS\n    rss = SUM(rss),\n    working_set = SUM(working_set),\n    available = SUM(available)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, rss, working_set, available"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -803,7 +1898,7 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    rss = AVG(k8s.pod.memory.rss),\n    working_set = AVG(k8s.pod.memory.working_set),\n    available = AVG(k8s.pod.memory.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.uid\n| STATS\n    rss = SUM(rss),\n    working_set = SUM(working_set),\n    available = SUM(available)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, rss, working_set, available"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS\n    rss = MAX(k8s.pod.memory.rss),\n    working_set = MAX(k8s.pod.memory.working_set),\n    available = MAX(k8s.pod.memory.available)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.uid\n| STATS\n    rss = SUM(rss),\n    working_set = SUM(working_set),\n    available = SUM(available)\n  BY timestamp\n| SORT timestamp\n| KEEP timestamp, rss, working_set, available"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -865,460 +1960,11 @@
                     "h": 12,
                     "i": "v2-pods-alt-memory-decomp",
                     "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 24,
-                    "x": 0,
-                    "y": 19
+                    "w": 16,
+                    "x": 32,
+                    "y": 12
                 },
                 "panelIndex": "v2-pods-alt-memory-decomp",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                    "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "d2b1c7a4-12c4-4163-8356-9fb68be35302": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "35dbcc0a-ac9f-4b99-89a8-e4efa05fad92",
-                                                    "customLabel": true,
-                                                    "fieldName": "pod_count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Total pods",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n| STATS last_seen = MAX(@timestamp) BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n| STATS pod_count = COUNT(*)"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "color": "#61A2FF",
-                                "colorMode": "background",
-                                "layerId": "d2b1c7a4-12c4-4163-8356-9fb68be35302",
-                                "layerType": "data",
-                                "metricAccessor": "35dbcc0a-ac9f-4b99-89a8-e4efa05fad92",
-                                "subtitle": "Last value",
-                                "titlesTextAlign": "left"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "drilldowns": []
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "v3-pods-health-total",
-                    "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 12,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "v3-pods-health-total",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                    "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "1584f8c0-f752-faf4-db13-b154044a3596": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "90f68402-9f74-4e9b-cc31-d8ed5fb8a06f",
-                                                    "customLabel": true,
-                                                    "fieldName": "running_count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Running pods",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 2\n| STATS running_count = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 2\n| STATS running_count = COUNT(*)"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "colorMode": "background",
-                                "layerId": "1584f8c0-f752-faf4-db13-b154044a3596",
-                                "layerType": "data",
-                                "metricAccessor": "90f68402-9f74-4e9b-cc31-d8ed5fb8a06f",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#BFDBFF",
-                                                "stop": 0
-                                            },
-                                            {
-                                                "color": "#24C292",
-                                                "stop": 1
-                                            }
-                                        ],
-                                        "continuity": "above",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": 0,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#BFDBFF",
-                                                "stop": 1
-                                            },
-                                            {
-                                                "color": "#24C292",
-                                                "stop": 110
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "showBar": false,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Running pods (phase=2). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 2.",
-                    "drilldowns": []
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "61c96cc1-a2d5-4575-a0d4-a9d1c3e364b7",
-                    "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 12,
-                    "x": 12,
-                    "y": 0
-                },
-                "panelIndex": "61c96cc1-a2d5-4575-a0d4-a9d1c3e364b7",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                    "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "5d1dd94c-747f-b8e3-fae6-1270d0306ec0": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "c023f2be-0769-f5f0-1cb2-0b164a453dba",
-                                                    "customLabel": true,
-                                                    "fieldName": "pending_count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Pending pods",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 1\n| STATS pending_count = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 1\n| STATS pending_count = COUNT(*)"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "colorMode": "background",
-                                "layerId": "5d1dd94c-747f-b8e3-fae6-1270d0306ec0",
-                                "layerType": "data",
-                                "metricAccessor": "c023f2be-0769-f5f0-1cb2-0b164a453dba",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#BFDBFF",
-                                                "stop": null
-                                            },
-                                            {
-                                                "color": "#EAAE01",
-                                                "stop": 1
-                                            }
-                                        ],
-                                        "continuity": "all",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": null,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#BFDBFF",
-                                                "stop": 1
-                                            },
-                                            {
-                                                "color": "#EAAE01",
-                                                "stop": 2
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "showBar": false,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Pending pods (phase=1). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 1.",
-                    "drilldowns": []
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "592fd6a5-5450-49bb-ba05-44307c0ae776",
-                    "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 12,
-                    "x": 24,
-                    "y": 0
-                },
-                "panelIndex": "592fd6a5-5450-49bb-ba05-44307c0ae776",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                    "managed": false,
-                                    "name": "metrics-k8sclusterreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-k8sclusterreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-k8sclusterreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "c1fc9697-b165-ea4d-cfee-1d9db3364b92": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "1025cb37-0d1e-c1ee-02ed-c1b868370a2d",
-                                                    "customLabel": true,
-                                                    "fieldName": "failed_count",
-                                                    "inMetricDimension": true,
-                                                    "label": "Failed pods",
-                                                    "meta": {
-                                                        "esType": "long",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
-                                            "query": {
-                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 4\n| STATS failed_count = COUNT(*)"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS current_phase = LAST(k8s.pod.phase, @timestamp),\n        last_seen = MAX(@timestamp)\n  BY k8s.pod.uid\n| INLINE STATS latest_ts = MAX(last_seen)\n| WHERE DATE_DIFF(\"minute\", last_seen, latest_ts) \u003c= 5\n  AND current_phase == 4\n| STATS failed_count = COUNT(*)"
-                            },
-                            "visualization": {
-                                "applyColorTo": "background",
-                                "colorMode": "background",
-                                "layerId": "c1fc9697-b165-ea4d-cfee-1d9db3364b92",
-                                "layerType": "data",
-                                "metricAccessor": "1025cb37-0d1e-c1ee-02ed-c1b868370a2d",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#BFDBFF",
-                                                "stop": null
-                                            },
-                                            {
-                                                "color": "#F6726A",
-                                                "stop": 1
-                                            }
-                                        ],
-                                        "continuity": "all",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": null,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#BFDBFF",
-                                                "stop": 1
-                                            },
-                                            {
-                                                "color": "#F6726A",
-                                                "stop": 2
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "showBar": false,
-                                "subtitle": "Last value"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsMetric"
-                    },
-                    "description": "Failed pods (phase=4). COUNT_DISTINCT(k8s.pod.uid) WHERE k8s.pod.phase == 4.",
-                    "drilldowns": []
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "0a6c7edb-c74a-45d5-8aef-7508a1125879",
-                    "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 12,
-                    "x": 36,
-                    "y": 0
-                },
-                "panelIndex": "0a6c7edb-c74a-45d5-8aef-7508a1125879",
                 "type": "vis"
             },
             {
@@ -1391,11 +2037,43 @@
                                                             }
                                                         }
                                                     }
+                                                },
+                                                {
+                                                    "columnId": "f87d9038-bacc-40bf-b7e2-c5b589572a0d",
+                                                    "fieldName": "k8s.namespace.name",
+                                                    "label": "k8s.namespace.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.namespace.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "8a9476af-3a6f-4363-8af8-f3a7948dfa88",
+                                                    "fieldName": "k8s.cluster.name",
+                                                    "label": "k8s.cluster.name",
+                                                    "meta": {
+                                                        "esType": "keyword",
+                                                        "params": {
+                                                            "id": "string"
+                                                        },
+                                                        "sourceParams": {
+                                                            "indexPattern": "metrics-kubeletstatsreceiver.otel-*",
+                                                            "sourceField": "k8s.cluster.name"
+                                                        },
+                                                        "type": "string"
+                                                    }
                                                 }
                                             ],
                                             "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
                                             "query": {
-                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp ASC, `Memory working set` DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, `Memory working set`"
+                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = MAX(k8s.pod.memory.working_set)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.name\n| SORT timestamp ASC, `Memory working set` DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.name, `Memory working set`"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1405,11 +2083,11 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = AVG(k8s.pod.memory.working_set)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp ASC, `Memory working set` DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, `Memory working set`"
+                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.cluster.name IS NOT NULL\n  AND k8s.cluster.name != \"\"\n  AND k8s.namespace.name IS NOT NULL\n  AND k8s.namespace.name != \"\"\n  AND k8s.pod.name IS NOT NULL\n  AND k8s.pod.uid IS NOT NULL\n  AND k8s.pod.memory.working_set IS NOT NULL\n| STATS `Memory working set` = MAX(k8s.pod.memory.working_set)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend),\n     k8s.cluster.name, k8s.namespace.name, k8s.pod.name\n| SORT timestamp ASC, `Memory working set` DESC\n| LIMIT 10 BY timestamp\n| SORT timestamp\n| KEEP timestamp, k8s.cluster.name, k8s.namespace.name, k8s.pod.name, `Memory working set`"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -1453,14 +2131,16 @@
                                         "layerType": "data",
                                         "seriesType": "line",
                                         "splitAccessors": [
-                                            "k8s.pod.name"
+                                            "k8s.pod.name",
+                                            "f87d9038-bacc-40bf-b7e2-c5b589572a0d",
+                                            "8a9476af-3a6f-4363-8af8-f3a7948dfa88"
                                         ],
                                         "xAccessor": "timestamp"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "layout": "list",
+                                    "maxLines": 2,
                                     "position": "bottom"
                                 },
                                 "preferredSeriesType": "line",
@@ -1480,176 +2160,14 @@
                     "title": "Top 10 pods by memory working set usage"
                 },
                 "gridData": {
-                    "h": 15,
+                    "h": 12,
                     "i": "a6929d90-b57f-4558-8418-4cdcc8ba1e3a",
                     "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 24,
-                    "x": 24,
-                    "y": 4
+                    "w": 20,
+                    "x": 28,
+                    "y": 0
                 },
                 "panelIndex": "a6929d90-b57f-4558-8418-4cdcc8ba1e3a",
-                "type": "vis"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldFormats": {},
-                                    "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                    "managed": false,
-                                    "name": "metrics-kubeletstatsreceiver.otel-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-kubeletstatsreceiver.otel-*",
-                                    "type": "esql"
-                                }
-                            },
-                            "datasourceStates": {
-                                "textBased": {
-                                    "indexPatternRefs": [
-                                        {
-                                            "id": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                            "timeField": "@timestamp",
-                                            "title": "metrics-kubeletstatsreceiver.otel-*"
-                                        }
-                                    ],
-                                    "layers": {
-                                        "a9390c0b-daa3-4ca8-893d-6b6775b34bb5": {
-                                            "columns": [
-                                                {
-                                                    "columnId": "timestamp",
-                                                    "customLabel": false,
-                                                    "fieldName": "timestamp",
-                                                    "label": "timestamp",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "k8s.pod.name",
-                                                    "customLabel": false,
-                                                    "fieldName": "k8s.pod.name",
-                                                    "label": "k8s.pod.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "CPU usage",
-                                                    "customLabel": false,
-                                                    "fieldName": "CPU usage",
-                                                    "inMetricDimension": true,
-                                                    "label": "CPU usage",
-                                                    "meta": {
-                                                        "esType": "double",
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            ],
-                                            "index": "c939011510bd38ce97144280e9fb6398f12e93be8321360479a2c467d6122e82",
-                                            "query": {
-                                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp ASC, `CPU usage` DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, `CPU usage`"
-                                            },
-                                            "timeField": "@timestamp"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "needsRefresh": false,
-                            "query": {
-                                "esql": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.pod.cpu.usage IS NOT NULL\n| STATS `CPU usage` = AVG(k8s.pod.cpu.usage)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name\n| SORT timestamp ASC, `CPU usage` DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, `CPU usage`"
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "Linear",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "CPU usage"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "elastic_line_optimized",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rules": [
-                                                        {
-                                                            "type": "other"
-                                                        }
-                                                    ],
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "a9390c0b-daa3-4ca8-893d-6b6775b34bb5",
-                                        "layerType": "data",
-                                        "seriesType": "line",
-                                        "splitAccessors": [
-                                            "k8s.pod.name"
-                                        ],
-                                        "xAccessor": "timestamp"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "layout": "list",
-                                    "position": "bottom",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "line",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "version": 2,
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "CPU usage per namespace (cores).\n\nShows the 10 namespaces consuming the most CPU.",
-                    "title": "Top 10 pods by CPU usage"
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "d3e5c442-b7c7-4291-8c4d-d0f7a0d99111",
-                    "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 24,
-                    "x": 0,
-                    "y": 4
-                },
-                "panelIndex": "d3e5c442-b7c7-4291-8c4d-d0f7a0d99111",
                 "type": "vis"
             },
             {
@@ -1682,43 +2200,77 @@
                                         }
                                     ],
                                     "layers": {
-                                        "c907c7dd-5808-4280-9edf-1c709a95093f": {
+                                        "4e7c2b26-a351-4708-b127-90a99d7638f6": {
                                             "columns": [
                                                 {
-                                                    "columnId": "timestamp",
-                                                    "customLabel": false,
-                                                    "fieldName": "timestamp",
-                                                    "label": "timestamp",
-                                                    "meta": {
-                                                        "esType": "date",
-                                                        "type": "date"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "k8s.pod.name",
-                                                    "customLabel": false,
-                                                    "fieldName": "k8s.pod.name",
-                                                    "label": "k8s.pod.name",
-                                                    "meta": {
-                                                        "esType": "keyword",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                {
-                                                    "columnId": "total_restarts",
-                                                    "customLabel": false,
-                                                    "fieldName": "total_restarts",
+                                                    "columnId": "col_running",
+                                                    "customLabel": true,
+                                                    "fieldName": "col_running",
                                                     "inMetricDimension": true,
-                                                    "label": "total_restarts",
+                                                    "label": "Running pods",
                                                     "meta": {
                                                         "esType": "long",
                                                         "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "col_pending",
+                                                    "customLabel": true,
+                                                    "fieldName": "col_pending",
+                                                    "inMetricDimension": true,
+                                                    "label": "Pending pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "col_failed",
+                                                    "customLabel": true,
+                                                    "fieldName": "col_failed",
+                                                    "inMetricDimension": true,
+                                                    "label": "Failed pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "col_succeeded",
+                                                    "customLabel": true,
+                                                    "fieldName": "col_succeeded",
+                                                    "inMetricDimension": true,
+                                                    "label": "Succeeded pods",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "col_unknown",
+                                                    "customLabel": true,
+                                                    "fieldName": "col_unknown",
+                                                    "inMetricDimension": true,
+                                                    "label": "Unknown",
+                                                    "meta": {
+                                                        "esType": "long",
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                {
+                                                    "columnId": "ts",
+                                                    "customLabel": false,
+                                                    "fieldName": "ts",
+                                                    "label": "ts",
+                                                    "meta": {
+                                                        "esType": "date",
+                                                        "type": "date"
                                                     }
                                                 }
                                             ],
                                             "index": "e5f06c52b3bd1edcb07a3d4b79333e5b4c9e3eeb578573940c2599ffcc4a1ac3",
                                             "query": {
-                                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, k8s.pod.name\n| WHERE total_restarts \u003e 0\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, total_restarts"
+                                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS ph = LAST(k8s.pod.phase, @timestamp) BY k8s.pod.uid, ts = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| STATS\n    col_total = COUNT(*),\n    col_running = COUNT(*) WHERE ph == 2,\n    col_pending = COUNT(*) WHERE ph == 1,\n    col_failed = COUNT(*) WHERE ph == 4,\n    col_succeeded = COUNT(*) WHERE ph == 3,\n    col_unknown = COUNT(*) WHERE ph \u003c 1 OR ph \u003e 4\n  BY ts\n| SORT ts ASC"
                                             },
                                             "timeField": "@timestamp"
                                         }
@@ -1728,11 +2280,11 @@
                             "filters": [],
                             "needsRefresh": false,
                             "query": {
-                                "esql": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.name IS NOT NULL\n  AND k8s.container.restarts IS NOT NULL\n  AND k8s.container.name IS NOT NULL\n| STATS max_restarts = MAX(k8s.container.restarts)\n  BY timestamp = TBUCKET(50, ?_tstart, ?_tend), k8s.pod.name, k8s.container.name\n| STATS total_restarts = SUM(max_restarts)\n  BY timestamp, k8s.pod.name\n| WHERE total_restarts \u003e 0\n| SORT timestamp ASC, total_restarts DESC\n| LIMIT 10 BY timestamp\n| KEEP timestamp, k8s.pod.name, total_restarts"
+                                "esql": "FROM metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.uid IS NOT NULL\n  AND k8s.pod.phase IS NOT NULL\n| STATS ph = LAST(k8s.pod.phase, @timestamp) BY k8s.pod.uid, ts = BUCKET(@timestamp, 50, ?_tstart, ?_tend)\n| STATS\n    col_total = COUNT(*),\n    col_running = COUNT(*) WHERE ph == 2,\n    col_pending = COUNT(*) WHERE ph == 1,\n    col_failed = COUNT(*) WHERE ph == 4,\n    col_succeeded = COUNT(*) WHERE ph == 3,\n    col_unknown = COUNT(*) WHERE ph \u003c 1 OR ph \u003e 4\n  BY ts\n| SORT ts ASC"
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
-                                    "x": true,
+                                    "x": false,
                                     "yLeft": false,
                                     "yRight": true
                                 },
@@ -1750,7 +2302,11 @@
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "total_restarts"
+                                            "col_running",
+                                            "col_pending",
+                                            "col_failed",
+                                            "col_succeeded",
+                                            "col_unknown"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
@@ -1772,18 +2328,14 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "c907c7dd-5808-4280-9edf-1c709a95093f",
+                                        "layerId": "4e7c2b26-a351-4708-b127-90a99d7638f6",
                                         "layerType": "data",
                                         "seriesType": "line",
-                                        "splitAccessors": [
-                                            "k8s.pod.name"
-                                        ],
-                                        "xAccessor": "timestamp"
+                                        "xAccessor": "ts"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
-                                    "layout": "list",
                                     "position": "bottom"
                                 },
                                 "preferredSeriesType": "line",
@@ -1799,18 +2351,18 @@
                         "version": 2,
                         "visualizationType": "lnsXY"
                     },
-                    "description": "Container restarts per pod.\n\nShows the 10 pods with the most container restarts.",
-                    "title": "Top 10 pods by container restarts"
+                    "description": " Pod counts over time. The series includes total, running, pending, failed, succeeded, and unknown pod counts (distinct pod UIDs per bucket).",
+                    "title": "Pod counts over time"
                 },
                 "gridData": {
-                    "h": 15,
-                    "i": "6da0c918-ddda-4d63-990b-c64ec4798c18",
+                    "h": 12,
+                    "i": "875e046b-7ed1-4c6f-9801-018fedb239e1",
                     "sectionId": "v3-pods-per-pod-metrics",
-                    "w": 24,
-                    "x": 24,
-                    "y": 19
+                    "w": 20,
+                    "x": 8,
+                    "y": 0
                 },
-                "panelIndex": "6da0c918-ddda-4d63-990b-c64ec4798c18",
+                "panelIndex": "875e046b-7ed1-4c6f-9801-018fedb239e1",
                 "type": "vis"
             }
         ],
@@ -1819,7 +2371,7 @@
                 "collapsed": false,
                 "gridData": {
                     "i": "v3-pods-per-pod-metrics",
-                    "y": 22
+                    "y": 15
                 },
                 "title": "Pods metrics"
             }
@@ -1830,42 +2382,37 @@
         "title": "[Kubernetes OTel] Pods"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-05-04T03:38:28.228Z",
+    "created_at": "2026-06-17T05:41:43.200Z",
     "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
     "references": [
         {
             "id": "kubernetes_otel-7b1ac87f-60ea-477f-b506-8a248026afbb",
-            "name": "v2-pods-alt-nav:link_b716e95e-38bd-46f5-a4b9-86e2bef5d9a9_dashboard",
+            "name": "v2-pods-alt-nav:link_471e0694-5d5b-46db-abe1-256aa8c1c8e5_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-fe68e0e9-0506-4ad7-96be-070cf7592a7e",
-            "name": "v2-pods-alt-nav:link_0e2908a4-4b83-4c99-b10d-88a345a61a5e_dashboard",
+            "name": "v2-pods-alt-nav:link_f027319d-e4ac-4138-a59b-053aaa296083_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0c88decf-de83-47a4-a5df-0a79dc8daff5",
-            "name": "v2-pods-alt-nav:link_482fd898-9655-4bfa-803a-a7fb5e1a2099_dashboard",
+            "name": "v2-pods-alt-nav:link_e2511d70-c333-4e94-b94b-8f2da06e7ba0_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-c0765efe-f172-42c4-a2ea-f4552b6f42dc",
-            "name": "v2-pods-alt-nav:link_2b6f6b33-9a22-46c9-ad1b-9b21e8fb3626_dashboard",
+            "name": "v2-pods-alt-nav:link_e701f90f-32c8-4746-b315-cf960c9bd1b5_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-0b70c6de-4d53-47c4-9844-5f964ba04a6f",
-            "name": "v2-pods-alt-nav:link_dc931af3-f804-4def-bfd1-372f4224af2a_dashboard",
+            "name": "v2-pods-alt-nav:link_1ff0f486-1ecb-49ba-a63a-3f8290575bc5_dashboard",
             "type": "dashboard"
         },
         {
             "id": "kubernetes_otel-aa37d8f8-56ca-4452-96ad-456b5154e23d",
-            "name": "v2-pods-alt-nav:link_7e2f1926-8938-4099-81cb-a54638b5bae4_dashboard",
-            "type": "dashboard"
-        },
-        {
-            "id": "kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
-            "name": "37c11d30-5003-4f4b-ba20-06cdad3441c7:dashboard_drilldown_kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
+            "name": "v2-pods-alt-nav:link_f0d76b3e-1834-41e2-a73a-86995ec36af6_dashboard",
             "type": "dashboard"
         },
         {
@@ -1881,6 +2428,11 @@
         {
             "id": "kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
             "name": "37c11d30-5003-4f4b-ba20-06cdad3441c7:dashboard_drilldown_kubernetes_otel-7b103a47-6eda-47e5-a949-9855bd58aa13",
+            "type": "dashboard"
+        },
+        {
+            "id": "kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
+            "name": "37c11d30-5003-4f4b-ba20-06cdad3441c7:dashboard_drilldown_kubernetes_otel-2a4e0bbf-43c9-4a02-b97d-87a4d05270fd",
             "type": "dashboard"
         },
         {

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 2.1.0-preview9
+version: 2.2.0-preview1
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:


### PR DESCRIPTION

- Enhancement

## Proposed commit message

- Improvements to the pod and pod details dashboard
- Removed invalid references from the cluster details dashboard
- Removed timestamp label from the x-axis of multiple dashboards

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Package upgrade testing
- [x] elastic-package edit dashboards test 

## How to test this PR locally

- `elastic-package build && elastic-package stack up -v -d --services package-registry `

## Screenshots

### Pod dashboard

<img width="1920" height="1341" alt="screencapture-localhost-5601-app-dashboards-2026-06-18-09_26_22" src="https://github.com/user-attachments/assets/b6474a47-5855-409e-9b34-3e9b398de7ab" />

### Pod details dashboard
<img width="5120" height="3370" alt="screencapture-oteldemo-nfxql-kb-us-west2-gcp-elastic-cloud-app-dashboards-2026-06-18-09_29_43" src="https://github.com/user-attachments/assets/8a3742af-4a72-4989-9f01-3fffda8624f7" />


