### PR TITLE
[ti_mandiant_advantage] Add agentless deployment

### DIFF
--- a/packages/ti_mandiant_advantage/_dev/build/docs/README.md
+++ b/packages/ti_mandiant_advantage/_dev/build/docs/README.md
@@ -8,6 +8,11 @@ These indicators can be used for correlation in Elastic Security to help discove
 
 Our threat intelligence is compiled by over 500 threat intelligence analysts across 30 countries, researching actors via undercover adversarial pursuits, incident forensics, malicious infrastructure reconstructions and actor identification processes that comprise the deep knowledge embedded in the Mandiant Intel Grid.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The Mandiant Advantage integration collects one type of data stream: `threat_intelligence`

--- a/packages/ti_mandiant_advantage/changelog.yml
+++ b/packages/ti_mandiant_advantage/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19699
 - version: "1.10.0"
   changes:
     - description: Prevent updating fleet health status to degraded when pagination completes.

--- a/packages/ti_mandiant_advantage/changelog.yml
+++ b/packages/ti_mandiant_advantage/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.10.0"
   changes:
     - description: Prevent updating fleet health status to degraded when pagination completes.

--- a/packages/ti_mandiant_advantage/data_stream/threat_intelligence/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_mandiant_advantage/data_stream/threat_intelligence/elasticsearch/ingest_pipeline/default.yml
@@ -6,6 +6,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
+- remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
 - set:
       field: ecs.version
       value: 8.11.0

--- a/packages/ti_mandiant_advantage/docs/README.md
+++ b/packages/ti_mandiant_advantage/docs/README.md
@@ -8,6 +8,11 @@ These indicators can be used for correlation in Elastic Security to help discove
 
 Our threat intelligence is compiled by over 500 threat intelligence analysts across 30 countries, researching actors via undercover adversarial pursuits, incident forensics, malicious infrastructure reconstructions and actor identification processes that comprise the deep knowledge embedded in the Mandiant Intel Grid.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The Mandiant Advantage integration collects one type of data stream: `threat_intelligence`

--- a/packages/ti_mandiant_advantage/manifest.yml
+++ b/packages/ti_mandiant_advantage/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.0.2
+format_version: 3.3.2
 name: ti_mandiant_advantage
 title: "Mandiant Advantage"
-version: "1.10.0"
+version: "1.11.0"
 source:
   license: "Elastic-2.0"
 description: "Collect Threat Intelligence from products within the Mandiant Advantage platform."
@@ -36,6 +36,15 @@ policy_templates:
   - name: ti_mandiant_advantage
     title: Mandiant Advantage
     description: "Collect Threat Intelligence from products within the Mandiant Advantage platform."
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: Collect data from Mandiant Advantage products


### PR DESCRIPTION
## Proposed commit message

```
ti_mandiant_advantage: add agentless support and update kibana version constraint
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/ti_mandiant_advantage directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #19590