### PR TITLE
o365: fix Painless regex character-limit and Sender mapping errors

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "3.10.3"
+  changes:
+    - description: Fix `script_item_attachments` processor failing with a Painless regex character-limit error on long attachment filenames that contain parentheses. The regex is replaced with string operations that have no backtracking cost.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
+    - description: "Set subobjects: false on o365.audit.Sender field to avoid document_parsing_exception when the field arrives as a structured object instead of a plain string."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "3.10.2"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,10 +3,10 @@
   changes:
     - description: Fix `script_item_attachments` processor failing with a Painless regex character-limit error on long attachment filenames that contain parentheses. The regex is replaced with string operations that have no backtracking cost.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/19801
     - description: "Set subobjects: false on o365.audit.Sender field to avoid document_parsing_exception when the field arrives as a structured object instead of a plain string."
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/19801
 - version: "3.10.2"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-exchange-item-edge-cases.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-exchange-item-edge-cases.json
@@ -1,0 +1,76 @@
+{
+    "events": [
+        {
+            "event": {
+                "original": "{\"ClientIP\": \"192.0.2.10\", \"CreationTime\": \"2024-04-15T08:30:00\", \"Id\": \"11111111-aaaa-bbbb-cccc-222222222222\", \"InternalLogonType\": \"0\", \"LogonType\": \"0\", \"LogonUserSid\": \"S-1-5-18\", \"MailboxGuid\": \"33333333-4444-5555-6666-777777777777\", \"MailboxOwnerMasterAccountSid\": \"S-1-5-10\", \"MailboxOwnerSid\": \"S-1-5-21-1111111111-2222222222-3333333333-44444444\", \"MailboxOwnerUPN\": \"alice@contoso.example\", \"Operation\": \"Create\", \"OrganizationId\": \"88888888-9999-aaaa-bbbb-cccccccccccc\", \"OrganizationName\": \"contoso.example\", \"OriginatingServer\": \"EXCH01 (192.0.2.20)\\n\", \"RecordType\": \"2\", \"ResultStatus\": \"Succeeded\", \"UserId\": \"S-1-5-18\", \"UserKey\": \"S-1-5-18\", \"UserType\": \"0\", \"Version\": \"1\", \"Workload\": \"Exchange\", \"Item\": {\"Attachments\": \"logo.png (8192b); banner.jpg (20480b); summary.xlsx (34816b); Project Gamma - Contract Amendment v2 (Draft 04_04_2024)(100112233.7).docx (73728b); Annex C - Scope of Work - Final rev3.1(200445566.12) (Review - 10_04_2024)(300778899.2).docx (147456b)\", \"Id\": \"RgAAAAC11111111111111111111111111BwC1111111111111111111111111111111111\", \"Subject\": \"Q2 Project Deliverables\"}}"
+            },
+            "o365audit": {
+                "ClientIP": "192.0.2.10",
+                "CreationTime": "2024-04-15T08:30:00",
+                "Id": "11111111-aaaa-bbbb-cccc-222222222222",
+                "InternalLogonType": "0",
+                "LogonType": "0",
+                "LogonUserSid": "S-1-5-18",
+                "MailboxGuid": "33333333-4444-5555-6666-777777777777",
+                "MailboxOwnerMasterAccountSid": "S-1-5-10",
+                "MailboxOwnerSid": "S-1-5-21-1111111111-2222222222-3333333333-44444444",
+                "MailboxOwnerUPN": "alice@contoso.example",
+                "Operation": "Create",
+                "OrganizationId": "88888888-9999-aaaa-bbbb-cccccccccccc",
+                "OrganizationName": "contoso.example",
+                "OriginatingServer": "EXCH01 (192.0.2.20)\n",
+                "RecordType": "2",
+                "ResultStatus": "Succeeded",
+                "UserId": "S-1-5-18",
+                "UserKey": "S-1-5-18",
+                "UserType": "0",
+                "Version": "1",
+                "Workload": "Exchange",
+                "Item": {
+                    "Attachments": "logo.png (8192b); banner.jpg (20480b); summary.xlsx (34816b); Project Gamma - Contract Amendment v2 (Draft 04_04_2024)(100112233.7).docx (73728b); Annex C - Scope of Work - Final rev3.1(200445566.12) (Review - 10_04_2024)(300778899.2).docx (147456b)",
+                    "Id": "RgAAAAC11111111111111111111111111BwC1111111111111111111111111111111111",
+                    "Subject": "Q2 Project Deliverables"
+                }
+            }
+        },
+        {
+            "event": {
+                "original": "{\"ClientIP\": \"192.0.2.11\", \"CreationTime\": \"2024-04-15T09:00:00\", \"Id\": \"55555555-dddd-eeee-ffff-666666666666\", \"InternalLogonType\": \"0\", \"LogonType\": \"0\", \"LogonUserSid\": \"S-1-5-18\", \"MailboxGuid\": \"33333333-4444-5555-6666-777777777777\", \"MailboxOwnerMasterAccountSid\": \"S-1-5-10\", \"MailboxOwnerSid\": \"S-1-5-21-1111111111-2222222222-3333333333-44444444\", \"MailboxOwnerUPN\": \"bob@fabrikam.example\", \"Operation\": \"Create\", \"OrganizationId\": \"aaaabbbb-cccc-dddd-eeee-ffffffffffff\", \"OrganizationName\": \"fabrikam.example\", \"OriginatingServer\": \"EXCH02 (192.0.2.21)\\n\", \"RecordType\": \"2\", \"ResultStatus\": \"Succeeded\", \"UserId\": \"S-1-5-18\", \"UserKey\": \"S-1-5-18\", \"UserType\": \"0\", \"Version\": \"1\", \"Workload\": \"Exchange\", \"Item\": {\"Id\": \"RgAAAAD22222222222222222222222222BwD2222222222222222222222222222222222\", \"Subject\": \"Teams Notification\"}, \"Sender\": {\"UPN\": \"support@fabrikam.example\", \"MRI\": \"8:orgid:a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"DisplayName\": \"IT Support\", \"OrganizationId\": \"aaaabbbb-cccc-dddd-eeee-ffffffffffff\", \"UserObjectId\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\"}}"
+            },
+            "o365audit": {
+                "ClientIP": "192.0.2.11",
+                "CreationTime": "2024-04-15T09:00:00",
+                "Id": "55555555-dddd-eeee-ffff-666666666666",
+                "InternalLogonType": "0",
+                "LogonType": "0",
+                "LogonUserSid": "S-1-5-18",
+                "MailboxGuid": "33333333-4444-5555-6666-777777777777",
+                "MailboxOwnerMasterAccountSid": "S-1-5-10",
+                "MailboxOwnerSid": "S-1-5-21-1111111111-2222222222-3333333333-44444444",
+                "MailboxOwnerUPN": "bob@fabrikam.example",
+                "Operation": "Create",
+                "OrganizationId": "aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+                "OrganizationName": "fabrikam.example",
+                "OriginatingServer": "EXCH02 (192.0.2.21)\n",
+                "RecordType": "2",
+                "ResultStatus": "Succeeded",
+                "UserId": "S-1-5-18",
+                "UserKey": "S-1-5-18",
+                "UserType": "0",
+                "Version": "1",
+                "Workload": "Exchange",
+                "Item": {
+                    "Id": "RgAAAAD22222222222222222222222222BwD2222222222222222222222222222222222",
+                    "Subject": "Teams Notification"
+                },
+                "Sender": {
+                    "UPN": "support@fabrikam.example",
+                    "MRI": "8:orgid:a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "DisplayName": "IT Support",
+                    "OrganizationId": "aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+                    "UserObjectId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                }
+            }
+        }
+    ]
+}

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-exchange-item-edge-cases.json-expected.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-exchange-item-edge-cases.json-expected.json
@@ -1,0 +1,275 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2024-04-15T08:30:00.000Z",
+            "client": {
+                "address": "192.0.2.10",
+                "ip": "192.0.2.10"
+            },
+            "destination": {
+                "ip": "192.0.2.20"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "email": {
+                "attachments": [
+                    {
+                        "file": {
+                            "extension": "png",
+                            "name": "logo.png",
+                            "size": 8192
+                        }
+                    },
+                    {
+                        "file": {
+                            "extension": "jpg",
+                            "name": "banner.jpg",
+                            "size": 20480
+                        }
+                    },
+                    {
+                        "file": {
+                            "extension": "xlsx",
+                            "name": "summary.xlsx",
+                            "size": 34816
+                        }
+                    },
+                    {
+                        "file": {
+                            "extension": "docx",
+                            "name": "Project Gamma - Contract Amendment v2 (Draft 04_04_2024)(100112233.7).docx",
+                            "size": 73728
+                        }
+                    },
+                    {
+                        "file": {
+                            "extension": "docx",
+                            "name": "Annex C - Scope of Work - Final rev3.1(200445566.12) (Review - 10_04_2024)(300778899.2).docx",
+                            "size": 147456
+                        }
+                    }
+                ],
+                "subject": [
+                    "Q2 Project Deliverables"
+                ]
+            },
+            "event": {
+                "action": "Create",
+                "category": [
+                    "web",
+                    "email"
+                ],
+                "code": "ExchangeItem",
+                "id": "11111111-aaaa-bbbb-cccc-222222222222",
+                "kind": "event",
+                "original": "{\"ClientIP\": \"192.0.2.10\", \"CreationTime\": \"2024-04-15T08:30:00\", \"Id\": \"11111111-aaaa-bbbb-cccc-222222222222\", \"InternalLogonType\": \"0\", \"LogonType\": \"0\", \"LogonUserSid\": \"S-1-5-18\", \"MailboxGuid\": \"33333333-4444-5555-6666-777777777777\", \"MailboxOwnerMasterAccountSid\": \"S-1-5-10\", \"MailboxOwnerSid\": \"S-1-5-21-1111111111-2222222222-3333333333-44444444\", \"MailboxOwnerUPN\": \"alice@contoso.example\", \"Operation\": \"Create\", \"OrganizationId\": \"88888888-9999-aaaa-bbbb-cccccccccccc\", \"OrganizationName\": \"contoso.example\", \"OriginatingServer\": \"EXCH01 (192.0.2.20)\\n\", \"RecordType\": \"2\", \"ResultStatus\": \"Succeeded\", \"UserId\": \"S-1-5-18\", \"UserKey\": \"S-1-5-18\", \"UserType\": \"0\", \"Version\": \"1\", \"Workload\": \"Exchange\", \"Item\": {\"Attachments\": \"logo.png (8192b); banner.jpg (20480b); summary.xlsx (34816b); Project Gamma - Contract Amendment v2 (Draft 04_04_2024)(100112233.7).docx (73728b); Annex C - Scope of Work - Final rev3.1(200445566.12) (Review - 10_04_2024)(300778899.2).docx (147456b)\", \"Id\": \"RgAAAAC11111111111111111111111111BwC1111111111111111111111111111111111\", \"Subject\": \"Q2 Project Deliverables\"}}",
+                "outcome": "success",
+                "provider": "Exchange",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "id": "88888888-9999-aaaa-bbbb-cccccccccccc",
+                "name": "contoso.example"
+            },
+            "network": {
+                "type": "ipv4"
+            },
+            "o365": {
+                "audit": {
+                    "CreationTime": "2024-04-15T08:30:00",
+                    "InternalLogonType": "0",
+                    "Item": {
+                        "Attachments": "logo.png (8192b); banner.jpg (20480b); summary.xlsx (34816b); Project Gamma - Contract Amendment v2 (Draft 04_04_2024)(100112233.7).docx (73728b); Annex C - Scope of Work - Final rev3.1(200445566.12) (Review - 10_04_2024)(300778899.2).docx (147456b)",
+                        "Id": "RgAAAAC11111111111111111111111111BwC1111111111111111111111111111111111",
+                        "Subject": "Q2 Project Deliverables"
+                    },
+                    "LogonType": "0",
+                    "LogonUserSid": "S-1-5-18",
+                    "MailboxGuid": "33333333-4444-5555-6666-777777777777",
+                    "MailboxOwnerMasterAccountSid": "S-1-5-10",
+                    "MailboxOwnerSid": "S-1-5-21-1111111111-2222222222-3333333333-44444444",
+                    "RecordType": "2",
+                    "ResultStatus": "Succeeded",
+                    "UserId": "S-1-5-18",
+                    "UserKey": "S-1-5-18",
+                    "UserType": "0",
+                    "Version": "1"
+                }
+            },
+            "organization": {
+                "id": "88888888-9999-aaaa-bbbb-cccccccccccc",
+                "name": "contoso.example"
+            },
+            "related": {
+                "hosts": [
+                    "contoso.example",
+                    "EXCH01"
+                ],
+                "ip": [
+                    "192.0.2.10",
+                    "192.0.2.20"
+                ],
+                "user": [
+                    "S-1-5-18",
+                    "alice@contoso.example"
+                ]
+            },
+            "server": {
+                "address": "192.0.2.20",
+                "domain": "EXCH01",
+                "ip": "192.0.2.20"
+            },
+            "source": {
+                "as": {
+                    "number": 64500,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Las Vegas",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 36.17497,
+                        "lon": -115.13722
+                    },
+                    "region_iso_code": "US-NV",
+                    "region_name": "Nevada"
+                },
+                "ip": "192.0.2.10"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "email": "alice@contoso.example",
+                "id": "S-1-5-18"
+            }
+        },
+        {
+            "@timestamp": "2024-04-15T09:00:00.000Z",
+            "client": {
+                "address": "192.0.2.11",
+                "ip": "192.0.2.11"
+            },
+            "destination": {
+                "ip": "192.0.2.21"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "email": {
+                "subject": [
+                    "Teams Notification"
+                ]
+            },
+            "event": {
+                "action": "Create",
+                "category": [
+                    "web",
+                    "email"
+                ],
+                "code": "ExchangeItem",
+                "id": "55555555-dddd-eeee-ffff-666666666666",
+                "kind": "event",
+                "original": "{\"ClientIP\": \"192.0.2.11\", \"CreationTime\": \"2024-04-15T09:00:00\", \"Id\": \"55555555-dddd-eeee-ffff-666666666666\", \"InternalLogonType\": \"0\", \"LogonType\": \"0\", \"LogonUserSid\": \"S-1-5-18\", \"MailboxGuid\": \"33333333-4444-5555-6666-777777777777\", \"MailboxOwnerMasterAccountSid\": \"S-1-5-10\", \"MailboxOwnerSid\": \"S-1-5-21-1111111111-2222222222-3333333333-44444444\", \"MailboxOwnerUPN\": \"bob@fabrikam.example\", \"Operation\": \"Create\", \"OrganizationId\": \"aaaabbbb-cccc-dddd-eeee-ffffffffffff\", \"OrganizationName\": \"fabrikam.example\", \"OriginatingServer\": \"EXCH02 (192.0.2.21)\\n\", \"RecordType\": \"2\", \"ResultStatus\": \"Succeeded\", \"UserId\": \"S-1-5-18\", \"UserKey\": \"S-1-5-18\", \"UserType\": \"0\", \"Version\": \"1\", \"Workload\": \"Exchange\", \"Item\": {\"Id\": \"RgAAAAD22222222222222222222222222BwD2222222222222222222222222222222222\", \"Subject\": \"Teams Notification\"}, \"Sender\": {\"UPN\": \"support@fabrikam.example\", \"MRI\": \"8:orgid:a1b2c3d4-e5f6-7890-abcd-ef1234567890\", \"DisplayName\": \"IT Support\", \"OrganizationId\": \"aaaabbbb-cccc-dddd-eeee-ffffffffffff\", \"UserObjectId\": \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\"}}",
+                "outcome": "success",
+                "provider": "Exchange",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "id": "aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+                "name": "fabrikam.example"
+            },
+            "network": {
+                "type": "ipv4"
+            },
+            "o365": {
+                "audit": {
+                    "CreationTime": "2024-04-15T09:00:00",
+                    "InternalLogonType": "0",
+                    "Item": {
+                        "Id": "RgAAAAD22222222222222222222222222BwD2222222222222222222222222222222222",
+                        "Subject": "Teams Notification"
+                    },
+                    "LogonType": "0",
+                    "LogonUserSid": "S-1-5-18",
+                    "MailboxGuid": "33333333-4444-5555-6666-777777777777",
+                    "MailboxOwnerMasterAccountSid": "S-1-5-10",
+                    "MailboxOwnerSid": "S-1-5-21-1111111111-2222222222-3333333333-44444444",
+                    "RecordType": "2",
+                    "ResultStatus": "Succeeded",
+                    "Sender": {
+                        "DisplayName": "IT Support",
+                        "MRI": "8:orgid:a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                        "OrganizationId": "aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+                        "UPN": "support@fabrikam.example",
+                        "UserObjectId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                    },
+                    "UserId": "S-1-5-18",
+                    "UserKey": "S-1-5-18",
+                    "UserType": "0",
+                    "Version": "1"
+                }
+            },
+            "organization": {
+                "id": "aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+                "name": "fabrikam.example"
+            },
+            "related": {
+                "hosts": [
+                    "fabrikam.example",
+                    "EXCH02"
+                ],
+                "ip": [
+                    "192.0.2.11",
+                    "192.0.2.21"
+                ],
+                "user": [
+                    "S-1-5-18",
+                    "bob@fabrikam.example"
+                ]
+            },
+            "server": {
+                "address": "192.0.2.21",
+                "domain": "EXCH02",
+                "ip": "192.0.2.21"
+            },
+            "source": {
+                "as": {
+                    "number": 64500,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Las Vegas",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 36.17497,
+                        "lon": -115.13722
+                    },
+                    "region_iso_code": "US-NV",
+                    "region_name": "Nevada"
+                },
+                "ip": "192.0.2.11"
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "email": "bob@fabrikam.example",
+                "id": "S-1-5-18"
+            }
+        }
+    ]
+}

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-exchange-item-events.json-expected.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-exchange-item-events.json-expected.json
@@ -16,57 +16,57 @@
                 "attachments": [
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": "warming_email_03_2017_calendar.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_calendar.png",
                             "size": 599
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_conversation.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_conversation.png",
                             "size": 614
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_links.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_links.png",
                             "size": 1403
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " google_play_store_badge.png ",
+                            "extension": "png",
+                            "name": "google_play_store_badge.png",
                             "size": 4824
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " apple_store_badge.png ",
+                            "extension": "png",
+                            "name": "apple_store_badge.png",
                             "size": 4446
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " windows_store_badge.png ",
+                            "extension": "png",
+                            "name": "windows_store_badge.png",
                             "size": 3681
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_files.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_files.png",
                             "size": 809
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_sharePoint.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_sharePoint.png",
                             "size": 1432
                         }
                     }
