### PR TITLE
[aws_cloudwatch_input_otel] add recently_active option

### DIFF
--- a/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
+++ b/packages/aws_cloudwatch_input_otel/agent/input/input.yml.hbs
@@ -28,6 +28,7 @@ receivers:
         filters:
           namespace: "{{namespace}}"
         limit: {{autodiscover_limit}}
+        recently_active: true
 {{#if autodiscover_aggregation}}
         stats:
 {{#each autodiscover_aggregation}}

--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Add `recently_active` option to restrict metric discovery to metrics active in the last three hours.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19695
 - version: "0.3.2"
   changes:
     - description: Update the integration documentation.

--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `recently_active` option to restrict metric discovery to metrics active in the last three hours.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/19695
+      link: https://github.com/elastic/integrations/pull/19790
 - version: "0.3.2"
   changes:
     - description: Update the integration documentation.

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: aws_cloudwatch_input_otel
 title: "AWS CloudWatch (OpenTelemetry)"
-version: 0.3.2
+version: 0.4.0
 source:
   license: "Elastic-2.0"
 description: "Collect AWS CloudWatch metrics for selected AWS services (EC2, RDS, SQS, ELB, Lambda, Fargate) using the OpenTelemetry Collector awscloudwatch receiver."


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Add `recently_active option` to **awscloudwatch** receiver config (https://github.com/elastic/opentelemetry-collector-contrib/pull/19)


```
    ? awscloudwatch/otelcol-aws-lambda/....
    :   credentials_provider: awscredentialsprovider/...
        metrics:
            collection_interval: 1m
            delay: 5m
            discovery:
                filters:
                    namespace: AWS/Lambda
                limit: 100
                recently_active: true <<<
                stats:
                    - Maximum
                    - Average
                    - Sum
            period: 1m
        region: us-east-1
    ? awscloudwatch/otelcol-aws-rds/....
    :   credentials_provider: awscredentialsprovider/...
        metrics:
            collection_interval: 1m
            delay: 5m
            discovery:
                filters:
                    namespace: AWS/RDS
                limit: 100
                recently_active: true  <<<
                stats:
                    - Average
                    - Maximum
            period: 1m
        region: us-east-1
    ? awscloudwatch/otelcol-aws-sqs/....
    :   credentials_provider: awscredentialsprovider/...
        metrics:
            collection_interval: 1m
            delay: 5m
            discovery:
                filters:
                    namespace: AWS/SQS
                limit: 100
                recently_active: true  <<< 
                stats:
                    - Maximum
                    - Sum
            period: 1m
``` 

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->


<img width="1512" height="404" alt="image" src="https://github.com/user-attachments/assets/e04c2cc2-f269-4e75-b305-5a92cd65e3fa" />
