### PR TITLE
[Slack] Simplify visible variable agentless experience

### DIFF
--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.29.0"
   changes:
-    - description: Apply simplified agentless onboarding so only the OAuth token is shown by default in the policy editor.
+    - description: Reorganize variable to hide advanced variables and make agentless the default deployment mode.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/19694
 - version: "1.28.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.0"
+  changes:
+    - description: Apply simplified agentless onboarding so only the OAuth token is shown by default in the policy editor.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "1.28.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/slack/data_stream/audit/manifest.yml
+++ b/packages/slack/data_stream/audit/manifest.yml
@@ -16,7 +16,7 @@ streams:
         title: Interval
         multi: false
         required: true
-        show_user: true
+        show_user: false
         description: Interval at which the logs will be pulled. The value must be between 2m and 1h. Supported units for this parameter are h/m/s.
         default: 1h
       - name: initial_interval
@@ -39,13 +39,13 @@ streams:
         title: Tags
         multi: true
         required: true
-        show_user: true
+        show_user: false
         default:
           - forwarded
           - slack-audit
       - name: preserve_original_event
         required: true
-        show_user: true
+        show_user: false
         title: Preserve original event
         description: Preserves a raw copy of the original event, added to the field `event.original`
         type: bool

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: slack
 title: "Slack Logs"
-version: "1.28.0"
+version: "1.29.0"
 description: "Slack Logs Integration"
 type: integration
 categories:
@@ -25,6 +25,7 @@ policy_templates:
       agentless:
         enabled: true
         release: beta
+        is_default: true
         organization: security
         division: engineering
         team: security-service-integrations
@@ -68,7 +69,7 @@ policy_templates:
             description: Duration before declaring that the HTTP client connection has timed out. Valid time units are ns, us, ms, s, m, h.
             multi: false
             required: false
-            show_user: true
+            show_user: false
             default: 60s
 owner:
   github: elastic/security-service-integrations


### PR DESCRIPTION
Resolve https://github.com/elastic/ingest-dev/issues/8153 

Reorganize variables and make agentless the default deployment mode.

<img width="697" height="553" alt="Screenshot 2026-06-22 at 11 26 41 AM" src="https://github.com/user-attachments/assets/b71f56c7-0cd0-4a54-82d3-c46df256c1b1" />
