### PR TITLE
[ti_opencti] Add agentless deployment

### DIFF
--- a/packages/ti_opencti/_dev/build/docs/README.md
+++ b/packages/ti_opencti/_dev/build/docs/README.md
@@ -4,6 +4,11 @@ The OpenCTI integration allows you to ingest data from the [OpenCTI](https://fil
 
 Use this integration to get indicator data from OpenCTI. You can monitor and explore the ingested data on the OpenCTI dashboard or in Kibana's Discover tab. Indicator match rules in {{ url "security" "Elastic Security" }} can then use the ingested indicator data to generate alerts about detected threats.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The OpenCTI integration collects one type of data stream: indicator.

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.14.1"
   changes:
     - description: Fix multi-value filter fields rendered as comma-separated strings instead of YAML lists in CEL state.

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19726
 - version: "2.14.1"
   changes:
     - description: Fix multi-value filter fields rendered as comma-separated strings instead of YAML lists in CEL state.

--- a/packages/ti_opencti/docs/README.md
+++ b/packages/ti_opencti/docs/README.md
@@ -4,6 +4,11 @@ The OpenCTI integration allows you to ingest data from the [OpenCTI](https://fil
 
 Use this integration to get indicator data from OpenCTI. You can monitor and explore the ingested data on the OpenCTI dashboard or in Kibana's Discover tab. Indicator match rules in [Elastic Security](https://www.elastic.co/guide/en/security/current/es-overview.html) can then use the ingested indicator data to generate alerts about detected threats.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The OpenCTI integration collects one type of data stream: indicator.

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: ti_opencti
 title: OpenCTI
-version: "2.14.1"
+version: "2.15.0"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:
@@ -11,7 +11,7 @@ categories:
   - threat_intel
 conditions:
   kibana:
-    version: "^8.16.0 || ^9.0.0"
+    version: "^8.19.2 || ^9.0.5"
 screenshots:
   - src: /img/screenshot1.png
     title: "Dashboard: OpenCTI Overview"
@@ -38,6 +38,15 @@ policy_templates:
   - name: opencti
     title: OpenCTI
     description: Collect OpenCTI data.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: cel
         title: OpenCTI


### PR DESCRIPTION
## Proposed commit message

```
ti_opencti: add agentless support and update kibana version constraint
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/ti_opencti directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #19592