### PR TITLE
fix: remove showApplySelections for Kibana 8.10 package install

### DIFF
--- a/packages/elasticsearch/kibana/dashboard/elasticsearch-consumption.json
+++ b/packages/elasticsearch/kibana/dashboard/elasticsearch-consumption.json
@@ -105,8 +105,7 @@
                     "type": "optionsListControl",
                     "width": "medium"
                 }
-            },
-            "showApplySelections": false
+            }
         },
         "description": "This dashboard presents per data stream usage information, allowing you to align ILM policy, cluster architecture with actual consumption patterns.",
         "kibanaSavedObjectMeta": {

--- a/packages/elasticsearch/kibana/dashboard/elasticsearch-ea888f80-61e4-11ee-b5a1-0d1803efe5cf.json
+++ b/packages/elasticsearch/kibana/dashboard/elasticsearch-ea888f80-61e4-11ee-b5a1-0d1803efe5cf.json
@@ -48,8 +48,7 @@
                     "type": "optionsListControl",
                     "width": "medium"
                 }
-            },
-            "showApplySelections": false
+            }
         },
         "description": "",
         "kibanaSavedObjectMeta": {


### PR DESCRIPTION
## Summary
Remove unsupported `controlGroupInput.showApplySelections` from elasticsearch dashboards modified in #19654.

Kibana 8.10 rejects this field during Fleet package install (400 Bad Request).

## Test plan
- [x] `elastic-package check` in `packages/elasticsearch`

Merge into #19654 branch.

Made with [Cursor](https://cursor.com)