### PR TITLE
fix(elasticsearch): point changelog entry to PR #19654

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Wire index mode and codec through the index_pivot transform, normalize missing values to standard/default in the monitoring_indices and index metrics ingest pipelines, and add dashboard visualizations for index mode and codec adoption. Requires Metricbeat 8.19+ (beats#49237) to collect elasticsearch.index.mode and elasticsearch.index.codec in the index metricset source data.
       type: enhancement
-      link: https://github.com/elastic/beats/pull/49237
+      link: https://github.com/elastic/integrations/pull/19654
 - version: "1.21.1"
   changes:
     - description: Bugfix for `querylog` new data stream (docs and dashboard)


### PR DESCRIPTION
Fixes Buildkite changelog link check for #19654.

Updates the 1.22.0 changelog entry link from the beats dependency PR to https://github.com/elastic/integrations/pull/19654.

Made with [Cursor](https://cursor.com)