### PR TITLE
crowdstrike: fix streaming system test mock to handle reconnection with offset

### DIFF
--- a/packages/crowdstrike/data_stream/falcon/_dev/deploy/docker/files/config.yml
+++ b/packages/crowdstrike/data_stream/falcon/_dev/deploy/docker/files/config.yml
@@ -62,6 +62,16 @@ rules:
           {"metadata":{"customerIDString":"abcabcabc22222","offset":2,"eventType":"RemoteResponseSessionStartEvent","eventCreationTime":1698932494000,"version":"1.0"},"event":{"SessionId":"1111-fffff-4bb4-99c1-74c13cfc3e5a","HostnameField":"UKCHUDL00206","UserName":"admin.rose@example.com","StartTimestamp":1698932494,"AgentIdString":"fffffffff33333"}}
           400
           {"metadata":{"customerIDString":"abcabcabc22223","offset":3,"eventType":"RemoteResponseSessionStartEvent","eventCreationTime":1698932494000,"version":"1.0"},"event":{"SessionId":"1111-fffff-4bb4-99c1-74c13cfc3e5a","HostnameField":"UKCHUDL00206","UserName":"admin.rose@example.com","StartTimestamp":1698932494,"AgentIdString":"fffffffff33333"}}
+  - path: /events
+    methods: ["GET"]
+    request_headers:
+      authorization: ["Token secretsessiontoken"]
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - "application/json"
+        body: ''
   - path: /refresh
     methods: ["POST"]
     responses:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
crowdstrike: fix streaming system test mock to handle reconnection with offset

The streaming input appends ?offset=N to the feed URL when
reconnecting after a stream ends. The mock server only had a rule
for /events with no query parameters (offset: null), so
reconnection requests got 404, causing the agent to go DEGRADED
and failing the system test.

Add a catch-all /events rule (without query_params constraints)
after the existing rule. It matches reconnection requests and
returns an empty 200, preventing the DEGRADED transition.
```

> [!NOTE]
> Not user-facing, so no changelog.
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #19766
- Fixes #19773

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
