### PR TITLE
[AWS Cloudwatch Input] Make secret false

### DIFF
--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Disable secrets flag.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: Add support for region specific to a service.

--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets flag.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19670
 - version: "0.3.0"
   changes:
     - description: Add support for region specific to a service.

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_cloudwatch_input_otel
 title: "AWS CloudWatch OpenTelemetry Input Package"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Collect AWS CloudWatch metrics for selected AWS services (EC2, RDS, SQS, ELB, Lambda, Fargate) using the OpenTelemetry Collector awscloudwatchmetrics receiver."
@@ -39,21 +39,21 @@ vars:
     description: Mapped to `AWS_ACCESS_KEY_ID` on the collector process when an IAM role is not available.
     required: false
     show_user: true
-    secret: true
+    secret: false
   - name: secret_access_key
     type: password
     title: AWS Secret Access Key
     description: Mapped to `AWS_SECRET_ACCESS_KEY`.
     required: false
     show_user: true
-    secret: true
+    secret: false
   - name: session_token
     type: password
     title: AWS Session Token
     description: Mapped to `AWS_SESSION_TOKEN` for temporary STS credentials.
     required: false
     show_user: true
-    secret: true
+    secret: false
   - name: role_arn
     type: text
     title: AWS Role ARN


### PR DESCRIPTION

- Enhancement

## Proposed commit message

This PR sets `secret: false` until `secret: true` has been verified to work with OTel input packages.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
