### PR TITLE
nextron_thor_apt_scanner: integration quality improvements - phase-1

### DIFF
--- a/packages/nextron_thor/_dev/deploy/docker/files/config.yml
+++ b/packages/nextron_thor/_dev/deploy/docker/files/config.yml
@@ -14,7 +14,91 @@ rules:
           Content-Type:
             - 'application/json'
         body: |-
-          { "data": [ { "id": "9bd91102-398c-4a19-986a-e664411d5ba1", "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111", "scanner_id": "b3691137-493e-4861-ad14-c02c02c21111", "creation_date": 1761779601, "modification_date": 1761780194, "last_launcher_update": 1761780194, "stage": "successful", "status": "successful", "stage_status": "good", "hostname": "myhostname", "os": "linux", "os_version": "Ubuntu 22.04.5 LTS", "architecture": "amd64", "progress": null, "admin_rights": true, "log_levels": { "alerts": 2, "warnings": 1, "notices": 47, "infos": 708, "errors": 0 }, "runtime": 592, "thor_version": "10.7.24", "signature_version": "25.10.27-143342", "thor_args": "", "custom_ioc_count": 0, "latest_host_scan": true, "logs_encrypted": false, "available_logs": [ "launcher.log", "thor.json", "thor.html", "thor.log" ], "disposed": false, "launcher_type": "executable" } ], "total": 1}
+          {{ minify_json `
+          {
+            "data": [
+              {
+                "id": "9bd91102-398c-4a19-986a-e664411d5ba1",
+                "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
+                "scanner_id": "b3691137-493e-4861-ad14-c02c02c21111",
+                "creation_date": 1761779601,
+                "modification_date": 1761780194,
+                "last_launcher_update": 1761780194,
+                "stage": "successful",
+                "status": "successful",
+                "stage_status": "good",
+                "hostname": "myhostname",
+                "os": "linux",
+                "os_version": "Ubuntu 22.04.5 LTS",
+                "architecture": "amd64",
+                "progress": null,
+                "admin_rights": true,
+                "log_levels": {
+                  "alerts": 2,
+                  "warnings": 1,
+                  "notices": 47,
+                  "infos": 708,
+                  "errors": 0
+                },
+                "runtime": 592,
+                "thor_version": "10.7.24",
+                "signature_version": "25.10.27-143342",
+                "thor_args": "",
+                "custom_ioc_count": 0,
+                "latest_host_scan": true,
+                "logs_encrypted": false,
+                "available_logs": [
+                  "launcher.log",
+                  "thor.json",
+                  "thor.html",
+                  "thor.log"
+                ],
+                "disposed": false,
+                "launcher_type": "executable"
+              },
+              {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "campaign_id": "11111111-1111-1111-1111-111111111111",
+                "scanner_id": "22222222-2222-2222-2222-222222222222",
+                "creation_date": 1700000000,
+                "modification_date": 1700003600,
+                "last_launcher_update": 1700001800,
+                "stage": "successful",
+                "status": "successful",
+                "stage_status": "good",
+                "hostname": "host01",
+                "os": "windows",
+                "os_version": "Windows OS",
+                "architecture": "amd64",
+                "progress": null,
+                "admin_rights": false,
+                "log_levels": {
+                  "alerts": 10,
+                  "warnings": 10,
+                  "notices": 10,
+                  "infos": 100,
+                  "errors": 0
+                },
+                "runtime": 1000,
+                "thor_version": "x.y.z",
+                "signature_version": "0.000000.000000",
+                "thor_args": "",
+                "custom_ioc_count": 0,
+                "latest_host_scan": false,
+                "logs_encrypted": false,
+                "available_logs": [
+                  "launcher.log",
+                  "thor.json",
+                  "thor.html",
+                  "thor.log"
+                ],
+                "disposed": false,
+                "launcher_type": "oneliner"
+              }
+            ],
+            "total": 20
+          }
+          `}}
   - path: /v1/scan/log
     methods: ['GET']
     query_params:
@@ -39,3 +123,22 @@ rules:
           {"time":"2025-11-10T17:52:49Z","hostname":"myhostname","level":"Info","module":"AtJobs","message":"At Job detected","scanid":"S-VavZi0stuDo","job":"C:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\UpdateOrchestrator\\Schedule Maintenance Work","command":"%systemroot%\\system32\\usoclient.exe","start":"","user":"S-1-5-18","runlevel":"","logontype":"","files":[{"path":"C:\\Windows\\system32\\usoclient.exe","exists":"yes","type":"EXE","size":90112,"md5":"1feddb97cdc1d931766010363f9b945e","sha1":"b3837bc524fb8d1c67025d7fa90c30c0a4a7657d","sha256":"0eccf139a5c8f2dcb8dd648eff85c42309456ea74ee90fae9adab4fb06968006","firstbytes":"4d5a90000300000004000000ffff0000b8000000 / MZ","created":"2025-09-12T18:15:53.5554443Z","owner":"NT SERVICE\\TrustedInstaller","company":"Microsoft Corporation","desc":"UsoClient","legal_copyright":"© Microsoft Corporation. All rights reserved.","product":"Microsoft® Windows® Operating System","original_name":"UsoClient","internal_name":"UsoClient","imphash":"59970db1d5ef76d2ab92ae1bf6482723"}],"log_version":"v2.0.0"}
           {"time":"2025-11-10T17:52:49Z","hostname":"myhostname","level":"Info","module":"AtJobs","message":"At Job detected","scanid":"S-VavZi0stuDo","job":"C:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\UpdateOrchestrator\\Schedule Scan","command":"%systemroot%\\system32\\usoclient.exe","start":"2019-01-01T12:00:00","user":"S-1-5-18","runlevel":"LeastPrivilege","logontype":"","files":[{"path":"C:\\Windows\\system32\\usoclient.exe","exists":"yes","type":"EXE","size":90112,"md5":"1feddb97cdc1d931766010363f9b945e","sha1":"b3837bc524fb8d1c67025d7fa90c30c0a4a7657d","sha256":"0eccf139a5c8f2dcb8dd648eff85c42309456ea74ee90fae9adab4fb06968006","firstbytes":"4d5a90000300000004000000ffff0000b8000000 / MZ","created":"2025-09-12T18:15:53.5554443Z","owner":"NT SERVICE\\TrustedInstaller","company":"Microsoft Corporation","desc":"UsoClient","legal_copyright":"© Microsoft Corporation. All rights reserved.","product":"Microsoft® Windows® Operating System","original_name":"UsoClient","internal_name":"UsoClient","imphash":"59970db1d5ef76d2ab92ae1bf6482723"}],"log_version":"v2.0.0"}
           {"time":"2025-11-10T17:52:49Z","hostname":"myhostname","level":"Info","module":"AtJobs","message":"At Job detected","scanid":"S-VavZi0stuDo","job":"C:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\UpdateOrchestrator\\Schedule Scan Static Task","command":"%systemroot%\\system32\\usoclient.exe","start":"","user":"S-1-5-18","runlevel":"","logontype":"","files":[{"path":"C:\\Windows\\system32\\usoclient.exe","exists":"yes","type":"EXE","size":90112,"md5":"1feddb97cdc1d931766010363f9b945e","sha1":"b3837bc524fb8d1c67025d7fa90c30c0a4a7657d","sha256":"0eccf139a5c8f2dcb8dd648eff85c42309456ea74ee90fae9adab4fb06968006","firstbytes":"4d5a90000300000004000000ffff0000b8000000 / MZ","created":"2025-09-12T18:15:53.5554443Z","owner":"NT SERVICE\\TrustedInstaller","company":"Microsoft Corporation","desc":"UsoClient","legal_copyright":"© Microsoft Corporation. All rights reserved.","product":"Microsoft® Windows® Operating System","original_name":"UsoClient","internal_name":"UsoClient","imphash":"59970db1d5ef76d2ab92ae1bf6482723"}],"log_version":"v2.0.0"}
+  - path: /v1/scan/log
+    methods: ['GET']
+    query_params:
+      scan: "00000000-0000-0000-0000-000000000000"
+      log: "thor.json"
+    request_headers:
+      Authorization:
+        - "xxxx"
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - 'application/json'
+        # Tests that identical log lines are ingested as separate events. Line 2 and 4 are identical.
+        body: |-
+          {"time":"2026-04-02T18:32:16Z","hostname":"HOSTNAME1","level":"Info","module":"Firewall","message":"Firewall Rule Incoming","scanid":"SCANID-1","rule":"grouping: {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}  localport: 7000  remoteport: Any  edge_traversal: No  action: Allow  profiles: Private  enabled: Yes  direction: In  localip: Any  remoteip: Any  protocol: UDP  rule_name: anonymized_rule_name","log_version":"v2.0.0"}
+          {"time":"2026-04-02T18:32:16Z","hostname":"HOSTNAME1","level":"Warning","module":"Firewall","message":"Suspicious Trojan/Backdoor Local Port defined in Firewall rule","scanid":"SCANID-1","signature":"ANONYMIZED_SIGNATURE","rule_name":"anonymized_rule_name","port":"7000","score":70,"log_version":"v2.0.0"}
+          {"time":"2026-04-02T18:32:16Z","hostname":"HOSTNAME1","level":"Info","module":"Firewall","message":"Firewall Rule Incoming","scanid":"SCANID-1","rule":"remoteport: Any  action: Allow  rule_name: anonymized_rule_name  direction: In  profiles: Public  grouping: {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}  localport: 7000  enabled: Yes  localip: Any  remoteip: Any  protocol: UDP  edge_traversal: No","log_version":"v2.0.0"}
+          {"time":"2026-04-02T18:32:16Z","hostname":"HOSTNAME1","level":"Warning","module":"Firewall","message":"Suspicious Trojan/Backdoor Local Port defined in Firewall rule","scanid":"SCANID-1","signature":"ANONYMIZED_SIGNATURE","rule_name":"anonymized_rule_name","port":"7000","score":70,"log_version":"v2.0.0"}

--- a/packages/nextron_thor/changelog.yml
+++ b/packages/nextron_thor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Fix CEL cursor advancement when scans produce no events, improve deduplication and file path parsing, handle AtJobs multi-value start timestamps, and drop API error responses from the index.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/nextron_thor/changelog.yml
+++ b/packages/nextron_thor/changelog.yml
@@ -1,13 +1,13 @@
 # newer versions go on top
 - version: "0.4.0"
   changes:
-    - description: Fix CEL cursor advancement when scans produce no events, improve deduplication and file path parsing, handle AtJobs multi-value start timestamps, and drop API error responses from the index.
+    - description: Fix CEL cursor advancement when scans produce no events, improve deduplication and file path parsing, handle AtJobs multi-value start timestamps, and terminate processing on API error responses.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/19713
     - description: Map event.category and event.type per THOR module, map process, registry, and rule fields to ECS, and set event.kind to alert for Alert-level findings.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19713
-    - description: Declare missing THOR module fields and normalize app, archive, and numeric field types in the ingest pipeline.
+    - description: "Renames and retypes several `thor.*` fields and removes the default `event.category: file`; saved searches, dashboards, and detection rules that use the previous field names, keyword mappings, or blanket file category must be updated."
       type: breaking-change
       link: https://github.com/elastic/integrations/pull/19713
 - version: "0.3.0"

--- a/packages/nextron_thor/changelog.yml
+++ b/packages/nextron_thor/changelog.yml
@@ -1,9 +1,15 @@
 # newer versions go on top
-- version: "0.3.1"
+- version: "0.4.0"
   changes:
     - description: Fix CEL cursor advancement when scans produce no events, improve deduplication and file path parsing, handle AtJobs multi-value start timestamps, and drop API error responses from the index.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19713
+    - description: Map event.category and event.type per THOR module, map process, registry, and rule fields to ECS, and set event.kind to alert for Alert-level findings.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19713
+    - description: Declare missing THOR module fields and normalize app, archive, and numeric field types in the ingest pipeline.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/19713
 - version: "0.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-atjobs-multivalue-start.log
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-atjobs-multivalue-start.log
@@ -1,0 +1,1 @@
+{"time":"2025-12-10T18:00:00Z","hostname":"testhost","level":"Info","module":"AtJobs","message":"At Job detected","scanid":"S-TestStart001","job":"C:\\Windows\\System32\\Tasks\\test","command":"","start":"2014-01-01T00:00:00+00:00, 2014-01-01T01:00:00+00:00","user":"","runlevel":"","logontype":"","files":null,"log_version":"v2.0.0"}

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-atjobs-multivalue-start.log-expected.json
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-atjobs-multivalue-start.log-expected.json
@@ -7,7 +7,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "AtJobs",
@@ -33,16 +33,9 @@
                 "preserve_original_event"
             ],
             "thor": {
-                "command": "",
-                "files": null,
                 "job": "C:\\Windows\\System32\\Tasks\\test",
-                "logontype": "",
-                "runlevel": "",
                 "scan_id": "S-TestStart001",
                 "start": "2014-01-01T00:00:00.000Z"
-            },
-            "user": {
-                "name": ""
             }
         }
     ]

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-atjobs-multivalue-start.log-expected.json
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-atjobs-multivalue-start.log-expected.json
@@ -1,0 +1,49 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2025-12-10T18:00:00.000Z",
+            "ecs": {
+                "version": "9.2.0"
+            },
+            "event": {
+                "category": [
+                    "file"
+                ],
+                "kind": "event",
+                "module": "AtJobs",
+                "original": "{\"time\":\"2025-12-10T18:00:00Z\",\"hostname\":\"testhost\",\"level\":\"Info\",\"module\":\"AtJobs\",\"message\":\"At Job detected\",\"scanid\":\"S-TestStart001\",\"job\":\"C:\\\\Windows\\\\System32\\\\Tasks\\\\test\",\"command\":\"\",\"start\":\"2014-01-01T00:00:00+00:00, 2014-01-01T01:00:00+00:00\",\"user\":\"\",\"runlevel\":\"\",\"logontype\":\"\",\"files\":null,\"log_version\":\"v2.0.0\"}",
+                "type": [
+                    "info"
+                ],
+                "version": "v2.0.0"
+            },
+            "host": {
+                "name": "testhost"
+            },
+            "log": {
+                "level": "Info"
+            },
+            "message": "At Job detected",
+            "related": {
+                "hosts": [
+                    "testhost"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "thor": {
+                "command": "",
+                "files": null,
+                "job": "C:\\Windows\\System32\\Tasks\\test",
+                "logontype": "",
+                "runlevel": "",
+                "scan_id": "S-TestStart001",
+                "start": "2014-01-01T00:00:00.000Z"
+            },
+            "user": {
+                "name": ""
+            }
+        }
+    ]
+}

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-file-name-extraction.log
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-file-name-extraction.log
@@ -1,3 +1,4 @@
 {"time":"2025-12-10T18:00:00Z","hostname":"testhost","level":"Warning","module":"Filescan","message":"Suspicious file found","scanid":"S-TestGrok001","score":50,"file":{"path":"c:\\users\\administrator\\mimidrv.sys","type":"EXE"},"log_version":"v2.0.0"}
 {"time":"2025-12-10T18:00:01Z","hostname":"testhost","level":"Warning","module":"Filescan","message":"Suspicious file found","scanid":"S-TestGrok002","score":50,"file":{"path":"/suspicious.bin","type":"ELF"},"log_version":"v2.0.0"}
 {"time":"2025-12-10T18:00:02Z","hostname":"testhost","level":"Warning","module":"Filescan","message":"Suspicious file found","scanid":"S-TestGrok003","score":50,"file":{"path":"\\\\server\\share\\malware.exe","type":"EXE"},"log_version":"v2.0.0"}
+{"time":"2025-12-10T18:00:03Z","hostname":"testhost","level":"Info","module":"Amcache","message":"Analyzing Amcache Hive","scanid":"S-TestString001","file":"C:\\Windows\\appcompat\\Programs\\Amcache.hve.tmp.LOG1","log_version":"v2.0.0"}

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-file-name-extraction.log-expected.json
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-file-name-extraction.log-expected.json
@@ -131,6 +131,46 @@
                 "scan_id": "S-TestGrok003",
                 "score": 50
             }
+        },
+        {
+            "@timestamp": "2025-12-10T18:00:03.000Z",
+            "ecs": {
+                "version": "9.2.0"
+            },
+            "event": {
+                "category": [
+                    "file"
+                ],
+                "kind": "event",
+                "module": "Amcache",
+                "original": "{\"time\":\"2025-12-10T18:00:03Z\",\"hostname\":\"testhost\",\"level\":\"Info\",\"module\":\"Amcache\",\"message\":\"Analyzing Amcache Hive\",\"scanid\":\"S-TestString001\",\"file\":\"C:\\\\Windows\\\\appcompat\\\\Programs\\\\Amcache.hve.tmp.LOG1\",\"log_version\":\"v2.0.0\"}",
+                "type": [
+                    "info"
+                ],
+                "version": "v2.0.0"
+            },
+            "file": {
+                "name": "Amcache.hve.tmp.LOG1",
+                "path": "C:\\Windows\\appcompat\\Programs\\Amcache.hve.tmp.LOG1"
+            },
+            "host": {
+                "name": "testhost"
+            },
+            "log": {
+                "level": "Info"
+            },
+            "message": "Analyzing Amcache Hive",
+            "related": {
+                "hosts": [
+                    "testhost"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "thor": {
+                "scan_id": "S-TestString001"
+            }
         }
     ]
 }

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-file-name-extraction.log-expected.json
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-file-name-extraction.log-expected.json
@@ -139,13 +139,13 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "registry"
                 ],
                 "kind": "event",
                 "module": "Amcache",
                 "original": "{\"time\":\"2025-12-10T18:00:03Z\",\"hostname\":\"testhost\",\"level\":\"Info\",\"module\":\"Amcache\",\"message\":\"Analyzing Amcache Hive\",\"scanid\":\"S-TestString001\",\"file\":\"C:\\\\Windows\\\\appcompat\\\\Programs\\\\Amcache.hve.tmp.LOG1\",\"log_version\":\"v2.0.0\"}",
                 "type": [
-                    "info"
+                    "access"
                 ],
                 "version": "v2.0.0"
             },

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-thorscanlogs.log-expected.json
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-thorscanlogs.log-expected.json
@@ -136,7 +136,8 @@
                 "version": "v2.0.0"
             },
             "file": {
-                "name": "C:\\Windows\\appcompat\\Programs\\Amcache.hve.tmp.LOG1"
+                "name": "Amcache.hve.tmp.LOG1",
+                "path": "C:\\Windows\\appcompat\\Programs\\Amcache.hve.tmp.LOG1"
             },
             "host": {
                 "name": "mymachinename"
@@ -1095,7 +1096,8 @@
                 "version": "v2.0.0"
             },
             "file": {
-                "name": "/home/customUser/vulnerabilitycheck/testdata/tomcat-users.xml"
+                "name": "tomcat-users.xml",
+                "path": "/home/customUser/vulnerabilitycheck/testdata/tomcat-users.xml"
             },
             "host": {
                 "name": "mymachinename"

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-thorscanlogs.log-expected.json
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/pipeline/test-thorscanlogs.log-expected.json
@@ -7,7 +7,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "end": "2025-11-10T17:58:42.4290563Z",
                 "kind": "event",
@@ -49,7 +49,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "EtwWatcher",
@@ -125,13 +125,13 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "registry"
                 ],
                 "kind": "event",
                 "module": "Amcache",
                 "original": "{\"campaign_id\": \"2b054111-bad7-4bac-a14e-8fa8a88f1111\",\"time\":\"2025-12-10T17:58:01Z\",\"hostname\":\"mymachinename\",\"level\":\"Info\",\"module\":\"Amcache\",\"message\":\"Analyzing Amcache Hive\",\"scanid\":\"S-VavZi0stuDo\",\"file\":\"C:\\\\Windows\\\\appcompat\\\\Programs\\\\Amcache.hve.tmp.LOG1\",\"log_version\":\"v2.0.0\"}",
                 "type": [
-                    "info"
+                    "access"
                 ],
                 "version": "v2.0.0"
             },