@@ -182,57 +182,57 @@
                 "attachments": [
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": "warming_email_03_2017_calendar.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_calendar.png",
                             "size": 598
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_conversation.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_conversation.png",
                             "size": 613
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_links.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_links.png",
                             "size": 1402
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " google_play_store_badge.png ",
+                            "extension": "png",
+                            "name": "google_play_store_badge.png",
                             "size": 4823
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " apple_store_badge.png ",
+                            "extension": "png",
+                            "name": "apple_store_badge.png",
                             "size": 4445
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " windows_store_badge.png ",
+                            "extension": "png",
+                            "name": "windows_store_badge.png",
                             "size": 3680
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_files.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_files.png",
                             "size": 808
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_sharePoint.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_sharePoint.png",
                             "size": 1431
                         }
                     }
@@ -348,57 +348,57 @@
                 "attachments": [
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": "warming_email_03_2017_calendar.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_calendar.png",
                             "size": 598
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_conversation.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_conversation.png",
                             "size": 613
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_links.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_links.png",
                             "size": 1402
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " google_play_store_badge.png ",
+                            "extension": "png",
+                            "name": "google_play_store_badge.png",
                             "size": 4823
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " apple_store_badge.png ",
+                            "extension": "png",
+                            "name": "apple_store_badge.png",
                             "size": 4445
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " windows_store_badge.png ",
+                            "extension": "png",
+                            "name": "windows_store_badge.png",
                             "size": 3680
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_files.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_files.png",
                             "size": 808
                         }
                     },
                     {
                         "file": {
-                            "extension": "png ",
-                            "name": " warming_email_03_2017_sharePoint.png ",
+                            "extension": "png",
+                            "name": "warming_email_03_2017_sharePoint.png",
                             "size": 1431
                         }
                     }

