### PR TITLE
EntityAnalytics Entra ID: fix last activity support

### DIFF
--- a/packages/entityanalytics_entra_id/changelog.yml
+++ b/packages/entityanalytics_entra_id/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.2"
+  changes:
+    - description: Include approximateLastSignInDateTime in the device selection when Intune Managed Device Properties is enabled.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.10.1"
   changes:
     - description: Remove misleading event.action values from sample events in documentation and clarify that this integration provides asset inventory, not an audit trail.

--- a/packages/entityanalytics_entra_id/changelog.yml
+++ b/packages/entityanalytics_entra_id/changelog.yml
@@ -4,6 +4,9 @@
     - description: Include approximateLastSignInDateTime in the device selection when Intune Managed Device Properties is enabled.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/99999
+    - description: Remove non-functional User Sign-in Activity option (the signInActivity property is not available via the delta query endpoint and requires a dedicated enrichment path not yet implemented in the agent).
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.10.1"
   changes:
     - description: Remove misleading event.action values from sample events in documentation and clarify that this integration provides asset inventory, not an audit trail.

--- a/packages/entityanalytics_entra_id/changelog.yml
+++ b/packages/entityanalytics_entra_id/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Include approximateLastSignInDateTime in the device selection when Intune Managed Device Properties is enabled.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/19672
     - description: Remove non-functional User Sign-in Activity option (the signInActivity property is not available via the delta query endpoint and requires a dedicated enrichment path not yet implemented in the agent).
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/19672
 - version: "1.10.1"
   changes:
     - description: Remove misleading event.action values from sample events in documentation and clarify that this integration provides asset inventory, not an audit trail.

--- a/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/policy/test-intune-with-custom-options.expected
+++ b/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/policy/test-intune-with-custom-options.expected
@@ -26,6 +26,7 @@ inputs:
             - physicalIds
             - extensionAttributes
             - alternativeSecurityIds
+            - approximateLastSignInDateTime
             - isCompliant
             - isManaged
             - manufacturer

--- a/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/policy/test-intune.expected
+++ b/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/policy/test-intune.expected
@@ -26,6 +26,7 @@ inputs:
             - physicalIds
             - extensionAttributes
             - alternativeSecurityIds
+            - approximateLastSignInDateTime
             - isCompliant
             - isManaged
             - manufacturer

--- a/packages/entityanalytics_entra_id/data_stream/entity/agent/stream/entity-analytics.yml.hbs
+++ b/packages/entityanalytics_entra_id/data_stream/entity/agent/stream/entity-analytics.yml.hbs
@@ -57,6 +57,7 @@ select.devices:
   - physicalIds
   - extensionAttributes
   - alternativeSecurityIds
+  - approximateLastSignInDateTime
   - isCompliant
   - isManaged
   - manufacturer

--- a/packages/entityanalytics_entra_id/data_stream/entity/agent/stream/entity-analytics.yml.hbs
+++ b/packages/entityanalytics_entra_id/data_stream/entity/agent/stream/entity-analytics.yml.hbs
@@ -23,20 +23,6 @@ login_scopes:
 enrich_with:
   - mfa
 {{/if}}
-{{#if user_sign_in_activity}}
-select.users:
-  - accountEnabled
-  - userPrincipalName
-  - mail
-  - displayName
-  - givenName
-  - surname
-  - jobTitle
-  - officeLocation
-  - mobilePhone
-  - businessPhones
-  - signInActivity
-{{/if}}
 {{#if user_direct_reports}}
 expand.users:
   - directReports

--- a/packages/entityanalytics_entra_id/data_stream/entity/manifest.yml
+++ b/packages/entityanalytics_entra_id/data_stream/entity/manifest.yml
@@ -85,7 +85,8 @@ streams:
           Enable collection of additional device properties managed by Microsoft
           Intune (isCompliant, isManaged, deviceCategory, deviceOwnership,
           enrollmentProfileName, mdmAppId, complianceExpirationDateTime,
-          manufacturer, model, registrationDateTime, systemLabels). Requires the
+          manufacturer, model, registrationDateTime, systemLabels) and the
+          device last sign-in time (approximateLastSignInDateTime). Requires the
           DeviceManagementManagedDevices.Read.All application permission and an
           active Intune license on the tenant.
         multi: false

--- a/packages/entityanalytics_entra_id/data_stream/entity/manifest.yml
+++ b/packages/entityanalytics_entra_id/data_stream/entity/manifest.yml
@@ -68,16 +68,6 @@ streams:
         required: false
         show_user: true
         default: false
-      - name: user_sign_in_activity
-        type: bool
-        title: User Sign-in Activity
-        description: >-
-          Enable collection of user sign-in activity by including signInActivity
-          in the user selection. Populates user.entity.lifecycle.last_activity.
-        multi: false
-        required: false
-        show_user: true
-        default: false
       - name: intune_managed_devices
         type: bool
         title: Intune Managed Device Properties

--- a/packages/entityanalytics_entra_id/manifest.yml
+++ b/packages/entityanalytics_entra_id/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: entityanalytics_entra_id
 title: "Microsoft Entra ID Entity Analytics"
-version: "1.10.1"
+version: "1.10.2"
 description: "Collect identities from Microsoft Entra ID (formerly Azure Active Directory) with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[Entra ID] Fix device last sign-in time and remove broken user sign-in activity option

Include approximateLastSignInDateTime in the Intune device select query so
the field is actually collected when Intune Managed Device Properties is enabled.

Remove the User Sign-in Activity (user_sign_in_activity) toggle and its
associated select.users: [signInActivity] configuration. The signInActivity
property is explicitly excluded from delta query responses by the Microsoft
Graph API; it is listed under "Properties not returned by default" and noted
as not supported in $select on delta endpoints:
https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0

Emitting it via select.users had no effect; the field was never populated.
Proper support requires a separate non-delta enrichment call in the agent,
which will be re-introduced once the beats-side implementation ships.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/19552
