### PR TITLE
[salesforce] Re-expose Request Timeout (resource.timeout) for all data streams

### DIFF
--- a/packages/salesforce/_dev/build/docs/README.md
+++ b/packages/salesforce/_dev/build/docs/README.md
@@ -283,10 +283,12 @@ This section provides solutions to common issues you might encounter while using
 If you experience delays in the response from the Salesforce server in the `apex`, `login`, `logout`, or `setupaudittrail` data streams, you might encounter a similar error:
 
 ```
-Error while processing http request: failed to execute rf.collectResponse: failed to execute http client.Do: failed to execute http client.Do: failed to read http.response.body
+Error running EventLogFile collection: error reading log file body: context deadline exceeded (Client.Timeout or context cancellation while reading body)
 ```
 
-**Solution:** Consider increasing the `Request timeout` setting in the `Advanced options` section for the affected data stream.
+This is most common in the `apex` data stream, where individual `EventLogFile` downloads can be large.
+
+**Solution:** Consider increasing the `Request timeout` setting in the `Advanced options` section for the affected data stream (it defaults to `30s`). For example, set it to `120s`.
 
 ### Data ingestion error
 

--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Expose the `Request Timeout` (`resource.timeout`) setting for all data streams so the HTTP client timeout can be increased when log collection (for example, large Apex EventLogFile downloads) times out.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19700
 - version: "1.7.1"
   changes:
     - description: Improve documentation.

--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose the `Request Timeout` (`resource.timeout`) setting for all data streams so the HTTP client timeout can be increased when log collection (for example, large Apex EventLogFile downloads) times out.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/19700
+      link: https://github.com/elastic/integrations/pull/19717
 - version: "1.7.1"
   changes:
     - description: Improve documentation.

--- a/packages/salesforce/data_stream/apex/agent/stream/salesforce.yml.hbs
+++ b/packages/salesforce/data_stream/apex/agent/stream/salesforce.yml.hbs
@@ -20,6 +20,10 @@ auth.oauth2:
 
 url: {{instance_url}}
 