--- a/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/o365/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -1589,26 +1589,43 @@ processors:
   - script:
       tag: script_item_attachments
       if: ctx.o365audit?.Item?.Attachments != null && ctx.o365audit.Item.Attachments != ''
-      description: Parse attachments from Item.Attachments.
+      description: >-
+        Parse attachments from Item.Attachments. Uses string operations instead of
+        a regex to avoid hitting the Painless regex character limit on long filenames
+        that contain parentheses (e.g. versioned document names).
       source: |-
         ctx.email = ctx.email ?: [:];
         ctx.email.attachments = [];
-        
-        // Split semicolon-delimited attachment string into individual attachment entries
+
         def attachmentList = ctx.o365audit.Item.Attachments.splitOnToken(';');
-        
+
         for (def attachment : attachmentList) {
+          def att = attachment.trim();
+          if (att.isEmpty() || !att.endsWith(')')) continue;
+
+          // Find the size marker at the end: " (<digits>b)"
+          int lastSep = att.lastIndexOf(' (');
+          if (lastSep < 0) continue;
+
+          def maybeSize = att.substring(lastSep + 2, att.length() - 1);
+          if (!maybeSize.endsWith('b')) continue;
+
+          def sizeStr = maybeSize.substring(0, maybeSize.length() - 1);
+          long sizeVal;
+          try { sizeVal = Long.parseLong(sizeStr); } catch (Exception e) { continue; }
+
+          def filename = att.substring(0, lastSep).trim();
+          if (filename.isEmpty()) continue;
+
+          int dotIdx = filename.lastIndexOf('.');
+          if (dotIdx < 0) continue;
+
           def attachmentObj = [:];
-          
-          // Parse pattern: "filename.extension (sizeb)"
-          def matcher = /^(.+?)\.([^.]+)\s*\((\d+)b\)$/.matcher(attachment);
-          if (matcher.matches()) {
-            attachmentObj.file = [:];
-            attachmentObj.file.extension = matcher.group(2);
-            attachmentObj.file.name = matcher.group(1) + '.' + matcher.group(2);
-            attachmentObj.file.size = Long.parseLong(matcher.group(3));
-            ctx.email.attachments.add(attachmentObj);
-          } 
+          attachmentObj.file = [:];
+          attachmentObj.file.extension = filename.substring(dotIdx + 1);
+          attachmentObj.file.name = filename;
+          attachmentObj.file.size = sizeVal;
+          ctx.email.attachments.add(attachmentObj);
         }
       on_failure:
         - append:

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -556,6 +556,11 @@
       type: keyword
     - name: SecurityComplianceCenterEventType
       type: keyword
