### PR TITLE
[CrowdStrike] Correct event.action, event.type, and message

### DIFF
--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -1258,11 +1258,6 @@ processors:
 
   # Library fields.
   - set:
-      tag: set_event_action_735cfe72
-      if: ctx._temp?.isDriver == true
-      field: event.type
-      value: start
-  - set:
       tag: set_dll_pe_original_file_name_7a4c66c0
       if: (ctx._temp?.isLibrary == true || ctx._temp?.isDriver == true) && ctx.host?.os?.type == 'windows'
       field: dll.pe.original_file_name

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -1405,7 +1405,7 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - script:
-      tag: script_set_event_action_and_type_29345ceb
+      tag: script_set_event_type_29345ceb
       if: ctx.crowdstrike?.RegOperationType != null
       params:
         op_types:

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -626,12 +626,6 @@ processors:
       value: '{{{#crowdstrike.id}}}{{{ crowdstrike.id }}}{{{/crowdstrike.id}}}|{{{#crowdstrike.aid}}}{{{ crowdstrike.aid }}}{{{/crowdstrike.aid}}}|{{{#crowdstrike.cid}}}{{{ crowdstrike.cid }}}{{{/crowdstrike.cid}}}'
       override: false
   - set:
-      tag: construct_message_from_event_simpleName_649b7fba
-      field: message
-      copy_from: crowdstrike.event_simpleName
-      override: false
-      ignore_empty_value: true
-  - set:
       tag: set_event_action_from_event_simpleName_0069f759
       field: event.action
       copy_from: crowdstrike.event_simpleName
@@ -1266,8 +1260,8 @@ processors:
   - set:
       tag: set_event_action_735cfe72
       if: ctx._temp?.isDriver == true
-      field: event.action
-      value: load
+      field: event.type
+      value: start
   - set:
       tag: set_dll_pe_original_file_name_7a4c66c0
       if: (ctx._temp?.isLibrary == true || ctx._temp?.isDriver == true) && ctx.host?.os?.type == 'windows'
@@ -1421,31 +1415,22 @@ processors:
       params:
         op_types:
           "1":
-            action: modification
             type: change
           "2":
-            action: deletion
             type: deletion
           "3":
-            action: creation
             type: creation
           "4":
-            action: deletion
             type: deletion
           "5":
-            action: modification
             type: change
           "6":
-            action: load
             type: info
           "7":
-            action: modification
             type: change
           "8":
-            action: open
             type: access
           "9":
-            action: query
             type: access
       source: |-
         def op = params.get('op_types')[ctx.crowdstrike.RegOperationType];
@@ -1453,7 +1438,6 @@ processors:
           ctx.event = ctx.event ?: [:];
           ctx.event.type = [];
           ctx.event.type.add(op.type);
-          ctx.event.action = op.action;
         }
   - script:
       tag: script_set_registry_data_type_e45a255a
@@ -2255,10 +2239,10 @@ processors:
       field: file.hash.sha256
       copy_from: crowdstrike.SHA256HashData
       ignore_empty_value: true
-  - set:
-      tag: set_event_action_526984f8
-      if: ctx.event?.action != null && ctx.event.action.endsWith('Written') && ctx.host?.os?.type == 'windows'
-      field: event.action
+  - append:
+      tag: append_event_action_526984f8
+      if: ctx.event?.action != null && ctx.event.action.endsWith('Written')
+      field: event.type
       value: creation
 
   # Device Fields.

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -2239,11 +2239,6 @@ processors:
       field: file.hash.sha256
       copy_from: crowdstrike.SHA256HashData
       ignore_empty_value: true
-  - append:
-      tag: append_event_action_526984f8
-      if: ctx.event?.action != null && ctx.event.action.endsWith('Written')
-      field: event.type
-      value: creation
 
   # Device Fields.
   - set:


### PR DESCRIPTION
## Proposed commit message

Update various sections to utilize event.type over stepping on event.action, allowing message to not be recreated after initial parsing.




## Related issues

- Closes #19807