@@ -166,13 +166,13 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "registry"
                 ],
                 "kind": "event",
                 "module": "RegistryHive",
                 "original": "{\"campaign_id\": \"2b054111-bad7-4bac-a14e-8fa8a88f1111\",\"time\":\"2025-12-10T17:58:01Z\",\"hostname\":\"mymachinename\",\"level\":\"Info\",\"module\":\"RegistryHive\",\"message\":\"Scanning registry\",\"scanid\":\"S-VavZi0stuDo\",\"hive\":\"C:\\\\Windows\\\\appcompat\\\\Programs\\\\Amcache.hve.tmp.LOG1\",\"log_version\":\"v2.0.0\"}",
                 "type": [
-                    "info"
+                    "access"
                 ],
                 "version": "v2.0.0"
             },
@@ -183,6 +183,9 @@
                 "level": "Info"
             },
             "message": "Scanning registry",
+            "registry": {
+                "path": "C:\\Windows\\appcompat\\Programs\\Amcache.hve.tmp.LOG1"
+            },
             "related": {
                 "hosts": [
                     "mymachinename"
@@ -193,7 +196,6 @@
             ],
             "thor": {
                 "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
-                "hive": "C:\\Windows\\appcompat\\Programs\\Amcache.hve.tmp.LOG1",
                 "scan_id": "S-VavZi0stuDo"
             }
         },
@@ -204,7 +206,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "AtJobs",
@@ -269,10 +271,8 @@
                     }
                 ],
                 "job": "C:\\Windows\\WaaS\\tasks\\5ffea6126f02e78b9099eb4614d2d339f03ca5a8.xml",
-                "logontype": "",
                 "runlevel": "LeastPrivilege",
-                "scan_id": "S-VavZi0stuDo",
-                "start": ""
+                "scan_id": "S-VavZi0stuDo"
             },
             "user": {
                 "name": "S-1-5-18"
@@ -285,7 +285,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "WMIPersistence",
@@ -312,7 +312,6 @@
             ],
             "thor": {
                 "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
-                "event_consumer": "",
                 "event_consumer_name": "SCM Event Log Consumer",
                 "event_filter": "select * from MSFT_SCMEventLogEvent",
                 "event_filter_name": "SCM Event Log Filter",
@@ -328,7 +327,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "Eventlog",
@@ -367,13 +366,13 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "registry"
                 ],
                 "kind": "event",
                 "module": "RegistryChecks",
                 "original": "{\"campaign_id\": \"2b054111-bad7-4bac-a14e-8fa8a88f1111\",\"time\":\"2025-12-10T17:13:54Z\",\"hostname\":\"mymachinename\",\"level\":\"Info\",\"module\":\"RegistryChecks\",\"message\":\"Finished module\",\"scanid\":\"S-VavZi0stuDo\",\"duration\":\"0 hours 0 mins 53 secs\",\"scanned_elements\":496069,\"log_version\":\"v2.0.0\"}",
                 "type": [
-                    "info"
+                    "access"
                 ],
                 "version": "v2.0.0"
             },
@@ -406,7 +405,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "ScheduledTasks",
@@ -418,6 +417,7 @@
             },
             "file": {
                 "accessed": "2021-05-08T09:37:44.634Z",
+                "created": "2021-05-08T09:37:44.634Z",
                 "hash": {
                     "md5": "ec604a0d8a27976ab136a489d9b6aa76",
                     "sha1": "5c8e0b60caad1cf28706f8389059c8603cf51eaf",
@@ -453,10 +453,9 @@
             "thor": {
                 "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
                 "command": "\"%ProgramFiles%\\Windows Media Player\\wmpnscfg.exe\"",
-                "enabled": "true",
+                "enabled": true,
                 "file": {
                     "company": "Microsoft Corporation",
-                    "created": "2021-05-08T09:37:44.634Z",
                     "description": "Windows Media Player Network Sharing Service Configuration Application",
                     "first_bytes": "4d5a90000300000004000000ffff0000b8000000 / MZ",
                     "imphash": "c38242470146ca32c2a3f1ab0cffd0ab",
@@ -465,7 +464,6 @@
                     "permissions": "APPLICATION PACKAGE AUTHORITY\\ALL APPLICATION PACKAGES:R / APPLICATION PACKAGE AUTHORITY\\ALL RESTRICTED APPLICATION PACKAGES:R / BUILTIN\\Administrators:R / BUILTIN\\Users:R / NT AUTHORITY\\SYSTEM:R / NT SERVICE\\TrustedInstaller:F",
                     "product": "Microsoft® Windows® Operating System"
                 },
-                "files": null,
                 "last_run": "0001-01-01T00:00:00.000Z",
                 "name": "UpdateLibrary",
                 "next_run": "0001-01-01T00:00:00.000Z",
@@ -480,7 +478,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "ServiceCheck",
@@ -525,13 +523,13 @@
                     "modified": "2025-09-12T18:15:45.130Z",
                     "original_name": "WpnUserService.dll.mui",
                     "owner": "NT SERVICE\\TrustedInstaller",
+                    "path": "%SystemRoot%\\system32\\svchost.exe -k UnistackSvcGroup",
                     "permissions": "APPLICATION PACKAGE AUTHORITY\\ALL APPLICATION PACKAGES:R / APPLICATION PACKAGE AUTHORITY\\ALL RESTRICTED APPLICATION PACKAGES:R / BUILTIN\\Administrators:R / BUILTIN\\Users:R / NT AUTHORITY\\SYSTEM:R / NT SERVICE\\TrustedInstaller:F",
                     "product": "Microsoft® Windows® Operating System",
                     "sha1": "0ea3742d5046b4dd49832672d677862f7cdfba16",
                     "sha256": "1a37ac55c634989d601bc5ff24e5d71b984eb7ad76217e5a52f36621fe86dd69",
                     "size": 106496
                 },
-                "image_path": "%SystemRoot%\\system32\\svchost.exe -k UnistackSvcGroup",
                 "key": "System\\CurrentControlSet\\Services\\WpnUserService",
                 "key_name": "WpnUserService",
                 "modified": "2025-09-12T18:24:28.210Z",
@@ -550,7 +548,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "ScheduledTasks",
@@ -562,6 +560,7 @@
             },
             "file": {
                 "accessed": "2025-09-12T18:15:06.552Z",
+                "created": "2025-09-12T18:15:06.552Z",
                 "hash": {
                     "md5": "6395857d79bc9b4290002c7d66839e8c",
                     "sha1": "10da9787bb8e69ef3f012265c29bd3fa9b37916a",
@@ -597,10 +596,9 @@
             "thor": {
                 "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
                 "command": "%windir%\\system32\\srvinitconfig.exe /disableconfigtask",
-                "enabled": "false",
+                "enabled": false,
                 "file": {
                     "company": "Microsoft Corporation",
-                    "created": "2025-09-12T18:15:06.552Z",
                     "description": "Server Configurations",
                     "first_bytes": "4d5a90000300000004000000ffff0000b8000000 / MZ",
                     "imphash": "b33f8014279efc94b8cc2b371d076f45",
@@ -610,7 +608,6 @@
                     "permissions": "APPLICATION PACKAGE AUTHORITY\\ALL APPLICATION PACKAGES:R / APPLICATION PACKAGE AUTHORITY\\ALL RESTRICTED APPLICATION PACKAGES:R / BUILTIN\\Administrators:R / BUILTIN\\Users:R / NT AUTHORITY\\SYSTEM:R / NT SERVICE\\TrustedInstaller:F",
                     "product": "Microsoft® Windows® Operating System"
                 },
-                "files": null,
                 "last_run": "2025-09-13T00:47:00.000Z",
                 "name": "Server Initial Configuration Task",
                 "next_run": "0001-01-01T00:00:00.000Z",
@@ -625,13 +622,14 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "iam"
                 ],
                 "kind": "event",
                 "module": "Users",
                 "original": "{\"campaign_id\": \"2b054111-bad7-4bac-a14e-8fa8a88f1111\",\"time\":\"2025-12-10T17:12:59Z\",\"hostname\":\"mymachinename\",\"level\":\"Info\",\"module\":\"Users\",\"message\":\"Finished module\",\"scanid\":\"S-VavZi0stuDo\",\"duration\":\"0 hours 0 mins 0 secs\",\"scanned_elements\":5,\"log_version\":\"v2.0.0\"}",
                 "type": [
-                    "info"
+                    "info",
+                    "user"
                 ],
                 "version": "v2.0.0"
             },
@@ -664,13 +662,14 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "iam"
                 ],
                 "kind": "event",
                 "module": "UserDir",
                 "original": "{\"campaign_id\": \"2b054111-bad7-4bac-a14e-8fa8a88f1111\",\"time\":\"2025-12-10T17:12:59Z\",\"hostname\":\"mymachinename\",\"level\":\"Notice\",\"module\":\"UserDir\",\"message\":\"Recently modified profile\",\"scanid\":\"S-VavZi0stuDo\",\"user\":\"Default\",\"created\":\"2021-05-08T08:06:51.7150288Z\",\"modified\":\"2025-11-10T16:07:40.9921271Z\",\"log_version\":\"v2.0.0\"}",
                 "type": [
-                    "info"
+                    "info",
+                    "user"
                 ],
                 "version": "v2.0.0"
             },
@@ -709,7 +708,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "network"
                 ],
                 "kind": "event",
                 "module": "NetworkShares",
@@ -785,7 +784,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "process"
                 ],
                 "kind": "event",
                 "module": "ProcessCheck",
@@ -802,6 +801,16 @@
                 "level": "Info"
             },
             "message": "Process info",
+            "process": {
+                "command_line": "\"C:\\Windows\\system32\\cmd.exe\" ",
+                "executable": "C:\\Windows\\System32\\cmd.exe",
+                "name": "cmd.exe",
+                "parent": {
+                    "executable": "C:\\Windows\\explorer.exe",
+                    "pid": 6156
+                },
+                "pid": 8596
+            },
             "related": {
                 "hosts": [
                     "mymachinename"
@@ -816,7 +825,6 @@
             ],
             "thor": {
                 "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
-                "command": "\"C:\\Windows\\system32\\cmd.exe\" ",
                 "connection_count": 0,
                 "created": "2025-11-10T16:41:59.000Z",
                 "files": [
@@ -872,7 +880,6 @@
                     "modified": "2025-09-12T18:15:50.460Z",
                     "original_name": "Cmd.Exe.MUI",
                     "owner": "NT SERVICE\\TrustedInstaller",
-                    "path": "C:\\Windows\\System32\\cmd.exe",
                     "permissions": "APPLICATION PACKAGE AUTHORITY\\ALL APPLICATION PACKAGES:R / APPLICATION PACKAGE AUTHORITY\\ALL RESTRICTED APPLICATION PACKAGES:R / BUILTIN\\Administrators:R / BUILTIN\\Users:R / NT AUTHORITY\\SYSTEM:R / NT SERVICE\\TrustedInstaller:F",
                     "product": "Microsoft® Windows® Operating System",
                     "sha1": "bc2820b5ee7b43c172005b66546f12316de8c081",
@@ -880,12 +887,7 @@
                     "size": 335872,
                     "type": "EXE"
                 },
-                "listen_ports": "",
                 "owner": "MY-WINDOWS\\user",
-                "parent": "C:\\Windows\\explorer.exe",
-                "pid": 8596,
-                "ppid": 6156,
-                "process_name": "cmd.exe",
                 "scan_id": "S-VavZi0stuDo",
                 "session": "RDP-Tcp#0"
             }
@@ -897,7 +899,8 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "session",
+                    "iam"
                 ],
                 "kind": "event",
                 "module": "LSASessions",
@@ -936,7 +939,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "configuration"
                 ],
                 "kind": "event",
                 "module": "Init",
@@ -1018,13 +1021,21 @@
                     "customUser"
                 ]
             },
+            "rule": {
+                "author": [
+                    "Florian Roth"
+                ],
+                "description": "YARA rule SUSP_Encoded_MimikatzKeywords1 / Detects encoded keyword - sekurlsa::logonpasswords",
+                "id": "SUSP_Encoded_MimikatzKeywords1",
+                "name": "YARA rule SUSP_Encoded_MimikatzKeywords1 / Detects encoded keyword - sekurlsa::logonpasswords",
+                "ruleset": "Internal Research - Permutator"
+            },
             "tags": [
                 "preserve_original_event"
             ],
             "thor": {
                 "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
                 "file": {
-                    "ext": "",
                     "first_bytes": "696d706f7274207b20637265617465486f74436f / import { createHotCo",
                     "permissions": "-rw-------",
                     "type": "Import"
@@ -1085,7 +1096,7 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "vulnerability"
                 ],
                 "kind": "event",
                 "module": "VulnerabilityCheck",
@@ -1134,13 +1145,13 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "registry"
                 ],
                 "kind": "event",
                 "module": "RegistryHive",
                 "original": "{\"campaign_id\": \"2b054111-bad7-4bac-a14e-8fa8a88f1111\",\"time\":\"2025-07-18T20:29:47Z\",\"hostname\":\"mymachinename\",\"level\":\"Warning\",\"module\":\"RegistryHive\",\"message\":\"Suspicious MS Office connection cache entry\",\"scanid\":\"S-7KSH3xjAGds\",\"path\":\"/home/customUser/registryhive/testdata/msofficecache.hve\",\"entry\":\"http://10.0.2.15:8000/\",\"reason\":\"Port explicitly specified\",\"modified\":\"2022-05-31T12:05:58+02:00\",\"key\":\"SOFTWARE\\\\Microsoft\\\\Office\\\\16.0\\\\Common\\\\Internet\\\\Server Cache\\\\http://10.0.2.15:8000/\",\"score\":70,\"log_version\":\"v2.0.0\"}",
                 "type": [
-                    "info"
+                    "access"
                 ],
                 "version": "v2.0.0"
             },
@@ -1151,6 +1162,10 @@
                 "level": "Warning"
             },
             "message": "Suspicious MS Office connection cache entry",
+            "registry": {
+                "key": "SOFTWARE\\Microsoft\\Office\\16.0\\Common\\Internet\\Server Cache\\http://10.0.2.15:8000/",
+                "value": "http://10.0.2.15:8000/"
+            },
             "related": {
                 "hosts": [
                     "mymachinename"
@@ -1161,8 +1176,6 @@
             ],
             "thor": {
                 "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
-                "entry": "http://10.0.2.15:8000/",
-                "key": "SOFTWARE\\Microsoft\\Office\\16.0\\Common\\Internet\\Server Cache\\http://10.0.2.15:8000/",
                 "modified": "2022-05-31T10:05:58.000Z",
                 "path": "/home/customUser/registryhive/testdata/msofficecache.hve",
                 "reason": "Port explicitly specified",
@@ -1222,6 +1235,11 @@
                     "customUser"
                 ]
             },
+            "rule": {
+                "description": "Filename IOC \\x.txt",
+                "name": "Filename IOC \\x.txt",
+                "ruleset": "BSI CSW-Nr. 2017-200525-1034"
+            },
             "tags": [
                 "preserve_original_event"
             ],
@@ -1263,7 +1281,7 @@
                     "file",
                     "malware"
                 ],
