### PR TITLE
[AWS Cloudwatch Input] Update collection period and stats

### DIFF
--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Update default collection period and stats.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: Add support for region specific to a service.

--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update default collection period and stats.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19665
 - version: "0.3.0"
   changes:
     - description: Add support for region specific to a service.

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_cloudwatch_input_otel
 title: "AWS CloudWatch OpenTelemetry Input Package"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Collect AWS CloudWatch metrics for selected AWS services (EC2, RDS, SQS, ELB, Lambda, Fargate) using the OpenTelemetry Collector awscloudwatchmetrics receiver."
@@ -130,6 +130,7 @@ policy_templates:
         default:
           - Average
           - Sum
+          - Maximum
         required: true
         show_user: false
 
@@ -159,14 +160,14 @@ policy_templates:
         type: duration
         title: Collection Interval
         description: How often the receiver polls CloudWatch.
-        default: 5m
+        default: 1m
         required: false
         show_user: false
       - name: period
         type: duration
         title: Period
         description: CloudWatch aggregation window. Must match the metric resolution.
-        default: 5m
+        default: 1m
         required: false
         show_user: true
       - name: delay
@@ -238,6 +239,7 @@ policy_templates:
         description: CloudWatch statistics applied to every discovered metric for this namespace.
         default:
           - Average
+          - Maximum
         required: true
         show_user: false
 
@@ -267,14 +269,14 @@ policy_templates:
         type: duration
         title: Collection Interval
         description: How often the receiver polls CloudWatch.
-        default: 5m
+        default: 1m
         required: false
         show_user: false
       - name: period
         type: duration
         title: Period
         description: CloudWatch aggregation window. Must match the metric resolution.
-        default: 5m
+        default: 1m
         required: false
         show_user: true
       - name: delay
@@ -346,6 +348,7 @@ policy_templates:
         description: CloudWatch statistics applied to every discovered metric for this namespace.
         default:
           - Maximum
+          - Minimum
           - Average
           - Sum
         required: true
@@ -377,14 +380,14 @@ policy_templates:
         type: duration
         title: Collection Interval
         description: How often the receiver polls CloudWatch.
-        default: 5m
+        default: 1m
         required: false
         show_user: false
       - name: period
         type: duration
         title: Period
         description: CloudWatch aggregation window. Must match the metric resolution.
-        default: 5m
+        default: 1m
         required: false
         show_user: true
       - name: delay
@@ -401,6 +404,8 @@ policy_templates:
         description: CloudWatch statistics applied to every discovered metric for this namespace.
         default:
           - Average
+          - Maximum
+          - Sum
         required: true
         show_user: false
 

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -293,7 +293,6 @@ policy_templates:
         description: CloudWatch statistics applied to every discovered metric for this namespace.
         default:
           - Maximum
-          - Average
           - Sum
         required: true
         show_user: false
@@ -348,7 +347,6 @@ policy_templates:
         description: CloudWatch statistics applied to every discovered metric for this namespace.
         default:
           - Maximum
-          - Minimum
           - Average
           - Sum
         required: true

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -118,7 +118,7 @@ policy_templates:
         type: duration
         title: Delay
         description: How far back from now each scrape's query window ends. Increase if metrics arrive late from CloudWatch.
-        default: 15m
+        default: 5m
         required: false
         show_user: false
       # required: true to fetch metrics appropriately as the metrics only needed is fetched.
@@ -174,7 +174,7 @@ policy_templates:
         type: duration
         title: Delay
         description: How far back from now each scrape's query window ends. Increase if metrics arrive late from CloudWatch.
-        default: 10m
+        default: 5m
         required: false
         show_user: false
       - name: autodiscover_aggregation
@@ -229,7 +229,7 @@ policy_templates:
         type: duration
         title: Delay
         description: How far back from now each scrape's query window ends. Increase if metrics arrive late from CloudWatch.
-        default: 10m
+        default: 5m
         required: false
         show_user: false
       - name: autodiscover_aggregation
@@ -283,7 +283,7 @@ policy_templates:
         type: duration
         title: Delay
         description: How far back from now each scrape's query window ends. Increase if metrics arrive late from CloudWatch.
-        default: 10m
+        default: 5m
         required: false
         show_user: false
       - name: autodiscover_aggregation
@@ -392,7 +392,7 @@ policy_templates:
         type: duration
         title: Delay
         description: How far back from now each scrape's query window ends. Increase if metrics arrive late from CloudWatch.
-        default: 10m
+        default: 5m
         required: false
         show_user: false
       - name: autodiscover_aggregation


### PR DESCRIPTION

- Enhancement

This PR updates the default collection interval to **1m** based on the official aws documentation and adds missing default stats based on the stats used in content packs.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
