### PR TITLE
cursor: add missing default for enable_request_tracer

### DIFF
--- a/packages/cursor/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cursor/_dev/deploy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   cursor-audit-mock:
-    image: docker.elastic.co/observability/stream:v0.20.0
+    image: docker.elastic.co/observability/stream:v0.22.0
     hostname: cursor-audit-mock
     ports:
       - 8090

--- a/packages/cursor/_dev/deploy/docker/files/config-audit.yml
+++ b/packages/cursor/_dev/deploy/docker/files/config-audit.yml
@@ -1,100 +1,8 @@
 rules:
-  # Round 3+ — steady-state, page 1.
-  # Fires on every subsequent interval once Round 2 has completed.
-  # The startTime exactly matches the last event timestamp returned by Round 2
-  # (2026-05-04T17:00:00.000Z), which the CEL stored as cursor.last_timestamp
-  # and then reformatted to RFC3339Nano (trailing zeros stripped to `Z`).
-  # Returns zero events so the cursor does not advance and polling terminates.
-  - path: /teams/audit-logs
-    methods: ["GET"]
-    query_params:
-      page: "1"
-      startTime: "2026-05-04T17:00:00Z"
-      endTime: "{endTime:.*}"
-      pageSize: "{pageSize:.*}"
-    request_headers:
-      Authorization:
-        - "Basic a2V5X3Rlc3QxMjM6"
-      Accept:
-        - "application/json"
-    responses:
-      - status_code: 200
-        headers:
-          Content-Type:
-            - "application/json"
-        body: |-
-          {
-            "events": [],
-            "pagination": {
-              "page": 1,
-              "pageSize": 100,
-              "totalCount": 0,
-              "totalPages": 0,
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            },
-            "params": { "teamId": 9990001, "startDate": 0, "endDate": 0 }
-          }
-  # Round 2 — page 1.
-  # Fires at the start of the second polling interval.
-  # The startTime exactly matches the last event timestamp from Round 1 page 2
-  # (2026-05-04T15:30:00.000Z), which the CEL stored as cursor.last_timestamp
-  # and then reformatted to RFC3339Nano (trailing zeros stripped to `Z`).
-  # Returns 2 events and hasNextPage=false so pagination stops immediately.
-  # The last event timestamp (2026-05-04T17:00:00.000Z) becomes the cursor for Round 3+.
-  - path: /teams/audit-logs
-    methods: ["GET"]
-    query_params:
-      page: "1"
-      startTime: "2026-05-04T15:30:00Z"
-      endTime: "{endTime:.*}"
-      pageSize: "{pageSize:.*}"
-    request_headers:
-      Authorization:
-        - "Basic a2V5X3Rlc3QxMjM6"
-      Accept:
-        - "application/json"
-    responses:
-      - status_code: 200
-        headers:
-          Content-Type:
-            - "application/json"
-        body: |-
-          {
-            "events": [
-              {
-                "event_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0007",
-                "timestamp": "2026-05-04T16:00:00.000Z",
-                "ip_address": "198.51.100.22",
-                "user_email": "admin@example.com",
-                "event_type": "add_user",
-                "event_data": { "user_email": "newuser@example.com" }
-              },
-              {
-                "event_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0008",
-                "timestamp": "2026-05-04T17:00:00.000Z",
-                "ip_address": "198.51.100.23",
-                "user_email": "admin2@example.com",
-                "event_type": "team_settings",
-                "event_data": { "setting": "allow_invites", "enabled": true }
-              }
-            ],
-            "pagination": {
-              "page": 1,
-              "pageSize": 100,
-              "totalCount": 2,
-              "totalPages": 1,
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            },
-            "params": { "teamId": 9990001, "startDate": 0, "endDate": 0 }
-          }
-  # Round 1 — page 2 (final page).
-  # Fires during the first polling interval after the CEL follows hasNextPage=true from page 1.
-  # startTime/endTime are dynamic (runtime values) so both are captured with a regex.
-  # Returns 3 events and hasNextPage=false, ending pagination for Round 1.
-  # The last event timestamp (2026-05-04T15:30:00.000Z) is stored as cursor.last_timestamp,
-  # which becomes the exact startTime the CEL sends in Round 2.
+  # Page 2 (final page).
+  # Returns 3 events and hasNextPage=false, ending pagination.
+  # Timestamps use now-relative offsets so they never age past the CEL
+  # program's 30-day API clamp.
   - path: /teams/audit-logs
     methods: ["GET"]
     query_params:
@@ -117,7 +25,7 @@ rules:
             "events": [
               {
                 "event_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0004",
-                "timestamp": "2026-05-04T13:00:00.000Z",
+                "timestamp": "{{ (now "-237h").Format "2006-01-02T15:04:05.000Z" }}",
                 "ip_address": "203.0.113.10",
                 "user_email": "unknown",
                 "event_type": "remove_user",
@@ -125,7 +33,7 @@ rules:
               },
               {
                 "event_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0005",
-                "timestamp": "2026-05-04T14:00:00.000Z",
+                "timestamp": "{{ (now "-236h").Format "2006-01-02T15:04:05.000Z" }}",
                 "ip_address": "198.51.100.20",
                 "user_email": "cloud@example.com",
                 "event_type": "cloud_agent_user_settings",
@@ -133,7 +41,7 @@ rules:
               },
               {
                 "event_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0006",
-                "timestamp": "2026-05-04T15:30:00.000Z",
+                "timestamp": "{{ (now "-235h").Format "2006-01-02T15:04:05.000Z" }}",
                 "ip_address": "198.51.100.21",
                 "user_email": "ops@example.com",
                 "event_type": "login",
@@ -150,12 +58,9 @@ rules:
             },
             "params": { "teamId": 9990001, "startDate": 0, "endDate": 0 }
           }
-  # Round 1 — page 1 (catchall).
-  # Fires at the very start of the first polling interval when no cursor exists.
-  # startTime is derived from now-initial_interval and endTime from now, both dynamic,
-  # so both are captured with a regex. This rule must be last among page=1 rules so
-  # the more-specific Round 2 and Round 3+ rules match first.
+  # Page 1 (catchall).
   # Returns 3 events and hasNextPage=true, driving the CEL to fetch page 2.
+  # startTime and endTime are dynamic (runtime values) so both use a regex.
   - path: /teams/audit-logs
     methods: ["GET"]
     query_params:
@@ -178,7 +83,7 @@ rules:
             "events": [
               {
                 "event_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0001",
-                "timestamp": "2026-05-04T10:00:00.000Z",
+                "timestamp": "{{ (now "-240h").Format "2006-01-02T15:04:05.000Z" }}",
                 "ip_address": "198.51.100.10",
                 "user_email": "alice@example.com",
                 "event_type": "login",
@@ -186,7 +91,7 @@ rules:
               },
               {
                 "event_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0002",
-                "timestamp": "2026-05-04T11:00:00.000Z",
+                "timestamp": "{{ (now "-239h").Format "2006-01-02T15:04:05.000Z" }}",
                 "ip_address": "192.0.2.50",
                 "user_email": "mcp@example.com",
                 "event_type": "mcp_server_config",
@@ -194,7 +99,7 @@ rules:
               },
               {
                 "event_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0003",
-                "timestamp": "2026-05-04T12:00:00.000Z",
+                "timestamp": "{{ (now "-238h").Format "2006-01-02T15:04:05.000Z" }}",
                 "ip_address": "198.51.100.11",
                 "user_email": "bob@example.com",
                 "event_type": "cloud_agent_user_settings",

--- a/packages/cursor/changelog.yml
+++ b/packages/cursor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Add missing default false value for enable_request_tracer configuration variable.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19675
 - version: "0.2.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/cursor/data_stream/audit/_dev/test/system/test-cel-config.yml
+++ b/packages/cursor/data_stream/audit/_dev/test/system/test-cel-config.yml
@@ -16,4 +16,4 @@ data_stream:
       - forwarded
       - cursor-audit
 assert:
-  hit_count: 8
+  hit_count: 6

--- a/packages/cursor/data_stream/audit/manifest.yml
+++ b/packages/cursor/data_stream/audit/manifest.yml
@@ -72,6 +72,7 @@ streams:
           The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/docs/reference/integrations/inputs/input-cel#_resource_tracer_filename) for details.
         required: false
         show_user: false
+        default: false
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/cursor/manifest.yml
+++ b/packages/cursor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.2
 name: cursor
 title: "Cursor"
-version: "0.2.0"
+version: "0.2.1"
 description: "Collect audit logs from Cursor with Elastic Agent"
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
cursor: add missing default for enable_request_tracer

The manifest was not being provided with a default false value as
required by the request tracer configuration system.

The mock's hardcoded May 2026 timestamps expire after the CEL
program's 30-day startTime clamp pushes the query window past
them. Replace the four cursor-round rules with two page-based
rules that use stream's {{ now }} template to keep event
timestamps ~10 days old indefinitely. Bump stream to v0.22.0
for the now template function and lower hit_count from 8 to 6
since the pipeline fingerprints _id from event_id, deduplicating
repeated rounds to 6 unique documents.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