+{{#if resource_timeout}}
+resource.timeout: {{resource_timeout}}
+{{/if}}
+
 event_monitoring_method:
   event_log_file:
     enabled: true

--- a/packages/salesforce/data_stream/apex/manifest.yml
+++ b/packages/salesforce/data_stream/apex/manifest.yml
@@ -35,6 +35,14 @@ streams:
         required: false
         show_user: true
         default: Hourly
+      - name: resource_timeout
+        type: text
+        title: Request Timeout
+        description: "Duration before declaring that the HTTP client connection has timed out. Valid time units are ns, us, ms, s, m, h. Increase this value if log collection times out while downloading large EventLogFile data (for example, Apex logs)."
+        multi: false
+        required: false
+        show_user: false
+        default: 30s
       - name: tags
         type: text
         title: Tags

--- a/packages/salesforce/data_stream/login/agent/stream/salesforce.yml.hbs
+++ b/packages/salesforce/data_stream/login/agent/stream/salesforce.yml.hbs
@@ -17,6 +17,9 @@ auth.oauth2:
     password: {{password}}
 {{/if}}
 url: {{instance_url}}
+{{#if resource_timeout}}
+resource.timeout: {{resource_timeout}}
+{{/if}}
 event_monitoring_method:
   event_log_file:
     enabled: {{#if event_log_file}}true{{else}}false{{/if}}

--- a/packages/salesforce/data_stream/login/manifest.yml
+++ b/packages/salesforce/data_stream/login/manifest.yml
@@ -59,6 +59,14 @@ streams:
         required: false
         show_user: true
         default: Hourly
+      - name: resource_timeout
+        type: text
+        title: Request Timeout
+        description: "Duration before declaring that the HTTP client connection has timed out. Valid time units are ns, us, ms, s, m, h. Increase this value if log collection times out while downloading large EventLogFile data."
+        multi: false
+        required: false
+        show_user: false
+        default: 30s
       - name: tags
         type: text
         title: Tags

--- a/packages/salesforce/data_stream/logout/agent/stream/salesforce.yml.hbs
+++ b/packages/salesforce/data_stream/logout/agent/stream/salesforce.yml.hbs
@@ -17,6 +17,9 @@ auth.oauth2:
     password: {{password}}
 {{/if}}
 url: {{instance_url}}
+{{#if resource_timeout}}
+resource.timeout: {{resource_timeout}}
+{{/if}}
 event_monitoring_method:
   event_log_file:
     enabled: {{#if event_log_file}}true{{else}}false{{/if}}

--- a/packages/salesforce/data_stream/logout/manifest.yml
+++ b/packages/salesforce/data_stream/logout/manifest.yml
@@ -59,6 +59,14 @@ streams:
         required: false
         show_user: true
         default: Hourly
+      - name: resource_timeout
+        type: text
+        title: Request Timeout
+        description: "Duration before declaring that the HTTP client connection has timed out. Valid time units are ns, us, ms, s, m, h. Increase this value if log collection times out while downloading large EventLogFile data."
+        multi: false
+        required: false
+        show_user: false
+        default: 30s
       - name: tags
         type: text
         title: Tags

--- a/packages/salesforce/data_stream/setupaudittrail/agent/stream/salesforce.yml.hbs
+++ b/packages/salesforce/data_stream/setupaudittrail/agent/stream/salesforce.yml.hbs
@@ -17,6 +17,9 @@ auth.oauth2:
     password: {{password}}
 {{/if}}
 url: {{instance_url}}
+{{#if resource_timeout}}
+resource.timeout: {{resource_timeout}}
+{{/if}}
 event_monitoring_method:
   object:
     enabled: true

--- a/packages/salesforce/data_stream/setupaudittrail/manifest.yml
+++ b/packages/salesforce/data_stream/setupaudittrail/manifest.yml
@@ -27,6 +27,14 @@ streams:
         required: false
         show_user: true
         default: 168h
+      - name: resource_timeout
+        type: text
+        title: Request Timeout
+        description: "Duration before declaring that the HTTP client connection has timed out. Valid time units are ns, us, ms, s, m, h. Increase this value if log collection times out."
+        multi: false
+        required: false
+        show_user: false
+        default: 30s
       - name: tags
         type: text
         title: Tags

--- a/packages/salesforce/docs/README.md
+++ b/packages/salesforce/docs/README.md
@@ -283,10 +283,12 @@ This section provides solutions to common issues you might encounter while using
 If you experience delays in the response from the Salesforce server in the `apex`, `login`, `logout`, or `setupaudittrail` data streams, you might encounter a similar error:
 
 ```
-Error while processing http request: failed to execute rf.collectResponse: failed to execute http client.Do: failed to execute http client.Do: failed to read http.response.body
+Error running EventLogFile collection: error reading log file body: context deadline exceeded (Client.Timeout or context cancellation while reading body)
 ```
 
-**Solution:** Consider increasing the `Request timeout` setting in the `Advanced options` section for the affected data stream.
+This is most common in the `apex` data stream, where individual `EventLogFile` downloads can be large.
+
+**Solution:** Consider increasing the `Request timeout` setting in the `Advanced options` section for the affected data stream (it defaults to `30s`). For example, set it to `120s`.
 
 ### Data ingestion error
 

--- a/packages/salesforce/manifest.yml
+++ b/packages/salesforce/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: salesforce
 title: Salesforce
-version: "1.7.1"
+version: "1.8.0"
 description: |
   Collect logs from Salesforce instances using the Elastic Agent. This integration enables monitoring and analysis of various Salesforce logs, including Login, Logout, Setup Audit Trail, and Apex execution logs. Gain insights into user activity, security events, and application performance.
 type: integration


### PR DESCRIPTION
## Proposed commit message

The `Request Timeout` setting was dropped in the v0.15.0 revamp (#9629), when
the integration moved from the `httpjson` input to the dedicated `salesforce`
Filebeat input. Since then there has been no way to override the input's
default `30s` HTTP client timeout, so large `EventLogFile` downloads (notably
Apex logs) can fail with `context deadline exceeded` and no available remedy.

This PR re-exposes it as a `resource_timeout` variable (default `30s`, under
Advanced options) for all four data streams (`apex`, `login`, `logout`,
`setupaudittrail`), wiring it to `resource.timeout` in each stream template.
The variable is emitted conditionally, so existing policies keep the input's
built-in default and there is no behavior change on upgrade.

The troubleshooting docs are updated to reflect the current error signature,
and the package version is bumped to `1.8.0`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## How to test this PR locally

- `elastic-package build` and `elastic-package lint` in `packages/salesforce`.
- `elastic-package test system --data-streams apex` (passes with the default `30s`, and with an explicit `resource_timeout` value such as `120s` added to the test config).
- On a live deployment, set `Request Timeout` (Advanced options) on a data stream and confirm `resource.timeout` is rendered into the compiled agent policy. Setting it to a very small value (e.g. `1ms`) makes the input fail with `context deadline exceeded`; restoring it (e.g. `30s`) recovers the unit — confirming the setting is honored.
