### PR TITLE
lastpass: use explicit JSON serialisation in response transform

### DIFF
--- a/packages/lastpass/changelog.yml
+++ b/packages/lastpass/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.1"
+  changes:
+    - description: Fix serialisation of detailed_shared_folder data stream response.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19811
 - version: "1.23.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/lastpass/data_stream/detailed_shared_folder/agent/stream/httpjson.yml.hbs
+++ b/packages/lastpass/data_stream/detailed_shared_folder/agent/stream/httpjson.yml.hbs
@@ -37,7 +37,7 @@ request.transforms:
 response.transforms:
   - set:
       target: body.data
-      value: '[[.last_response.body]]'
+      value: '[[toJSON .last_response.body]]'
       value_type: json
 response.pagination:
   - set:

--- a/packages/lastpass/manifest.yml
+++ b/packages/lastpass/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: lastpass
 title: LastPass
-version: "1.23.0"
+version: "1.23.1"
 description: Collect logs from LastPass with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
lastpass: use explicit JSON serialisation in response transform

A Beats regression (elastic/beats#50384) changed response body
template values from mapstr.M (whose String method produces JSON)
to plain map[string]interface{} (whose String method produces Go
map syntax). This breaks the detailed_shared_folder response
transform which renders the whole body with value_type: json.

Use the toJSON template function to serialise the body explicitly,
bypassing the implicit serialisation path.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Updates #18754
- Updates #19767
- Updates #19774

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
