### PR TITLE
Expose http timeout setting in Kubernetes package for kube state metrics

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -24,6 +24,11 @@
     - description: Add kubernetes.container.status.last_terminated_exitcode field to the state_container data stream.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/16680
+- version: "1.83.1"
+  changes:
+    - description: Add `timeout` setting to the kube-state-metrics input for tuning the HTTP request timeout on large clusters.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19391
 - version: "1.83.0"
   changes:
     - description: Update the container logs documentation on how to ingest rotated logs, including GZIP-compressed logs.

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.85.2"
+  changes:
+    - description: Add `timeout` setting to the kube-state-metrics input for tuning the HTTP request timeout on large clusters.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19391
 - version: "1.85.1"
   changes:
     - description: Add container_logs system tests and update base-fields.yml

--- a/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
@@ -8,6 +8,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_cronjob/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_cronjob/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_daemonset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_daemonset/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_deployment/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_deployment/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_namespace/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_namespace/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 condition: ${kubernetes_leaderelection.leader} == true
 {{/if}}

--- a/packages/kubernetes/data_stream/state_node/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_node/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_persistentvolume/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_persistentvolume/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
@@ -8,6 +8,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_replicaset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_replicaset/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_resourcequota/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_resourcequota/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_service/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_service/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_statefulset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_statefulset/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/data_stream/state_storageclass/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_storageclass/agent/stream/stream.yml.hbs
@@ -5,6 +5,9 @@ hosts:
   - {{this}}
 {{/each}}
 period: {{period}}
+{{#if timeout}}
+timeout: {{timeout}}
+{{/if}}
 {{#if leaderelection}}
 {{#if condition }}
 condition: ${kubernetes_leaderelection.leader} == true and {{ condition }}

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.85.1
+version: 1.85.2
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:
@@ -102,6 +102,14 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+          - name: timeout
+            type: text
+            title: Timeout
+            description: HTTP request timeout. Raise on large clusters if scrapes exceed 10s and you see `context deadline exceeded` errors. Valid time units are ns, us, ms, s, m, h.
+            multi: false
+            required: false
+            show_user: false
+            default: 10s
     icons:
       - src: /img/logo_kubernetes.svg
         title: Logo Kubernetes


### PR DESCRIPTION
## Proposed commit message

In large Kubernetes clusters, fetching metrics from kube state metrics can exceed the default HTTP timeout of 10s. This error leads to leader node failures that are unrecoverable. This PR exposes the `timeout` option for KSM datasets, controlling the HTTP timeout. This option is available in Beats and standalone agent.

This is a forward-port of #19391 (merged into `backport-kubernetes-1.83`) to `main`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)