### PR TITLE
[Synthetics] Map `observer.geo.name` as keyword instead of wildcard

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Map `observer.geo.name` as `keyword` instead of `wildcard` so it works with Kibana aggregations (e.g. `terms`, `top_metrics`).
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/19200
+      link: https://github.com/elastic/integrations/pull/19757
 - version: "1.6.1"
   changes:
     - description: Add monitor interval field to synthetics package

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.7.0"
+  changes:
+    - description: Map `observer.geo.name` as `keyword` instead of `wildcard` so it works with Kibana aggregations (e.g. `terms`, `top_metrics`).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19200
 - version: "1.6.1"
   changes:
     - description: Add monitor interval field to synthetics package

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.7.0"
   changes:
-    - description: Map `observer.geo.name` as `keyword` instead of `wildcard` so it works with Kibana aggregations (e.g. `terms`, `top_metrics`).
+    - description: Map `observer.geo.name` as `keyword` instead of `wildcard` so it works with Kibana aggregations (for example, `terms` and `top_metrics`).
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19757
 - version: "1.6.1"

--- a/packages/synthetics/data_stream/browser/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser/fields/ecs.yml
@@ -454,7 +454,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation."
       example: boston-dc
     - name: geo.region_iso_code

--- a/packages/synthetics/data_stream/browser_network/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/ecs.yml
@@ -454,7 +454,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation."
       example: boston-dc
     - name: geo.region_iso_code

--- a/packages/synthetics/data_stream/browser_screenshot/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/ecs.yml
@@ -454,7 +454,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation."
       example: boston-dc
     - name: geo.region_iso_code

--- a/packages/synthetics/data_stream/http/fields/ecs.yml
+++ b/packages/synthetics/data_stream/http/fields/ecs.yml
@@ -454,7 +454,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation."
       example: boston-dc
     - name: geo.region_iso_code

--- a/packages/synthetics/data_stream/icmp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/icmp/fields/ecs.yml
@@ -454,7 +454,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation."
       example: boston-dc
     - name: geo.region_iso_code

--- a/packages/synthetics/data_stream/tcp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/tcp/fields/ecs.yml
@@ -454,7 +454,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation."
       example: boston-dc
     - name: geo.region_iso_code

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.6.1
+version: 1.7.0
 categories:
   - observability
   # Added monitoring category as Synthetics provides synthetic monitoring capabilities


### PR DESCRIPTION
## Summary

`observer.geo.name` in the Synthetics package was mapped as `wildcard` (inherited from ECS) across all data streams. While `wildcard` is in the `keyword` type family and `_field_caps` reports it to Kibana **as** `keyword`, it is **not** a drop-in replacement for real keyword-only aggregations at the Elasticsearch level. In particular `top_metrics` fails:

> `top_metrics can only collect bytes that have segment ordinals but Field [observer.geo.name] of type [wildcard] does not`

This abstraction leak means Kibana offers the field as aggregatable but certain aggregations silently fail. The Synthetics app already carries explicit workarounds for this (e.g. `overview_status_service.ts` resolves the location label via a separate `terms` sub-agg because `top_metrics` can't collect a wildcard field).

This PR maps `observer.geo.name` as `keyword` (with `ignore_above: 1024`) across all data streams, which:

- Makes the field fully usable in Kibana aggregations (`terms`, `top_metrics`, sorting).
- Aligns the raw data mapping with the synthetics **alerts-as-data** field map, which already declares `observer.geo.name` (and `observer.name`) as `keyword`.
- Is more efficient for the SLO synthetics-availability transform `group_by`.

Note: `observer.name` was already `keyword`; only `observer.geo.name` changes here.

### Data streams changed
`browser`, `browser_network`, `browser_screenshot`, `http`, `icmp`, `tcp`

## Upgrade / existing data behavior

Validated end-to-end via a real Fleet package upgrade (`1.6.1` → keyword build) against a live cluster:

- The Fleet upgrade succeeds; it does **not** attempt an illegal in-place type change and leaves existing wildcard backing indices untouched.
- `_field_caps` reports a single `keyword` type across old (wildcard) + new (keyword) indices, so **no Kibana data-view conflict**.
- Existing data stays searchable; `terms` works throughout.
- New data (after rollover) gains working `top_metrics`.
- The only transition caveat: `top_metrics` over still-existing wildcard backing indices produces a partial shard failure until those indices age out via ILM — strictly better than today (where it fails on all data) and self-resolving.

## Test plan

- [ ] CI package validation passes (`elastic-package check`)
- [ ] Verify `observer.geo.name` maps as `keyword` on a freshly created data stream after install
- [ ] Confirm `terms` and `top_metrics` aggregations work on `observer.geo.name`
- [ ] Confirm Synthetics app location-related views render correctly

Made with [Cursor](https://cursor.com)