-                "kind": "event",
+                "kind": "alert",
                 "module": "Filescan",
                 "original": "{\"campaign_id\": \"2b054111-bad7-4bac-a14e-8fa8a88f1111\",\"time\":\"2025-07-18T20:29:03Z\",\"hostname\":\"mymachinename\",\"level\":\"Alert\",\"module\":\"Filescan\",\"message\":\"Malware file found\",\"scanid\":\"S-7KSH3xjAGds\",\"score\":96,\"file\":{\"path\":\"/home/customUser/workdir/thorhtml/public/testEvents1.json\",\"ext\":\".json\",\"type\":\"UNKNOWN\",\"size\":165705,\"md5\":\"4417209fab0f7bc3c0b9f3933bddb9fb\",\"sha1\":\"75ecd244a8db5c6f4b906da28783d113e7b66dfc\",\"sha256\":\"f787ce7b2f941d0b4fa9dd9e9cf81d7a6b1215cbb99b9932ca3c0ed0388d78e5\",\"firstbytes\":\"5b0a202020207b0a202020202020202022747970 / [     {         \\\"typ\",\"changed\":\"2024-03-15T09:35:01.142549038+01:00\",\"modified\":\"2024-03-15T09:35:01.142549038+01:00\",\"accessed\":\"2025-07-18T10:57:49.116288713+02:00\",\"permissions\":\"-rw-r--r--\",\"owner\":\"customUser\",\"group\":\"customUser\"},\"reasons\":[{\"name\":\"YARA rule Bitcoin_Miner_cpuminer / Detects a Bitcoin CPU Miner - often bundled with malware - file sppscv.exe\",\"score\":90,\"signature\":{\"ref\":\"Internal Research\",\"ruledate\":\"2016-12-02\",\"tags\":[\"EXE\",\"FILE\",\"MAL\"],\"rulename\":\"Bitcoin_Miner_cpuminer\",\"author\":\"Florian Roth\"},\"matched\":[{\"data\":\"User-Agent: cpuminer\",\"context\":\"               {\\u000a                        \\\"data\\\": \\\"User-Agent: cpuminer\\\",\\u000a                        \\\"context\\\": \\\"\\\\u0080JSON \",\"offset\":159364},{\"data\":\"-p, --pass=PASSWORD   password for mining server\",\"context\":\"SERNAME   username for mining server\\\\u000d\\\\u000a  -p, --pass=PASSWORD   password for mining server\\\\u000d\\\\u000a      --cert=FILE       certificate fo\",\"offset\":157003}],\"sigtype\":\"internal\",\"sigclass\":\"YARA Rule\"},{\"name\":\"YARA rule SIGNATURE_BASE_PUA_Cryptominer_Jan19_1 / Detects Crypto Miner strings\",\"score\":80,\"signature\":{\"ref\":\"Internal Research\",\"ruledate\":\"2023-12-05\",\"tags\":[\"FILE\"],\"rulename\":\"SIGNATURE_BASE_PUA_Cryptominer_Jan19_1\",\"author\":\"Florian Roth (Nextron Systems)\"},\"matched\":[{\"data\":\"Stratum notify: invalid Merkle branch\",\"context\":\"               {\\u000a                        \\\"data\\\": \\\"Stratum notify: invalid Merkle branch\\\",\\u000a                        \\\"context\\\": \\\".0\\\\u0000\\\\u0\",\"offset\":160890},{\"data\":\"-t, --threads=N       number of miner threads (default: number of processors)\",\"context\":\"HOST[:PORT]  connect through a proxy\\\\u000d\\\\u000a  -t, --threads=N       number of miner threads (default: number of processors)\\\\u000d\\\\u000a  -r, --retries=N       number of time\",\"offset\":157293},{\"data\":\"User-Agent: cpuminer/\",\"context\":\"u000a%s\\\\u000d\\\\u000a\\\\u0000Content-Length: %lu\\\\u0000User-Agent: cpuminer/2.3.3\\\\u0000X-Mining-Extensions: midstate\\\\u0000HTTP\",\"offset\":158272}],\"sigtype\":\"custom\",\"sigclass\":\"YARA Rule\"}],\"log_version\":\"v2.0.0\"}",
                 "type": [
@@ -1305,6 +1323,15 @@
                 "user": [
                     "customUser"
                 ]
+            },
+            "rule": {
+                "author": [
+                    "Florian Roth"
+                ],
+                "description": "YARA rule Bitcoin_Miner_cpuminer / Detects a Bitcoin CPU Miner - often bundled with malware - file sppscv.exe",
+                "id": "Bitcoin_Miner_cpuminer",
+                "name": "YARA rule Bitcoin_Miner_cpuminer / Detects a Bitcoin CPU Miner - often bundled with malware - file sppscv.exe",
+                "ruleset": "Internal Research"
             },
             "tags": [
                 "preserve_original_event"
@@ -1391,13 +1418,14 @@
             },
             "event": {
                 "category": [
-                    "file"
+                    "iam"
                 ],
                 "kind": "event",
                 "module": "Users",
                 "original": "{\"campaign_id\": \"2b054111-bad7-4bac-a14e-8fa8a88f1111\",\"time\":\"2025-07-18T20:01:02Z\",\"hostname\":\"mymachinename\",\"level\":\"Notice\",\"module\":\"Users\",\"message\":\"User is disabled with active login shell\",\"scanid\":\"S-7KSH3xjAGds\",\"user\":\"git\",\"userid\":\"971\",\"groupid\":\"971\",\"home\":\"/\",\"full_name\":\"git daemon user\",\"shell\":\"/usr/bin/git-shell\",\"score\":50,\"log_version\":\"v2.0.0\"}",
                 "type": [
-                    "info"
+                    "info",
+                    "user"
                 ],
                 "version": "v2.0.0"
             },
@@ -1421,7 +1449,6 @@
             ],
             "thor": {
                 "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
-                "full_name": "git daemon user",
                 "groupid": "971",
                 "home": "/",
                 "scan_id": "S-7KSH3xjAGds",
@@ -1429,6 +1456,7 @@
                 "shell": "/usr/bin/git-shell"
             },
             "user": {
+                "full_name": "git daemon user",
                 "id": "971",
                 "name": "git"
             }

--- a/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/system/test-default-config.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/_dev/test/system/test-default-config.yml
@@ -9,4 +9,4 @@ data_stream:
     batch_size: 10
     preserve_original_event: false
 assert:
-  hit_count: 10
+  hit_count: 14

