### PR TITLE
[Entity Analytics - Okta] Set host.id from the Okta device id in the device pipeline

### DIFF
--- a/packages/entityanalytics_okta/changelog.yml
+++ b/packages/entityanalytics_okta/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set host.id from the Okta device id so device entities are keyed consistently and the user owns relationship resolves to them.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/274537
+      link: https://github.com/elastic/integrations/pull/19722
 - version: "3.2.1"
   changes:
     - description: Remove misleading event.action values from sample events in documentation and clarify that this integration provides asset inventory, not an audit trail.

--- a/packages/entityanalytics_okta/changelog.yml
+++ b/packages/entityanalytics_okta/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "3.2.2"
+- version: "3.3.0"
   changes:
     - description: Set host.id from the Okta device id so device entities are keyed consistently
       type: enhancement

--- a/packages/entityanalytics_okta/changelog.yml
+++ b/packages/entityanalytics_okta/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "3.2.2"
   changes:
-    - description: Set host.id from the Okta device id so device entities are keyed consistently and the user owns relationship resolves to them.
+    - description: Set host.id from the Okta device id so device entities are keyed consistently
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19722
 - version: "3.2.1"

--- a/packages/entityanalytics_okta/changelog.yml
+++ b/packages/entityanalytics_okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.2.2"
+  changes:
+    - description: Set host.id from the Okta device id so device entities are keyed consistently and the user owns relationship resolves to them.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/274537
 - version: "3.2.1"
   changes:
     - description: Remove misleading event.action values from sample events in documentation and clarify that this integration provides asset inventory, not an audit trail.

--- a/packages/entityanalytics_okta/data_stream/entity/_dev/test/pipeline/test-device.json-expected.json
+++ b/packages/entityanalytics_okta/data_stream/entity/_dev/test/pipeline/test-device.json-expected.json
@@ -77,6 +77,7 @@
                 ]
             },
             "host": {
+                "id": "guo4a5u7YAHhjXrMK0g4",
                 "name": "trial-xxxxxxx-admin.okta.com"
             },
             "input": {
@@ -147,6 +148,7 @@
                         "managed": true
                     }
                 },
+                "id": "guo4a5uyerdpvAiJT0h7",
                 "name": "trial-xxxxxxx-admin.okta.com",
                 "os": {
                     "version": "10.0.19043"

--- a/packages/entityanalytics_okta/data_stream/entity/elasticsearch/ingest_pipeline/device.yml
+++ b/packages/entityanalytics_okta/data_stream/entity/elasticsearch/ingest_pipeline/device.yml
@@ -48,6 +48,11 @@ processors:
       copy_from: entityanalytics_okta.device.id
       tag: set_asset_id
       ignore_empty_value: true
+  - set:
+      field: host.id
+      copy_from: entityanalytics_okta.device.id
+      tag: set_host_id
+      ignore_empty_value: true
   - rename:
       field: okta.status
       target_field: entityanalytics_okta.device.status

--- a/packages/entityanalytics_okta/manifest.yml
+++ b/packages/entityanalytics_okta/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: entityanalytics_okta
 title: Okta Entity Analytics
-version: "3.2.1"
+version: "3.2.2"
 description: "Collect Identities from Okta with Elastic Agent."
 type: integration
 categories:

--- a/packages/entityanalytics_okta/manifest.yml
+++ b/packages/entityanalytics_okta/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: entityanalytics_okta
 title: Okta Entity Analytics
-version: "3.2.2"
+version: "3.3.0"
 description: "Collect Identities from Okta with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The owns relationship (user -> host) is built from each user's enrolled devices and writes. `user.entity.relationships.owns.host.id` = the Okta device id. However, device documents did not key their host entity on that id: the device pipeline stored the device id in asset.id (not host.id) and the only host identity set was host.name = the tenant domain. Since the host EUID ranking is host.id -> host.name -> host.hostname, every Okta device collapsed into a single host:<okta_domain> entity and nothing was keyed on the device id, so owns.host.id resolved to no entity.

Set host.id from entityanalytics_okta.device.id in the device pipeline so each device is keyed as host:<device.id> and the user owns relationship resolves to the corresponding device entity. Update the device pipeline test expected fixtures accordingly and bump the package version.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist



Closes https://github.com/elastic/integrations/issues/19720
<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. `cd packages/entityanalytics_okta`
2. Bring up a stack and run the ingest pipeline tests:
   ```bash
   elastic-package stack up -d -v
   eval "$(elastic-package stack shellinit)"
   elastic-package test pipeline -v --data-streams entity

3. Confirm the device test cases now include host.id equal to the Okta device id:
`test-device.json-expected.json shows host.id: ["guo4a5u7YAHhjXrMK0g4"] and host.id: ["guo4a5uyerdpvAiJT0h7"].
`
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 



## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