+    - name: Sender
+      type: object
+      object_type: keyword
+      object_type_mapping_type: '*'
+      subobjects: false
     - name: SenderIP
       type: keyword
     - name: SenderIp

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -526,6 +526,7 @@ An example event for `audit` looks as following:
 | o365.audit.ResultStatus |  | keyword |
 | o365.audit.RunningTime |  | keyword |
 | o365.audit.SecurityComplianceCenterEventType |  | keyword |
+| o365.audit.Sender |  | object |
 | o365.audit.SenderIP |  | keyword |
 | o365.audit.SenderIp |  | keyword |
 | o365.audit.SensitiveInfoDetectionIsIncluded |  | boolean |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "3.10.2"
+version: "3.10.3"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Proposed commit message

```
o365: fix Painless regex character-limit and Sender mapping errors

Two production pipeline errors observed in `logs-o365.audit`:

1. `script_item_attachments` failed with a Painless regex character-limit
   error on long attachment filenames containing parentheses.
   The regex `/^(.+?)\.([^.]+)\s*\((\d+)b\)$/` was replaced
   with string operations (`lastIndexOf`, `substring`, `parseLong`)
   that have no backtracking cost and no character-count limit.

2. `document_parsing_exception` on `o365.audit.Sender` when Teams-originated
   ExchangeItem events deliver the field as a structured object
   `{UPN=..., MRI=..., DisplayName=...}` instead of a plain string. Fixed by
   setting `subobjects: false` with `object_type: keyword` on the field
   definition, following the same pattern used for `Parameters` and
   `ModifiedProperties`.

Includes regression test fixture `test-exchange-item-edge-cases.json` with
one event reproducing each bug.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

