### PR TITLE
[Google Workspace] Reduce default lag time for data streams

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.5.0"
+  changes:
+    - description: Reduce default lag times for login, gcp, user_accounts, groups, group_enterprise, and calendar data streams to align with Google documented reporting delays.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.4.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Reduce default lag times for login, gcp, user_accounts, groups, group_enterprise, and calendar data streams to align with Google documented reporting delays.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19780
 - version: "3.4.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/google_workspace/data_stream/calendar/manifest.yml
+++ b/packages/google_workspace/data_stream/calendar/manifest.yml
@@ -32,7 +32,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 30m
       - name: batch_size
         type: integer
         title: Batch Size

--- a/packages/google_workspace/data_stream/gcp/manifest.yml
+++ b/packages/google_workspace/data_stream/gcp/manifest.yml
@@ -23,7 +23,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 3h
+        default: 5m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/group_enterprise/manifest.yml
+++ b/packages/google_workspace/data_stream/group_enterprise/manifest.yml
@@ -23,7 +23,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 30m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/groups/manifest.yml
+++ b/packages/google_workspace/data_stream/groups/manifest.yml
@@ -23,7 +23,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 2h
+        default: 30m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/login/manifest.yml
+++ b/packages/google_workspace/data_stream/login/manifest.yml
@@ -23,7 +23,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 3h
+        default: 3m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/data_stream/user_accounts/manifest.yml
+++ b/packages/google_workspace/data_stream/user_accounts/manifest.yml
@@ -23,7 +23,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: 1h
+        default: 10m
       - name: tags
         type: text
         title: Tags

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "3.4.1"
+version: "3.5.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
## Proposed commit message

```
google_workspace: reduce default lag time for select data streams

Reduce default lag time on login (3h to 3m), gcp (3h to 5m), user_accounts (1h to 10m), 
groups (2h to 30m), group_enterprise (2h to 30m), and calendar (2h to 30m) data streams to 
align with Google documented reporting delays. Leave alert interval, token lag time, and 
gmail interval unchanged.

Existing Fleet policies retain their configured values; only new policy receive the updated defaults.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes #19072 