### PR TITLE
[ti_otx] Add agentless deployment

### DIFF
--- a/packages/ti_otx/_dev/build/docs/README.md
+++ b/packages/ti_otx/_dev/build/docs/README.md
@@ -2,6 +2,11 @@
 
 This integration is for [Alienvault OTX](https://otx.alienvault.com/api). It retrieves indicators for all pulses subscribed to a specific user account on OTX
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Configuration
 
 To use this package, it is required to have an account on [Alienvault OTX](https://otx.alienvault.com/). Once an account has been created, and at least 1 pulse has been subscribed to, the API key can be retrieved from your [user profile dashboard](https://otx.alienvault.com/api). In the top right corner there should be an OTX KEY.

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19641
 - version: "1.31.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.31.0"
   changes:
     - description: Use num_failure_retries instead of unattended mode for transform failure recovery.

--- a/packages/ti_otx/data_stream/pulses_subscribed/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_otx/data_stream/pulses_subscribed/elasticsearch/ingest_pipeline/default.yml
@@ -32,6 +32,7 @@ processors:
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
       field: message
+      tag: remove_message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'

--- a/packages/ti_otx/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_otx/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -24,6 +24,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: otx

--- a/packages/ti_otx/docs/README.md
+++ b/packages/ti_otx/docs/README.md
@@ -2,6 +2,11 @@
 
 This integration is for [Alienvault OTX](https://otx.alienvault.com/api). It retrieves indicators for all pulses subscribed to a specific user account on OTX
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Configuration
 
 To use this package, it is required to have an account on [Alienvault OTX](https://otx.alienvault.com/). Once an account has been created, and at least 1 pulse has been subscribed to, the API key can be retrieved from your [user profile dashboard](https://otx.alienvault.com/api). In the top right corner there should be an OTX KEY.

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,15 +1,15 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.31.0"
+version: "1.32.0"
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration
-format_version: "3.0.2"
+format_version: 3.3.2
 categories:
   - security
   - threat_intel
 conditions:
   kibana:
-    version: "^8.19.4 || ~9.0.7 || ^9.1.4"
+    version: "^8.19.16 || ^9.3.5"
 icons:
   - src: /img/otx.svg
     title: Alienvault OTX
@@ -19,6 +19,15 @@ policy_templates:
   - name: ti_otx
     title: Alienvault OTX
     description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: "Ingest threat intelligence indicators from Alienvault OTX via API"


### PR DESCRIPTION
## Proposed commit message

```
ti_otx: add agentless support and update kibana version constraint
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/ti_otx directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #19593