### PR TITLE
chore: upgrade fetch-github-token to v1.5.3

### DIFF
--- a/.github/workflows/trigger-package-tests-security-ml.yml
+++ b/.github/workflows/trigger-package-tests-security-ml.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Fetch ephemeral token for security-ml dispatch
         id: auth
-        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.0
+        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3
         with:
           vault-instance: ci-prod
 


### PR DESCRIPTION
## Summary

Upgrades `elastic/ci-gh-actions/fetch-github-token` to `v1.5.3` across all affected workflow files.

## Reason

Version `v1.5.3` includes a fix for a security concern related to new GitHub token formats. Previous pinned versions (including commit SHAs and older semver tags) do not handle the updated token format correctly.

See: https://github.com/elastic/ci-gh-actions/releases/tag/v1.5.3

## Changes

Bumps `fetch-github-token` references from older versions/SHAs to `v1.5.3`.

---
*This PR was created automatically to address a security concern in CI workflows.*