--- a/packages/nextron_thor/data_stream/thor_forwarding/agent/stream/cel.yml.hbs
+++ b/packages/nextron_thor/data_stream/thor_forwarding/agent/stream/cel.yml.hbs
@@ -55,34 +55,25 @@ program: |
                             new_items.map(s,
                               get_request(state.url + "/v1/scan/log?scan=" + s.id + "&log=thor.json").with(auth_header).do_request().as(lr,
                                 (lr.StatusCode == 200) ?
-                                  string(lr.Body).split("\n").filter(line, line != "").map(line, {"message": line.decode_json().with({?"campaign_id": s.?campaign_id}).encode_json()})
+                                  string(lr.Body).split("\n").filter(line, line != "").transformList(i, line, {"message": line.decode_json().with({?"campaign_id": s.?campaign_id}).encode_json(), "log_line": string(i + 1)})
                                 :
                                   []
                               )
                             ).flatten().as(events,
-                              page.filter(s,
-                                (has(s.last_launcher_update) ? int(s.last_launcher_update) : int(s.creation_date)) >= latest_scan_ts &&
-                                s.id != latest_scan_id
-                              ).size().as(new_count_all,
-                                (body.total > batch_size).as(more_pages,
-                                  (
-                                    (events.size() > 0) ?
-                                      (has(page[page.size() - 1].last_launcher_update) ? int(page[page.size() - 1].last_launcher_update) : int(page[page.size() - 1].creation_date))
-                                    :
-                                      latest_scan_ts
-                                  ).as(new_latest_scan_ts,
-                                    ((events.size() > 0) ? page[page.size() - 1].id : latest_scan_id).as(new_latest_scan_id,
-                                      {
-                                        "events": events,
-                                        "cursor": {
-                                          "latest_scan_ts": new_latest_scan_ts,
-                                          "latest_scan_id": new_latest_scan_id,
-                                        },
-                                        "want_more": more_pages,
-                                        "total_scans": body.total,
-                                      }
-                                    )
-                                  )
+                              (
+                                has(page[page.size() - 1].last_launcher_update) ?
+                                  int(page[page.size() - 1].last_launcher_update) :
+                                  int(page[page.size() - 1].creation_date)
+                              ).as(new_latest_scan_ts,
+                                page[page.size() - 1].id.as(new_latest_scan_id,
+                                  {
+                                    "events": events,
+                                    "cursor": {
+                                      "latest_scan_ts": new_latest_scan_ts,
+                                      "latest_scan_id": new_latest_scan_id,
+                                    },
+                                    "want_more": page.size() >= batch_size,
+                                  }
                                 )
                               )
                             )

--- a/packages/nextron_thor/data_stream/thor_forwarding/agent/stream/cel.yml.hbs
+++ b/packages/nextron_thor/data_stream/thor_forwarding/agent/stream/cel.yml.hbs
@@ -55,14 +55,23 @@ program: |
                             new_items.map(s,
                               get_request(state.url + "/v1/scan/log?scan=" + s.id + "&log=thor.json").with(auth_header).do_request().as(lr,
                                 (lr.StatusCode == 200) ?
-                                  string(lr.Body).split("\n").filter(line, line != "").transformList(i, line, {"message": line.decode_json().with({?"campaign_id": s.?campaign_id}).encode_json(), "log_line": string(i + 1)})
+                                  string(lr.Body).split("\n").filter(line, line != "").transformList(i, line,
+                                    {
+                                      "message": has(s.campaign_id) ?
+                                        line.decode_json().with({"campaign_id": s.campaign_id}).encode_json()
+                                      :
+                                        line,
+                                      "log_line": string(i + 1),
+                                    }
+                                  )
                                 :
                                   []
                               )
                             ).flatten().as(events,
                               (
                                 has(page[page.size() - 1].last_launcher_update) ?
-                                  int(page[page.size() - 1].last_launcher_update) :
+                                  int(page[page.size() - 1].last_launcher_update)
+                                :
                                   int(page[page.size() - 1].creation_date)
                               ).as(new_latest_scan_ts,
                                 page[page.size() - 1].id.as(new_latest_scan_id,

--- a/packages/nextron_thor/data_stream/thor_forwarding/elasticsearch/ingest_pipeline/categorize.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/elasticsearch/ingest_pipeline/categorize.yml
@@ -1,0 +1,276 @@
+---
+description: Pipeline for categorizing Thor logs.
+processors:
+  - script:
+      tag: script_set_event_categorization
+      lang: painless
+      if: ctx.thor?.module != null
+      description: Categorize event.category, kind, and type for THOR based on module.
+      params:
+        Amcache:
+          category:
+            - registry
+          kind: event
+          type:
+            - access
+        AtJobs:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Autoruns:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        DNSCache:
+          category:
+            - network
+          kind: event
+          type:
+            - info
+        EnvCheck:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        EtwWatcher:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Eventlog:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Events:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Filescan:
+          category:
+            - file
+          kind: event
+          type:
+            - info
+        Firewall:
+          category:
+            - network
+          kind: event
+          type:
+            - info
+        Hosts:
+          category:
+            - host
+          kind: event
+          type:
+            - info
+        HotfixCheck:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Init:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        LSASessions:
+          category:
+            - session
+            - iam
+          kind: event
+          type:
+            - info
+        LogScan:
+          category:
+            - file
+          kind: event
+          type:
+            - info
+        LoggedIn:
+          category:
+            - iam
+          kind: event
+          type:
+            - info
+        Mutex:
+          category:
+            - process
+          kind: event
+          type:
+            - info
+        NetworkSessions:
+          category:
+            - network
+            - session
+          kind: event
+          type:
+            - info
+        NetworkShares:
+          category:
+            - network
+          kind: event
+          type:
+            - info
+        Pipes:
+          category:
+            - process
+          kind: event
+          type:
+            - info
+        ProcessCheck:
+          category:
+            - process
+          kind: event
+          type:
+            - info
+        ProcessConnections:
+          category:
+            - process
+            - network
+          kind: event
+          type:
+            - info
+        RegistryChecks:
+          category:
+            - registry
+          kind: event
+          type:
+            - access
+        RegistryHive:
+          category:
+            - registry
+          kind: event
+          type:
+            - access
+        Report:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Rootkit:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        SHIMCache:
+          category:
+            - registry
+          kind: event
+          type:
+            - access
+        ScheduledTasks:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        ServiceCheck:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Sigma:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Startup:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Timestomp:
+          category:
+            - file
+          kind: event
+          type:
+            - info
+        UserDir:
+          category:
+            - iam
+          kind: event
+          type:
+            - info
+            - user
+        Users:
+          category:
+            - iam
+          kind: event
+          type:
+            - info
+            - user
+        VulnerabilityCheck:
+          category:
+            - vulnerability
+          kind: event
+          type:
+            - info
+        WER:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        WMIPersistence:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        WMIStartup:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+        Yara:
+          category:
+            - configuration
+          kind: event
+          type:
+            - info
+      source: |-
+        ctx.event = ctx.event ?: [:];
+        def m = params.get(ctx.thor.module);
+        if (m != null) {
+          m.forEach((k, v) -> {
+            if (v instanceof List) {
+              ctx.event[k] = new ArrayList(v);
+            } else {
+              ctx.event[k] = v;
+            }
+          });
+        }
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            tag: append_error_message_script_set_event_categorization
+  - set:
+      field: event.kind
+      tag: set_event_kind_to_alert
+      value: alert
+      if: ctx.thor?.level == "Alert"
+  - append:
+      field: event.category
+      value: malware
+      if: ctx.thor?.message == "Malware file found"
+      allow_duplicates: false
+      tag: append_event_category_malware

--- a/packages/nextron_thor/data_stream/thor_forwarding/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/elasticsearch/ingest_pipeline/default.yml
@@ -8,18 +8,6 @@ processors:
   - terminate:
       tag: data_collection_error
       if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
-  - append:
-      field: event.category
-      value: file
-      tag: append_ecs_category
-  - set:
-      field: event.kind
-      value: event
-      tag: set_event_kind
-  - append:
-      field: event.type
-      value: info
-      tag: append_event_type
   - rename:
       ignore_missing: true
       field: message
@@ -41,6 +29,27 @@ processors:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
             tag: append_error_message_parse_event_original_json
+  # Categorization
+  - pipeline:
+      tag: pipeline_20a0e7f1
+      name: '{{ IngestPipeline "categorize" }}'
+      ignore_missing_pipeline: true
+  # Cached event category for category-dependent processors.
+  - set:
+      tag: set__temp_isProcess_279add73
+      if: ctx.event?.category?.contains('process') == true
+      field: _temp.isProcess
+      value: true
+  - set:
+      tag: set__temp_isNetwork_70f64bff
+      if: ctx.event?.category?.contains('network') == true
+      field: _temp.isNetwork
+      value: true
+  - set:
+      tag: set__temp_isRegistry_1ecc0df5
+      if: ctx.event?.category?.contains('registry') == true
+      field: _temp.isRegistry
+      value: true
   - rename:
       field: thor.scanid
       target_field: thor.scan_id
@@ -72,6 +81,7 @@ processors:
       tag: parse_thor_time
       on_failure:
         - append:
+            tag: append_error_message_8357ea02
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -99,6 +109,398 @@ processors:
       field: thor.module
       target_field: event.module
       tag: rename_thor_module_to_event_module
+  # Field name normalization
+  - set:
+      field: thor.image.path
+      copy_from: thor.image_path
+      if: ctx.thor?.image_path != null && ctx.thor?.image?.path == null
+      tag: set_thor_image_path_from_image_path
+  - remove:
+      field: thor.image_path
+      ignore_missing: true
+      if: ctx.thor?.image?.path != null
+      tag: remove_thor_image_path_after_normalization
+  # Data type normalization
+  - convert:
+      field: thor.exec_flag
+      type: boolean
+      ignore_missing: true
+      tag: convert_thor_exec_flag_to_boolean
+      on_failure:
+        - remove:
+            tag: remove_thor_exec_flag_9e9f17fa
+            field: thor.exec_flag
+            ignore_missing: true
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            tag: append_error_message_convert_thor_exec_flag_to_boolean
+  - convert:
+      field: thor.enabled
+      type: boolean
+      ignore_missing: true
+      tag: convert_thor_enabled_to_boolean
+      on_failure:
+        - remove:
+            tag: remove_thor_enabled_f499f627
+            field: thor.enabled
+            ignore_missing: true
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            tag: append_error_message_convert_thor_enabled_to_boolean
+  - convert:
+      field: thor.is_admin
+      type: boolean
+      ignore_missing: true
+      tag: convert_thor_is_admin_to_boolean
+      on_failure:
+        - remove:
+            tag: remove_thor_is_admin_b9a2e54d
+            field: thor.is_admin
+            ignore_missing: true
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            tag: append_error_message_0ee4eab3
+  - convert:
+      field: thor.no_expire
+      type: boolean
+      ignore_missing: true
+      tag: convert_thor_no_expire_to_boolean
+      on_failure:
+        - remove:
+            tag: remove_thor_no_expire_401acd0f
+            field: thor.no_expire
+            ignore_missing: true
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            tag: append_error_message_6a99b434
+  - convert:
+      field: thor.active
+      type: boolean
+      ignore_missing: true
+      tag: convert_thor_active_to_boolean
+      on_failure:
+        - remove:
+            tag: remove_thor_active_0a6828cd
+            field: thor.active
+            ignore_missing: true
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            tag: append_error_message_389e044d
+  - convert:
+      field: thor.locked
+      type: boolean
+      ignore_missing: true
+      tag: convert_thor_locked_to_boolean
+      on_failure:
+        - remove:
+            tag: remove_thor_locked_edceea37
+            field: thor.locked
+            ignore_missing: true
+        - append:
+            tag: append_error_message_85ffaa0d
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
+      field: thor.valid
+      type: boolean
+      ignore_missing: true
+      tag: convert_thor_valid_to_boolean
+      on_failure:
+        - remove:
+            tag: remove_thor_valid_deae5b8d
+            field: thor.valid
+            ignore_missing: true
+        - append:
+            tag: append_error_message_aec15d4b
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
+      field: thor.badpwcount
+      type: long
+      ignore_missing: true
+      tag: convert_thor_badpwcount_to_long
+      on_failure:
+        - remove:
+            tag: remove_thor_badpwcount_28d0760d
+            field: thor.badpwcount
+            ignore_missing: true
+        - append:
+            tag: append_error_message_aa5128c6
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
+      field: thor.entries
+      type: long
+      ignore_missing: true
+      tag: convert_thor_entries_to_long
+      on_failure:
+        - remove:
+            tag: remove_thor_entries_68f2d69d
+            field: thor.entries
+            ignore_missing: true
+        - append:
+            tag: append_error_message_c544e739
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
+      field: thor.event_id
+      type: long
+      ignore_missing: true
+      tag: convert_thor_event_id_to_long
+      on_failure:
+        - remove:
+            tag: remove_thor_event_id_aaad9f9b
+            field: thor.event_id
+            ignore_missing: true
+        - append:
+            tag: append_error_message_5c6bc027
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
+      field: thor.num_logons
+      type: long
+      ignore_missing: true
+      tag: convert_thor_num_logons_to_long
+      on_failure:
+        - remove:
+            tag: remove_thor_num_logons_5b40ded1
+            field: thor.num_logons
+            ignore_missing: true
+        - append:
+            tag: append_error_message_8525825a
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
+      field: thor.scanned
+      type: long
+      ignore_missing: true
+      tag: convert_thor_scanned_to_long
+      on_failure:
+        - remove:
+            tag: remove_thor_scanned_22822ef5
+            field: thor.scanned
+            ignore_missing: true
+        - append:
+            tag: append_error_message_b77bc345
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
+      field: thor.pass_age
+      type: double
+      ignore_missing: true
+      tag: convert_thor_pass_age_to_double
+      on_failure:
+        - remove:
+            tag: remove_thor_pass_age_99759a09
+            field: thor.pass_age
+            ignore_missing: true
+        - append:
+            tag: append_error_message_f81a8f3e
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  # Process fields
+  - rename:
+      ignore_missing: true
+      field: thor.pid
+      target_field: process.pid
+      if: ctx._temp?.isProcess == true
+      tag: rename_thor_pid_to_process_pid
+  - rename:
+      ignore_missing: true
+      field: thor.ppid
+      target_field: process.parent.pid
+      if: ctx._temp?.isProcess == true
+      tag: rename_thor_ppid_to_process_parent_pid
+  - rename:
+      ignore_missing: true
+      field: thor.process_name
+      target_field: process.name
+      if: ctx._temp?.isProcess == true
+      tag: rename_thor_process_name_to_process_name
+  - rename:
+      ignore_missing: true
+      field: thor.command
+      target_field: process.command_line
+      if: ctx._temp?.isProcess == true
+      tag: rename_thor_command_to_process_command_line
+  - rename:
+      ignore_missing: true
+      field: thor.parent
+      target_field: process.parent.executable
+      if: ctx._temp?.isProcess == true
+      tag: rename_thor_parent_to_process_parent_executable
+  - rename:
+      ignore_missing: true
+      field: thor.image.path
+      target_field: process.executable
+      if: ctx._temp?.isProcess == true
+      tag: rename_thor_image_path_to_process_executable
+  # Network fields
+  - rename:
+      ignore_missing: true
+      field: thor.protocol
+      target_field: network.transport
+      if: ctx._temp?.isNetwork == true
+      tag: rename_thor_protocol_to_network_transport
+  - lowercase:
+      field: network.transport
+      ignore_missing: true
+      tag: lowercase_network_transport
+  - convert:
+      tag: convert_thor_ip_24095cde
+      field: thor.ip
+      type: ip
+      ignore_missing: true
+      if: ctx.thor?.ip != null && ctx.thor.ip != '*'
+      on_failure:
+        - remove:
+            tag: remove_thor_ip_90e30997
+            field: thor.ip
+            ignore_missing: true
+        - append:
+            tag: append_error_message_3de1e5e8
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - rename:
+      field: thor.ip
+      target_field: source.ip
+      tag: rename_thor_ip_to_source_ip
+      if: ctx._temp?.isNetwork == true
+      ignore_missing: true
+  - convert:
+      tag: convert_thor_port_8044a21e
+      field: thor.port
+      type: long
+      ignore_missing: true
+      on_failure:
+        - remove:
+            tag: remove_thor_port_61d2db41
+            field: thor.port
+            ignore_missing: true
+        - append:
+            tag: append_error_message_593b04d0
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - rename:
+      field: thor.port
+      target_field: source.port
+      tag: rename_thor_port_to_source_port
+      if: ctx._temp?.isNetwork == true
+      ignore_missing: true
+  - convert:
+      tag: convert_thor_rip_061cd984
+      field: thor.rip
+      type: ip
+      ignore_missing: true
+      if: ctx.thor?.rip != null && ctx.thor.rip != '*'
+      on_failure:
+        - remove:
+            tag: remove_thor_rip_323b2117
+            field: thor.rip
+            ignore_missing: true
+        - append:
+            tag: append_error_message_c0b7206e
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - rename:
+      field: thor.rip
+      target_field: destination.ip
+      tag: rename_thor_rip_to_destination_ip
+      if: ctx._temp?.isNetwork == true
+      ignore_missing: true
+  - convert:
+      tag: convert_thor_rport_08e203a6
+      field: thor.rport
+      type: long
+      ignore_missing: true
+      on_failure:
+        - remove:
+            tag: remove_thor_rport_51a5edcb
+            field: thor.rport
+            ignore_missing: true
+        - append:
+            tag: append_error_message_c2acd798
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - rename:
+      field: thor.rport
+      target_field: destination.port
+      tag: rename_thor_rport_to_destination_port
+      if: ctx._temp?.isNetwork == true
+      ignore_missing: true
+  - append:
+      field: event.type
+      value: connection
+      if: ctx.event?.module == 'ProcessConnections'
+      allow_duplicates: false
+      tag: append_event_type_connection
+  - append:
+      field: related.ip
+      value: '{{{source.ip}}}'
+      ignore_empty_values: true
+      allow_duplicates: false
+      tag: append_source_ip_to_related_ip
+  - append:
+      field: related.ip
+      value: '{{{destination.ip}}}'
+      ignore_empty_values: true
+      allow_duplicates: false
+      tag: append_destination_ip_to_related_ip
+  # Registry fields
+  - rename:
+      ignore_missing: true
+      field: thor.key
+      target_field: registry.key
+      if: ctx._temp?.isRegistry == true
+      tag: rename_thor_key_to_registry_key
+  - rename:
+      ignore_missing: true
+      field: thor.entry
+      target_field: registry.value
+      if: ctx._temp?.isRegistry == true
+      tag: rename_thor_entry_to_registry_value
+  - rename:
+      ignore_missing: true
+      field: thor.hive
+      target_field: registry.path
+      if: ctx._temp?.isRegistry == true
+      tag: rename_thor_hive_to_registry_path
+  # Rule fields
+  - set:
+      field: rule.name
+      copy_from: thor.reasons.0.name
+      ignore_empty_value: true
+      if: ctx.thor?.reasons instanceof List && ctx.thor.reasons.size() > 0
+      tag: set_rule_name_from_thor_reasons
+  - set:
+      field: rule.id
+      copy_from: thor.reasons.0.signature.rulename
+      ignore_empty_value: true
+      if: ctx.thor?.reasons instanceof List && ctx.thor.reasons.size() > 0 && ctx.thor.reasons[0]?.signature?.rulename != null
+      tag: set_rule_id_from_thor_reasons_signature
+  - set:
+      field: rule.author
+      value: ['{{{thor.reasons.0.signature.author}}}']
+      ignore_empty_value: true
+      if: ctx.thor?.reasons instanceof List && ctx.thor.reasons.size() > 0 && ctx.thor.reasons[0]?.signature?.author != null
+      tag: set_rule_author_from_thor_reasons_signature
+  - set:
+      field: rule.description
+      copy_from: thor.reasons.0.name
+      ignore_empty_value: true
+      if: ctx.thor?.reasons instanceof List && ctx.thor.reasons.size() > 0
+      tag: set_rule_description_from_thor_reasons
+  - set:
+      field: rule.ruleset
+      copy_from: thor.reasons.0.signature.ref
+      ignore_empty_value: true
+      if: ctx.thor?.reasons instanceof List && ctx.thor.reasons.size() > 0 && ctx.thor.reasons[0]?.signature?.ref != null
+      tag: set_rule_ruleset_from_thor_reasons_signature
   - rename:
       ignore_missing: true
       field: thor.log_version
@@ -121,6 +523,17 @@ processors:
       field: thor.userid
       target_field: user.id
       tag: rename_thor_userid_to_user_id
+  - rename:
+      ignore_missing: true
+      field: thor.full_name
+      target_field: user.full_name
+      tag: rename_thor_full_name_to_user_full_name
+      if: ctx.event?.module == 'Users'
+  - rename:
+      ignore_missing: true
+      field: thor.domain
+      target_field: user.domain
+      tag: rename_thor_domain_to_user_domain
   - rename:
       ignore_missing: true
       field: thor.hostname
@@ -249,7 +662,7 @@ processors:
       field: thor.files
       if: ctx.thor?.files instanceof List
       ignore_missing: true
-      tag: rename_thor_files_desc_to_thor_files_description
+      tag: foreach_thor_files_1b06416b
       processor:
         rename:
           field: _ingest._value.desc
@@ -266,6 +679,21 @@ processors:
       field: thor.image.firstbytes
       target_field: thor.image.first_bytes
       tag: rename_thor_image_firstbytes_to_thor_first_bytes_description
+  - rename:
+      ignore_missing: true
+      field: thor.app.firstbytes
+      target_field: thor.app.first_bytes
+      tag: rename_thor_app_firstbytes_to_thor_app_first_bytes
+  - rename:
+      ignore_missing: true
+      field: thor.app.desc
+      target_field: thor.app.description
+      tag: rename_thor_app_desc_to_thor_app_description
+  - rename:
+      ignore_missing: true
+      field: thor.archive.firstbytes
+      target_field: thor.archive.first_bytes
+      tag: rename_thor_archive_firstbytes_to_thor_archive_first_bytes
   - date:
       formats:
       - ISO8601
@@ -275,6 +703,7 @@ processors:
       tag: parse_thor_file_accessed
       on_failure:
         - append:
+            tag: append_error_message_ccca74f9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -291,6 +720,7 @@ processors:
       tag: parse_thor_file_changed
       on_failure:
         - append:
+            tag: append_error_message_551d7629
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -307,6 +737,7 @@ processors:
       tag: parse_thor_file_modified
       on_failure:
         - append:
+            tag: append_error_message_45995d16
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - remove:
@@ -322,6 +753,7 @@ processors:
       tag: parse_thor_image_accessed
       on_failure:
         - append:
+            tag: append_error_message_5589ed66
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -333,6 +765,7 @@ processors:
       tag: parse_thor_image_created
       on_failure:
         - append:
+            tag: append_error_message_2f200476
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -344,6 +777,7 @@ processors:
       tag: parse_thor_image_modified
       on_failure:
         - append:
+            tag: append_error_message_ef28d57e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -360,19 +794,59 @@ processors:
           - ISO8601
       on_failure:
         - append:
+            tag: append_error_message_308ff79d
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - foreach:
+      field: thor.files
+      if: ctx.thor?.files instanceof List
+      ignore_missing: true
+      tag: foreach_parse_thor_files_accessed
+      processor:
+        date:
+          field: _ingest._value.accessed
+          target_field: _ingest._value.accessed
+          ignore_failure: true
+          formats:
+          - ISO8601
+      on_failure:
+        - append:
+            tag: append_error_message_b693f214
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - foreach:
+      field: thor.files
+      if: ctx.thor?.files instanceof List
+      ignore_missing: true
+      tag: foreach_parse_thor_files_modified
+      processor:
+        date:
+          field: _ingest._value.modified
+          target_field: _ingest._value.modified
+          ignore_failure: true
+          formats:
+          - ISO8601
+      on_failure:
+        - append:
+            tag: append_error_message_d3354e98
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       formats:
       - ISO8601
       field: thor.file.created
-      target_field: thor.file.created
+      target_field: file.created
       if: ctx.thor?.file?.created != null
       tag: parse_thor_file_created
       on_failure:
         - append:
+            tag: append_error_message_01d593b5
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - remove:
+      field: thor.file.created
+      if: ctx.file?.created != null
+      tag: remove_thor_file_created_if_file_created_set
   - date:
       formats:
       - ISO8601
@@ -382,6 +856,7 @@ processors:
       tag: parse_thor_created
       on_failure:
         - append:
+            tag: append_error_message_54845386
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -393,6 +868,7 @@ processors:
       tag: parse_thor_last_run
       on_failure:
         - append:
+            tag: append_error_message_e3f8d0fc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -404,6 +880,7 @@ processors:
       tag: parse_thor_modified
       on_failure:
         - append:
+            tag: append_error_message_c34393d2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -415,6 +892,7 @@ processors:
       tag: parse_thor_next_run
       on_failure:
         - append:
+            tag: append_error_message_87cf5e46
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -425,6 +903,7 @@ processors:
         ctx.thor.start = ctx.thor.start.splitOnToken(',')[0].trim();
       on_failure:
         - append:
+            tag: append_error_message_ede4208e
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -436,6 +915,7 @@ processors:
       tag: parse_thor_start
       on_failure:
         - append:
+            tag: append_error_message_35959a41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -447,6 +927,217 @@ processors:
       tag: parse_thor_image_changed
       on_failure:
         - append:
+            tag: append_error_message_71e52892
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.app.created
+      target_field: thor.app.created
+      if: ctx.thor?.app?.created != null && ctx.thor.app.created != ''
+      tag: parse_thor_app_created
+      on_failure:
+        - remove:
+            tag: remove_thor_app_created_85b10117
+            field: thor.app.created
+            ignore_missing: true
+        - append:
+            tag: append_error_message_a9201134
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.archive.accessed
+      target_field: thor.archive.accessed
+      if: ctx.thor?.archive?.accessed != null && ctx.thor.archive.accessed != ''
+      tag: parse_thor_archive_accessed
+      on_failure:
+        - remove:
+            tag: remove_thor_archive_accessed_7a40c5e5
+            field: thor.archive.accessed
+            ignore_missing: true
+        - append:
+            tag: append_error_message_984b224c
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.archive.created
+      target_field: thor.archive.created
+      if: ctx.thor?.archive?.created != null && ctx.thor.archive.created != ''
+      tag: parse_thor_archive_created
+      on_failure:
+        - remove:
+            tag: remove_thor_archive_created_00085ca6
+            field: thor.archive.created
+            ignore_missing: true
+        - append:
+            tag: append_error_message_ac941512
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.archive.modified
+      target_field: thor.archive.modified
+      if: ctx.thor?.archive?.modified != null && ctx.thor.archive.modified != ''
+      tag: parse_thor_archive_modified
+      on_failure:
+        - remove:
+            tag: remove_thor_archive_modified_ebfedce5
+            field: thor.archive.modified
+            ignore_missing: true
+        - append:
+            tag: append_error_message_d38bc0b8
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.date
+      target_field: thor.date
+      if: ctx.thor?.date != null && ctx.thor.date != ''
+      tag: parse_thor_date
+      on_failure:
+        - remove:
+            tag: remove_thor_date_ce31103a
+            field: thor.date
+            ignore_missing: true
+        - append:
+            tag: append_error_message_730ba142
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.event_time
+      target_field: thor.event_time
+      if: ctx.thor?.event_time != null && ctx.thor.event_time != ''
+      tag: parse_thor_event_time
+      on_failure:
+        - remove:
+            tag: remove_thor_event_time_c0b886d6
+            field: thor.event_time
+            ignore_missing: true
+        - append:
+            tag: append_error_message_18b1674e
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.last_logon
+      target_field: thor.last_logon
+      if: ctx.thor?.last_logon != null && ctx.thor.last_logon != ''
+      tag: parse_thor_last_logon
+      on_failure:
+        - remove:
+            tag: remove_thor_last_logon_8ebdb6f2
+            field: thor.last_logon
+            ignore_missing: true
+        - append:
+            tag: append_error_message_e1f3b502
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.log_accessed
+      target_field: thor.log_accessed
+      if: ctx.thor?.log_accessed != null && ctx.thor.log_accessed != ''
+      tag: parse_thor_log_accessed
+      on_failure:
+        - remove:
+            tag: remove_thor_log_accessed_151b866a
+            field: thor.log_accessed
+            ignore_missing: true
+        - append:
+            tag: append_error_message_10ff401a
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.log_created
+      target_field: thor.log_created
+      if: ctx.thor?.log_created != null && ctx.thor.log_created != ''
+      tag: parse_thor_log_created
+      on_failure:
+        - remove:
+            tag: remove_thor_log_created_237f11ab
+            field: thor.log_created
+            ignore_missing: true
+        - append:
+            tag: append_error_message_8dc7faa6
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.log_modified
+      target_field: thor.log_modified
+      if: ctx.thor?.log_modified != null && ctx.thor.log_modified != ''
+      tag: parse_thor_log_modified
+      on_failure:
+        - remove:
+            tag: remove_thor_log_modified_44b121ae
+            field: thor.log_modified
+            ignore_missing: true
+        - append:
+            tag: append_error_message_47ec4ace
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.start_time
+      target_field: thor.start_time
+      if: ctx.thor?.start_time != null && ctx.thor.start_time != ''
+      tag: parse_thor_start_time
+      on_failure:
+        - remove:
+            tag: remove_thor_start_time_d996ed46
+            field: thor.start_time
+            ignore_missing: true
+        - append:
+            tag: append_error_message_cdeda302
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      field: thor.timestamp
+      target_field: thor.timestamp
+      if: ctx.thor?.timestamp != null && ctx.thor.timestamp != ''
+      tag: parse_thor_timestamp
+      on_failure:
+        - remove:
+            tag: remove_thor_timestamp_c1b0b698
+            field: thor.timestamp
+            ignore_missing: true
+        - append:
+            tag: append_error_message_d23041f4
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - date:
+      formats:
+      - ISO8601
+      - M/d/yyyy
+      - MM/dd/yyyy
+      field: thor.installed_on
+      target_field: thor.installed_on
+      if: ctx.thor?.installed_on != null && ctx.thor.installed_on != ''
+      tag: parse_thor_installed_on
+      on_failure:
+        - remove:
+            tag: remove_thor_installed_on_95308dcd
+            field: thor.installed_on
+            ignore_missing: true
+        - append:
+            tag: append_error_message_32b98437
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
@@ -463,6 +1154,7 @@ processors:
           - ISO8601
       on_failure:
         - append:
+            tag: append_error_message_246fd80a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -501,11 +1193,6 @@ processors:
 
           ctx.thor.duration = hours * 3600L + mins * 60L + secs;
   - append:
-      field: event.category
-      value: malware
-      if: ctx.message == "Malware file found"
-      tag: append_event_category_malware
-  - append:
       field: related.hash
       value: "{{{file.hash.md5}}}"
       ignore_empty_values: true
@@ -537,11 +1224,6 @@ processors:
       tag: append_related_user_exe_owner
   - append:
       field: related.user
-      value: "{{{thor.files.owner}}}"
-      ignore_empty_values: true
-      tag: append_related_user_files_owner
-  - append:
-      field: related.user
       value: "{{{thor.image.owner}}}"
       ignore_empty_values: true
       tag: append_related_user_image_owner
@@ -555,6 +1237,47 @@ processors:
       value: "{{{thor.unit_owner}}}"
       ignore_empty_values: true
       tag: append_related_user_unit_owner
+  - foreach:
+      field: thor.files
+      if: ctx.thor?.files instanceof List
+      ignore_missing: true
+      tag: foreach_append_related_user_from_thor_files
+      processor:
+        append:
+          field: related.user
+          value: '{{{_ingest._value.owner}}}'
+          allow_duplicates: false
+          if: ctx._ingest?._value?.owner != null && ctx._ingest._value.owner != ''
+  - remove:
+      field: _temp
+      tag: remove_temp
+      ignore_missing: true
+  - script:
+      description: This script processor iterates over the whole document to remove fields with null values.
+      tag: script_to_drop_null_values
+      lang: painless
+      source: |
+        void handleMap(Map map) {
+          map.values().removeIf(v -> {
+            if (v instanceof Map) {
+                handleMap(v);
+            } else if (v instanceof List) {
+                handleList(v);
+            }
+            return v == null || v == '' || (v instanceof Map && v.size() == 0) || (v instanceof List && v.size() == 0)
+          });
+        }
+        void handleList(List list) {
+          list.removeIf(v -> {
+            if (v instanceof Map) {
+                handleMap(v);
+            } else if (v instanceof List) {
+                handleList(v);
+            }
+            return v == null || v == '' || (v instanceof Map && v.size() == 0) || (v instanceof List && v.size() == 0)
+          });
+        }
+        handleMap(ctx);
   - pipeline:
       name: global@custom
       ignore_missing_pipeline: true

--- a/packages/nextron_thor/data_stream/thor_forwarding/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/elasticsearch/ingest_pipeline/default.yml
@@ -5,6 +5,9 @@ processors:
       field: ecs.version
       value: 9.2.0
       tag: set_ecs_version
+  - terminate:
+      tag: data_collection_error
+      if: ctx.error?.message != null && ctx.message == null && ctx.event?.original == null
   - append:
       field: event.category
       value: file
@@ -30,16 +33,37 @@ processors:
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
-      ignore_failure: true
       field: event.original
       target_field: thor
       tag: parse_event_original_json
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            tag: append_error_message_parse_event_original_json
   - rename:
-      field: thor.file
-      target_field: file.name
-      if: ctx.thor?.file != null && ctx.thor?.file instanceof String
+      field: thor.scanid
+      target_field: thor.scan_id
+      tag: rename_thor_scanid_to_thor_scan_id
       ignore_missing: true
-      tag: rename_thor_file_to_file_name
+  - fingerprint:
+      ignore_missing: true
+      target_field: _id
+      fields:
+        - event.original
+        - log_line
+      method: SHA-256
+      tag: fingerprint_event_original_and_log_line
+  - remove:
+      field: log_line
+      tag: remove_log_line
+      ignore_missing: true
+  - rename:
+      ignore_missing: true
+      field: thor.file
+      target_field: file.path
+      if: ctx.thor?.file != null && ctx.thor.file instanceof String
+      tag: rename_thor_file_to_file_path_if_string
   - date:
       formats:
       - ISO8601
@@ -129,6 +153,7 @@ processors:
       field: thor.file.path
       target_field: file.path
       tag: rename_thor_file_path_to_file_path
+      if: ctx.file?.path == null
   - grok:
       ignore_missing: true
       field: file.path
@@ -139,6 +164,11 @@ processors:
       - '^(?:[A-Za-z]:\\|\\)(?:.*\\)?%{WINFILENAME:file.name}$'
       - '^/(?:.*/)?%{FILENAME:file.name}$'
       tag: extract_file_name_from_path
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            tag: append_error_message_extract_file_name_from_path
   - rename:
       ignore_missing: true
       field: thor.file.sha1
@@ -164,11 +194,6 @@ processors:
       field: thor.nextrun
       target_field: thor.next_run
       tag: rename_thor_nextrun_to_thor_next_run
-  - rename:
-      ignore_missing: true
-      field: thor.scanid
-      target_field: thor.scan_id
-      tag: rename_thor_scanid_to_thor_scan_id
   - rename:
       ignore_missing: true
       field: thor.firstbytes
@@ -392,6 +417,16 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - script:
+      tag: script_normalize_thor_start_multivalue
+      lang: painless
+      if: ctx.thor?.start != null && ctx.thor.start instanceof String && ctx.thor.start.indexOf(',') > 0
+      source: |-
+        ctx.thor.start = ctx.thor.start.splitOnToken(',')[0].trim();
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
       formats:
       - ISO8601
@@ -520,16 +555,6 @@ processors:
       value: "{{{thor.unit_owner}}}"
       ignore_empty_values: true
       tag: append_related_user_unit_owner
-  - fingerprint:
-      ignore_missing: true
-      target_field: _id
-      fields:
-      - thor
-      - message
-      - "@timestamp"
-      - file
-      method: SHA-256
-      tag: fingerprint_event
   - pipeline:
       name: global@custom
       ignore_missing_pipeline: true

--- a/packages/nextron_thor/data_stream/thor_forwarding/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/elasticsearch/ingest_pipeline/default.yml
@@ -24,11 +24,6 @@ processors:
       field: event.original
       target_field: thor
       tag: parse_event_original_json
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-            tag: append_error_message_parse_event_original_json
   # Categorization
   - pipeline:
       tag: pipeline_20a0e7f1
@@ -351,12 +346,21 @@ processors:
       field: network.transport
       ignore_missing: true
       tag: lowercase_network_transport
+  - remove:
+      field: thor.ip
+      ignore_missing: true
+      if: ctx.thor?.ip == '*'
+      tag: remove_thor_ip_wildcard
+  - remove:
+      field: thor.rip
+      ignore_missing: true
+      if: ctx.thor?.rip == '*'
+      tag: remove_thor_rip_wildcard
   - convert:
       tag: convert_thor_ip_24095cde
       field: thor.ip
       type: ip
       ignore_missing: true
-      if: ctx.thor?.ip != null && ctx.thor.ip != '*'
       on_failure:
         - remove:
             tag: remove_thor_ip_90e30997
@@ -397,7 +401,6 @@ processors:
       field: thor.rip
       type: ip
       ignore_missing: true
-      if: ctx.thor?.rip != null && ctx.thor.rip != '*'
       on_failure:
         - remove:
             tag: remove_thor_rip_323b2117

--- a/packages/nextron_thor/data_stream/thor_forwarding/fields/fields.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/fields/fields.yml
@@ -387,3 +387,11 @@
 - name: thor.reasons.matched.offset
   type: long
   description: Byte offset within a file where a signature match occurred.
+- name: thor.port
+  type: keyword
+- name: thor.rule
+  type: keyword
+- name: thor.rule_name
+  type: keyword
+- name: thor.signature
+  type: keyword

--- a/packages/nextron_thor/data_stream/thor_forwarding/fields/fields.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/fields/fields.yml
@@ -2,11 +2,89 @@
   type: long
   metric_type: counter
   description: Number of alerts generated during the THOR scan.
+- name: thor.app
+  type: group
+  description: Application metadata from a Windows Error Reporting (WER) event.
+  fields:
+    - name: company
+      type: keyword
+    - name: created
+      type: date
+    - name: description
+      type: keyword
+    - name: exists
+      type: keyword
+    - name: first_bytes
+      type: keyword
+    - name: imphash
+      type: keyword
+    - name: internal_name
+      type: keyword
+    - name: legal_copyright
+      type: keyword
+    - name: md5
+      type: keyword
+    - name: original_name
+      type: keyword
+    - name: owner
+      type: keyword
+    - name: permissions
+      type: keyword
+    - name: product
+      type: keyword
+    - name: sha1
+      type: keyword
+    - name: sha256
+      type: keyword
+    - name: size
+      type: long
+    - name: type
+      type: keyword
+- name: thor.apppath
+  type: keyword
+  description: Application path from a Windows Error Reporting (WER) event.
+- name: thor.arch
+  type: keyword
+  description: CPU architecture of the scanned system (e.g., ARM64, AMD64).
+- name: thor.archive
+  type: group
+  description: Archive metadata for a file extracted during scanning.
+  fields:
+    - name: accessed
+      type: date
+    - name: created
+      type: date
+    - name: first_bytes
+      type: keyword
+    - name: md5
+      type: keyword
+    - name: modified
+      type: date
+    - name: owner
+      type: keyword
+    - name: path
+      type: keyword
+    - name: permissions
+      type: keyword
+    - name: sha1
+      type: keyword
+    - name: sha256
+      type: keyword
+    - name: size
+      type: long
+    - name: type
+      type: keyword
+- name: thor.arguments
+  type: keyword
+  description: Command-line arguments for an autostart entry.
+- name: thor.badpwcount
+  type: long
+  description: Number of bad password attempts for a user account.
 - name: thor.campaign_id
   type: keyword
   description: Campaign ID of a THOR scan.
 - name: thor.command
-  type: keyword
+  type: wildcard
   description: Command line or executable path associated with a scheduled task, service, or process.
 - name: thor.connection_count
   type: long
@@ -24,6 +102,64 @@
 - name: thor.enabled
   type: boolean
   description: Whether a scheduled task or service is enabled.
+- name: thor.exec_flag
+  type: boolean
+- name: thor.is_admin
+  type: boolean
+- name: thor.no_expire
+  type: boolean
+- name: thor.active
+  type: boolean
+- name: thor.build_number
+  type: keyword
+  description: Operating system build number.
+- name: thor.caption
+  type: keyword
+  description: Caption or description for a Windows hotfix.
+- name: thor.comment
+  type: keyword
+  description: Comment associated with a user account.
+- name: thor.date
+  type: date
+  description: Date of a Windows Error Reporting (WER) event.
+- name: thor.directory
+  type: keyword
+  description: Directory path being analyzed.
+- name: thor.drive
+  type: keyword
+  description: Drive letter being analyzed.
+- name: thor.entries
+  type: long
+  description: Number of entries in a cache or hive analysis.
+- name: thor.error
+  type: wildcard
+  description: Error message from a Windows Error Reporting (WER) event.
+- name: thor.event_channel
+  type: keyword
+  description: Windows event log channel name.
+- name: thor.event_id
+  type: long
+  description: Windows event log event ID.
+- name: thor.event_level
+  type: keyword
+  description: Windows event log level (e.g., Information, Warning).
+- name: thor.event_time
+  type: date
+  description: Timestamp of a Windows event log entry.
+- name: thor.exe
+  type: keyword
+  description: Executable name from a Windows Error Reporting (WER) event.
+- name: thor.expires
+  type: keyword
+  description: License expiration date.
+- name: thor.failure_command
+  type: wildcard
+  description: Failure recovery command for a Windows service.
+- name: thor.fault_in_module
+  type: keyword
+  description: Module where a fault occurred in a Windows Error Reporting (WER) event.
+- name: thor.locked
+  type: boolean
 - name: thor.errors
   type: float
   description: Number of errors encountered during the THOR scan.
@@ -58,6 +194,8 @@
   type: group
   description: Group of file objects associated with a detection or system object.
   fields:
+    - name: exists
+      type: keyword
     - name: company
       type: keyword
       description: Company name from PE file metadata.
@@ -94,10 +232,19 @@
     - name: type
       type: keyword
       description: File type classification (e.g., EXE, DLL, UNKNOWN, Import).
+    - name: target
+      type: keyword
+      description: Link target path for shortcut (LNK) files.
 - name: thor.files
   type: group
   description: Nested array of file objects associated with a detection or system object.
   fields:
+    - name: accessed
+      type: date
+    - name: modified
+      type: date
+    - name: permissions
+      type: keyword
     - name: company
       type: keyword
       description: Company name from PE file metadata in a files array.
@@ -155,6 +302,18 @@
 - name: thor.hive
   type: keyword
   description: Path to a Windows registry hive file being analyzed.
+- name: thor.hotfix_id
+  type: keyword
+  description: Windows hotfix identifier (e.g., KB5066128).
+- name: thor.image_name
+  type: keyword
+  description: Image or executable name for an autostart entry.
+- name: thor.installed_by
+  type: keyword
+  description: Account that installed a Windows hotfix.
+- name: thor.installed_on
+  type: date
+  description: Date a Windows hotfix or component was installed.
 - name: thor.image_path
   type: keyword
   description: Image path or executable path for a Windows service.
@@ -212,6 +371,8 @@
 - name: thor.image.size
   type: long
   description: Size of an image/executable file in bytes.
+- name: thor.image.exists
+  type: keyword
 - name: thor.image.type
   type: keyword
   description: File type classification of an image/executable (e.g., EXE, DLL).
@@ -227,6 +388,27 @@
 - name: thor.last_run
   type: date
   description: Last execution time of a scheduled task.
+- name: thor.last_logon
+  type: date
+  description: Last logon time for a user account.
+- name: thor.launch_string
+  type: wildcard
+  description: Launch string for an autostart entry.
+- name: thor.license
+  type: keyword
+  description: Path to the THOR license file.
+- name: thor.location
+  type: keyword
+  description: Registry location for an autostart entry.
+- name: thor.log_accessed
+  type: date
+  description: Last access time of a log file.
+- name: thor.log_created
+  type: date
+  description: Creation time of a log file.
+- name: thor.log_modified
+  type: date
+  description: Modification time of a log file.
 - name: thor.listen_ports
   type: keyword
   description: Network ports on which a process is listening.
@@ -236,6 +418,9 @@
 - name: thor.memory_usage
   type: keyword
   description: Memory usage information for a process or system.
+- name: thor.md5
+  type: keyword
+  description: MD5 hash of a file at the top level of a THOR event.
 - name: thor.modified
   type: date
   description: Modification time of a file, registry key, or other object.
@@ -248,12 +433,21 @@
 - name: thor.notices
   type: float
   description: Number of notices generated during the THOR scan.
+- name: thor.num_logons
+  type: long
+  description: Number of logons for a user account.
+- name: thor.other_domains
+  type: keyword
+  description: Other domains associated with a logged-in user.
 - name: thor.owner
   type: keyword
   description: Owner of a process, file, THOR license or other system object.
 - name: thor.parent
   type: keyword
   description: Path to the parent process executable.
+- name: thor.pass_age
+  type: double
+  description: Password age in days for a user account.
 - name: thor.path
   type: keyword
   description: Path to a file, scheduled task, or other system object.
@@ -266,6 +460,9 @@
 - name: thor.process_name
   type: keyword
   description: Name of a running process executable.
+- name: thor.proc
+  type: keyword
+  description: Processor description for the scanned system.
 - name: thor.reasons
   type: group
   description: Group of detection reasons explaining why a file or object was flagged.
@@ -278,6 +475,12 @@
 - name: thor.runlevel
   type: keyword
   description: Run level or privilege level for a scheduled task (e.g., LeastPrivilege).
+- name: thor.ref
+  type: keyword
+  description: Reference identifier for a THOR signature or rule.
+- name: thor.scanned
+  type: long
+  description: Number of event log entries scanned.
 - name: thor.scan_id
   type: keyword
   description: Unique identifier for a THOR scan.
@@ -285,12 +488,21 @@
   type: long
   metric_type: counter
   description: Number of elements scanned with a module.
+- name: thor.scanner
+  type: keyword
+  description: THOR scanner product name from the license file.
+- name: thor.server
+  type: keyword
+  description: Server or host name for a logged-in user session.
 - name: thor.service_name
   type: keyword
   description: Name or display name of a Windows service.
 - name: thor.session
   type: keyword
   description: Session identifier for a process (e.g., Console, Services)
+- name: thor.sha256
+  type: keyword
+  description: SHA256 hash of a file at the top level of a THOR event.
 - name: thor.sha1
   type: keyword
   description: SHA1 hash of a file.
@@ -300,6 +512,21 @@
 - name: thor.start
   type: date
   description: Start time or start condition for a scheduled task.
+- name: thor.share_name
+  type: keyword
+  description: Name of a network share.
+- name: thor.start_time
+  type: date
+  description: THOR scan start time.
+- name: thor.starts
+  type: keyword
+  description: License start date.
+- name: thor.timestamp
+  type: date
+  description: Timestamp of a SHIM cache entry.
+- name: thor.type
+  type: keyword
+  description: Type classification for a THOR module event (e.g., run_key, SIGMA, Server).
 - name: thor.unit_group
   type: keyword
   description: Group owner of a systemd unit file (Linux systems).
@@ -315,11 +542,20 @@
 - name: thor.unit
   type: keyword
   description: Name of a systemd unit (Linux systems).
+- name: thor.valid
+  type: boolean
+  description: Whether the THOR license is valid.
+- name: thor.var
+  type: keyword
+  description: Environment variable name from EnvCheck module.
+- name: thor.version
+  type: keyword
+  description: Operating system or component version string.
 - name: thor.warnings
   type: float
   description: Number of warnings generated during the THOR scan.
 - name: thor.entry
-  type: keyword
+  type: wildcard
   description: Registry entry value or cache entry (e.g., URL in MS Office connection cache).
 - name: group
   type: keyword
@@ -363,6 +599,15 @@
 - name: thor.reasons.signature.author
   type: keyword
   description: Author of a signature rule.
+- name: thor.reasons.signature.description
+  type: keyword
+  description: Description of a signature or Sigma rule.
+- name: thor.reasons.signature.falsepositives
+  type: keyword
+  description: Known false positive conditions for a signature rule.
+- name: thor.reasons.signature.id
+  type: keyword
+  description: Identifier of a signature or Sigma rule.
 - name: thor.reasons.signature.ref
   type: keyword
   description: Reference or source of a signature rule (e.g., threat intelligence feed, research).
@@ -384,14 +629,34 @@
 - name: thor.reasons.matched.data
   type: keyword
   description: Actual data that matched a signature rule (matched string or pattern).
+- name: thor.reasons.matched.field
+  type: keyword
+  description: Field name that matched in a Sigma or signature rule.
 - name: thor.reasons.matched.offset
   type: long
   description: Byte offset within a file where a signature match occurred.
 - name: thor.port
+  type: long
+  description: Network port associated with a process connection or firewall event.
+- name: thor.ip
+  type: ip
+  description: Local IP address for a process connection event.
+- name: thor.protocol
   type: keyword
+  description: Network protocol for a process connection event (e.g., TCP, UDP).
+- name: thor.rip
+  type: ip
+  description: Remote IP address for an established process connection.
+- name: thor.rport
+  type: long
+  description: Remote port for an established process connection.
 - name: thor.rule
   type: keyword
 - name: thor.rule_name
   type: keyword
 - name: thor.signature
   type: keyword
+- name: thor.string
+  type: wildcard
+- name: thor.value
+  type: wildcard

--- a/packages/nextron_thor/data_stream/thor_forwarding/fields/fields.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/fields/fields.yml
@@ -8,72 +8,101 @@
   fields:
     - name: company
       type: keyword
+      description: Company name from PE file metadata of a WER application.
     - name: created
       type: date
+      description: Creation time of the WER application file.
     - name: description
       type: keyword
+      description: File description from PE file metadata of a WER application.
     - name: exists
       type: keyword
+      description: Whether the WER application file exists on the filesystem.
     - name: first_bytes
       type: keyword
+      description: First bytes of the WER application file in hexadecimal format.
     - name: imphash
       type: keyword
+      description: Import hash (imphash) of the WER application PE file.
     - name: internal_name
       type: keyword
+      description: Internal name from PE file metadata of a WER application.
     - name: legal_copyright
       type: keyword
+      description: Legal copyright information from PE file metadata of a WER application.
     - name: md5
       type: keyword
+      description: MD5 hash of the WER application file.
     - name: original_name
       type: keyword
+      description: Original filename from PE file metadata of a WER application.
     - name: owner
       type: keyword
+      description: Owner of the WER application file.
     - name: permissions
       type: keyword
+      description: File permissions or access control list (ACL) of the WER application.
     - name: product
       type: keyword
+      description: Product name from PE file metadata of a WER application.
     - name: sha1
       type: keyword
+      description: SHA1 hash of the WER application file.
     - name: sha256
       type: keyword
+      description: SHA256 hash of the WER application file.
     - name: size
       type: long
+      description: Size of the WER application file in bytes.
     - name: type
       type: keyword
+      description: File type classification of the WER application (for example, EXE, DLL).
 - name: thor.apppath
   type: keyword
   description: Application path from a Windows Error Reporting (WER) event.
 - name: thor.arch
   type: keyword
-  description: CPU architecture of the scanned system (e.g., ARM64, AMD64).
+  description: CPU architecture of the scanned system (for example, ARM64, AMD64).
 - name: thor.archive
   type: group
   description: Archive metadata for a file extracted during scanning.
   fields:
     - name: accessed
       type: date
+      description: Last access time of the archive file.
     - name: created
       type: date
+      description: Creation time of the archive file.
     - name: first_bytes
       type: keyword
+      description: First bytes of the archive file in hexadecimal format.
     - name: md5
       type: keyword
+      description: MD5 hash of the archive file.
     - name: modified
       type: date
+      description: Modification time of the archive file.
     - name: owner
       type: keyword
+      description: Owner of the archive file.
     - name: path
       type: keyword
+      description: Full path to the archive file.
     - name: permissions
       type: keyword
+      description: File permissions or access control list (ACL) of the archive file.
     - name: sha1
       type: keyword
+      description: SHA1 hash of the archive file.
     - name: sha256
       type: keyword
+      description: SHA256 hash of the archive file.
     - name: size
       type: long
+      description: Size of the archive file in bytes.
     - name: type
       type: keyword
+      description: File type classification of the archive (for example, ZIP, RAR).
 - name: thor.arguments
   type: keyword
   description: Command-line arguments for an autostart entry.
@@ -104,12 +133,16 @@
   description: Whether a scheduled task or service is enabled.
 - name: thor.exec_flag
   type: boolean
+  description: Whether the autostart entry is flagged as executable.
 - name: thor.is_admin
   type: boolean
+  description: Whether the user account has administrator rights.
 - name: thor.no_expire
   type: boolean
+  description: Whether a user account password is configured to never expire.
 - name: thor.active
   type: boolean
+  description: Whether a user account is active.
 - name: thor.build_number
   type: keyword
   description: Operating system build number.
@@ -142,7 +175,7 @@
   description: Windows event log event ID.
 - name: thor.event_level
   type: keyword
-  description: Windows event log level (e.g., Information, Warning).
+  description: Windows event log level (for example, Information, Warning).
 - name: thor.event_time
   type: date
   description: Timestamp of a Windows event log entry.
@@ -160,6 +193,7 @@
   description: Module where a fault occurred in a Windows Error Reporting (WER) event.
 - name: thor.locked
   type: boolean
+  description: Whether a user account is locked.
 - name: thor.errors
   type: float
   description: Number of errors encountered during the THOR scan.
@@ -196,6 +230,7 @@
   fields:
     - name: exists
       type: keyword
+      description: Whether the file exists on the filesystem.
     - name: company
       type: keyword
       description: Company name from PE file metadata.
@@ -241,10 +276,13 @@
   fields:
     - name: accessed
       type: date
+      description: Last access time of a file in a files array.
     - name: modified
       type: date
+      description: Modification time of a file in a files array.
     - name: permissions
       type: keyword
+      description: File permissions of a file in a files array.
     - name: company
       type: keyword
       description: Company name from PE file metadata in a files array.
@@ -304,7 +342,7 @@
   description: Path to a Windows registry hive file being analyzed.
 - name: thor.hotfix_id
   type: keyword
-  description: Windows hotfix identifier (e.g., KB5066128).
+  description: Windows hotfix identifier (for example, KB5066128).
 - name: thor.image_name
   type: keyword
   description: Image or executable name for an autostart entry.
@@ -373,6 +411,7 @@
   description: Size of an image/executable file in bytes.
 - name: thor.image.exists
   type: keyword
+  description: Whether the image or executable file exists on the filesystem.
 - name: thor.image.type
   type: keyword
   description: File type classification of an image/executable (e.g., EXE, DLL).
@@ -526,7 +565,7 @@
   description: Timestamp of a SHIM cache entry.
 - name: thor.type
   type: keyword
-  description: Type classification for a THOR module event (e.g., run_key, SIGMA, Server).
+  description: Type classification for a THOR module event (for example, run_key, SIGMA, Server).
 - name: thor.unit_group
   type: keyword
   description: Group owner of a systemd unit file (Linux systems).
@@ -652,11 +691,16 @@
   description: Remote port for an established process connection.
 - name: thor.rule
   type: keyword
+  description: Identifier or name of a firewall or security rule.
 - name: thor.rule_name
   type: keyword
+  description: Display name of a firewall or security rule.
 - name: thor.signature
   type: keyword
+  description: Signature identifier associated with a detection.
 - name: thor.string
   type: wildcard
+  description: String value from a registry or configuration check.
 - name: thor.value
   type: wildcard
+  description: Registry or configuration value from a THOR check.

--- a/packages/nextron_thor/data_stream/thor_forwarding/manifest.yml
+++ b/packages/nextron_thor/data_stream/thor_forwarding/manifest.yml
@@ -7,102 +7,98 @@ streams:
       Collect logs with API
     template_path: cel.yml.hbs
     vars:
-       - name: initial_interval
-         type: text
-         title: Initial Interval
-         description: How far back to pull the scan logs. Supported units for this parameter are h/m/s.
-         multi: false
-         required: true
-         show_user: true
-         default: 24h
-       - name: url
-         type: text
-         title: API url
-         required: true
-         show_user: true
-         default: "https://thor-cloud.nextron-services.com/api"
-       - name: api_key
-         type: password
-         title: API Key
-         description: API Key of the THOR Cloud API.
-         secret: true
-         multi: false
-         required: true
-         show_user: true
-       - name: interval
-         type: text
-         title: Interval
-         description: Duration between requests to the API. Supported units for this parameter are h/m/s.
-         default: 5m
-         multi: false
-         required: true
-         show_user: true
-       - name: batch_size
-         type: integer
-         title: batch_size
-         description: Batch size for the response of the API.
-         default: 100
-         multi: false
-         required: true
-         show_user: false
-       - name: http_client_timeout
-         type: text
-         title: HTTP Client Timeout
-         description: Duration before declaring that the HTTP client connection has timed out. Valid time units are ns, us, ms, s, m, h.
-         multi: false
-         required: true
-         show_user: false
-         default: 30s
-       - name: max_executions
-         type: integer
-         title: Maximum Pages Per Interval
-         description: Maximum Pages Per Interval is the maximum number of pages that can be collected at each interval.
-         multi: false
-         required: false
-         show_user: false
-         default: 1000
-       - name: enable_request_tracer
-         type: bool
-         title: Enable request tracing
-         default: false
-         multi: false
-         required: false
-         show_user: false
-         description: >-
-           The request tracer logs requests and responses to the agent's local file-system for debugging configurations.
-           Enabling this request tracing compromises security and should only be used for debugging. Disabling the request
-           tracer will delete any stored traces.
-           See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable)
-           for details.
-       - name: tags
-         type: text
-         title: Tags
-         multi: true
-         required: true
-         show_user: false
-         default:
-           - forwarded
-       - name: preserve_original_event
-         required: true
-         show_user: true
-         title: Preserve original event
-         description: Preserves a raw copy of the original event, added to the field `event.original`.
-         type: bool
-         multi: false
-         default: false
-       - name: preserve_duplicate_custom_fields
-         required: true
-         show_user: false
-         title: Preserve duplicate custom fields
-         description: Preserve wiz.issue fields that were copied to Elastic Common Schema (ECS) fields.
-         type: bool
-         multi: false
-         default: false
-       - name: processors
-         type: yaml
-         title: Processors
-         multi: false
-         required: false
-         show_user: false
-         description: >-
-           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: initial_interval
+        type: text
+        title: Initial Interval
+        description: How far back to pull the scan logs. Supported units for this parameter are h/m/s.
+        multi: false
+        required: true
+        show_user: true
+        default: 24h
+      - name: url
+        type: text
+        title: API url
+        required: true
+        show_user: true
+        default: "https://thor-cloud.nextron-services.com/api"
+      - name: api_key
+        type: password
+        title: API Key
+        description: API Key of the THOR Cloud API.
+        secret: true
+        multi: false
+        required: true
+        show_user: true
+      - name: interval
+        type: text
+        title: Interval
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
+        default: 5m
+        multi: false
+        required: true
+        show_user: true
+      - name: batch_size
+        type: integer
+        title: batch_size
+        description: Batch size for the response of the API.
+        default: 100
+        multi: false
+        required: true
+        show_user: false
+      - name: http_client_timeout
+        type: text
+        title: HTTP Client Timeout
+        description: Duration before declaring that the HTTP client connection has timed out. Valid time units are ns, us, ms, s, m, h.
+        multi: false
+        required: true
+        show_user: false
+        default: 30s
+      - name: max_executions
+        type: integer
+        title: Maximum Pages Per Interval
+        description: Maximum Pages Per Interval is the maximum number of pages that can be collected at each interval.
+        multi: false
+        required: false
+        show_user: false
+        default: 1000
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        default: false
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. Disabling the request tracer will delete any stored traces. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_enable) for details.
+      - name: tags
+        type: text
+        title: Tags
+        multi: true
+        required: true
+        show_user: false
+        default:
+          - forwarded
+      - name: preserve_original_event
+        required: true
+        show_user: true
+        title: Preserve original event
+        description: Preserves a raw copy of the original event, added to the field `event.original`.
+        type: bool
+        multi: false
+        default: false
+      - name: preserve_duplicate_custom_fields
+        required: true
+        show_user: false
+        title: Preserve duplicate custom fields
+        description: Preserve thor.* fields that were copied to Elastic Common Schema (ECS) fields.
+        type: bool
+        multi: false
+        default: false
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/nextron_thor/data_stream/thor_forwarding/sample_event.json
+++ b/packages/nextron_thor/data_stream/thor_forwarding/sample_event.json
@@ -1,32 +1,32 @@
 {
     "@timestamp": "2025-11-10T17:52:49.000Z",
     "agent": {
-        "ephemeral_id": "d61b7b77-8d8d-4ef8-9b52-d8a8d6d0cf7e",
-        "id": "dbf9ff1e-dde8-48a9-807f-6d3e79a7ed39",
-        "name": "elastic-agent-35188",
+        "ephemeral_id": "bc4c18cc-a516-406c-9b56-2739477d64e8",
+        "id": "2db840ba-4c34-418b-943c-f492160edcf9",
+        "name": "elastic-agent-50088",
         "type": "filebeat",
         "version": "9.2.0"
     },
     "data_stream": {
         "dataset": "nextron_thor_apt_scanner.thor_forwarding",
-        "namespace": "56874",
+        "namespace": "55098",
         "type": "logs"
     },
     "ecs": {
         "version": "9.2.0"
     },
     "elastic_agent": {
-        "id": "dbf9ff1e-dde8-48a9-807f-6d3e79a7ed39",
+        "id": "2db840ba-4c34-418b-943c-f492160edcf9",
         "snapshot": false,
         "version": "9.2.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
-            "file"
+            "configuration"
         ],
         "dataset": "nextron_thor_apt_scanner.thor_forwarding",
-        "ingested": "2026-06-19T06:10:58Z",
+        "ingested": "2026-06-26T05:35:52Z",
         "kind": "event",
         "module": "AtJobs",
         "type": [
@@ -54,13 +54,7 @@
     ],
     "thor": {
         "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
-        "command": "",
         "job": "C:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\Task Manager\\Interactive",
-        "logontype": "",
-        "runlevel": "",
         "scan_id": "S-VavZi0stuDo"
-    },
-    "user": {
-        "name": ""
     }
 }

--- a/packages/nextron_thor/data_stream/thor_forwarding/sample_event.json
+++ b/packages/nextron_thor/data_stream/thor_forwarding/sample_event.json
@@ -1,31 +1,32 @@
 {
     "@timestamp": "2025-11-10T17:52:49.000Z",
     "agent": {
-        "ephemeral_id": "d19073f3-c079-49cd-acc9-bee532a04c98",
-        "id": "94d55e09-8bee-4d3c-9a56-7122f344472e",
-        "name": "elastic-agent-56458",
+        "ephemeral_id": "d61b7b77-8d8d-4ef8-9b52-d8a8d6d0cf7e",
+        "id": "dbf9ff1e-dde8-48a9-807f-6d3e79a7ed39",
+        "name": "elastic-agent-35188",
         "type": "filebeat",
-        "version": "9.4.1"
+        "version": "9.2.0"
     },
     "data_stream": {
         "dataset": "nextron_thor_apt_scanner.thor_forwarding",
-        "namespace": "90783",
+        "namespace": "56874",
         "type": "logs"
     },
     "ecs": {
         "version": "9.2.0"
     },
     "elastic_agent": {
-        "id": "94d55e09-8bee-4d3c-9a56-7122f344472e",
+        "id": "dbf9ff1e-dde8-48a9-807f-6d3e79a7ed39",
         "snapshot": false,
-        "version": "9.4.1"
+        "version": "9.2.0"
     },
     "event": {
+        "agent_id_status": "verified",
         "category": [
             "file"
         ],
         "dataset": "nextron_thor_apt_scanner.thor_forwarding",
-        "ingested": "2026-05-28T09:45:16Z",
+        "ingested": "2026-06-19T06:10:58Z",
         "kind": "event",
         "module": "AtJobs",
         "type": [

--- a/packages/nextron_thor/docs/README.md
+++ b/packages/nextron_thor/docs/README.md
@@ -124,39 +124,39 @@ To completely set up the Nextron Thor APT Scanner integration:
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |  |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |  |
 | tags | List of keywords used to tag each event. | keyword |  |
-| thor.active |  | boolean |  |
+| thor.active | Whether a user account is active. | boolean |  |
 | thor.alerts | Number of alerts generated during the THOR scan. | long | counter |
-| thor.app.company |  | keyword |  |
-| thor.app.created |  | date |  |
-| thor.app.description |  | keyword |  |
-| thor.app.exists |  | keyword |  |
-| thor.app.first_bytes |  | keyword |  |
-| thor.app.imphash |  | keyword |  |
-| thor.app.internal_name |  | keyword |  |
-| thor.app.legal_copyright |  | keyword |  |
-| thor.app.md5 |  | keyword |  |
-| thor.app.original_name |  | keyword |  |
-| thor.app.owner |  | keyword |  |
-| thor.app.permissions |  | keyword |  |
-| thor.app.product |  | keyword |  |
-| thor.app.sha1 |  | keyword |  |
-| thor.app.sha256 |  | keyword |  |
-| thor.app.size |  | long |  |
-| thor.app.type |  | keyword |  |
+| thor.app.company | Company name from PE file metadata of a WER application. | keyword |  |
+| thor.app.created | Creation time of the WER application file. | date |  |
+| thor.app.description | File description from PE file metadata of a WER application. | keyword |  |
+| thor.app.exists | Whether the WER application file exists on the filesystem. | keyword |  |
+| thor.app.first_bytes | First bytes of the WER application file in hexadecimal format. | keyword |  |
+| thor.app.imphash | Import hash (imphash) of the WER application PE file. | keyword |  |
+| thor.app.internal_name | Internal name from PE file metadata of a WER application. | keyword |  |
+| thor.app.legal_copyright | Legal copyright information from PE file metadata of a WER application. | keyword |  |
+| thor.app.md5 | MD5 hash of the WER application file. | keyword |  |
+| thor.app.original_name | Original filename from PE file metadata of a WER application. | keyword |  |
+| thor.app.owner | Owner of the WER application file. | keyword |  |
+| thor.app.permissions | File permissions or access control list (ACL) of the WER application. | keyword |  |
+| thor.app.product | Product name from PE file metadata of a WER application. | keyword |  |
+| thor.app.sha1 | SHA1 hash of the WER application file. | keyword |  |
+| thor.app.sha256 | SHA256 hash of the WER application file. | keyword |  |
+| thor.app.size | Size of the WER application file in bytes. | long |  |
+| thor.app.type | File type classification of the WER application (for example, EXE, DLL). | keyword |  |
 | thor.apppath | Application path from a Windows Error Reporting (WER) event. | keyword |  |
-| thor.arch | CPU architecture of the scanned system (e.g., ARM64, AMD64). | keyword |  |
-| thor.archive.accessed |  | date |  |
-| thor.archive.created |  | date |  |
-| thor.archive.first_bytes |  | keyword |  |
-| thor.archive.md5 |  | keyword |  |
-| thor.archive.modified |  | date |  |
-| thor.archive.owner |  | keyword |  |
-| thor.archive.path |  | keyword |  |
-| thor.archive.permissions |  | keyword |  |
-| thor.archive.sha1 |  | keyword |  |
-| thor.archive.sha256 |  | keyword |  |
-| thor.archive.size |  | long |  |
-| thor.archive.type |  | keyword |  |
+| thor.arch | CPU architecture of the scanned system (for example, ARM64, AMD64). | keyword |  |
+| thor.archive.accessed | Last access time of the archive file. | date |  |
+| thor.archive.created | Creation time of the archive file. | date |  |
+| thor.archive.first_bytes | First bytes of the archive file in hexadecimal format. | keyword |  |
+| thor.archive.md5 | MD5 hash of the archive file. | keyword |  |
+| thor.archive.modified | Modification time of the archive file. | date |  |
+| thor.archive.owner | Owner of the archive file. | keyword |  |
+| thor.archive.path | Full path to the archive file. | keyword |  |
+| thor.archive.permissions | File permissions or access control list (ACL) of the archive file. | keyword |  |
+| thor.archive.sha1 | SHA1 hash of the archive file. | keyword |  |
+| thor.archive.sha256 | SHA256 hash of the archive file. | keyword |  |
+| thor.archive.size | Size of the archive file in bytes. | long |  |
+| thor.archive.type | File type classification of the archive (for example, ZIP, RAR). | keyword |  |
 | thor.arguments | Command-line arguments for an autostart entry. | keyword |  |
 | thor.badpwcount | Number of bad password attempts for a user account. | long |  |
 | thor.build_number | Operating system build number. | keyword |  |
@@ -182,14 +182,14 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.event_filter | WMI event filter query (e.g., WQL SELECT statement). | keyword |  |
 | thor.event_filter_name | Name of a WMI event filter used for persistence. | keyword |  |
 | thor.event_id | Windows event log event ID. | long |  |
-| thor.event_level | Windows event log level (e.g., Information, Warning). | keyword |  |
+| thor.event_level | Windows event log level (for example, Information, Warning). | keyword |  |
 | thor.event_time | Timestamp of a Windows event log entry. | date |  |
 | thor.exe | Executable name from a Windows Error Reporting (WER) event. | keyword |  |
 | thor.exe_group | Group owner of an executable file (Linux/Unix systems). | keyword |  |
 | thor.exe_magic | Detected file type based on magic bytes. | keyword |  |
 | thor.exe_mode | File permissions mode of an executable (Linux/Unix systems). | keyword |  |
 | thor.exe_owner | Owner of an executable file. | keyword |  |
-| thor.exec_flag |  | boolean |  |
+| thor.exec_flag | Whether the autostart entry is flagged as executable. | boolean |  |
 | thor.executable | Path to an executable file. | keyword |  |
 | thor.expires | License expiration date. | keyword |  |
 | thor.failure_command | Failure recovery command for a Windows service. | wildcard |  |
@@ -197,7 +197,7 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.file.company | Company name from PE file metadata. | keyword |  |
 | thor.file.created | creation time of the file | date |  |
 | thor.file.description | File description from PE file metadata. | keyword |  |
-| thor.file.exists |  | keyword |  |
+| thor.file.exists | Whether the file exists on the filesystem. | keyword |  |
 | thor.file.ext | File extension of a detected file. | keyword |  |
 | thor.file.first_bytes | First bytes of a file in hexadecimal format, often with ASCII representation. | keyword |  |
 | thor.file.imphash | Import hash (imphash) of a PE file, used for malware classification. | keyword |  |
@@ -208,7 +208,7 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.file.product | Product name from PE file metadata. | keyword |  |
 | thor.file.target | Link target path for shortcut (LNK) files. | keyword |  |
 | thor.file.type | File type classification (e.g., EXE, DLL, UNKNOWN, Import). | keyword |  |
-| thor.files.accessed |  | date |  |
+| thor.files.accessed | Last access time of a file in a files array. | date |  |
 | thor.files.company | Company name from PE file metadata in a files array. | keyword |  |
 | thor.files.created | creation time of the file | date |  |
 | thor.files.description | File description from PE file metadata in a files array. | keyword |  |
@@ -218,11 +218,11 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.files.internal_name | Internal name from PE file metadata in a files array. | keyword |  |
 | thor.files.legal_copyright | Legal copyright information from PE file metadata in a files array. | keyword |  |
 | thor.files.md5 | MD5 hash of a file in a files array. | keyword |  |
-| thor.files.modified |  | date |  |
+| thor.files.modified | Modification time of a file in a files array. | date |  |
 | thor.files.original_name | Original filename from PE file metadata in a files array. | keyword |  |
 | thor.files.owner | Owner of a file in a files array. | keyword |  |
 | thor.files.path | Full path to a file in a files array. | keyword |  |
-| thor.files.permissions |  | keyword |  |
+| thor.files.permissions | File permissions of a file in a files array. | keyword |  |
 | thor.files.product | Product name from PE file metadata in a files array. | keyword |  |
 | thor.files.sha1 | SHA1 hash of a file in a files array. | keyword |  |
 | thor.files.sha256 | SHA256 hash of a file in a files array. | keyword |  |
@@ -233,13 +233,13 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.groupid | Group ID (GID) of a user account (Linux/Unix systems). | keyword |  |
 | thor.hive | Path to a Windows registry hive file being analyzed. | keyword |  |
 | thor.home | Home directory path of a user account. | keyword |  |
-| thor.hotfix_id | Windows hotfix identifier (e.g., KB5066128). | keyword |  |
+| thor.hotfix_id | Windows hotfix identifier (for example, KB5066128). | keyword |  |
 | thor.image.accessed | access time of the image | date |  |
 | thor.image.changed | Change time (ctime) of an image/executable file (Linux/Unix systems). | date |  |
 | thor.image.company | Company name from PE file metadata of an image/executable. | keyword |  |
 | thor.image.created | creation time of the image | date |  |
 | thor.image.description | File description from PE file metadata of an image/executable. | keyword |  |
-| thor.image.exists |  | keyword |  |
+| thor.image.exists | Whether the image or executable file exists on the filesystem. | keyword |  |
 | thor.image.first_bytes | First bytes of an image/executable file in hexadecimal format. | keyword |  |
 | thor.image.group | Group owner of an image/executable file (Linux/Unix systems). | keyword |  |
 | thor.image.imphash | Import hash (imphash) of an image/executable PE file. | keyword |  |
@@ -261,7 +261,7 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.installed_by | Account that installed a Windows hotfix. | keyword |  |
 | thor.installed_on | Date a Windows hotfix or component was installed. | date |  |
 | thor.ip | Local IP address for a process connection event. | ip |  |
-| thor.is_admin |  | boolean |  |
+| thor.is_admin | Whether the user account has administrator rights. | boolean |  |
 | thor.job | Path to a Windows At Job (scheduled task) file. | keyword |  |
 | thor.key | Full path to a registry key or WMI binding key. | keyword |  |
 | thor.key_name | Name of a registry key or service name. | keyword |  |
@@ -271,7 +271,7 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.license | Path to the THOR license file. | keyword |  |
 | thor.listen_ports | Network ports on which a process is listening. | keyword |  |
 | thor.location | Registry location for an autostart entry. | keyword |  |
-| thor.locked |  | boolean |  |
+| thor.locked | Whether a user account is locked. | boolean |  |
 | thor.log_accessed | Last access time of a log file. | date |  |
 | thor.log_created | Creation time of a log file. | date |  |
 | thor.log_modified | Modification time of a log file. | date |  |
@@ -281,7 +281,7 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.modified | Modification time of a file, registry key, or other object. | date |  |
 | thor.name | Name of a scheduled task, service, or other system object. | keyword |  |
 | thor.next_run | Next scheduled execution time of a scheduled task. | date |  |
-| thor.no_expire |  | boolean |  |
+| thor.no_expire | Whether a user account password is configured to never expire. | boolean |  |
 | thor.notices | Number of notices generated during the THOR scan. | float |  |
 | thor.num_logons | Number of logons for a user account. | long |  |
 | thor.other_domains | Other domains associated with a logged-in user. | keyword |  |
@@ -315,8 +315,8 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.ref | Reference identifier for a THOR signature or rule. | keyword |  |
 | thor.rip | Remote IP address for an established process connection. | ip |  |
 | thor.rport | Remote port for an established process connection. | long |  |
-| thor.rule |  | keyword |  |
-| thor.rule_name |  | keyword |  |
+| thor.rule | Identifier or name of a firewall or security rule. | keyword |  |
+| thor.rule_name | Display name of a firewall or security rule. | keyword |  |
 | thor.run_as_group | Group under which a systemd service runs. | keyword |  |
 | thor.run_as_user | User account under which a systemd service runs. | keyword |  |
 | thor.runlevel | Run level or privilege level for a scheduled task (e.g., LeastPrivilege). | keyword |  |
@@ -332,21 +332,21 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.sha256 | SHA256 hash of a file at the top level of a THOR event. | keyword |  |
 | thor.share_name | Name of a network share. | keyword |  |
 | thor.shell | Login shell path for a user account (Linux/Unix systems). | keyword |  |
-| thor.signature |  | keyword |  |
+| thor.signature | Signature identifier associated with a detection. | keyword |  |
 | thor.start | Start time or start condition for a scheduled task. | date |  |
 | thor.start_time | THOR scan start time. | date |  |
 | thor.start_type | Startup type of a Windows service (e.g., AUTO_START, MANUAL, DISABLED). | keyword |  |
 | thor.starts | License start date. | keyword |  |
-| thor.string |  | wildcard |  |
+| thor.string | String value from a registry or configuration check. | wildcard |  |
 | thor.timestamp | Timestamp of a SHIM cache entry. | date |  |
-| thor.type | Type classification for a THOR module event (e.g., run_key, SIGMA, Server). | keyword |  |
+| thor.type | Type classification for a THOR module event (for example, run_key, SIGMA, Server). | keyword |  |
 | thor.unit | Name of a systemd unit (Linux systems). | keyword |  |
 | thor.unit_group | Group owner of a systemd unit file (Linux systems). | keyword |  |
 | thor.unit_mode | File permissions mode of a systemd unit file (Linux systems). | keyword |  |
 | thor.unit_owner | Owner of a systemd unit file (Linux systems). | keyword |  |
 | thor.unit_path | Path to a systemd unit file (Linux systems). | keyword |  |
 | thor.valid | Whether the THOR license is valid. | boolean |  |
-| thor.value |  | wildcard |  |
+| thor.value | Registry or configuration value from a THOR check. | wildcard |  |
 | thor.var | Environment variable name from EnvCheck module. | keyword |  |
 | thor.version | Operating system or component version string. | keyword |  |
 | thor.warnings | Number of warnings generated during the THOR scan. | float |  |
@@ -360,32 +360,32 @@ An example event for `thor_forwarding` looks as following:
 {
     "@timestamp": "2025-11-10T17:52:49.000Z",
     "agent": {
-        "ephemeral_id": "d61b7b77-8d8d-4ef8-9b52-d8a8d6d0cf7e",
-        "id": "dbf9ff1e-dde8-48a9-807f-6d3e79a7ed39",
-        "name": "elastic-agent-35188",
+        "ephemeral_id": "bc4c18cc-a516-406c-9b56-2739477d64e8",
+        "id": "2db840ba-4c34-418b-943c-f492160edcf9",
+        "name": "elastic-agent-50088",
         "type": "filebeat",
         "version": "9.2.0"
     },
     "data_stream": {
         "dataset": "nextron_thor_apt_scanner.thor_forwarding",
-        "namespace": "56874",
+        "namespace": "55098",
         "type": "logs"
     },
     "ecs": {
         "version": "9.2.0"
     },
     "elastic_agent": {
-        "id": "dbf9ff1e-dde8-48a9-807f-6d3e79a7ed39",
+        "id": "2db840ba-4c34-418b-943c-f492160edcf9",
         "snapshot": false,
         "version": "9.2.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
-            "file"
+            "configuration"
         ],
         "dataset": "nextron_thor_apt_scanner.thor_forwarding",
-        "ingested": "2026-06-19T06:10:58Z",
+        "ingested": "2026-06-26T05:35:52Z",
         "kind": "event",
         "module": "AtJobs",
         "type": [
@@ -413,14 +413,8 @@ An example event for `thor_forwarding` looks as following:
     ],
     "thor": {
         "campaign_id": "2b054111-bad7-4bac-a14e-8fa8a88f1111",
-        "command": "",
         "job": "C:\\Windows\\System32\\Tasks\\Microsoft\\Windows\\Task Manager\\Interactive",
-        "logontype": "",
-        "runlevel": "",
         "scan_id": "S-VavZi0stuDo"
-    },
-    "user": {
-        "name": ""
     }
 }
 ```

--- a/packages/nextron_thor/docs/README.md
+++ b/packages/nextron_thor/docs/README.md
@@ -124,28 +124,80 @@ To completely set up the Nextron Thor APT Scanner integration:
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |  |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |  |
 | tags | List of keywords used to tag each event. | keyword |  |
+| thor.active |  | boolean |  |
 | thor.alerts | Number of alerts generated during the THOR scan. | long | counter |
+| thor.app.company |  | keyword |  |
+| thor.app.created |  | date |  |
+| thor.app.description |  | keyword |  |
+| thor.app.exists |  | keyword |  |
+| thor.app.first_bytes |  | keyword |  |
+| thor.app.imphash |  | keyword |  |
+| thor.app.internal_name |  | keyword |  |
+| thor.app.legal_copyright |  | keyword |  |
+| thor.app.md5 |  | keyword |  |
+| thor.app.original_name |  | keyword |  |
+| thor.app.owner |  | keyword |  |
+| thor.app.permissions |  | keyword |  |
+| thor.app.product |  | keyword |  |
+| thor.app.sha1 |  | keyword |  |
+| thor.app.sha256 |  | keyword |  |
+| thor.app.size |  | long |  |
+| thor.app.type |  | keyword |  |
+| thor.apppath | Application path from a Windows Error Reporting (WER) event. | keyword |  |
+| thor.arch | CPU architecture of the scanned system (e.g., ARM64, AMD64). | keyword |  |
+| thor.archive.accessed |  | date |  |
+| thor.archive.created |  | date |  |
+| thor.archive.first_bytes |  | keyword |  |
+| thor.archive.md5 |  | keyword |  |
+| thor.archive.modified |  | date |  |
+| thor.archive.owner |  | keyword |  |
+| thor.archive.path |  | keyword |  |
+| thor.archive.permissions |  | keyword |  |
+| thor.archive.sha1 |  | keyword |  |
+| thor.archive.sha256 |  | keyword |  |
+| thor.archive.size |  | long |  |
+| thor.archive.type |  | keyword |  |
+| thor.arguments | Command-line arguments for an autostart entry. | keyword |  |
+| thor.badpwcount | Number of bad password attempts for a user account. | long |  |
+| thor.build_number | Operating system build number. | keyword |  |
 | thor.campaign_id | Campaign ID of a THOR scan. | keyword |  |
-| thor.command | Command line or executable path associated with a scheduled task, service, or process. | keyword |  |
+| thor.caption | Caption or description for a Windows hotfix. | keyword |  |
+| thor.command | Command line or executable path associated with a scheduled task, service, or process. | wildcard |  |
+| thor.comment | Comment associated with a user account. | keyword |  |
 | thor.connection_count | Total number of network connections associated with a process. | long | gauge |
 | thor.created | creation time | date |  |
+| thor.date | Date of a Windows Error Reporting (WER) event. | date |  |
 | thor.description | Description text for a service, file, or other system object. | keyword |  |
+| thor.directory | Directory path being analyzed. | keyword |  |
+| thor.drive | Drive letter being analyzed. | keyword |  |
 | thor.duration | Duration of a THOR scan module execution in seconds. | long |  |
 | thor.enabled | Whether a scheduled task or service is enabled. | boolean |  |
-| thor.entry | Registry entry value or cache entry (e.g., URL in MS Office connection cache). | keyword |  |
+| thor.entries | Number of entries in a cache or hive analysis. | long |  |
+| thor.entry | Registry entry value or cache entry (e.g., URL in MS Office connection cache). | wildcard |  |
+| thor.error | Error message from a Windows Error Reporting (WER) event. | wildcard |  |
 | thor.errors | Number of errors encountered during the THOR scan. | float |  |
+| thor.event_channel | Windows event log channel name. | keyword |  |
 | thor.event_consumer | WMI event consumer configuration or command. | keyword |  |
 | thor.event_consumer_name | Name of a WMI event consumer used for persistence. | keyword |  |
 | thor.event_filter | WMI event filter query (e.g., WQL SELECT statement). | keyword |  |
 | thor.event_filter_name | Name of a WMI event filter used for persistence. | keyword |  |
+| thor.event_id | Windows event log event ID. | long |  |
+| thor.event_level | Windows event log level (e.g., Information, Warning). | keyword |  |
+| thor.event_time | Timestamp of a Windows event log entry. | date |  |
+| thor.exe | Executable name from a Windows Error Reporting (WER) event. | keyword |  |
 | thor.exe_group | Group owner of an executable file (Linux/Unix systems). | keyword |  |
 | thor.exe_magic | Detected file type based on magic bytes. | keyword |  |
 | thor.exe_mode | File permissions mode of an executable (Linux/Unix systems). | keyword |  |
 | thor.exe_owner | Owner of an executable file. | keyword |  |
+| thor.exec_flag |  | boolean |  |
 | thor.executable | Path to an executable file. | keyword |  |
+| thor.expires | License expiration date. | keyword |  |
+| thor.failure_command | Failure recovery command for a Windows service. | wildcard |  |
+| thor.fault_in_module | Module where a fault occurred in a Windows Error Reporting (WER) event. | keyword |  |
 | thor.file.company | Company name from PE file metadata. | keyword |  |
 | thor.file.created | creation time of the file | date |  |
 | thor.file.description | File description from PE file metadata. | keyword |  |
+| thor.file.exists |  | keyword |  |
 | thor.file.ext | File extension of a detected file. | keyword |  |
 | thor.file.first_bytes | First bytes of a file in hexadecimal format, often with ASCII representation. | keyword |  |
 | thor.file.imphash | Import hash (imphash) of a PE file, used for malware classification. | keyword |  |
@@ -154,7 +206,9 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.file.original_name | Original filename from PE file metadata. | keyword |  |
 | thor.file.permissions | File permissions or access control list (ACL) information. | keyword |  |
 | thor.file.product | Product name from PE file metadata. | keyword |  |
+| thor.file.target | Link target path for shortcut (LNK) files. | keyword |  |
 | thor.file.type | File type classification (e.g., EXE, DLL, UNKNOWN, Import). | keyword |  |
+| thor.files.accessed |  | date |  |
 | thor.files.company | Company name from PE file metadata in a files array. | keyword |  |
 | thor.files.created | creation time of the file | date |  |
 | thor.files.description | File description from PE file metadata in a files array. | keyword |  |
@@ -164,9 +218,11 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.files.internal_name | Internal name from PE file metadata in a files array. | keyword |  |
 | thor.files.legal_copyright | Legal copyright information from PE file metadata in a files array. | keyword |  |
 | thor.files.md5 | MD5 hash of a file in a files array. | keyword |  |
+| thor.files.modified |  | date |  |
 | thor.files.original_name | Original filename from PE file metadata in a files array. | keyword |  |
 | thor.files.owner | Owner of a file in a files array. | keyword |  |
 | thor.files.path | Full path to a file in a files array. | keyword |  |
+| thor.files.permissions |  | keyword |  |
 | thor.files.product | Product name from PE file metadata in a files array. | keyword |  |
 | thor.files.sha1 | SHA1 hash of a file in a files array. | keyword |  |
 | thor.files.sha256 | SHA256 hash of a file in a files array. | keyword |  |
@@ -177,11 +233,13 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.groupid | Group ID (GID) of a user account (Linux/Unix systems). | keyword |  |
 | thor.hive | Path to a Windows registry hive file being analyzed. | keyword |  |
 | thor.home | Home directory path of a user account. | keyword |  |
+| thor.hotfix_id | Windows hotfix identifier (e.g., KB5066128). | keyword |  |
 | thor.image.accessed | access time of the image | date |  |
 | thor.image.changed | Change time (ctime) of an image/executable file (Linux/Unix systems). | date |  |
 | thor.image.company | Company name from PE file metadata of an image/executable. | keyword |  |
 | thor.image.created | creation time of the image | date |  |
 | thor.image.description | File description from PE file metadata of an image/executable. | keyword |  |
+| thor.image.exists |  | keyword |  |
 | thor.image.first_bytes | First bytes of an image/executable file in hexadecimal format. | keyword |  |
 | thor.image.group | Group owner of an image/executable file (Linux/Unix systems). | keyword |  |
 | thor.image.imphash | Import hash (imphash) of an image/executable PE file. | keyword |  |
@@ -198,58 +256,99 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.image.sha256 | SHA256 hash of an image/executable file. | keyword |  |
 | thor.image.size | Size of an image/executable file in bytes. | long |  |
 | thor.image.type | File type classification of an image/executable (e.g., EXE, DLL). | keyword |  |
+| thor.image_name | Image or executable name for an autostart entry. | keyword |  |
 | thor.image_path | Image path or executable path for a Windows service. | keyword |  |
+| thor.installed_by | Account that installed a Windows hotfix. | keyword |  |
+| thor.installed_on | Date a Windows hotfix or component was installed. | date |  |
+| thor.ip | Local IP address for a process connection event. | ip |  |
+| thor.is_admin |  | boolean |  |
 | thor.job | Path to a Windows At Job (scheduled task) file. | keyword |  |
 | thor.key | Full path to a registry key or WMI binding key. | keyword |  |
 | thor.key_name | Name of a registry key or service name. | keyword |  |
+| thor.last_logon | Last logon time for a user account. | date |  |
 | thor.last_run | Last execution time of a scheduled task. | date |  |
+| thor.launch_string | Launch string for an autostart entry. | wildcard |  |
+| thor.license | Path to the THOR license file. | keyword |  |
 | thor.listen_ports | Network ports on which a process is listening. | keyword |  |
+| thor.location | Registry location for an autostart entry. | keyword |  |
+| thor.locked |  | boolean |  |
+| thor.log_accessed | Last access time of a log file. | date |  |
+| thor.log_created | Creation time of a log file. | date |  |
+| thor.log_modified | Modification time of a log file. | date |  |
 | thor.logontype | Logon type for a scheduled task or service. | keyword |  |
+| thor.md5 | MD5 hash of a file at the top level of a THOR event. | keyword |  |
 | thor.memory_usage | Memory usage information for a process or system. | keyword |  |
 | thor.modified | Modification time of a file, registry key, or other object. | date |  |
 | thor.name | Name of a scheduled task, service, or other system object. | keyword |  |
 | thor.next_run | Next scheduled execution time of a scheduled task. | date |  |
+| thor.no_expire |  | boolean |  |
 | thor.notices | Number of notices generated during the THOR scan. | float |  |
+| thor.num_logons | Number of logons for a user account. | long |  |
+| thor.other_domains | Other domains associated with a logged-in user. | keyword |  |
 | thor.owner | Owner of a process, file, THOR license or other system object. | keyword |  |
 | thor.parent | Path to the parent process executable. | keyword |  |
+| thor.pass_age | Password age in days for a user account. | double |  |
 | thor.path | Path to a file, scheduled task, or other system object. | keyword |  |
 | thor.pid | Process ID (PID) of a running process. | long |  |
-| thor.port |  | keyword |  |
+| thor.port | Network port associated with a process connection or firewall event. | long |  |
 | thor.ppid | Parent process ID (PPID) of a running process. | long |  |
+| thor.proc | Processor description for the scanned system. | keyword |  |
 | thor.process_name | Name of a running process executable. | keyword |  |
+| thor.protocol | Network protocol for a process connection event (e.g., TCP, UDP). | keyword |  |
 | thor.reason | Reason for a detection or alert (e.g., "Password is too short", "Port explicitly specified"). | keyword |  |
 | thor.reasons.matched.context | Contextual data surrounding a signature match (surrounding bytes or text). | keyword |  |
 | thor.reasons.matched.data | Actual data that matched a signature rule (matched string or pattern). | keyword |  |
+| thor.reasons.matched.field | Field name that matched in a Sigma or signature rule. | keyword |  |
 | thor.reasons.matched.offset | Byte offset within a file where a signature match occurred. | long |  |
 | thor.reasons.name | Name or description of a detection reason (e.g., YARA rule name with description). | keyword |  |
 | thor.reasons.score | Threat score assigned to a specific detection reason. | long |  |
 | thor.reasons.sigclass | Signature class or type (e.g., YARA Rule, Filename IOC, Sigma Rule). | keyword |  |
 | thor.reasons.signature.author | Author of a signature rule. | keyword |  |
+| thor.reasons.signature.description | Description of a signature or Sigma rule. | keyword |  |
+| thor.reasons.signature.falsepositives | Known false positive conditions for a signature rule. | keyword |  |
+| thor.reasons.signature.id | Identifier of a signature or Sigma rule. | keyword |  |
 | thor.reasons.signature.ref | Reference or source of a signature rule (e.g., threat intelligence feed, research). | keyword |  |
 | thor.reasons.signature.ruledate | Date when a signature rule was created or last updated. | date |  |
 | thor.reasons.signature.rulename | Name of a signature rule (e.g., YARA rule name). | keyword |  |
 | thor.reasons.signature.tags | Tags associated with a signature rule (e.g., MITRE ATT&CK techniques, threat categories). | keyword |  |
 | thor.reasons.sigtype | Signature type classification (e.g., internal, custom). | keyword |  |
+| thor.ref | Reference identifier for a THOR signature or rule. | keyword |  |
+| thor.rip | Remote IP address for an established process connection. | ip |  |
+| thor.rport | Remote port for an established process connection. | long |  |
 | thor.rule |  | keyword |  |
 | thor.rule_name |  | keyword |  |
 | thor.run_as_group | Group under which a systemd service runs. | keyword |  |
 | thor.run_as_user | User account under which a systemd service runs. | keyword |  |
 | thor.runlevel | Run level or privilege level for a scheduled task (e.g., LeastPrivilege). | keyword |  |
 | thor.scan_id | Unique identifier for a THOR scan. | keyword |  |
+| thor.scanned | Number of event log entries scanned. | long |  |
 | thor.scanned_elements | Number of elements scanned with a module. | long | counter |
+| thor.scanner | THOR scanner product name from the license file. | keyword |  |
 | thor.score | Threat score assigned to a detection (higher scores indicate higher severity). | long |  |
+| thor.server | Server or host name for a logged-in user session. | keyword |  |
 | thor.service_name | Name or display name of a Windows service. | keyword |  |
 | thor.session | Session identifier for a process (e.g., Console, Services) | keyword |  |
 | thor.sha1 | SHA1 hash of a file. | keyword |  |
+| thor.sha256 | SHA256 hash of a file at the top level of a THOR event. | keyword |  |
+| thor.share_name | Name of a network share. | keyword |  |
 | thor.shell | Login shell path for a user account (Linux/Unix systems). | keyword |  |
 | thor.signature |  | keyword |  |
 | thor.start | Start time or start condition for a scheduled task. | date |  |
+| thor.start_time | THOR scan start time. | date |  |
 | thor.start_type | Startup type of a Windows service (e.g., AUTO_START, MANUAL, DISABLED). | keyword |  |
+| thor.starts | License start date. | keyword |  |
+| thor.string |  | wildcard |  |
+| thor.timestamp | Timestamp of a SHIM cache entry. | date |  |
+| thor.type | Type classification for a THOR module event (e.g., run_key, SIGMA, Server). | keyword |  |
 | thor.unit | Name of a systemd unit (Linux systems). | keyword |  |
 | thor.unit_group | Group owner of a systemd unit file (Linux systems). | keyword |  |
 | thor.unit_mode | File permissions mode of a systemd unit file (Linux systems). | keyword |  |
 | thor.unit_owner | Owner of a systemd unit file (Linux systems). | keyword |  |
 | thor.unit_path | Path to a systemd unit file (Linux systems). | keyword |  |
+| thor.valid | Whether the THOR license is valid. | boolean |  |
+| thor.value |  | wildcard |  |
+| thor.var | Environment variable name from EnvCheck module. | keyword |  |
+| thor.version | Operating system or component version string. | keyword |  |
 | thor.warnings | Number of warnings generated during the THOR scan. | float |  |
 
 

--- a/packages/nextron_thor/docs/README.md
+++ b/packages/nextron_thor/docs/README.md
@@ -214,6 +214,7 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.parent | Path to the parent process executable. | keyword |  |
 | thor.path | Path to a file, scheduled task, or other system object. | keyword |  |
 | thor.pid | Process ID (PID) of a running process. | long |  |
+| thor.port |  | keyword |  |
 | thor.ppid | Parent process ID (PPID) of a running process. | long |  |
 | thor.process_name | Name of a running process executable. | keyword |  |
 | thor.reason | Reason for a detection or alert (e.g., "Password is too short", "Port explicitly specified"). | keyword |  |
@@ -229,6 +230,8 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.reasons.signature.rulename | Name of a signature rule (e.g., YARA rule name). | keyword |  |
 | thor.reasons.signature.tags | Tags associated with a signature rule (e.g., MITRE ATT&CK techniques, threat categories). | keyword |  |
 | thor.reasons.sigtype | Signature type classification (e.g., internal, custom). | keyword |  |
+| thor.rule |  | keyword |  |
+| thor.rule_name |  | keyword |  |
 | thor.run_as_group | Group under which a systemd service runs. | keyword |  |
 | thor.run_as_user | User account under which a systemd service runs. | keyword |  |
 | thor.runlevel | Run level or privilege level for a scheduled task (e.g., LeastPrivilege). | keyword |  |
@@ -239,6 +242,7 @@ To completely set up the Nextron Thor APT Scanner integration:
 | thor.session | Session identifier for a process (e.g., Console, Services) | keyword |  |
 | thor.sha1 | SHA1 hash of a file. | keyword |  |
 | thor.shell | Login shell path for a user account (Linux/Unix systems). | keyword |  |
+| thor.signature |  | keyword |  |
 | thor.start | Start time or start condition for a scheduled task. | date |  |
 | thor.start_type | Startup type of a Windows service (e.g., AUTO_START, MANUAL, DISABLED). | keyword |  |
 | thor.unit | Name of a systemd unit (Linux systems). | keyword |  |
@@ -257,31 +261,32 @@ An example event for `thor_forwarding` looks as following:
 {
     "@timestamp": "2025-11-10T17:52:49.000Z",
     "agent": {
-        "ephemeral_id": "d19073f3-c079-49cd-acc9-bee532a04c98",
-        "id": "94d55e09-8bee-4d3c-9a56-7122f344472e",
-        "name": "elastic-agent-56458",
+        "ephemeral_id": "d61b7b77-8d8d-4ef8-9b52-d8a8d6d0cf7e",
+        "id": "dbf9ff1e-dde8-48a9-807f-6d3e79a7ed39",
+        "name": "elastic-agent-35188",
         "type": "filebeat",
-        "version": "9.4.1"
+        "version": "9.2.0"
     },
     "data_stream": {
         "dataset": "nextron_thor_apt_scanner.thor_forwarding",
-        "namespace": "90783",
+        "namespace": "56874",
         "type": "logs"
     },
     "ecs": {
         "version": "9.2.0"
     },
     "elastic_agent": {
-        "id": "94d55e09-8bee-4d3c-9a56-7122f344472e",
+        "id": "dbf9ff1e-dde8-48a9-807f-6d3e79a7ed39",
         "snapshot": false,
-        "version": "9.4.1"
+        "version": "9.2.0"
     },
     "event": {
+        "agent_id_status": "verified",
         "category": [
             "file"
         ],
         "dataset": "nextron_thor_apt_scanner.thor_forwarding",
-        "ingested": "2026-05-28T09:45:16Z",
+        "ingested": "2026-06-19T06:10:58Z",
         "kind": "event",
         "module": "AtJobs",
         "type": [

--- a/packages/nextron_thor/manifest.yml
+++ b/packages/nextron_thor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: nextron_thor_apt_scanner
 title: "Nextron Thor APT Scanner"
-version: 0.3.1
+version: 0.4.0
 source:
   license: "Elastic-2.0"
 description: "Integration for Nextron Thor APT Scanner"

--- a/packages/nextron_thor/manifest.yml
+++ b/packages/nextron_thor/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: nextron_thor_apt_scanner
 title: "Nextron Thor APT Scanner"
-version: 0.3.0
+version: 0.3.1
 source:
   license: "Elastic-2.0"
 description: "Integration for Nextron Thor APT Scanner"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
```
nextron_thor_apt_scanner: fix pipeline data integrity and ECS field normalization

Address Workstream 1 (pipeline & data integrity) and Workstream 2 (ECS
mapping & field normalization) from elastic/integrations#19162.

Workstream 1 — Pipeline & data integrity
- Redesign document _id fingerprint to hash event.original + log_line instead
  of thor/message/@timestamp/file, preventing undercounting of duplicate
  findings and collisions between Starting/Finished module lifecycle events
- Add per-line log_line index in CEL so identical JSON lines within a scan
  index as separate documents
- Move thor.scanid → thor.scan_id rename before fingerprint so scan ID is
  normalized regardless of downstream processor failures
- Fix string-format thor.file handling: rename to file.path and extract
  file.name via grok (including lowercase Windows drive letters)
- Handle AtJobs multi-value start timestamps by keeping the first value
  before date parsing
- Add terminate processor to stop processing CEL API/collection error events
  before JSON parsing
- Fix CEL cursor advancement when filtered scans produce no log lines;
  always advance to the last scan on the page and derive want_more from
  page.size() >= batch_size
- Expand docker mock config for system test coverage

Workstream 2 — ECS mapping & field normalization
- Add categorize.yml sub-pipeline with per-module event.category, event.type,
  and event.kind mappings for all THOR Cloud modules
- Set event.kind to alert when thor.level is Alert; append malware category
  for Filescan Malware file found findings
- Map module-specific THOR fields to ECS: process.*, registry.*, source.*,
  destination.*, network.transport, rule.*, user.*, host.name, file.*
- Normalize inconsistent field names: thor.image_path → thor.image.path,
  camelCase/snake_case renames (lastrun, firstbytes, desc, eventconsumer, etc.)
- Convert semantic types in pipeline: boolean (exec_flag, enabled, valid, …),
  long (port, event_id, scanned, …), ip (thor.ip, thor.rip), double (pass_age)
- Change long-value THOR fields from keyword to wildcard (entry, command,
  value, string, error, failure_command, launch_string) to avoid _ignored
- Declare missing thor.app, thor.archive, and additional module field groups
  in fields.yml
- Remove blanket event.category: file default; categorization is now per module
- Add null/empty field cleanup script and foreach-based related.user extraction
  from thor.files[].owner
- Parse additional THOR date fields (app, archive, image, files[], reasons, etc.)

Package & docs
- Fix preserve_duplicate_custom_fields description (wiz → thor.*)
- Format data stream manifest indentation
```

> [!NOTE]
> This PR addresses the workstream-1 and workstream-2 from elastic/integrations#19162.
> 
> Review commit wise.
>
> ## Workstream 1 — Pipeline &amp; Data Integrity
> 
> - [x] The count of findings in Elastic Security matches the count reported in THOR Cloud for the same scan.
> - [x] Both `Starting module` and `Finished module` events appear in Discover for all modules.
> - [x] A THOR finding that appears multiple times in the same scan is indexed as multiple separate documents.
> - [x] Events that fail pipeline processing do not produce duplicate index entries.
> 
> - [ ] ~Configuring the integration with an invalid API key produces a visible validation error at setup time.~ (This is not possible to achieve with the current architecture.)
> - [ ] API error responses from THOR Cloud are not indexed as THOR scan events. (Added `terminate` instead)
> - [x] No secondary pipeline parsing errors are generated when an authentication failure occurs.
> 
> - [x] `file.name` is correctly extracted for Windows paths with both uppercase and lowercase drive letters.
> - [x] `file.path` is correctly populated when `file` is sent as a plain string.
> - [x] No pipeline errors are generated for lowercase Windows file paths.
> - [x] PR #18641 (or equivalent fix) is merged to the main branch.
> 
> - [x] `AtJobs` events are indexed without pipeline errors.
> - [x] The `start` field is queryable as a date, using at minimum the first timestamp value when multiple are present.
> 
> ## Workstream 2 — Field Mapping
> 
> - [x] Each THOR module has a correct `event.category` mapping.
> - [x] `RegistryChecks` events show `event.category: registry` in Discover.
> - [x] `ProcessCheck` and `ProcessConnections` events show `event.category: process`.
> - [x] Key module-specific fields (process, registry, network, rule) are mapped to their ECS counterparts.
> - [x] `thor.entry`, `thor.command`, and `thor.value` are indexed as `wildcard` and are fully searchable.
> 
> - [x] `thor.entry`, `thor.command`, `thor.value`, and `thor.string` are mapped as `wildcard` fields.
> - [ ] No THOR fields appear in the `_ignored` array in the data quality view. (Fixed for ignored fields observed during testing.)
> - [ ] Long field values are fully searchable via KQL and Lucene. (Fixed for long field values observed during testing.)
> 
> - [x] Image path is queryable with a single, consistent field name across all modules.
> - [x] `thor.scan_id` is populated consistently for all events regardless of pipeline errors in preceding processors.
> - [x] No events in the index contain both `thor.scanid` and `thor.scan_id` simultaneously.
> 
> - [x] `thor.port` fields are indexed as `long` and support numeric range queries.
> - [x] `exec_flag` and similar boolean fields are indexed as `boolean`.
> - [x] `thor.ip` fields are indexed as `ip` type and support CIDR range queries.


## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/nextron_thor_apt_scanner directory.
- Run the following command to run tests.
> elastic-package test

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #19162 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
<img width="1717" height="215" alt="thor_cloud_count" src="https://github.com/user-attachments/assets/eb781e96-3853-4762-b240-259475d7e1bd" />
<img width="1728" height="997" alt="thor_elasticsearch_count" src="https://github.com/user-attachments/assets/a184e5dd-afcb-4c58-b1f7-5e1e949861c4" />

