### PR TITLE
[aws] Add processor tags to ingest pipelines

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.20.3"
+  changes:
+    - description: Add processor tags to all ingest pipeline processors to satisfy elastic-package linter requirements for format_version 3.6.0 and above.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19824
 - version: "6.20.2"
   changes:
     - description: Skip AWS service-linked Config rules when collecting compliance details so the AWS Config data stream no longer degrades on `AccessDeniedException`, and treat per-rule compliance errors as non-fatal so a single failing rule does not stop ingestion of the rest.

--- a/packages/aws/data_stream/apigateway_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/apigateway_logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,85 +3,105 @@ description: "Pipeline for API Gateway logs in CloudWatch"
 
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - rename:
+      tag: rename_message_to_event_original_c74b1d7e
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
+      tag: json_event_original_to_aws_apigateway_f58e2e48
       field: event.original
       target_field: aws.apigateway
       ignore_failure: true
   - rename:
+      tag: rename_aws_apigateway_requestId_to_aws_apigateway_request_id_f8d45745
       field: aws.apigateway.requestId
       target_field: aws.apigateway.request_id
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_responseLength_to_aws_apigateway_response_length_351accf5
       field: aws.apigateway.responseLength
       target_field: aws.apigateway.response_length
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_requestTime_to_aws_apigateway_request_time_452b54dd
       field: aws.apigateway.requestTime
       target_field: aws.apigateway.request_time
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_httpMethod_to_aws_apigateway_http_method_0f8ceff7
       field: aws.apigateway.httpMethod
       target_field: aws.apigateway.http_method
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_routeKey_to_aws_apigateway_route_key_24f23c8b
       field: aws.apigateway.routeKey
       target_field: aws.apigateway.route_key
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_ip_to_aws_apigateway_ip_address_bcb43f2f
       field: aws.apigateway.ip
       target_field: aws.apigateway.ip_address
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_resourcePath_to_aws_apigateway_resource_path_a086dd8b
       field: aws.apigateway.resourcePath
       target_field: aws.apigateway.resource_path
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_connectionId_to_aws_apigateway_connection_id_6f806acf
       field: aws.apigateway.connectionId
       target_field: aws.apigateway.connection_id
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_eventType_to_aws_apigateway_event_type_2a463e2f
       field: aws.apigateway.eventType
       target_field: aws.apigateway.event_type
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_apiId_to_aws_apigateway_api_id_1b4980ad
       field: aws.apigateway.apiId
       target_field: aws.apigateway.api_id
       ignore_missing: true
   - rename:
+      tag: rename_aws_apigateway_domainName_to_aws_apigateway_domain_name_732b5853
       field: aws.apigateway.domainName
       target_field: aws.apigateway.domain_name
       ignore_missing: true
   - grok:
+      tag: grok_aws_apigateway_ip_address_e6f24967
       field: aws.apigateway.ip_address
       patterns:
         - '%{IPORHOST:aws.apigateway.ip_address}'
       ignore_failure: true
   - convert:
+      tag: convert_aws_apigateway_ip_address_10d88955
       field: aws.apigateway.ip_address
       type: ip
       ignore_missing: true
   - convert:
+      tag: convert_aws_apigateway_response_length_de377d20
       field: aws.apigateway.response_length
       type: long
       ignore_missing: true
   - convert:
+      tag: convert_aws_apigateway_status_28a91148
       field: aws.apigateway.status
       type: long
       ignore_missing: true
   - date:
+      tag: date_aws_apigateway_request_time_to_aws_apigateway_request_time_6995b9b1
       field: aws.apigateway.request_time
       target_field: "aws.apigateway.request_time"
       formats:
@@ -96,4 +116,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/awshealth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/awshealth/elasticsearch/ingest_pipeline/default.yml
@@ -2,11 +2,13 @@
 description: Pipeline for AWS Health metrics
 processors:
 - script:
+    tag: script_aad5131d
     if: "ctx.aws != null && ctx.aws.awshealth != null && ctx.aws.awshealth.end_time == '0001-01-01T00:00:00.000Z'"
     "lang": "painless"
     "source": "ctx.aws.awshealth.end_time = null"
 
 - script:
+    tag: script_7a0bd239
     lang: painless
     source: |-
         boolean drop(Object o) {
@@ -33,4 +35,4 @@ on_failure:
     value: >-
       Processor '{{{ _ingest.on_failure_processor_type }}}'
       {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-      {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+      {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/billing/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/billing/elasticsearch/ingest_pipeline/default.yml
@@ -2,14 +2,17 @@
 description: "Pipeline for AWS Billing"
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
       ignore_empty_value: true
   - fingerprint:
+      tag: fingerprint_deb4df05
       fields: ["aws.billing.group_by"]
       target_field: 'aws.billing.group_by.fingerprint'
       ignore_missing: true
@@ -22,4 +25,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/cloudfront_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudfront_logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,78 +3,88 @@ description: "Pipeline for CloudFront standard access logs"
 
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_category_5c638872
       field: event.category
       value: ["web"]
   - append:
+      tag: append_event_type_8860cef4
       field: event.type
       value: ["access"]
   - set:
+      tag: set_cloud_provider_208bdd6b
       field: cloud.provider
       value: aws
   - rename:
+      tag: rename_message_to_event_original_c74b1d7e
       field: message
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - drop:
+      tag: drop_0dd3bc87
       if: ctx.event?.original?.startsWith('#')
       description: "Drop if logline contains header(s), which startswith `#`"
   - csv:
+      tag: csv_event_original_f330f590
       description: Parse cloudfront csv row
       field: event.original
       separator: "\t"
       target_fields:
-      - _tmp.date                                   # date
-      - _tmp.time                                   # time
-      - _tmp.x_edge_location                        # x-edge-location
-      - _tmp.sc_bytes                               # sc-bytes
-      - _tmp.c_ip                                   # c-ip
-      - _tmp.cs_method                              # cs-method
-      - _tmp.cs_host                                # cs(Host)
-      - _tmp.cs_uri_stem                            # cs-uri-stem
-      - _tmp.cs_status                              # cs-status
-      - _tmp.cs_referer                             # cs(Referer)
-      - _tmp.cs_user_agent                          # cs(User-Agent)
-      - _tmp.cs_uri_query                           # cs-uri-query
-      - _tmp.cs_cookie                              # cs(Cookie)
-      - _tmp.x_edge_result_type                     # x-edge-result-type
-      - _tmp.x_edge_request_id                      # x-edge-request-id
-      - _tmp.x_host_header                          # x-host-header
-      - _tmp.cs_protocol                            # cs-protocol
-      - _tmp.cs_bytes                               # cs-bytes
-      - _tmp.time_taken                             # time-taken
-      - _tmp.x_forwarded_for                        # x-forwarded-for
-      - _tmp.ssl_protocol                           # ssl-protocol
-      - _tmp.ssl_cipher                             # ssl-cipher
-      - _tmp.x_edge_response_result_type            # x-edge-response-result-type
-      - _tmp.cs_protocol_version                    # cs-protocol-version
-      - _tmp.fle_status                             # fle-status
-      - _tmp.fle_encrypted_fields                   # fle-encrypted-fields
-      - _tmp.c_port                                 # c-port
-      - _tmp.time_to_first_byte                     # time-to-first-byte
-      - _tmp.x_edge_detailed_result_type            # x-edge-detailed-result-type
-      - _tmp.sc_content_type                        # sc-content-type
-      - _tmp.sc_content_len                         # sc-content-len
-      - _tmp.sc_range_start                         # sc-range-start
-      - _tmp.sc_range_end                           # sc-range-end
+      - _tmp.date # date
+      - _tmp.time # time
+      - _tmp.x_edge_location # x-edge-location
+      - _tmp.sc_bytes # sc-bytes
+      - _tmp.c_ip # c-ip
+      - _tmp.cs_method # cs-method
+      - _tmp.cs_host # cs(Host)
+      - _tmp.cs_uri_stem # cs-uri-stem
+      - _tmp.cs_status # cs-status
+      - _tmp.cs_referer # cs(Referer)
+      - _tmp.cs_user_agent # cs(User-Agent)
+      - _tmp.cs_uri_query # cs-uri-query
+      - _tmp.cs_cookie # cs(Cookie)
+      - _tmp.x_edge_result_type # x-edge-result-type
+      - _tmp.x_edge_request_id # x-edge-request-id
+      - _tmp.x_host_header # x-host-header
+      - _tmp.cs_protocol # cs-protocol
+      - _tmp.cs_bytes # cs-bytes
+      - _tmp.time_taken # time-taken
+      - _tmp.x_forwarded_for # x-forwarded-for
+      - _tmp.ssl_protocol # ssl-protocol
+      - _tmp.ssl_cipher # ssl-cipher
+      - _tmp.x_edge_response_result_type # x-edge-response-result-type
+      - _tmp.cs_protocol_version # cs-protocol-version
+      - _tmp.fle_status # fle-status
+      - _tmp.fle_encrypted_fields # fle-encrypted-fields
+      - _tmp.c_port # c-port
+      - _tmp.time_to_first_byte # time-to-first-byte
+      - _tmp.x_edge_detailed_result_type # x-edge-detailed-result-type
+      - _tmp.sc_content_type # sc-content-type
+      - _tmp.sc_content_len # sc-content-len
+      - _tmp.sc_range_start # sc-range-start
+      - _tmp.sc_range_end # sc-range-end
 
   ### CSV fields ###################################################################################
 
   # date
   # time
   - script:
+      tag: script_f139af51
       description: timestamp composed of date and time. Script processor performs better than equivalent set processor.
       lang: painless
       source: >-
@@ -82,6 +92,7 @@ processors:
       if: ctx._tmp?.date != null && ctx._tmp?.time != null
 
   - date:
+      tag: date__tmp_timestamp_to_timestamp_8b2cfb0e
       field: _tmp.timestamp
       target_field: '@timestamp'
       ignore_failure: true
@@ -91,117 +102,140 @@ processors:
       if: ctx._tmp?.timestamp != null
   # x-edge-location
   - rename:
+      tag: rename__tmp_x_edge_location_to_aws_cloudfront_edge_location_1f77194c
       field: _tmp.x_edge_location
       target_field: aws.cloudfront.edge_location
       ignore_missing: true
   # sc-bytes
   - convert:
+      tag: convert__tmp_sc_bytes_to_http_response_bytes_42e8e3b3
       field: _tmp.sc_bytes
       target_field: http.response.bytes
       type: long
       ignore_missing: true
   # c-ip
   - rename:
+      tag: rename__tmp_c_ip_to_source_address_6a7d61c6
       field: _tmp.c_ip
       target_field: source.address
       ignore_missing: true
   - convert:
+      tag: convert_source_address_to_source_ip_f5632a20
       field: source.address
       target_field: source.ip
       type: ip
       ignore_missing: true
       ignore_failure: true
   - append:
+      tag: append_related_ip_a6980940
       field: related.ip
       value: "{{{ source.ip }}}"
       if: ctx.source?.ip != null
   # cs-method
   - rename:
+      tag: rename__tmp_cs_method_to_http_request_method_527978d4
       field: _tmp.cs_method
       target_field: http.request.method
       ignore_missing: true
   # cs-host
   - rename:
+      tag: rename__tmp_cs_host_to_aws_cloudfront_domain_86134746
       field: _tmp.cs_host
       target_field: aws.cloudfront.domain
       ignore_missing: true
   - append:
+      tag: append_related_hosts_fb3a071a
       field: related.hosts
       value: "{{{ aws.cloudfront.domain }}}"
       allow_duplicates: false
       if: ctx.aws?.cloudfront?.domain != null
   # cs-uri-stem
   - rename:
+      tag: rename__tmp_cs_uri_stem_to_url_path_ece26d29
       field: _tmp.cs_uri_stem
       target_field: url.path
       ignore_missing: true
   # cs-status
   - convert:
+      tag: convert__tmp_cs_status_to_http_response_status_code_e24d2c27
       field: _tmp.cs_status
       target_field: http.response.status_code
       type: long
       ignore_missing: true
   # cs-referer
   - rename:
+      tag: rename__tmp_cs_referer_to_http_request_referrer_2c2fbcde
       field: _tmp.cs_referer
       target_field: http.request.referrer
       ignore_missing: true
       if: ctx._tmp?.cs_referer != null && ctx._tmp.cs_referer != '-'
   # cs(User-Agent)
   - urldecode:
+      tag: urldecode__tmp_cs_user_agent_9d900b49
       field: _tmp.cs_user_agent
       ignore_missing: true
   - user_agent:
+      tag: user_agent__tmp_cs_user_agent_to_user_agent_e7a89250
       field: _tmp.cs_user_agent
       target_field: user_agent
       ignore_missing: true
   # cs-uri-query
   - rename:
+      tag: rename__tmp_cs_uri_query_to_url_query_da8b8986
       field: _tmp.cs_uri_query
       target_field: url.query
       if: ctx._tmp?.cs_uri_query != null && ctx._tmp.cs_uri_query != '-'
   # cs(Cookie)
   - rename:
+      tag: rename__tmp_cs_cookie_to_aws_cloudfront_cookies_acec7028
       field: _tmp.cs_cookie
       target_field: aws.cloudfront.cookies
       if: ctx._tmp?.cs_cookie != null && ctx._tmp.cs_cookie != '-'
   # x-edge-result-type
   - rename:
+      tag: rename__tmp_x_edge_result_type_to_aws_cloudfront_edge_result_type_638df050
       field: _tmp.x_edge_result_type
       target_field: aws.cloudfront.edge_result_type
       ignore_missing: true
   # x-edge-request-id
   - rename:
+      tag: rename__tmp_x_edge_request_id_to_http_request_id_32bab328
       field: _tmp.x_edge_request_id
       target_field: http.request.id
       ignore_missing: true
   # x-host-header
   - rename:
+      tag: rename__tmp_x_host_header_to_destination_address_fd283543
       field: _tmp.x_host_header
       target_field: destination.address
       ignore_missing: true
   - set:
+      tag: set_destination_domain_f8666391
       field: destination.domain
       copy_from: destination.address
       ignore_empty_value: true
   - append:
+      tag: append_related_hosts_c7da3247
       field: related.hosts
       value: "{{{ destination.domain }}}"
       allow_duplicates: false
       if: ctx.destination?.domain != null
   # cs-protocol
   - rename:
+      tag: rename__tmp_cs_protocol_to_network_protocol_ff9f9715
       field: _tmp.cs_protocol
       target_field: network.protocol
       ignore_missing: true
   # cs-bytes
   - convert:
+      tag: convert__tmp_cs_bytes_to_http_request_bytes_f11e63d7
       field: _tmp.cs_bytes
       target_field: http.request.bytes
       type: long
       ignore_missing: true
   # time-taken
   - script:
+      tag: script_23aaa173
       lang: painless
       if: ctx._tmp?.time_taken != null
       params:
@@ -210,19 +244,22 @@ processors:
         ctx.event.duration = (Long)(Float.parseFloat(ctx._tmp.time_taken) * params.S_TO_NS);
   # x-forwarded-for
   - split:
+      tag: split__tmp_x_forwarded_for_to__tmp_split_x_forwarded_for_1e5bcf9f
       field: _tmp.x_forwarded_for
       separator: ","
       target_field: _tmp.split_x_forwarded_for
       if: ctx._tmp?.x_forwarded_for != null && ctx._tmp.x_forwarded_for != '-'
   - script:
+      tag: script_b5f7a689
       lang: painless
-      description: trim leading and trailing whitespace from the split IPs 
+      description: trim leading and trailing whitespace from the split IPs
       if: ctx._tmp?.split_x_forwarded_for != null
       source: |
         for (int i = 0; i < ctx._tmp.split_x_forwarded_for.length; i++) {
           ctx._tmp.split_x_forwarded_for[i] = ctx._tmp.split_x_forwarded_for[i].trim();
         }
   - foreach:
+      tag: foreach__tmp_split_x_forwarded_for_da3a40fc
       field: _tmp.split_x_forwarded_for
       if: ctx._tmp.split_x_forwarded_for instanceof List
       processor:
@@ -231,10 +268,12 @@ processors:
           tag: pipeline_process_ip
           ignore_missing_pipeline: true
   - append:
+      tag: append_error_message_ef8b6636
       field: error.message
       value: "Invalid IP addresses: {{_tmp.invalid_ips}}"
       if: ctx._tmp.invalid_ips != null
   - script:
+      tag: script_608e808f
       lang: painless
       description: Handle 'localhost' edge case, currently not handled via grok
       if: ctx._tmp?.split_x_forwarded_for != null && ctx._tmp.split_x_forwarded_for != '-'
@@ -252,6 +291,7 @@ processors:
             }
           }
   - foreach:
+      tag: foreach_network_forwarded_ip_1b3ce008
       field: network.forwarded_ip
       processor:
         append:
@@ -260,6 +300,7 @@ processors:
       ignore_missing: true
   # ssl-protocol
   - grok:
+      tag: grok__tmp_ssl_protocol_6d96558a
       field: _tmp.ssl_protocol
       patterns:
         - '(-|%{TLS:tls.version_protocol}v%{NUMBER:tls.version})'
@@ -267,64 +308,70 @@ processors:
         TLS: '(TLS|SSL)'
       ignore_missing: true
   - lowercase:
+      tag: lowercase_tls_version_protocol_b840a1f9
       field: tls.version_protocol
       ignore_missing: true
   # ssl-cipher
   - rename:
+      tag: rename__tmp_ssl_cipher_to_tls_cipher_8b9f4aff
       field: _tmp.ssl_cipher
       target_field: tls.cipher
       ignore_missing: true
       if: ctx._tmp?.ssl_cipher != null && ctx._tmp?.ssl_cipher != '-'
   # x-edge-response-result-type
   - rename:
-      field: _tmp.x_edge_response_result_type
-      target_field: aws.cloudfront.edge_response_result_type
-      ignore_missing: true
-  # x-edge-response-result-type
-  - rename:
+      tag: rename__tmp_x_edge_response_result_type_to_aws_cloudfront_edge_response_result_type_76796664
       field: _tmp.x_edge_response_result_type
       target_field: aws.cloudfront.edge_response_result_type
       ignore_missing: true
   # cs-protocol-version
   - dissect:
+      tag: dissect__tmp_cs_protocol_version_2633f435
       field: _tmp.cs_protocol_version
       pattern: "%{}/%{http.version}"
       ignore_missing: true
       ignore_failure: true
   # fle-status
   - rename:
+      tag: rename__tmp_fle_status_to_aws_cloudfront_fle_status_7cb39258
       field: _tmp.fle_status
       target_field: aws.cloudfront.fle_status
       if: ctx._tmp?.fle_status != null && ctx._tmp.fle_status != '-'
   # fle-encrypted-fields
   - rename:
+      tag: rename__tmp_fle_encrypted_fields_to_aws_cloudfront_fle_encrypted_fields_25e8676c
       field: _tmp.fle_encrypted_fields
       target_field: aws.cloudfront.fle_encrypted_fields
       if: ctx._tmp?.encrypted_fields != null && ctx._tmp.encrypted_fields != '-'
   # c-port
   - convert:
+      tag: convert__tmp_c_port_to_source_port_0b224af5
       field: _tmp.c_port
       target_field: source.port
       type: long
       if: ctx._tmp?.c_port != null && ctx._tmp.c_port != '-'
   # time-to-first-byte
   - convert:
+      tag: convert__tmp_time_to_first_byte_to_aws_cloudfront_time_to_first_byte_1a90d30d
       field: _tmp.time_to_first_byte
       target_field: aws.cloudfront.time_to_first_byte
       type: float
       if: ctx._tmp?.time_to_first_byte != null && ctx._tmp.time_to_first_byte != '-'
   # x-edge-detailed-result-type
   - rename:
+      tag: rename__tmp_x_edge_detailed_result_type_to_aws_cloudfront_edge_detailed_result_type_04ed32f3
       field: _tmp.x_edge_detailed_result_type
       target_field: aws.cloudfront.edge_detailed_result_type
       if: ctx._tmp?.x_edge_detailed_result_type != null && ctx._tmp.x_edge_detailed_result_type != '-'
   # sc-content-type
   - rename:
+      tag: rename__tmp_sc_content_type_to_http_response_mime_type_e53420cb
       field: _tmp.sc_content_type
       target_field: http.response.mime_type
       ignore_missing: true
   # sc-content-len
   - convert:
+      tag: convert__tmp_sc_content_len_to_http_response_body_bytes_3ab14d13
       field: _tmp.sc_content_len
       target_field: http.response.body.bytes
       type: long
@@ -332,6 +379,7 @@ processors:
       if: ctx._tmp?.sc_content_len != null && ctx._tmp.sc_content_len != '-'
   # sc-range-start
   - convert:
+      tag: convert__tmp_sc_range_start_to_aws_cloudfront_range_start_6c8b753b
       field: _tmp.sc_range_start
       target_field: aws.cloudfront.range_start
       type: long
@@ -339,16 +387,17 @@ processors:
       if: ctx._tmp?.sc_range_start != null && ctx._tmp.sc_range_start != '-'
   # sc-range-end
   - convert:
+      tag: convert__tmp_sc_range_end_to_aws_cloudfront_range_end_0b335fad
       field: _tmp.sc_range_end
       target_field: aws.cloudfront.range_end
       type: long
       ignore_missing: true
       if: ctx._tmp?.sc_range_end != null && ctx._tmp.sc_range_end != '-'
 
-
-### Additional fields ##############################################################################
+  ### Additional fields ##############################################################################
   # url
   - script:
+      tag: script_4558c244
       lang: painless
       description: This script builds the `url.full` field out of the available `url.*` parts.
       source: |
@@ -369,34 +418,41 @@ processors:
             ctx._tmp.url_full = full
         }
   - uri_parts:
+      tag: uri_parts__tmp_url_full_to_url_42a2ff23
       field: _tmp.url_full
       target_field: url
       keep_original: false
       ignore_missing: true
   - rename:
+      tag: rename__tmp_url_full_to_url_full_19094d63
       field: _tmp.url_full
       target_field: url.full
       ignore_missing: true
   - registered_domain:
+      tag: registered_domain_url_domain_to_url_ca99c8cd
       field: url.domain
       target_field: url
       ignore_missing: true
   # Network type
   - set:
+      tag: set_network_type_70901334
       field: network.type
       value: ipv4
       if: ctx.source?.ip != null && ctx.source.ip.contains('.')
   - set:
+      tag: set_network_type_9631521e
       field: network.type
       value: ipv6
       if: ctx.source?.ip != null && ctx.source.ip.contains(':')
   # IP Geolocation Lookup
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   # IP Autonomous System (AS) Lookup
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -405,33 +461,40 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   # event.id
   - set:
+      tag: set_event_id_958971ee
       field: event.id
       copy_from: http.request.id
       ignore_empty_value: true
   # event.outcome
   - set:
+      tag: set_event_outcome_98d2c715
       field: event.outcome
       value: failure
       if: ctx.http?.response?.status_code >= 400
   - set:
+      tag: set_event_outcome_f1ee170a
       field: event.outcome
       value: success
       if: ctx.http?.response?.status_code < 400 && ctx.http?.response?.status_code > 000
   - set:
+      tag: set_event_outcome_d22bf5c9
       field: event.outcome
       value: failure
       if: ctx.http?.response?.status_code == 000
   # cleanup
   - remove:
+      tag: remove__tmp_cc7d8d90
       field: _tmp
       ignore_missing: true
 on_failure:
@@ -441,6 +504,6 @@ on_failure:
   - append:
       field: error.message
       value: >-
-        Processor '{{ _ingest.on_failure_processor_type }}'
-        {{#_ingest.on_failure_processor_tag}}with tag '{{ _ingest.on_failure_processor_tag }}'
-        {{/_ingest.on_failure_processor_tag}}failed with message '{{ _ingest.on_failure_message }}'
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/cloudfront_logs/elasticsearch/ingest_pipeline/pipeline_process_ip.yml
+++ b/packages/aws/data_stream/cloudfront_logs/elasticsearch/ingest_pipeline/pipeline_process_ip.yml
@@ -16,18 +16,32 @@ processors:
         IPV6NOCOMPRESS: '([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}'
       on_failure:
         - set:
+            tag: set__tmp_invalid_ip_bee79126
             field: _tmp.invalid_ip
             value: "{{_ingest._value}}"
         - append:
+            tag: append_error_message_5cc5cb03
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_network_forwarded_ip_aa3cb3ed
       field: network.forwarded_ip
       value: "{{_tmp.valid_ip}}"
       if: ctx._tmp.valid_ip != null && ctx._tmp.valid_ip != ""
       allow_duplicates: false
   - append:
+      tag: append__tmp_invalid_ips_86b45edc
       field: _tmp.invalid_ips
       value: "{{_tmp.invalid_ip}}"
       if: ctx._tmp.invalid_ip != null && ctx._tmp.invalid_ip != ""
       allow_duplicates: false
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudtrail/elasticsearch/ingest_pipeline/default.yml
@@ -2,26 +2,32 @@
 description: Pipeline for AWS CloudTrail Logs
 processors:
   - rename:
+      tag: rename_message_to_event_original_b273fe21
       field: message
       target_field: event.original
       if: ctx.event?.original == null
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: ctx.event?.original != null
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
+      tag: set_event_created_3b69f632
       if: ctx['@timestamp'] != null
       field: event.created
       copy_from: '@timestamp'
   - json:
+      tag: json_event_original_to_json_5e54dc16
       field: event.original
       target_field: json
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - date:
+      tag: date_json_eventTime_to_timestamp_e9417ba3
       field: json.eventTime
       target_field: "@timestamp"
       ignore_failure: true
@@ -130,10 +136,12 @@ processors:
           'AssumedRole': true
       on_failure:
         - append:
+            tag: append_tags_84976466
             field: tags
             value: preserve_original_event
             allow_duplicates: false
         - set:
+            tag: set_error_message_10fabed8
             description: Add error reason
             field: error.message
             value: |
@@ -1010,6 +1018,7 @@ processors:
         field("related.entity").set(enrichCtx.related);
 
   - rename:
+      tag: rename_json_eventVersion_to_aws_cloudtrail_event_version_6f418145
       field: json.eventVersion
       target_field: aws.cloudtrail.event_version
       ignore_failure: true
@@ -1029,28 +1038,34 @@ processors:
       ignore_missing: true
       tag: rename_user_identity_principal_id
   - rename:
+      tag: rename_json_userIdentity_arn_to_aws_cloudtrail_user_identity_arn_02745565
       field: json.userIdentity.arn
       target_field: aws.cloudtrail.user_identity.arn
       ignore_failure: true
   - rename:
+      tag: rename_json_userIdentity_accountId_to_cloud_account_id_3b445356
       field: json.userIdentity.accountId
       target_field: cloud.account.id
       ignore_failure: true
   - rename:
+      tag: rename_json_userIdentity_accessKeyId_to_aws_cloudtrail_user_identity_access_key_id_066b3e77
       field: json.userIdentity.accessKeyId
       target_field: aws.cloudtrail.user_identity.access_key_id
       ignore_failure: true
   - rename:
+      tag: rename_json_userIdentity_sessionContext_attributes_mfaAuthenticated_to_aws_cloudtrail_user_identity_session_context_mfa_authenticated_2c5df2fe
       field: json.userIdentity.sessionContext.attributes.mfaAuthenticated
       target_field: aws.cloudtrail.user_identity.session_context.mfa_authenticated
       ignore_failure: true
   - date:
+      tag: date_json_userIdentity_sessionContext_attributes_creationDate_to_aws_cloudtrail_user_identity_session_context_creation_date_7cf57f10
       field: json.userIdentity.sessionContext.attributes.creationDate
       target_field: aws.cloudtrail.user_identity.session_context.creation_date
       ignore_failure: true
       formats:
         - ISO8601
   - rename:
+      tag: rename_json_userIdentity_sessionContext_sessionIssuer_type_to_aws_cloudtrail_user_identity_session_context_session_issuer_type_7b65c83f
       field: json.userIdentity.sessionContext.sessionIssuer.type
       target_field: aws.cloudtrail.user_identity.session_context.session_issuer.type
       ignore_failure: true
@@ -1063,6 +1078,7 @@ processors:
       if: ctx.aws?.cloudtrail?.user_identity?.type == 'AssumedRole' || ctx.aws?.cloudtrail?.user_identity?.type == 'FederatedUser'
       tag: rename_user_name_assumed_role
   - rename:
+      tag: rename_json_userIdentity_sessionContext_sessionIssuer_principalId_to_aws_cloudtrail_user_identity_session_context_session_issuer_principal_id_9cb05993
       field: json.userIdentity.sessionContext.sessionIssuer.principalId
       target_field: aws.cloudtrail.user_identity.session_context.session_issuer.principal_id
       ignore_missing: true
@@ -1081,32 +1097,39 @@ processors:
       if: ctx.aws?.cloudtrail?.user_identity?.type == 'IdentityCenterUser' && ctx.user?.id == null
       tag: rename_user_id_identity_center_user
   - rename:
+      tag: rename_json_userIdentity_sessionContext_sessionIssuer_arn_to_aws_cloudtrail_user_identity_session_context_session_issuer_arn_7ea9b97b
       field: json.userIdentity.sessionContext.sessionIssuer.arn
       target_field: aws.cloudtrail.user_identity.session_context.session_issuer.arn
       ignore_failure: true
   - rename:
+      tag: rename_json_userIdentity_sessionContext_sessionIssuer_accountId_to_aws_cloudtrail_user_identity_session_context_session_issuer_account_id_8cbd5a9e
       field: json.userIdentity.sessionContext.sessionIssuer.accountId
       target_field: aws.cloudtrail.user_identity.session_context.session_issuer.account_id
       ignore_failure: true
   - rename:
+      tag: rename_json_sessionCredentialFromConsole_to_aws_cloudtrail_session_credential_from_console_6cdda950
       field: json.sessionCredentialFromConsole
       target_field: aws.cloudtrail.session_credential_from_console
       ignore_missing: true
       ignore_failure: true
   - rename:
+      tag: rename_json_userIdentity_invokedBy_to_aws_cloudtrail_user_identity_invoked_by_0bc27c76
       field: json.userIdentity.invokedBy
       target_field: aws.cloudtrail.user_identity.invoked_by
       ignore_failure: true
   - rename:
+      tag: rename_json_eventSource_to_event_provider_4648c27c
       field: json.eventSource
       target_field: event.provider
       ignore_failure: true
   - set:
+      tag: set_event_action_c4f8aee8
       field: event.action
       value: '{{{json.eventName}}}'
       ignore_failure: true
       ignore_empty_value: true
   - rename:
+      tag: rename_json_eventCategory_to_aws_cloudtrail_event_category_14bbb655
       field: json.eventCategory
       target_field: aws.cloudtrail.event_category
       ignore_failure: true
@@ -1114,26 +1137,31 @@ processors:
       field: json.additionalEventData.UserName
       tag: rename_additionalEventData_UserName_to_username
       target_field: user.name
-      if: ctx.event?.action == 'UserAuthentication' && ctx.user?.name == null && ctx.json?.additionalEventData?.UserName != null 
+      if: ctx.event?.action == 'UserAuthentication' && ctx.user?.name == null && ctx.json?.additionalEventData?.UserName != null
   - set:
+      tag: set_cloud_region_5d7559a1
       field: cloud.region
       copy_from: json.awsRegion
       ignore_empty_value: true
   - rename:
+      tag: rename_json_sourceIPAddress_to_source_address_03dee86f
       field: json.sourceIPAddress
       target_field: source.address
       ignore_failure: true
   - grok:
+      tag: grok_source_address_146128d9
       field: source.address
       ignore_failure: true
       patterns:
         - ^%{IP:source.ip}$
   - geoip:
+      tag: geoip_source_ip_to_source_geo_253d8f4f
       field: source.ip
       target_field: source.geo
       ignore_failure: true
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -1142,26 +1170,32 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - user_agent:
+      tag: user_agent_json_userAgent_to_user_agent_12c778f0
       field: json.userAgent
       target_field: user_agent
       on_failure:
         - rename:
+            tag: rename_json_userAgent_to_user_agent_original_638aaaff
             field: json.userAgent
             target_field: user_agent.original
             ignore_failure: true
   - rename:
+      tag: rename_json_errorCode_to_aws_cloudtrail_error_code_f6ce7f43
       field: json.errorCode
       target_field: aws.cloudtrail.error_code
       ignore_failure: true
   - rename:
+      tag: rename_json_errorMessage_to_aws_cloudtrail_error_message_4764ab25
       field: json.errorMessage
       target_field: aws.cloudtrail.error_message
       ignore_failure: true
@@ -1216,22 +1250,27 @@ processors:
         }
       ignore_failure: true
   - rename:
+      tag: rename_json_requestID_to_aws_cloudtrail_request_id_cc292e2f
       field: json.requestID
       target_field: aws.cloudtrail.request_id
       ignore_failure: true
   - rename:
+      tag: rename_json_eventID_to_event_id_f952b9c8
       field: json.eventID
       target_field: event.id
       ignore_failure: true
   - rename:
+      tag: rename_json_eventType_to_aws_cloudtrail_event_type_8540078d
       field: json.eventType
       target_field: aws.cloudtrail.event_type
       ignore_failure: true
   - rename:
+      tag: rename_json_apiVersion_to_aws_cloudtrail_api_version_07d67e45
       field: json.apiVersion
       target_field: aws.cloudtrail.api_version
       ignore_failure: true
   - script:
+      tag: script_bb5a6300
       lang: painless
       source: |
         if (ctx.json?.managementEvent != null) {
@@ -1239,10 +1278,12 @@ processors:
         }
       ignore_failure: true
   - rename:
+      tag: rename_json_readOnly_to_aws_cloudtrail_read_only_910e0493
       field: json.readOnly
       target_field: aws.cloudtrail.read_only
       ignore_failure: true
   - script:
+      tag: script_729dd190
       description: 'Drops duplicates where the same combination of ARN, accountId and type is found multiple times in the resources list.'
       lang: painless
       source: >
@@ -1269,42 +1310,51 @@ processors:
           ctx.json.resources = new ArrayList(uniqueResources.values());
         }
   - rename:
+      tag: rename_json_resources_to_aws_cloudtrail_resources_ca12a9ee
       field: json.resources
       target_field: aws.cloudtrail.resources
       ignore_failure: true
   - rename:
+      tag: rename_json_recipientAccountId_to_aws_cloudtrail_recipient_account_id_69771ba8
       field: json.recipientAccountId
       target_field: aws.cloudtrail.recipient_account_id
       ignore_failure: true
   - set:
+      tag: set_cloud_account_id_0ab85f1e
       field: cloud.account.id
       copy_from: aws.cloudtrail.recipient_account_id
       override: false
       ignore_empty_value: true
   - rename:
+      tag: rename_json_sharedEventId_to_aws_cloudtrail_shared_event_id_593eca9a
       field: json.sharedEventId
       target_field: aws.cloudtrail.shared_event_id
       ignore_failure: true
   - rename:
+      tag: rename_json_vpcEndpointId_to_aws_cloudtrail_vpc_endpoint_id_21ac588e
       field: json.vpcEndpointId
       target_field: aws.cloudtrail.vpc_endpoint_id
       ignore_failure: true
   - append:
+      tag: append_related_user_0121b806
       field: related.user
       value: '{{json.requestParameters.userName}}'
       allow_duplicates: false
       if: ctx.json?.requestParameters?.userName != null
   - append:
+      tag: append_related_user_5ff399b8
       field: related.user
       value: '{{json.requestParameters.newUserName}}'
       allow_duplicates: false
       if: ctx.json?.requestParameters?.newUserName != null
   - append:
+      tag: append_related_user_e323b1c9
       field: related.user
       value: '{{json.responseElements.user.userId}}'
       allow_duplicates: false
       if: ctx.json?.responseElements?.user?.userId != null
   - script:
+      tag: script_0221d805
       lang: painless
       ignore_failure: true
       source: >-
@@ -1853,131 +1903,159 @@ processors:
 
         def hm = new HashMap(params.get(ctx.event.action));
         hm.forEach((k, v) -> ctx.event[k] = v);
-
   - rename:
+      tag: rename_json_awsAccountId_to_cloud_account_id_8aa111ca
       field: json.awsAccountId
       target_field: cloud.account.id
       ignore_failure: true
   - rename:
+      tag: rename_json_digestS3Object_to_file_path_42209760
       field: json.digestS3Object
       target_field: file.path
       ignore_failure: true
   - rename:
+      tag: rename_json_previousDigestSignature_to_file_hash_sha256_0cfc4a19
       field: json.previousDigestSignature
       target_field: file.hash.sha256
       if: >-
         ctx.json?.previousDigestHashAlgorithm != null && ctx.json?.previousDigestHashAlgorithm == 'SHA-256'
   - append:
+      tag: append_related_hash_7574f0ee
       field: related.hash
       value: '{{{file.hash.sha256}}}'
       if: ctx.file?.hash?.sha256 != null
   - rename:
+      tag: rename_json_logFiles_to_aws_cloudtrail_digest_log_files_84d51ab1
       field: json.logFiles
       target_field: aws.cloudtrail.digest.log_files
       ignore_failure: true
   - date:
+      tag: date_json_digestStartTime_to_aws_cloudtrail_digest_start_time_3c1d2845
       field: json.digestStartTime
       target_field: aws.cloudtrail.digest.start_time
       ignore_failure: true
       formats:
         - ISO8601
   - date:
+      tag: date_json_digestEndTime_to_timestamp_3953c970
       field: json.digestEndTime
       target_field: "@timestamp"
       ignore_failure: true
       formats:
         - ISO8601
   - date:
+      tag: date_json_digestEndTime_to_aws_cloudtrail_digest_end_time_d95ac027
       field: json.digestEndTime
       target_field: aws.cloudtrail.digest.end_time
       ignore_failure: true
       formats:
         - ISO8601
   - rename:
+      tag: rename_json_digestS3Bucket_to_aws_cloudtrail_digest_s3_bucket_91e31365
       field: json.digestS3Bucket
       target_field: aws.cloudtrail.digest.s3_bucket
       ignore_failure: true
   - date:
+      tag: date_json_newestEventTime_to_aws_cloudtrail_digest_newest_event_time_66ba4c38
       field: json.newestEventTime
       target_field: aws.cloudtrail.digest.newest_event_time
       ignore_failure: true
       formats:
         - ISO8601
   - date:
+      tag: date_json_oldestEventTime_to_aws_cloudtrail_digest_oldest_event_time_51f01072
       field: json.oldestEventTime
       target_field: aws.cloudtrail.digest.oldest_event_time
       ignore_failure: true
       formats:
         - ISO8601
   - rename:
+      tag: rename_json_previousDigestS3Bucket_to_aws_cloudtrail_digest_previous_s3_bucket_6835b0bc
       field: json.previousDigestS3Bucket
       target_field: aws.cloudtrail.digest.previous_s3_bucket
       ignore_failure: true
   - rename:
+      tag: rename_json_previousDigestHashAlgorithm_to_aws_cloudtrail_digest_previous_hash_algorithm_dd0916ee
       field: json.previousDigestHashAlgorithm
       target_field: aws.cloudtrail.digest.previous_hash_algorithm
       ignore_failure: true
   - rename:
+      tag: rename_json_publicKeyFingerprint_to_aws_cloudtrail_digest_public_key_fingerprint_6babc730
       field: json.publicKeyFingerprint
       target_field: aws.cloudtrail.digest.public_key_fingerprint
       ignore_failure: true
   - rename:
+      tag: rename_json_digestSignatureAlgorithm_to_aws_cloudtrail_digest_signature_algorithm_71bf5c31
       field: json.digestSignatureAlgorithm
       target_field: aws.cloudtrail.digest.signature_algorithm
       ignore_failure: true
   - set:
+      tag: set_group_id_984fd6e8
       field: group.id
       copy_from: json.responseElements.group.groupId
       ignore_empty_value: true
   - set:
+      tag: set_user_target_id_a3857f4f
       field: user.target.id
       copy_from: json.responseElements.user.userId
       ignore_empty_value: true
   - set:
+      tag: set_user_changes_name_6fb02109
       field: user.changes.name
       copy_from: json.requestParameters.newUserName
       ignore_empty_value: true
   - set:
+      tag: set_group_name_1861a4b8
       field: group.name
       copy_from: json.requestParameters.groupName
       ignore_empty_value: true
   - set:
+      tag: set_user_target_name_75aa7975
       field: user.target.name
       copy_from: json.requestParameters.userName
       ignore_empty_value: true
   - remove:
+      tag: remove_27608874
       field:
         - aws.cloudtrail.digest
         - json.insightDetails
       if: '!ctx._conf.keep_flattened_duplicates'
       ignore_missing: true
   - rename:
+      tag: rename_aws_cloudtrail_digest_to_aws_cloudtrail_flattened_digest_6c535acf
       field: aws.cloudtrail.digest
       target_field: aws.cloudtrail.flattened.digest
       ignore_missing: true
   - rename:
+      tag: rename_json_insightDetails_to_aws_cloudtrail_flattened_insight_details_7f4ccf4c
       field: json.insightDetails
       target_field: aws.cloudtrail.flattened.insight_details
       ignore_missing: true
   - remove:
+      tag: remove_json_tlsDetails_d5e86911
       field: json.tlsDetails
       if: ctx.json?.tlsDetails?.tlsVersion == 'tlsVersion'
   - dissect:
+      tag: dissect_json_tlsDetails_tlsVersion_7a65d5ad
       field: json.tlsDetails.tlsVersion
       pattern: "%{tls.version_protocol}v%{tls.version}"
       ignore_missing: true
       on_failure:
         - rename:
+            tag: rename_json_tlsDetails_tlsVersion_to_tls_version_f271a1f0
             field: json.tlsDetails.tlsVersion
             target_field: tls.version
   - lowercase:
+      tag: lowercase_tls_version_protocol_b840a1f9
       field: tls.version_protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_tlsDetails_cipherSuite_to_tls_cipher_01d89d76
       field: json.tlsDetails.cipherSuite
       target_field: tls.cipher
       ignore_missing: true
   - rename:
+      tag: rename_json_tlsDetails_clientProvidedHostHeader_to_tls_client_server_name_af2e4313
       field: json.tlsDetails.clientProvidedHostHeader
       target_field: tls.client.server_name
       ignore_missing: true
@@ -1990,12 +2068,14 @@ processors:
   # Don't dissect the user email into <user.name>@<user.domain>
   # as the parts are meaningless on their own
   - append:
+      tag: append_related_user_3b2f7fde
       field: related.user
       value: '{{{user.id}}}'
       if: ctx.user?.id != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_user_3b423052
       field: related.user
       value: '{{{user.name}}}'
       if: ctx.user?.name != null
@@ -2003,6 +2083,7 @@ processors:
       ignore_failure: true
 
   - append:
+      tag: append_related_user_25fd8c1b
       field: related.user
       value: '{{{user.changes.name}}}'
       if: ctx.user?.changes?.name != null
@@ -2051,6 +2132,7 @@ processors:
         }
         ctx.aws.cloudtrail.flattened = flattened;
   - remove:
+      tag: remove_9365dd2c
       field:
         - aws.cloudtrail.response_elements
         - aws.cloudtrail.request_parameters
@@ -2059,6 +2141,7 @@ processors:
       if: ctx._conf?.retain != null && ctx._conf.retain != '' && ctx._conf.retain != 'all' && ctx._conf.retain != 'keyword' && ctx._conf.retain != 'minimal'
 
   - remove:
+      tag: remove_9926bb8b
       field:
         - json
         - _conf
@@ -2099,7 +2182,7 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - remove:
       field:
         - json

--- a/packages/aws/data_stream/cloudwatch_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudwatch_logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,20 +3,25 @@ description: "Pipeline for logs ingested from CloudWatch"
 
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - set:
+      tag: set_event_original_6f8a8b2e
       field: event.original
       copy_from: message
       ignore_empty_value: true
       if: 'ctx.event?.original == null'
   - set:
+      tag: set_cloud_provider_208bdd6b
       field: cloud.provider
       value: aws
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_timestamp_0ab892ee
       field: '@timestamp'
       value: "{{{_ingest.timestamp}}}"
       override: false
@@ -29,4 +34,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/cloudwatch_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/cloudwatch_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: "Pipeline for AWS CloudWatch metrics"
 processors:
   - fingerprint:
+      tag: fingerprint_0aa9a14c
       fields: ["aws.dimensions"]
       target_field: 'aws.dimensions_fingerprint'
       ignore_missing: true
@@ -14,4 +15,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/config/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/config/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -118,6 +119,7 @@ processors:
       target_field: aws.config.rule_info.config_rule_state
       ignore_missing: true
   - append:
+      tag: append_related_user_3621e5fc
       field: related.user
       value: '{{{json.ConfigRuleInfo.CreatedBy}}}'
       allow_duplicates: false
@@ -143,6 +145,7 @@ processors:
       copy_from: aws.config.rule_info.description
       ignore_empty_value: true
   - foreach:
+      tag: foreach_json_ConfigRuleInfo_EvaluationModes_304c981e
       field: json.ConfigRuleInfo.EvaluationModes
       if: ctx.json?.ConfigRuleInfo?.EvaluationModes instanceof List
       processor:
@@ -163,6 +166,7 @@ processors:
       target_field: aws.config.rule_info.input_parameters
       on_failure:
         - append:
+            tag: append_error_message_baa553ee
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -193,6 +197,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9a2af158
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -211,6 +216,7 @@ processors:
       target_field: aws.config.rule_info.source.owner
       ignore_missing: true
   - foreach:
+      tag: foreach_json_ConfigRuleInfo_Source_SourceDetails_d391333b
       field: json.ConfigRuleInfo.Source.SourceDetails
       if: ctx.json?.ConfigRuleInfo?.Source?.SourceDetails instanceof List
       processor:
@@ -220,6 +226,7 @@ processors:
           target_field: _ingest._value.event_source
           ignore_missing: true
   - foreach:
+      tag: foreach_json_ConfigRuleInfo_Source_SourceDetails_34d6947d
       field: json.ConfigRuleInfo.Source.SourceDetails
       if: ctx.json?.ConfigRuleInfo?.Source?.SourceDetails instanceof List
       processor:
@@ -229,6 +236,7 @@ processors:
           target_field: _ingest._value.maximum_execution_frequency
           ignore_missing: true
   - foreach:
+      tag: foreach_json_ConfigRuleInfo_Source_SourceDetails_d1c5db73
       field: json.ConfigRuleInfo.Source.SourceDetails
       if: ctx.json?.ConfigRuleInfo?.Source?.SourceDetails instanceof List
       processor:
@@ -257,6 +265,7 @@ processors:
       if: ctx.json?.ConfigRuleInvokedTime != null && ctx.json.ConfigRuleInvokedTime != ''
       on_failure:
         - append:
+            tag: append_error_message_bb64b97f
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -279,6 +288,7 @@ processors:
       if: ctx.json?.EvaluationResultIdentifier?.OrderingTimestamp != null && ctx.json.EvaluationResultIdentifier.OrderingTimestamp != ''
       on_failure:
         - append:
+            tag: append_error_message_6f824f1c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -306,6 +316,7 @@ processors:
       if: ctx.json?.ResultRecordedTime != null && ctx.json.ResultRecordedTime != ''
       on_failure:
         - append:
+            tag: append_error_message_8f8c1e7b
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -342,7 +353,7 @@ processors:
       tag: set_event_outcome_and_result_evaluation_from_aws_config_compliance_type
       lang: painless
       description: set event.outcome and result.evaluation from compliance_type
-      if : ctx.aws?.config?.compliance_type instanceof String
+      if: ctx.aws?.config?.compliance_type instanceof String
       source: >-
         if (ctx.aws.config.compliance_type == 'NON_COMPLIANT') {
           ctx.event.outcome = 'failure';
@@ -426,6 +437,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false
@@ -433,7 +445,10 @@ processors:
 on_failure:
   - append:
       field: error.message
-      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws/data_stream/dynamodb/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/dynamodb/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,11 @@ description: "Pipeline for DynamoDB metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
@@ -19,4 +21,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/ec2_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/ec2_logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,30 +3,36 @@ description: "Pipeline for EC2 logs in CloudWatch"
 
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - rename:
+      tag: rename_message_to_event_original_c74b1d7e
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
+      tag: grok_event_original_4999d300
       field: event.original
       patterns:
         - '%{TIMESTAMP_ISO8601:_tmp.timestamp} %{SYSLOGTIMESTAMP:_tmp.syslog_timestamp} %{IPORHOST:aws.ec2.ip_address} %{DATA:process.name}(?:\\[%{POSINT:process.pid}\\])?: %{GREEDYDATA:message}'
   - date:
+      tag: date__tmp_timestamp_to_timestamp_b4a5e43c
       field: _tmp.timestamp
       target_field: '@timestamp'
       ignore_failure: true
       formats:
         - ISO8601
   - remove:
+      tag: remove_3f4f84fc
       field:
         - _tmp
       ignore_missing: true
@@ -39,4 +45,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/ec2_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/ec2_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -3,14 +3,17 @@ description: "Pipeline for EC2 metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
       ignore_empty_value: true
   - script:
+      tag: script_682928e2
       lang: painless
       description: This script converts aws.ec2.metrics.CPUUtilization.avg from percentage to decimal.
       source: |
@@ -18,36 +21,43 @@ processors:
             ctx.aws.ec2.metrics.CPUUtilization.avg = ctx.aws.ec2.metrics.CPUUtilization.avg / 100;
         }
   - rename:
+      tag: rename_aws_ec2_metrics_CPUUtilization_avg_to_host_cpu_usage_c2a42cb4
       field: aws.ec2.metrics.CPUUtilization.avg
       target_field: host.cpu.usage
       ignore_missing: true
       ignore_failure: true
   - rename:
+      tag: rename_aws_ec2_metrics_NetworkIn_sum_to_host_network_ingress_bytes_dabf5cc1
       field: aws.ec2.metrics.NetworkIn.sum
       target_field: host.network.ingress.bytes
       ignore_missing: true
       ignore_failure: true
   - rename:
+      tag: rename_aws_ec2_metrics_NetworkOut_sum_to_host_network_egress_bytes_17a73fa2
       field: aws.ec2.metrics.NetworkOut.sum
       target_field: host.network.egress.bytes
       ignore_missing: true
       ignore_failure: true
   - rename:
+      tag: rename_aws_ec2_metrics_NetworkPacketsIn_sum_to_host_network_ingress_packets_b05e0f26
       field: aws.ec2.metrics.NetworkPacketsIn.sum
       target_field: host.network.ingress.packets
       ignore_missing: true
       ignore_failure: true
   - rename:
+      tag: rename_aws_ec2_metrics_NetworkPacketsOut_sum_to_host_network_egress_packets_e7b45209
       field: aws.ec2.metrics.NetworkPacketsOut.sum
       target_field: host.network.egress.packets
       ignore_missing: true
       ignore_failure: true
   - rename:
+      tag: rename_aws_ec2_metrics_DiskReadBytes_sum_to_host_disk_read_bytes_5e316e1c
       field: aws.ec2.metrics.DiskReadBytes.sum
       target_field: host.disk.read.bytes
       ignore_missing: true
       ignore_failure: true
   - rename:
+      tag: rename_aws_ec2_metrics_DiskWriteBytes_sum_to_host_disk_write_bytes_391326ee
       field: aws.ec2.metrics.DiskWriteBytes.sum
       target_field: host.disk.write.bytes
       ignore_missing: true
@@ -61,4 +71,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/elb_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/elb_logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,20 +3,24 @@ description: "Pipeline for ELB logs"
 
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - rename:
+      tag: rename_message_to_event_original_c74b1d7e
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
+      tag: grok_event_original_e92d64ff
       field: event.original
       # Classic ELB patterns documented in https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html
       # ELB v2 Application load balancers https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
@@ -44,7 +48,6 @@ processors:
           \"(?:-|%{DATA:_tmp.actions_executed})\"
           \"(?:-|%{DATA:aws.elb.redirect_url})\"
           \"(?:-|%{DATA:aws.elb.error.reason})\"( \"(?:-|%{DATA:_tmp.target_port})\")?( \"(?:-|%{DATA:_tmp.target_status_code})\")?( \"(?:-|%{DATA:aws.elb.classification})\")?( \"(?:-|%{DATA:aws.elb.classification_reason})\")?
-
         # TCP from Network Load Balancers (v2 Load Balancers)
         - >-
           %{ELBV2TYPE}
@@ -68,7 +71,6 @@ processors:
           (?:-|%{NOTSPACE:aws.elb.alpn_be_protocol})
           (?:-|\\?\"%{DATA:aws.elb.alpn_client_preference_list}\\?\")
           (?:%{TIMESTAMP_ISO8601:aws.elb.tls_connection_creation_time_str}|-)
-        
         # ALB Connection Logs
         - >-
           %{ELBTIMESTAMP}
@@ -82,7 +84,6 @@ processors:
           (?:-|NotBefore=%{TIMESTAMP_ISO8601:aws.elb.leaf_client_cert_not_before_str};NotAfter=%{TIMESTAMP_ISO8601:aws.elb.leaf_client_cert_not_after_str})
           (?:-|%{NOTSPACE:aws.elb.leaf_client_cert_serial_number})
           (%{WORD:aws.elb.tls_verify_status})?(?::%{NOTSPACE:aws.elb.tls_error_code})?
-
       pattern_definitions:
         ELBTIMESTAMP: '%{TIMESTAMP_ISO8601:_tmp.timestamp}'
         ELBNAME: '%{NOTSPACE:aws.elb.name}'
@@ -120,88 +121,108 @@ processors:
           \"-\"
           %{ELBSSL}
         ELBV2TYPE: '%{WORD:aws.elb.type}'
-        ELBV2LOGVERSION: '%{NOTSPACE}'  # Could be used to support different log versions, only 1.0 exists now
+        ELBV2LOGVERSION: '%{NOTSPACE}' # Could be used to support different log versions, only 1.0 exists now
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_cloud_provider_208bdd6b
       field: cloud.provider
       value: aws
   - set:
+      tag: set_aws_elb_protocol_b784f9b5
       if: ctx.http != null
       field: aws.elb.protocol
       value: http
 
   - uri_parts:
+      tag: uri_parts__tmp_uri_orig_1f81b122
       if: 'ctx?._tmp?.uri_orig != null'
       field: _tmp.uri_orig
       ignore_failure: true
 
   - user_agent:
+      tag: user_agent__tmp_user_agent_fa8e1ed4
       if: 'ctx?._tmp?.user_agent != null'
       field: _tmp.user_agent
       ignore_missing: true
 
   - set:
+      tag: set_event_category_4d0fc261
       if: ctx.http != null
       field: event.category
       value: [web]
   - set:
+      tag: set_aws_elb_protocol_8b498026
       field: aws.elb.protocol
       value: tcp
       if: ctx.http == null
   - set:
+      tag: set_event_category_41205ee5
       field: event.category
       value: [network]
       if: ctx.http == null
   - set:
+      tag: set_event_outcome_7c17c411
       field: event.outcome
       value: success
       if: 'ctx?.http?.response?.status_code != null && ctx.http.response.status_code < 400'
   - set:
+      tag: set_event_outcome_712a938b
       field: event.outcome
       value: failure
       if: 'ctx?.http?.response?.status_code != null && ctx.http.response.status_code >= 400'
   - set:
+      tag: set_trace_id_53565e4a
       field: trace.id
       value: '{{aws.elb.trace_id}}'
       if: ctx?.aws?.elb?.trace_id != null
   - split:
+      tag: split__tmp_actions_executed_to_aws_elb_action_executed_2b54cfea
       field: _tmp.actions_executed
       target_field: aws.elb.action_executed
       separator: ','
       ignore_missing: true
   - split:
+      tag: split__tmp_target_port_to_aws_elb_target_port_13b05dad
       field: _tmp.target_port
       target_field: aws.elb.target_port
       separator: ' '
       ignore_missing: true
   - split:
+      tag: split__tmp_target_status_code_to_aws_elb_target_status_code_8b9f803b
       field: _tmp.target_status_code
       target_field: aws.elb.target_status_code
       separator: ' '
       ignore_missing: true
   - date:
+      tag: date__tmp_timestamp_41d263a1
       field: _tmp.timestamp
       formats:
         - ISO8601
   - set:
+      tag: set_event_end_e0a643f5
       field: event.end
       value: '{{ @timestamp }}'
   - convert:
+      tag: convert_source_address_to_source_ip_0a89ba51
       field: source.address
       target_field: source.ip
       type: ip
       ignore_failure: true
   - convert:
+      tag: convert_source_port_361b30ff
       field: source.port
       type: long
       ignore_failure: true
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -210,18 +231,22 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - set:
+      tag: set_tls_cipher_1573a52b
       field: tls.cipher
       value: '{{aws.elb.ssl_cipher}}'
       if: ctx.aws?.elb?.ssl_cipher != null
   - script:
+      tag: script_f4b0bf28
       lang: painless
       if: ctx.aws?.elb?.ssl_protocol != null
       source: >-
@@ -236,31 +261,37 @@ processors:
         }
         ctx.tls.version_protocol = parts[0].toLowerCase();
   - remove:
+      tag: remove_3f4f84fc
       field:
         - _tmp
       ignore_missing: true
   - date:
+      tag: date_aws_elb_tls_connection_creation_time_str_to_aws_elb_tls_connection_creation_time_468c578f
       field: aws.elb.tls_connection_creation_time_str
       target_field: aws.elb.tls_connection_creation_time
-      formats:  ["ISO8601"]
+      formats: ["ISO8601"]
       "if": "ctx.aws?.elb?.tls_connection_creation_time_str != null && ctx.aws?.elb?.tls_connection_creation_time_str != '-' && ctx.aws?.elb?.tls_connection_creation_time_str != ''"
   - remove:
+      tag: remove_aws_elb_tls_connection_creation_time_str_e3adb590
       field: aws.elb.tls_connection_creation_time_str
       ignore_missing: true
-  
+
   - date:
+      tag: date_aws_elb_leaf_client_cert_not_after_str_to_aws_elb_leaf_client_cert_not_after_6477be93
       field: aws.elb.leaf_client_cert_not_after_str
       target_field: aws.elb.leaf_client_cert_not_after
-      formats:  ["ISO8601"]
+      formats: ["ISO8601"]
       "if": "ctx.aws?.elb?.leaf_client_cert_not_after_str != null && ctx.aws?.elb?.leaf_client_cert_not_after_str != '-' && ctx.aws?.elb?.leaf_client_cert_not_after_str != ''"
-  
+
   - date:
+      tag: date_aws_elb_leaf_client_cert_not_before_str_to_aws_elb_leaf_client_cert_not_before_dad4c6c0
       field: aws.elb.leaf_client_cert_not_before_str
       target_field: aws.elb.leaf_client_cert_not_before
-      formats:  ["ISO8601"]
+      formats: ["ISO8601"]
       "if": "ctx.aws?.elb?.leaf_client_cert_not_before_str != null && ctx.aws?.elb?.leaf_client_cert_not_before_str != '-' && ctx.aws?.elb?.leaf_client_cert_not_before_str != ''"
-  
+
   - remove:
+      tag: remove_d2e67527
       field: ["aws.elb.leaf_client_cert_not_after_str", "aws.elb.leaf_client_cert_not_before_str"]
       ignore_missing: true
 
@@ -273,4 +304,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/emr_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/emr_logs/elasticsearch/ingest_pipeline/default.yml
@@ -2,20 +2,24 @@
 description: "Pipeline for EMR logs"
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - rename:
+      tag: rename_message_to_event_original_c74b1d7e
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
+      tag: grok_event_original_46a3eccb
       field: event.original
       pattern_definitions:
         GREEDYMULTILINE: "(.|\\n)*"
@@ -23,6 +27,7 @@ processors:
         - '%{TIMESTAMP_ISO8601:_tmp.timestamp}%{SPACE}%{LOGLEVEL:log.level}%{SPACE}%{DATA:process.name}(?:\\[%{GREEDYDATA:process.entrypoint}\\])?:%{SPACE}%{GREEDYDATA:message}%{SPACE}%{GREEDYMULTILINE:process.message}'
       ignore_missing: true
   - date:
+      tag: date__tmp_timestamp_to_timestamp_a2e51d3f
       field: _tmp.timestamp
       target_field: '@timestamp'
       ignore_failure: true
@@ -30,10 +35,12 @@ processors:
         - ISO8601
         - yyyy-MM-dd HH:mm:ss,SSS
   - remove:
+      tag: remove_3f4f84fc
       field:
         - _tmp
       ignore_missing: true
   - script:
+      tag: script_9d6fa8ba
       description: Drops null/empty values recursively
       lang: painless
       ignore_failure: true
@@ -60,4 +67,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/firewall_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/firewall_logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,33 +3,40 @@ description: "Pipeline for AWS Network Firewall logs"
 processors:
   # General data
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: 8.11.0
   - rename:
+      tag: rename_message_to_event_original_b273fe21
       field: message
       target_field: event.original
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
+      tag: json_event_original_to_json_0ae73460
       field: event.original
       allow_duplicate_keys: true
       target_field: json
   - date:
+      tag: date_json_event_timestamp_to_timestamp_6f056b56
       field: json.event.timestamp
       target_field: "@timestamp"
       formats:
         - ISO8601
       ignore_failure: true
   - rename:
+      tag: rename_json_availability_zone_to_cloud_availability_zone_2454a9cd
       field: json.availability_zone
       target_field: cloud.availability_zone
       ignore_missing: true
   - grok:
+      tag: grok_cloud_availability_zone_15df6cab
       field: cloud.availability_zone
       ignore_missing: true
       ignore_failure: true
@@ -38,65 +45,80 @@ processors:
       pattern_definitions:
         LETTER: '[a-z]+'
   - rename:
+      tag: rename_json_firewall_name_to_observer_name_d1444b7b
       field: json.firewall_name
       target_field: observer.name
       ignore_missing: true
   - set:
+      tag: set_observer_type_5dddf3ba
       field: observer.type
       value: firewall
   - set:
+      tag: set_observer_vendor_a5a87193
       field: observer.vendor
       value: AWS
   - set:
+      tag: set_observer_product_4f4e632d
       field: observer.product
       value: "Network Firewall"
 
   # Event metadata
   - append:
+      tag: append_event_category_2559ac69
       field: event.category
       value: network
       allow_duplicates: false
   - append:
+      tag: append_event_type_22176541
       field: event.type
       value: connection
       allow_duplicates: false
   - set:
+      tag: set_json_event_event_type_a8d1ed03
       field: json.event.event_type
       value: event
       if: ctx.json?.event?.event_type == "netflow"
   - set:
+      tag: set_event_kind_388ffb0b
       field: event.kind
       value: "{{json.event.event_type}}"
       if: ctx.json?.event?.event_type != null
   - set:
+      tag: set_json_event_alert_action_19dd3d46
       field: json.event.alert.action
       value: denied
       if: ctx.json?.event?.alert?.action == "blocked"
   - append:
+      tag: append_event_type_1265169e
       field: event.type
       value: "{{json.event.alert.action}}"
       if: ctx.json?.event?.alert?.action != null
 
   # Source IP/port/geo
   - convert:
+      tag: convert_json_event_src_ip_to_source_address_2e76e663
       field: json.event.src_ip
       target_field: source.address
       type: ip
       ignore_missing: true
   - set:
+      tag: set_source_ip_6f8ffc88
       field: source.ip
       copy_from: source.address
       if: ctx?.source?.address != null
   - convert:
+      tag: convert_json_event_src_port_to_source_port_2c835d7c
       field: json.event.src_port
       type: integer
       target_field: source.port
       if: ctx?.json?.event?.src_port != null
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       ignore_missing: true
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
@@ -105,42 +127,51 @@ processors:
         - asn
         - organization_name
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - set:
+      tag: set_network_type_146bf959
       field: network.type
       value: 'ipv4'
       if: 'ctx.network?.type == null && ctx.source?.ip != null && ctx.source.ip.contains(".")'
   - set:
+      tag: set_network_type_c269de1b
       field: network.type
       value: 'ipv6'
       if: 'ctx.network?.type == null && ctx.source?.ip != null && ctx.source.ip.contains(":")'
 
   # Destination IP/port/geo
   - convert:
+      tag: convert_json_event_dest_ip_to_destination_address_95c075f8
       field: json.event.dest_ip
       target_field: destination.address
       type: ip
       ignore_missing: true
   - set:
+      tag: set_destination_ip_7eb05f79
       field: destination.ip
       copy_from: destination.address
       if: ctx?.destination?.address != null
   - convert:
+      tag: convert_json_event_dest_port_to_destination_port_4bcb82c9
       field: json.event.dest_port
       type: integer
       target_field: destination.port
       if: ctx?.json?.event?.dest_port != null
   - geoip:
+      tag: geoip_destination_ip_to_destination_geo_ab5e2968
       field: destination.ip
       target_field: destination.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_destination_ip_to_destination_as_8a007787
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
       target_field: destination.as
@@ -149,151 +180,185 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_asn_to_destination_as_number_3b459fcd
       field: destination.as.asn
       target_field: destination.as.number
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_organization_name_to_destination_as_organization_name_814bd459
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
 
   # Transport protocol
   - rename:
+      tag: rename_json_event_proto_to_network_transport_3cf4d2ef
       field: json.event.proto
       target_field: network.transport
       ignore_missing: true
   - lowercase:
+      tag: lowercase_network_transport_bc8c1c12
       field: network.transport
       ignore_missing: true
 
   # Alert and metadata
   - convert:
+      tag: convert_json_event_alert_category_to_message_ae9cfdeb
       field: json.event.alert.category
       target_field: message
       type: string
       ignore_missing: true
   - set:
+      tag: set_rule_category_29a34b20
       field: rule.category
       value: "{{json.event.alert.category}}"
       ignore_empty_value: true
   - set:
+      tag: set_rule_id_9ed09f85
       field: rule.id
       value: "{{json.event.alert.signature_id}}"
       ignore_empty_value: true
   - set:
+      tag: set_rule_name_eea661d5
       field: rule.name
       value: "{{json.event.alert.signature}}"
       ignore_empty_value: true
   - set:
+      tag: set_rule_name_80701699
       field: rule.name
       value: rule.id
       if: ctx?.rule?.name == null && ctx?.rule?.id != null
   - rename:
+      tag: rename_json_event_alert_rev_id_to_rule_version_1e31fb0d
       field: json.event.alert.rev_id
       target_field: rule.version
       ignore_missing: true
   - rename:
+      tag: rename_json_event_alert_severity_to_event_severity_5e62b906
       field: json.event.alert.severity
       target_field: event.severity
       ignore_missing: true
   - rename:
+      tag: rename_json_event_app_proto_to_network_protocol_55c990a4
       field: json.event.app_proto
       target_field: network.protocol
       ignore_missing: true
   - set:
+      tag: set_network_protocol_f69bbc1f
       field: network.protocol
       value: "unknown"
       if: ctx?.network?.protocol == null || ctx?.network?.protocol == "failed"
 
   # HTTP
   - rename:
+      tag: rename_json_event_http_hostname_to_destination_domain_2572dd3d
       field: json.event.http.hostname
       target_field: destination.domain
       ignore_missing: true
   - uri_parts:
+      tag: uri_parts_json_event_http_url_4103c275
       field: json.event.http.url
       if: ctx?.json?.event?.http?.url != null
   - rename:
+      tag: rename_json_event_http_http_method_to_http_request_method_70266904
       field: json.event.http.http_method
       target_field: http.request.method
       ignore_missing: true
   - user_agent:
+      tag: user_agent_json_event_http_http_user_agent_66d79569
       field: json.event.http.http_user_agent
       ignore_missing: true
   - dissect:
+      tag: dissect_json_event_http_protocol_77be47a3
       field: json.event.http.protocol
       pattern: "HTTP/%{http.version}"
       ignore_missing: true
 
   # TLS
   - rename:
+      tag: rename_json_event_tls_sni_to_tls_client_server_name_474e13fa
       field: json.event.tls.sni
       target_field: tls.client.server_name
       ignore_missing: true
   - set:
+      tag: set_destination_domain_864b52ef
       field: destination.domain
       copy_from: tls.client.server_name
       if: ctx?.tls?.client?.server_name != null
   - dissect:
+      tag: dissect_json_event_tls_version_52c351e4
       field: json.event.tls.version
       pattern: "%{tls.version_protocol} %{tls.version}"
       ignore_missing: true
       if: ctx?.json?.event?.tls?.version != "UNDETERMINED"
   - lowercase:
+      tag: lowercase_tls_version_protocol_b840a1f9
       field: tls.version_protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_event_tls_ja3s_hash_to_tls_server_ja3s_c9fa4297
       field: json.event.tls.ja3s.hash
       target_field: tls.server.ja3s
       ignore_missing: true
   - rename:
+      tag: rename_json_event_tls_ja3_hash_to_tls_server_ja3_3776ddd5
       field: json.event.tls.ja3.hash
       target_field: tls.server.ja3
       ignore_missing: true
   - rename:
+      tag: rename_json_event_tls_certificate_to_tls_server_certificate_09c0fb43
       field: json.event.tls.certificate
       target_field: tls.server.certificate
       ignore_missing: true
   - rename:
+      tag: rename_tls_server_certificate_chain_to_json_event_tls_chain_dca83faf
       field: tls.server.certificate_chain
       target_field: json.event.tls.chain
       ignore_missing: true
   - rename:
+      tag: rename_tls_server_x509_serial_number_to_json_event_tls_serial_97fa0a5d
       field: tls.server.x509.serial_number
       target_field: json.event.tls.serial
       ignore_missing: true
   - gsub:
+      tag: gsub_tls_server_x509_serial_number_a894c049
       field: tls.server.x509.serial_number
       pattern: ":"
       replacement: ""
       ignore_missing: true
   - date:
+      tag: date_json_event_tls_notafter_to_tls_server_not_after_93ed6459
       field: json.event.tls.notafter
       target_field: tls.server.not_after
       formats:
         - ISO8601
       if: ctx.json?.event?.tls?.notafter != null
   - date:
+      tag: date_json_event_tls_notbefore_to_tls_server_not_before_c4281b44
       field: json.event.tls.notbefore
       target_field: tls.server.not_before
       formats:
         - ISO8601
       if: ctx.json?.event?.tls?.notbefore != null
   - rename:
+      tag: rename_tls_server_not_after_to_tls_server_x509_not_after_a7deac2e
       field: tls.server.not_after
       target_field: tls.server.x509.not_after
       ignore_missing: true
   - rename:
+      tag: rename_tls_server_not_before_to_tls_server_x509_not_before_21c1974c
       field: tls.server.not_before
       target_field: tls.server.x509.not_before
       ignore_missing: true
 
   # TCP
   - rename:
+      tag: rename_json_event_tcp_tcp_flags_to_aws_firewall_tcp_flags_933918f8
       field: json.event.tcp.tcp_flags
       target_field: aws.firewall.tcp_flags
       ignore_missing: true
   - script:
+      tag: script_ec11aadf
       lang: painless
       ignore_failure: true
       if: "ctx?.aws?.firewall?.tcp_flags != null"
@@ -326,30 +391,36 @@ processors:
 
   # Flow
   - rename:
+      tag: rename_json_event_netflow_to_aws_firewall_flow_864d0936
       field: json.event.netflow
       target_field: aws.firewall.flow
       ignore_missing: true
   - rename:
+      tag: rename_json_event_flow_id_to_aws_firewall_flow_id_9bf339da
       field: json.event.flow_id
       target_field: aws.firewall.flow.id
       ignore_missing: true
   - convert:
+      tag: convert_aws_firewall_flow_id_24962d4e
       field: aws.firewall.flow.id
       type: string
       ignore_missing: true
 
   # Related IPs
   - append:
+      tag: append_related_hosts_dc368f48
       field: related.hosts
       value: "{{url.domain}}"
       if: ctx.url?.domain != null && ctx.url?.domain != ""
       allow_duplicates: false
   - append:
+      tag: append_related_ip_a2836bfa
       if: ctx?.source?.ip != null
       field: related.ip
       value: "{{source.ip}}"
       allow_duplicates: false
   - append:
+      tag: append_related_ip_bd4aa684
       if: ctx?.destination?.ip != null
       field: related.ip
       value: "{{destination.ip}}"
@@ -357,11 +428,13 @@ processors:
 
   # Community ID
   - community_id:
+      tag: community_id_99f56bc8
       ignore_missing: true
       ignore_failure: true
 
   # Remove other fields
   - script:
+      tag: script_fa6ab501
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |
@@ -386,6 +459,7 @@ processors:
         }
         handleMap(ctx);
   - remove:
+      tag: remove_json_29cdffdc
       field: json
       ignore_missing: true
 on_failure:
@@ -397,4 +471,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/guardduty/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/guardduty/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,7 @@
 description: Pipeline for processing Amazon GuardDuty Findings logs.
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - remove:
@@ -16,31 +17,39 @@ processors:
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
+      tag: set_event_kind_addc330c
       field: event.kind
       value: [alert]
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
   - rename:
+      tag: rename_message_to_event_original_56a77271
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
+      tag: json_event_original_to_json_90c6475f
       field: event.original
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_45b808be
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - drop:
+      tag: drop_3fd47ae7
       if: ctx.json?.findings != null && ctx.json.findings.isEmpty()
   - fingerprint:
+      tag: fingerprint_50b4b39d
       fields:
         - json.updatedAt
         - json.id
@@ -50,18 +59,22 @@ processors:
       target_field: _id
       ignore_missing: true
   - rename:
+      tag: rename_json_accountId_to_aws_guardduty_account_id_de69fb3d
       field: json.accountId
       target_field: aws.guardduty.account_id
       ignore_missing: true
   - rename:
+      tag: rename_json_arn_to_aws_guardduty_arn_d0d8e506
       field: json.arn
       target_field: aws.guardduty.arn
       ignore_missing: true
   - rename:
+      tag: rename_json_confidence_to_aws_guardduty_confidence_8e1b4cea
       field: json.confidence
       target_field: aws.guardduty.confidence
       ignore_missing: true
   - date:
+      tag: date_json_createdAt_to_aws_guardduty_created_at_24472679
       field: json.createdAt
       target_field: aws.guardduty.created_at
       formats:
@@ -71,84 +84,104 @@ processors:
       if: ctx.json?.createdAt != null
       on_failure:
         - append:
+            tag: append_error_message_7e1ec022
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_description_to_aws_guardduty_description_f84519dc
       field: json.description
       target_field: aws.guardduty.description
       ignore_missing: true
   - rename:
+      tag: rename_json_id_to_aws_guardduty_id_44e9307e
       field: json.id
       target_field: aws.guardduty.id
       ignore_missing: true
   - rename:
+      tag: rename_json_partition_to_aws_guardduty_partition_ea20d518
       field: json.partition
       target_field: aws.guardduty.partition
       ignore_missing: true
   - rename:
+      tag: rename_json_region_to_aws_guardduty_region_22da8882
       field: json.region
       target_field: aws.guardduty.region
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_accessKeyDetails_accessKeyId_to_aws_guardduty_resource_access_key_details_accesskey_id_e7c63cc1
       field: json.resource.accessKeyDetails.accessKeyId
       target_field: aws.guardduty.resource.access_key_details.accesskey_id
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_accessKeyDetails_userType_to_aws_guardduty_resource_access_key_details_user_type_9da3548e
       field: json.resource.accessKeyDetails.userType
       target_field: aws.guardduty.resource.access_key_details.user.type
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_accessKeyDetails_principalId_to_aws_guardduty_resource_access_key_details_principal_id_589ba1db
       field: json.resource.accessKeyDetails.principalId
       target_field: aws.guardduty.resource.access_key_details.principal_id
       ignore_missing: true
   - append:
+      tag: append_related_user_5afdc23c
       field: related.user
       value: '{{{aws.guardduty.resource.access_key_details.principal_id}}}'
       if: ctx.aws?.guardduty?.resource?.access_key_details?.principal_id != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_resource_accessKeyDetails_userName_to_aws_guardduty_resource_access_key_details_user_name_cbd040ac
       field: json.resource.accessKeyDetails.userName
       target_field: aws.guardduty.resource.access_key_details.user.name
       ignore_missing: true
   - append:
+      tag: append_related_user_ec3fccb1
       field: related.user
       value: '{{{aws.guardduty.resource.access_key_details.user.name}}}'
       if: ctx.aws?.guardduty?.resource?.access_key_details?.user?.name != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_resource_containerDetails_containerRuntime_to_aws_guardduty_resource_container_details_container_runtime_baa5d67c
       field: json.resource.containerDetails.containerRuntime
       target_field: aws.guardduty.resource.container_details.container_runtime
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_containerDetails_id_to_aws_guardduty_resource_container_details_id_f28c2c43
       field: json.resource.containerDetails.id
       target_field: aws.guardduty.resource.container_details.id
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_containerDetails_image_to_aws_guardduty_resource_container_details_image_value_401a7af6
       field: json.resource.containerDetails.image
       target_field: aws.guardduty.resource.container_details.image.value
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_containerDetails_imagePrefix_to_aws_guardduty_resource_container_details_image_prefix_10ae6797
       field: json.resource.containerDetails.imagePrefix
       target_field: aws.guardduty.resource.container_details.image.prefix
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_containerDetails_name_to_aws_guardduty_resource_container_details_name_8fbc116b
       field: json.resource.containerDetails.name
       target_field: aws.guardduty.resource.container_details.name
       ignore_missing: true
   - convert:
+      tag: convert_json_resource_containerDetails_securityContext_privileged_to_aws_guardduty_resource_container_details_security_context_privileged_8d0f193a
       field: json.resource.containerDetails.securityContext.privileged
       target_field: aws.guardduty.resource.container_details.security_context.privileged
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6ac299f9
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_container_security_context_privileged_70153214
       field: container.security_context.privileged
       copy_from: aws.guardduty.resource.container_details.security_context.privileged
       ignore_empty_value: true
   - foreach:
+      tag: foreach_json_resource_containerDetails_volumeMounts_4cd5055c
       field: json.resource.containerDetails.volumeMounts
       if: ctx.json?.resource?.containerDetails?.volumeMounts instanceof List
       processor:
@@ -157,10 +190,12 @@ processors:
           target_field: _ingest._value.mount_path
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_containerDetails_volumeMounts_to_aws_guardduty_resource_container_details_volume_mounts_35e96c4c
       field: json.resource.containerDetails.volumeMounts
       target_field: aws.guardduty.resource.container_details.volume_mounts
       ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_scannedVolumeDetails_a603f278
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.scannedVolumeDetails instanceof List
       processor:
@@ -169,6 +204,7 @@ processors:
           target_field: _ingest._value.device_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_scannedVolumeDetails_e26196d2
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.scannedVolumeDetails instanceof List
       processor:
@@ -177,6 +213,7 @@ processors:
           target_field: _ingest._value.encryption_type
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_scannedVolumeDetails_29ab45c4
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.scannedVolumeDetails instanceof List
       processor:
@@ -185,6 +222,7 @@ processors:
           target_field: _ingest._value.kmskey_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_scannedVolumeDetails_939858a8
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.scannedVolumeDetails instanceof List
       processor:
@@ -193,6 +231,7 @@ processors:
           target_field: _ingest._value.snapshot_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_scannedVolumeDetails_75361203
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.scannedVolumeDetails instanceof List
       processor:
@@ -201,6 +240,7 @@ processors:
           target_field: _ingest._value.volume.arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_scannedVolumeDetails_3e85e393
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.scannedVolumeDetails instanceof List
       processor:
@@ -214,6 +254,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_scannedVolumeDetails_61b8cae1
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.scannedVolumeDetails instanceof List
       processor:
@@ -222,6 +263,7 @@ processors:
           target_field: _ingest._value.volume.type
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_scannedVolumeDetails_ae37f3dd
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.scannedVolumeDetails instanceof List
       processor:
@@ -229,10 +271,12 @@ processors:
           field: _ingest._value.volumeSizeInGB
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_ebsVolumeDetails_scannedVolumeDetails_to_aws_guardduty_resource_ebs_volume_details_scanned_volume_details_bf340eb6
       field: json.resource.ebsVolumeDetails.scannedVolumeDetails
       target_field: aws.guardduty.resource.ebs_volume_details.scanned_volume_details
       ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_skippedVolumeDetails_6e161594
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.skippedVolumeDetails instanceof List
       processor:
@@ -241,6 +285,7 @@ processors:
           target_field: _ingest._value.device_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_skippedVolumeDetails_2c12175e
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.skippedVolumeDetails instanceof List
       processor:
@@ -249,6 +294,7 @@ processors:
           target_field: _ingest._value.encryption_type
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_skippedVolumeDetails_36667da0
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.skippedVolumeDetails instanceof List
       processor:
@@ -257,6 +303,7 @@ processors:
           target_field: _ingest._value.kmskey_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_skippedVolumeDetails_39e2baa4
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.skippedVolumeDetails instanceof List
       processor:
@@ -265,6 +312,7 @@ processors:
           target_field: _ingest._value.snapshot_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_skippedVolumeDetails_d7fc160f
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.skippedVolumeDetails instanceof List
       processor:
@@ -273,6 +321,7 @@ processors:
           target_field: _ingest._value.volume.arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_skippedVolumeDetails_c8ef0cd7
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.skippedVolumeDetails instanceof List
       processor:
@@ -286,6 +335,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_skippedVolumeDetails_a2ca465d
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.skippedVolumeDetails instanceof List
       processor:
@@ -294,6 +344,7 @@ processors:
           target_field: _ingest._value.volume.type
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ebsVolumeDetails_skippedVolumeDetails_cbcc5981
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       if: ctx.json?.resource?.ebsVolumeDetails?.skippedVolumeDetails instanceof List
       processor:
@@ -301,57 +352,70 @@ processors:
           field: _ingest._value.volumeSizeInGB
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_ebsVolumeDetails_skippedVolumeDetails_to_aws_guardduty_resource_ebs_volume_details_skipped_volume_details_bcaffada
       field: json.resource.ebsVolumeDetails.skippedVolumeDetails
       target_field: aws.guardduty.resource.ebs_volume_details.skipped_volume_details
       ignore_missing: true
   - convert:
+      tag: convert_json_resource_ecsClusterDetails_activeServicesCount_to_aws_guardduty_resource_ecs_cluster_details_active_services_count_f9b99b86
       field: json.resource.ecsClusterDetails.activeServicesCount
       target_field: aws.guardduty.resource.ecs_cluster_details.active_services_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_62a0d1a7
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_arn_to_aws_guardduty_resource_ecs_cluster_details_arn_24f51c0e
       field: json.resource.ecsClusterDetails.arn
       target_field: aws.guardduty.resource.ecs_cluster_details.arn
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_name_to_aws_guardduty_resource_ecs_cluster_details_name_2ae9808c
       field: json.resource.ecsClusterDetails.name
       target_field: aws.guardduty.resource.ecs_cluster_details.name
       ignore_missing: true
   - convert:
+      tag: convert_json_resource_ecsClusterDetails_registeredContainerInstancesCount_to_aws_guardduty_resource_ecs_cluster_details_registered_container_instances_count_1ce7424b
       field: json.resource.ecsClusterDetails.registeredContainerInstancesCount
       target_field: aws.guardduty.resource.ecs_cluster_details.registered_container_instances_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b7328388
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_resource_ecsClusterDetails_runningTasksCount_to_aws_guardduty_resource_ecs_cluster_details_running_tasks_count_71dc5e26
       field: json.resource.ecsClusterDetails.runningTasksCount
       target_field: aws.guardduty.resource.ecs_cluster_details.running_tasks_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_05862817
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_status_to_aws_guardduty_resource_ecs_cluster_details_status_b8050c26
       field: json.resource.ecsClusterDetails.status
       target_field: aws.guardduty.resource.ecs_cluster_details.status
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_tags_to_aws_guardduty_resource_ecs_cluster_details_tags_4cd5e494
       field: json.resource.ecsClusterDetails.tags
       target_field: aws.guardduty.resource.ecs_cluster_details.tags
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_taskDetails_arn_to_aws_guardduty_resource_ecs_cluster_details_task_details_arn_2d01aa29
       field: json.resource.ecsClusterDetails.taskDetails.arn
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.arn
       ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ecsClusterDetails_taskDetails_containers_24a299f5
       field: json.resource.ecsClusterDetails.taskDetails.containers
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.containers instanceof List
       processor:
@@ -360,6 +424,7 @@ processors:
           target_field: _ingest._value.container_runtime
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ecsClusterDetails_taskDetails_containers_c3bbc73f
       field: json.resource.ecsClusterDetails.taskDetails.containers
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.containers instanceof List
       processor:
@@ -368,6 +433,7 @@ processors:
           target_field: _ingest._value.image.value
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ecsClusterDetails_taskDetails_containers_08e59464
       field: json.resource.ecsClusterDetails.taskDetails.containers
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.containers instanceof List
       processor:
@@ -376,6 +442,7 @@ processors:
           target_field: _ingest._value.image.prefix
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ecsClusterDetails_taskDetails_containers_e3bd0b8d
       field: json.resource.ecsClusterDetails.taskDetails.containers
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.containers instanceof List
       processor:
@@ -389,6 +456,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_ecsClusterDetails_taskDetails_containers_dfd4bb01
       field: json.resource.ecsClusterDetails.taskDetails.containers
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.containers instanceof List
       processor:
@@ -401,6 +469,7 @@ processors:
               target_field: _ingest._value.mount_path
               ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ecsClusterDetails_taskDetails_containers_ae9dfcd1
       field: json.resource.ecsClusterDetails.taskDetails.containers
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.containers instanceof List
       processor:
@@ -409,6 +478,7 @@ processors:
           target_field: _ingest._value.volume_mounts
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ecsClusterDetails_taskDetails_containers_5e165403
       field: json.resource.ecsClusterDetails.taskDetails.containers
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.containers instanceof List
       processor:
@@ -416,18 +486,22 @@ processors:
           field: _ingest._value.securityContext.privileged
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_taskDetails_containers_to_aws_guardduty_resource_ecs_cluster_details_task_details_containers_89601ed7
       field: json.resource.ecsClusterDetails.taskDetails.containers
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.containers
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_taskDetails_definitionArn_to_aws_guardduty_resource_ecs_cluster_details_task_details_definitionarn_1e54cc53
       field: json.resource.ecsClusterDetails.taskDetails.definitionArn
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.definitionarn
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_taskDetails_group_to_aws_guardduty_resource_ecs_cluster_details_task_details_group_709b5dc1
       field: json.resource.ecsClusterDetails.taskDetails.group
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.group
       ignore_missing: true
   - date:
+      tag: date_json_resource_ecsClusterDetails_taskDetails_startedAt_to_aws_guardduty_resource_ecs_cluster_details_task_details_started_at_b86c2e20
       field: json.resource.ecsClusterDetails.taskDetails.startedAt
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.started_at
       formats:
@@ -437,17 +511,21 @@ processors:
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.startedAt != null
       on_failure:
         - append:
+            tag: append_error_message_b5ad12ad
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_taskDetails_startedBy_to_aws_guardduty_resource_ecs_cluster_details_task_details_started_by_83dab2ac
       field: json.resource.ecsClusterDetails.taskDetails.startedBy
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.started_by
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_taskDetails_tags_to_aws_guardduty_resource_ecs_cluster_details_task_details_tags_61ba8c23
       field: json.resource.ecsClusterDetails.taskDetails.tags
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.tags
       ignore_missing: true
   - date:
+      tag: date_json_resource_ecsClusterDetails_taskDetails_createdAt_to_aws_guardduty_resource_ecs_cluster_details_task_details_created_at_857f6997
       field: json.resource.ecsClusterDetails.taskDetails.createdAt
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.created_at
       formats:
@@ -457,13 +535,16 @@ processors:
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.createdAt != null
       on_failure:
         - append:
+            tag: append_error_message_c5a4d9f6
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_taskDetails_version_to_aws_guardduty_resource_ecs_cluster_details_task_details_version_8c3dc61b
       field: json.resource.ecsClusterDetails.taskDetails.version
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.version
       ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_ecsClusterDetails_taskDetails_volumes_4bbb17e7
       field: json.resource.ecsClusterDetails.taskDetails.volumes
       if: ctx.json?.resource?.ecsClusterDetails?.taskDetails?.volumes instanceof List
       processor:
@@ -472,14 +553,17 @@ processors:
           target_field: _ingest._value.host_path
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_ecsClusterDetails_taskDetails_volumes_to_aws_guardduty_resource_ecs_cluster_details_task_details_volumes_28022689
       field: json.resource.ecsClusterDetails.taskDetails.volumes
       target_field: aws.guardduty.resource.ecs_cluster_details.task_details.volumes
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_eksClusterDetails_arn_to_aws_guardduty_resource_eks_cluster_details_arn_e0ada8ee
       field: json.resource.eksClusterDetails.arn
       target_field: aws.guardduty.resource.eks_cluster_details.arn
       ignore_missing: true
   - date:
+      tag: date_json_resource_eksClusterDetails_createdAt_to_aws_guardduty_resource_eks_cluster_details_created_at_01775990
       field: json.resource.eksClusterDetails.createdAt
       target_field: aws.guardduty.resource.eks_cluster_details.created_at
       formats:
@@ -489,53 +573,66 @@ processors:
       if: ctx.json?.resource?.eksClusterDetails?.createdAt != null
       on_failure:
         - append:
+            tag: append_error_message_1d41e2c1
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_resource_eksClusterDetails_name_to_aws_guardduty_resource_eks_cluster_details_name_bef936fc
       field: json.resource.eksClusterDetails.name
       target_field: aws.guardduty.resource.eks_cluster_details.name
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_eksClusterDetails_status_to_aws_guardduty_resource_eks_cluster_details_status_3f482ea6
       field: json.resource.eksClusterDetails.status
       target_field: aws.guardduty.resource.eks_cluster_details.status
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_eksClusterDetails_tags_to_aws_guardduty_resource_eks_cluster_details_tags_24f2a6e4
       field: json.resource.eksClusterDetails.tags
       target_field: aws.guardduty.resource.eks_cluster_details.tags
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_eksClusterDetails_vpcId_to_aws_guardduty_resource_eks_cluster_details_vpcid_d8cd0eb2
       field: json.resource.eksClusterDetails.vpcId
       target_field: aws.guardduty.resource.eks_cluster_details.vpcid
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_availabilityZone_to_aws_guardduty_resource_instance_details_availability_zone_75776e8c
       field: json.resource.instanceDetails.availabilityZone
       target_field: aws.guardduty.resource.instance_details.availability_zone
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_iamInstanceProfile_to_aws_guardduty_resource_instance_details_iaminstance_profile_87b32a08
       field: json.resource.instanceDetails.iamInstanceProfile
       target_field: aws.guardduty.resource.instance_details.iaminstance_profile
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_imageDescription_to_aws_guardduty_resource_instance_details_image_description_c2c26409
       field: json.resource.instanceDetails.imageDescription
       target_field: aws.guardduty.resource.instance_details.image.description
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_imageId_to_aws_guardduty_resource_instance_details_image_id_226da069
       field: json.resource.instanceDetails.imageId
       target_field: aws.guardduty.resource.instance_details.image.id
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_instanceId_to_aws_guardduty_resource_instance_details_instance_id_9f93f7e3
       field: json.resource.instanceDetails.instanceId
       target_field: aws.guardduty.resource.instance_details.instance.id
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_instanceState_to_aws_guardduty_resource_instance_details_instance_state_69b73dd5
       field: json.resource.instanceDetails.instanceState
       target_field: aws.guardduty.resource.instance_details.instance.state
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_instanceType_to_aws_guardduty_resource_instance_details_instance_type_194f8071
       field: json.resource.instanceDetails.instanceType
       target_field: aws.guardduty.resource.instance_details.instance.type
       ignore_missing: true
   - date:
+      tag: date_json_resource_instanceDetails_launchTime_to_aws_guardduty_resource_instance_details_launch_time_1614bf1e
       field: json.resource.instanceDetails.launchTime
       target_field: aws.guardduty.resource.instance_details.launch_time
       formats:
@@ -545,9 +642,11 @@ processors:
       if: ctx.json?.resource?.instanceDetails?.launchTime != null
       on_failure:
         - append:
+            tag: append_error_message_24c9061b
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_3c0b85a7
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -566,6 +665,7 @@ processors:
                     field: error.message
                     value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_6594e02e
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -578,6 +678,7 @@ processors:
               value: '{{{_ingest._value}}}'
               allow_duplicates: false
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_6a0327f6
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -586,6 +687,7 @@ processors:
           target_field: _ingest._value.ipv6_addresses
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_357f808b
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -594,6 +696,7 @@ processors:
           target_field: _ingest._value.network_interface_id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_7287c794
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -602,6 +705,7 @@ processors:
           target_field: _ingest._value.private.dns_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_5b311ebd
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -615,6 +719,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_acc4fba8
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -623,6 +728,7 @@ processors:
           value: '{{{_ingest._value.private.ip_address}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_ad88fc8d
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -640,6 +746,7 @@ processors:
                     field: error.message
                     value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_065d7e54
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -652,6 +759,7 @@ processors:
               value: '{{{_ingest._value.private.ip_address}}}'
               allow_duplicates: false
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_ac500ec8
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -664,6 +772,7 @@ processors:
               target_field: _ingest._value.private.dns_name
               ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_d4b080e4
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -675,6 +784,7 @@ processors:
               field: _ingest._value.privateIpAddress
               ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_9b7f2948
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -683,6 +793,7 @@ processors:
           target_field: _ingest._value.private.ip_addresses
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_c76d6df6
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -691,6 +802,7 @@ processors:
           target_field: _ingest._value.public.dns_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_b7fe1cb2
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -704,6 +816,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_0751ca5d
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -712,6 +825,7 @@ processors:
           value: '{{{_ingest._value.public.ip}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_c40f614b
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -724,6 +838,7 @@ processors:
               target_field: _ingest._value.group.id
               ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_4d6bf777
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -736,6 +851,7 @@ processors:
               target_field: _ingest._value.group.name
               ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_66f09108
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -744,6 +860,7 @@ processors:
           target_field: _ingest._value.security_groups
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_1d5fbd6e
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -752,6 +869,7 @@ processors:
           target_field: _ingest._value.subnet_id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_b3726f9e
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -760,6 +878,7 @@ processors:
           target_field: _ingest._value.vpc_id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_networkInterfaces_ef48520b
       field: json.resource.instanceDetails.networkInterfaces
       if: ctx.json?.resource?.instanceDetails?.networkInterfaces instanceof List
       processor:
@@ -769,18 +888,22 @@ processors:
             - _ingest._value.publicIp
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_networkInterfaces_to_aws_guardduty_resource_instance_details_network_interfaces_8611526a
       field: json.resource.instanceDetails.networkInterfaces
       target_field: aws.guardduty.resource.instance_details.network_interfaces
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_outpostArn_to_aws_guardduty_resource_instance_details_outpost_arn_49f25d50
       field: json.resource.instanceDetails.outpostArn
       target_field: aws.guardduty.resource.instance_details.outpost_arn
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_platform_to_aws_guardduty_resource_instance_details_platform_a51999b5
       field: json.resource.instanceDetails.platform
       target_field: aws.guardduty.resource.instance_details.platform
       ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_productCodes_10bb02c2
       field: json.resource.instanceDetails.productCodes
       if: ctx.json?.resource?.instanceDetails?.productCodes instanceof List
       processor:
@@ -789,6 +912,7 @@ processors:
           target_field: _ingest._value.product_code.id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_instanceDetails_productCodes_7a343192
       field: json.resource.instanceDetails.productCodes
       if: ctx.json?.resource?.instanceDetails?.productCodes instanceof List
       processor:
@@ -797,36 +921,44 @@ processors:
           target_field: _ingest._value.product_code.type
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_productCodes_to_aws_guardduty_resource_instance_details_product_codes_2b82a692
       field: json.resource.instanceDetails.productCodes
       target_field: aws.guardduty.resource.instance_details.product_codes
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_instanceDetails_tags_to_aws_guardduty_resource_instance_details_tags_1d4a71d5
       field: json.resource.instanceDetails.tags
       target_field: aws.guardduty.resource.instance_details.tags
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesUserDetails_uid_to_aws_guardduty_resource_kubernetes_details_kubernetes_user_details_uid_0534a2f9
       field: json.resource.kubernetesDetails.kubernetesUserDetails.uid
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_user_details.uid
       ignore_missing: true
   - append:
+      tag: append_related_user_ec7f8585
       field: related.user
       value: '{{{aws.guardduty.resource.kubernetes_details.kubernetes_user_details.uid}}}'
       if: ctx.aws?.guardduty?.resource?.kubernetes_details?.kubernetes_user_details?.uid != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesUserDetails_username_to_aws_guardduty_resource_kubernetes_details_kubernetes_user_details_user_name_3864ddf8
       field: json.resource.kubernetesDetails.kubernetesUserDetails.username
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_user_details.user_name
       ignore_missing: true
   - append:
+      tag: append_related_user_265d2df3
       field: related.user
       value: '{{{aws.guardduty.resource.kubernetes_details.kubernetes_user_details.user_name}}}'
       if: ctx.aws?.guardduty?.resource?.kubernetes_details?.kubernetes_user_details?.user_name != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesUserDetails_groups_to_aws_guardduty_resource_kubernetes_details_kubernetes_user_details_groups_07b9a337
       field: json.resource.kubernetesDetails.kubernetesUserDetails.groups
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_user_details.groups
       ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_kubernetesDetails_kubernetesWorkloadDetails_containers_2beae3f5
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.containers
       if: ctx.json?.resource?.kubernetesDetails?.kubernetesWorkloadDetails?.containers instanceof List
       processor:
@@ -835,6 +967,7 @@ processors:
           target_field: _ingest._value.container_runtime
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_kubernetesDetails_kubernetesWorkloadDetails_containers_bd39153f
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.containers
       if: ctx.json?.resource?.kubernetesDetails?.kubernetesWorkloadDetails?.containers instanceof List
       processor:
@@ -843,6 +976,7 @@ processors:
           target_field: _ingest._value.image.value
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_kubernetesDetails_kubernetesWorkloadDetails_containers_94c90e64
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.containers
       if: ctx.json?.resource?.kubernetesDetails?.kubernetesWorkloadDetails?.containers instanceof List
       processor:
@@ -851,6 +985,7 @@ processors:
           target_field: _ingest._value.image.prefix
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_kubernetesDetails_kubernetesWorkloadDetails_containers_e96f698d
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.containers
       if: ctx.json?.resource?.kubernetesDetails?.kubernetesWorkloadDetails?.containers instanceof List
       processor:
@@ -864,6 +999,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resource_kubernetesDetails_kubernetesWorkloadDetails_containers_9d364501
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.containers
       if: ctx.json?.resource?.kubernetesDetails?.kubernetesWorkloadDetails?.containers instanceof List
       processor:
@@ -876,6 +1012,7 @@ processors:
               target_field: _ingest._value.mount_path
               ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_kubernetesDetails_kubernetesWorkloadDetails_containers_6b0f06d1
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.containers
       if: ctx.json?.resource?.kubernetesDetails?.kubernetesWorkloadDetails?.containers instanceof List
       processor:
@@ -884,6 +1021,7 @@ processors:
           target_field: _ingest._value.volume_mounts
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_kubernetesDetails_kubernetesWorkloadDetails_containers_9fba5e03
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.containers
       if: ctx.json?.resource?.kubernetesDetails?.kubernetesWorkloadDetails?.containers instanceof List
       processor:
@@ -891,35 +1029,43 @@ processors:
           field: _ingest._value.securityContext.privileged
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesWorkloadDetails_containers_to_aws_guardduty_resource_kubernetes_details_kubernetes_workload_details_containers_723687a3
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.containers
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.containers
       ignore_missing: true
   - convert:
+      tag: convert_json_resource_kubernetesDetails_kubernetesWorkloadDetails_hostNetwork_to_aws_guardduty_resource_kubernetes_details_kubernetes_workload_details_host_network_0f6297bc
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.hostNetwork
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.host_network
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d600423f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesWorkloadDetails_name_to_aws_guardduty_resource_kubernetes_details_kubernetes_workload_details_name_81f6b17f
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.name
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.name
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesWorkloadDetails_namespace_to_aws_guardduty_resource_kubernetes_details_kubernetes_workload_details_name_space_5d8e973c
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.namespace
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.name_space
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesWorkloadDetails_type_to_aws_guardduty_resource_kubernetes_details_kubernetes_workload_details_type_00555c5b
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.type
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.type
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesWorkloadDetails_uid_to_aws_guardduty_resource_kubernetes_details_kubernetes_workload_details_uid_c9f5ea15
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.uid
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.uid
       ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_kubernetesDetails_kubernetesWorkloadDetails_volumes_9be578d5
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.volumes
       if: ctx.json?.resource?.kubernetesDetails?.kubernetesWorkloadDetails?.volumes instanceof List
       processor:
@@ -928,64 +1074,79 @@ processors:
           target_field: _ingest._value.host_path
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_kubernetesDetails_kubernetesWorkloadDetails_volumes_to_aws_guardduty_resource_kubernetes_details_kubernetes_workload_details_volumes_977c30af
       field: json.resource.kubernetesDetails.kubernetesWorkloadDetails.volumes
       target_field: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.volumes
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_rdsDbInstanceDetails_dbInstanceIdentifier_to_aws_guardduty_resource_rdsdb_instance_details_instance_identifier_119015e1
       field: json.resource.rdsDbInstanceDetails.dbInstanceIdentifier
       target_field: aws.guardduty.resource.rdsdb_instance_details.instance_identifier
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_rdsDbInstanceDetails_engine_to_aws_guardduty_resource_rdsdb_instance_details_engine_3c4b4a2a
       field: json.resource.rdsDbInstanceDetails.engine
       target_field: aws.guardduty.resource.rdsdb_instance_details.engine
       ignore_missing: true
   - convert:
+      tag: convert_json_resource_rdsDbInstanceDetails_engineVersion_to_aws_guardduty_resource_rdsdb_instance_details_engine_version_e4e870d4
       field: json.resource.rdsDbInstanceDetails.engineVersion
       target_field: aws.guardduty.resource.rdsdb_instance_details.engine_version
       type: string
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c628c4fb
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_resource_rdsDbInstanceDetails_dbClusterIdentifier_to_aws_guardduty_resource_rdsdb_instance_details_cluster_identifier_57d21369
       field: json.resource.rdsDbInstanceDetails.dbClusterIdentifier
       target_field: aws.guardduty.resource.rdsdb_instance_details.cluster_identifier
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_rdsDbInstanceDetails_dbInstanceArn_to_aws_guardduty_resource_rdsdb_instance_details_instance_arn_db5a5cf9
       field: json.resource.rdsDbInstanceDetails.dbInstanceArn
       target_field: aws.guardduty.resource.rdsdb_instance_details.instance_arn
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_rdsDbUserDetails_user_to_aws_guardduty_resource_rdsdb_user_details_user_df5bb0aa
       field: json.resource.rdsDbUserDetails.user
       target_field: aws.guardduty.resource.rdsdb_user_details.user
       ignore_missing: true
   - append:
+      tag: append_related_user_85ea5276
       field: related.user
       value: '{{{aws.guardduty.resource.rdsdb_user_details.user}}}'
       if: ctx.aws?.guardduty?.resource?.rdsdb_user_details?.user != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_resource_rdsDbUserDetails_application_to_aws_guardduty_resource_rdsdb_user_details_application_b38b3928
       field: json.resource.rdsDbUserDetails.application
       target_field: aws.guardduty.resource.rdsdb_user_details.application
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_rdsDbUserDetails_database_to_aws_guardduty_resource_rdsdb_user_details_database_c4add0aa
       field: json.resource.rdsDbUserDetails.database
       target_field: aws.guardduty.resource.rdsdb_user_details.database
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_rdsDbUserDetails_ssl_to_aws_guardduty_resource_rdsdb_user_details_ssl_539c70c0
       field: json.resource.rdsDbUserDetails.ssl
       target_field: aws.guardduty.resource.rdsdb_user_details.ssl
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_rdsDbUserDetails_authMethod_to_aws_guardduty_resource_rdsdb_user_details_auth_method_5bed48d7
       field: json.resource.rdsDbUserDetails.authMethod
       target_field: aws.guardduty.resource.rdsdb_user_details.auth_method
       ignore_missing: true
   - rename:
+      tag: rename_json_resource_resourceType_to_aws_guardduty_resource_type_50e5334c
       field: json.resource.resourceType
       target_field: aws.guardduty.resource.type
       ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_s3BucketDetails_cf1d5276
       field: json.resource.s3BucketDetails
       if: ctx.json?.resource?.s3BucketDetails instanceof List
       processor:
@@ -998,6 +1159,7 @@ processors:
             - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
           ignore_failure: true
   - foreach:
+      tag: foreach_json_resource_s3BucketDetails_769afd4c
       field: json.resource.s3BucketDetails
       if: ctx.json?.resource?.s3BucketDetails instanceof List
       processor:
@@ -1006,6 +1168,7 @@ processors:
           target_field: _ingest._value.default_server_side_encryption.encryption_type
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_s3BucketDetails_5fe97eaf
       field: json.resource.s3BucketDetails
       if: ctx.json?.resource?.s3BucketDetails instanceof List
       processor:
@@ -1014,6 +1177,7 @@ processors:
           target_field: _ingest._value.default_server_side_encryption.kms_masterkey_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_s3BucketDetails_5f8629d7
       field: json.resource.s3BucketDetails
       if: ctx.json?.resource?.s3BucketDetails instanceof List
       processor:
@@ -1022,6 +1186,7 @@ processors:
           target_field: _ingest._value.public_access
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resource_s3BucketDetails_09ef983c
       field: json.resource.s3BucketDetails
       if: ctx.json?.resource?.s3BucketDetails instanceof List
       processor:
@@ -1030,6 +1195,7 @@ processors:
           value: '{{{_ingest._value.owner.id}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_resource_s3BucketDetails_0c795368
       field: json.resource.s3BucketDetails
       if: ctx.json?.resource?.s3BucketDetails instanceof List
       processor:
@@ -1037,191 +1203,236 @@ processors:
           field: _ingest._value.createdAt
           ignore_missing: true
   - rename:
+      tag: rename_json_resource_s3BucketDetails_to_aws_guardduty_resource_s3_bucket_details_cb752360
       field: json.resource.s3BucketDetails
       target_field: aws.guardduty.resource.s3_bucket_details
       ignore_missing: true
   - convert:
+      tag: convert_json_schemaVersion_to_aws_guardduty_schema_version_69dc54d8
       field: json.schemaVersion
       target_field: aws.guardduty.schema_version
       type: string
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e1c13483
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_action_actionType_to_aws_guardduty_service_action_type_028ef6dc
       field: json.service.action.actionType
       target_field: aws.guardduty.service.action.type
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_affectedResources_to_aws_guardduty_service_action_aws_api_call_action_affected_resources_216aae06
       field: json.service.action.awsApiCallAction.affectedResources
       target_field: aws.guardduty.service.action.aws_api_call_action.affected_resources
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_api_to_aws_guardduty_service_action_aws_api_call_action_api_30a8fea7
       field: json.service.action.awsApiCallAction.api
       target_field: aws.guardduty.service.action.aws_api_call_action.api
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_callerType_to_aws_guardduty_service_action_aws_api_call_action_caller_type_717c8114
       field: json.service.action.awsApiCallAction.callerType
       target_field: aws.guardduty.service.action.aws_api_call_action.caller_type
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_domainDetails_domain_to_aws_guardduty_service_action_aws_api_call_action_domain_details_domain_edcfd30e
       field: json.service.action.awsApiCallAction.domainDetails.domain
       target_field: aws.guardduty.service.action.aws_api_call_action.domain_details.domain
       ignore_missing: true
   - append:
+      tag: append_related_hosts_67278242
       field: related.hosts
       value: '{{{aws.guardduty.service.action.aws_api_call_action.domain_details.domain}}}'
       if: ctx.aws?.guardduty?.service?.action?.aws_api_call_action?.domain_details?.domain != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_errorCode_to_aws_guardduty_service_action_aws_api_call_action_error_code_b674b710
       field: json.service.action.awsApiCallAction.errorCode
       target_field: aws.guardduty.service.action.aws_api_call_action.error_code
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteAccountDetails_accountId_to_aws_guardduty_service_action_aws_api_call_action_remote_account_details_account_id_1a54dfe0
       field: json.service.action.awsApiCallAction.remoteAccountDetails.accountId
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_account_details.account_id
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_awsApiCallAction_remoteAccountDetails_affiliated_to_aws_guardduty_service_action_aws_api_call_action_remote_account_details_affiliated_e8fe1585
       field: json.service.action.awsApiCallAction.remoteAccountDetails.affiliated
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_account_details.affiliated
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_46d16fe8
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteIpDetails_city_cityName_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_city_name_16faa7a2
       field: json.service.action.awsApiCallAction.remoteIpDetails.city.cityName
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.city.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteIpDetails_country_countryCode_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_country_code_367c6cbd
       field: json.service.action.awsApiCallAction.remoteIpDetails.country.countryCode
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.country.code
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteIpDetails_country_countryName_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_country_name_8df2b655
       field: json.service.action.awsApiCallAction.remoteIpDetails.country.countryName
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.country.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteIpDetails_geoLocation_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_geo_location_7a387ab4
       field: json.service.action.awsApiCallAction.remoteIpDetails.geoLocation
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.geo_location
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_awsApiCallAction_remoteIpDetails_ipAddressV4_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_ip_address_v4_0fc42b8a
       field: json.service.action.awsApiCallAction.remoteIpDetails.ipAddressV4
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.ip_address_v4
       type: ip
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ebf26b95
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_535419a8
       field: related.ip
       value: '{{{aws.guardduty.service.action.aws_api_call_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.aws_api_call_action?.remote_ip_details?.ip_address_v4 != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteIpDetails_organization_asn_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_organization_asn_7d21d51b
       field: json.service.action.awsApiCallAction.remoteIpDetails.organization.asn
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.organization.asn
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteIpDetails_organization_asnOrg_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_organization_asnorg_c4b69713
       field: json.service.action.awsApiCallAction.remoteIpDetails.organization.asnOrg
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.organization.asnorg
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteIpDetails_organization_isp_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_organization_isp_45420663
       field: json.service.action.awsApiCallAction.remoteIpDetails.organization.isp
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.organization.isp
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_remoteIpDetails_organization_org_to_aws_guardduty_service_action_aws_api_call_action_remote_ip_details_organization_org_9e19a983
       field: json.service.action.awsApiCallAction.remoteIpDetails.organization.org
       target_field: aws.guardduty.service.action.aws_api_call_action.remote_ip_details.organization.org
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_serviceName_to_aws_guardduty_service_action_aws_api_call_action_service_name_07606b20
       field: json.service.action.awsApiCallAction.serviceName
       target_field: aws.guardduty.service.action.aws_api_call_action.service_name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_awsApiCallAction_userAgent_to_aws_guardduty_service_action_aws_api_call_action_user_agent_ecf57696
       field: json.service.action.awsApiCallAction.userAgent
       target_field: aws.guardduty.service.action.aws_api_call_action.user_agent
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_dnsRequestAction_blocked_to_aws_guardduty_service_action_dns_request_action_blocked_137598ec
       field: json.service.action.dnsRequestAction.blocked
       target_field: aws.guardduty.service.action.dns_request_action.blocked
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9d8c93d3
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_action_dnsRequestAction_domain_to_aws_guardduty_service_action_dns_request_action_domain_ce5f6abc
       field: json.service.action.dnsRequestAction.domain
       target_field: aws.guardduty.service.action.dns_request_action.domain
       ignore_missing: true
   - append:
+      tag: append_related_hosts_39917e99
       field: related.hosts
       value: '{{{aws.guardduty.service.action.dns_request_action.domain}}}'
       if: ctx.aws?.guardduty?.service?.action?.dns_request_action?.domain != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_service_action_dnsRequestAction_protocol_to_aws_guardduty_service_action_dns_request_action_protocol_45ca3004
       field: json.service.action.dnsRequestAction.protocol
       target_field: aws.guardduty.service.action.dns_request_action.protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_parameters_to_aws_guardduty_service_action_kubernetes_api_call_action_parameters_27b57e3f
       field: json.service.action.kubernetesApiCallAction.parameters
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.parameters
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_remoteIpDetails_city_cityName_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_city_name_8bcde06c
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.city.cityName
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.city.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_remoteIpDetails_country_countryCode_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_country_code_75833237
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.country.countryCode
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.country.code
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_remoteIpDetails_country_countryName_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_country_name_6e0909e3
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.country.countryName
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.country.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_remoteIpDetails_geoLocation_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_geo_location_7ef771d0
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.geoLocation
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.geo_location
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_kubernetesApiCallAction_remoteIpDetails_ipAddressV4_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_ip_address_v4_0f586928
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.ipAddressV4
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.ip_address_v4
       type: ip
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_dadb20e3
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_99bef742
       field: related.ip
       value: '{{{aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.kubernetes_api_call_action?.remote_ip_details?.ip_address_v4 != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_remoteIpDetails_organization_asn_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_organization_asn_e76a844f
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.organization.asn
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.organization.asn
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_remoteIpDetails_organization_asnOrg_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_organization_asnorg_b9aa2731
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.organization.asnOrg
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.organization.asnorg
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_remoteIpDetails_organization_isp_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_organization_isp_6bede6eb
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.organization.isp
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.organization.isp
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_remoteIpDetails_organization_org_to_aws_guardduty_service_action_kubernetes_api_call_action_remote_ip_details_organization_org_d94d392f
       field: json.service.action.kubernetesApiCallAction.remoteIpDetails.organization.org
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.organization.org
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_requestUri_to_aws_guardduty_service_action_kubernetes_api_call_action_request_uri_25a60634
       field: json.service.action.kubernetesApiCallAction.requestUri
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.request_uri
       ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_kubernetesApiCallAction_sourceIPs_dff42353
       field: json.service.action.kubernetesApiCallAction.sourceIPs
       if: ctx.json?.service?.action?.kubernetesApiCallAction?.sourceIPs instanceof List
       processor:
@@ -1236,6 +1447,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_service_action_kubernetesApiCallAction_sourceIPs_0101c4ce
       field: json.service.action.kubernetesApiCallAction.sourceIPs
       if: ctx.json?.service?.action?.kubernetesApiCallAction?.sourceIPs instanceof List
       processor:
@@ -1244,139 +1456,171 @@ processors:
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_sourceIPs_to_aws_guardduty_service_action_kubernetes_api_call_action_source_ips_1111f058
       field: json.service.action.kubernetesApiCallAction.sourceIPs
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.source_ips
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_kubernetesApiCallAction_statusCode_to_aws_guardduty_service_action_kubernetes_api_call_action_status_code_a22b070c
       field: json.service.action.kubernetesApiCallAction.statusCode
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.status_code
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6ed9d2f9
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_userAgent_to_aws_guardduty_service_action_kubernetes_api_call_action_user_agent_f11c6338
       field: json.service.action.kubernetesApiCallAction.userAgent
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.user_agent
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_kubernetesApiCallAction_verb_to_aws_guardduty_service_action_kubernetes_api_call_action_verb_2666170f
       field: json.service.action.kubernetesApiCallAction.verb
       target_field: aws.guardduty.service.action.kubernetes_api_call_action.verb
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_networkConnectionAction_blocked_to_aws_guardduty_service_action_network_connection_action_blocked_57bbe3c2
       field: json.service.action.networkConnectionAction.blocked
       target_field: aws.guardduty.service.action.network_connection_action.blocked
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_eb5f3cf9
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_connectionDirection_to_aws_guardduty_service_action_network_connection_action_connection_direction_98f0bb8f
       field: json.service.action.networkConnectionAction.connectionDirection
       target_field: aws.guardduty.service.action.network_connection_action.connection_direction
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_networkConnectionAction_localIpDetails_ipAddressV4_to_aws_guardduty_service_action_network_connection_action_local_ip_details_ip_address_v4_816000bb
       field: json.service.action.networkConnectionAction.localIpDetails.ipAddressV4
       target_field: aws.guardduty.service.action.network_connection_action.local_ip_details.ip_address_v4
       type: ip
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0aedfc4a
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_394d4502
       field: related.ip
       value: '{{{aws.guardduty.service.action.network_connection_action.local_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.local_ip_details?.ip_address_v4 != null
       allow_duplicates: false
   - convert:
+      tag: convert_json_service_action_networkConnectionAction_localPortDetails_port_to_aws_guardduty_service_action_network_connection_action_local_port_details_port_value_3dbc2d4f
       field: json.service.action.networkConnectionAction.localPortDetails.port
       target_field: aws.guardduty.service.action.network_connection_action.local_port_details.port.value
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_113ab8aa
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_localPortDetails_portName_to_aws_guardduty_service_action_network_connection_action_local_port_details_port_name_7cd40924
       field: json.service.action.networkConnectionAction.localPortDetails.portName
       target_field: aws.guardduty.service.action.network_connection_action.local_port_details.port.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_protocol_to_aws_guardduty_service_action_network_connection_action_transport_2d29329f
       field: json.service.action.networkConnectionAction.protocol
       target_field: aws.guardduty.service.action.network_connection_action.transport
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remoteIpDetails_city_cityName_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_city_name_c4ee0d0d
       field: json.service.action.networkConnectionAction.remoteIpDetails.city.cityName
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.city.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remoteIpDetails_country_countryCode_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_country_code_bcbe701c
       field: json.service.action.networkConnectionAction.remoteIpDetails.country.countryCode
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.country.code
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remoteIpDetails_country_countryName_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_country_name_37c10080
       field: json.service.action.networkConnectionAction.remoteIpDetails.country.countryName
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.country.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remoteIpDetails_geoLocation_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_geo_location_fa74973d
       field: json.service.action.networkConnectionAction.remoteIpDetails.geoLocation
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.geo_location
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_networkConnectionAction_remoteIpDetails_ipAddressV4_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_ip_address_v4_264baf15
       field: json.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.ip_address_v4
       type: ip
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c1230e1c
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_73032f80
       field: related.ip
       value: '{{{aws.guardduty.service.action.network_connection_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.remote_ip_details?.ip_address_v4 != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remoteIpDetails_organization_asn_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_organization_asn_d2fe1194
       field: json.service.action.networkConnectionAction.remoteIpDetails.organization.asn
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.organization.asn
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remoteIpDetails_organization_asnOrg_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_organization_asnorg_e337f580
       field: json.service.action.networkConnectionAction.remoteIpDetails.organization.asnOrg
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.organization.asnorg
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remoteIpDetails_organization_isp_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_organization_isp_8bef8b10
       field: json.service.action.networkConnectionAction.remoteIpDetails.organization.isp
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.organization.isp
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remoteIpDetails_organization_org_to_aws_guardduty_service_action_network_connection_action_remote_ip_details_organization_org_6054c5e0
       field: json.service.action.networkConnectionAction.remoteIpDetails.organization.org
       target_field: aws.guardduty.service.action.network_connection_action.remote_ip_details.organization.org
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_networkConnectionAction_remotePortDetails_port_to_aws_guardduty_service_action_network_connection_action_remote_port_details_port_value_11544c03
       field: json.service.action.networkConnectionAction.remotePortDetails.port
       target_field: aws.guardduty.service.action.network_connection_action.remote_port_details.port.value
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d72b72c2
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_action_networkConnectionAction_remotePortDetails_portName_to_aws_guardduty_service_action_network_connection_action_remote_port_details_port_name_e53e5c5a
       field: json.service.action.networkConnectionAction.remotePortDetails.portName
       target_field: aws.guardduty.service.action.network_connection_action.remote_port_details.port.name
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_portProbeAction_blocked_to_aws_guardduty_service_action_port_probe_action_blocked_56873752
       field: json.service.action.portProbeAction.blocked
       target_field: aws.guardduty.service.action.port_probe_action.blocked
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b8a8d8d1
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_c9f443eb
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1390,6 +1634,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_bdce3837
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1398,6 +1643,7 @@ processors:
           value: '{{{_ingest._value.local_ip_details.ip_address_v4}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_b41e33eb
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1411,6 +1657,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_f0cac07a
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1419,6 +1666,7 @@ processors:
           target_field: _ingest._value.local_port_details.port.name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_ef5d725f
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1427,6 +1675,7 @@ processors:
           target_field: _ingest._value.remote_ip_details.city.name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_6c08cb26
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1435,6 +1684,7 @@ processors:
           target_field: _ingest._value.remote_ip_details.country.code
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_aea12362
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1443,6 +1693,7 @@ processors:
           target_field: _ingest._value.remote_ip_details.country.name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_473b3597
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1451,6 +1702,7 @@ processors:
           target_field: _ingest._value.remote_ip_details.geo_location
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_424306cd
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1464,6 +1716,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_44f55762
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1472,6 +1725,7 @@ processors:
           value: '{{{_ingest._value.remote_ip_details.ip_address_v4}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_2fdb475e
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1480,6 +1734,7 @@ processors:
           target_field: _ingest._value.remote_ip_details.organization.isp
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_6519152a
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1488,6 +1743,7 @@ processors:
           target_field: _ingest._value.remote_ip_details.organization.org
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_4455a5da
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1496,6 +1752,7 @@ processors:
           target_field: _ingest._value.remote_ip_details.organization.asn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_eeb5626a
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1504,6 +1761,7 @@ processors:
           target_field: _ingest._value.remote_ip_details.organization.asnorg
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_action_portProbeAction_portProbeDetails_f71b0e57
       field: json.service.action.portProbeAction.portProbeDetails
       if: ctx.json?.service?.action?.portProbeAction?.portProbeDetails instanceof List
       processor:
@@ -1514,82 +1772,101 @@ processors:
             - _ingest._value.remoteIpDetails.ipAddressV4
           ignore_missing: true
   - rename:
+      tag: rename_json_service_action_portProbeAction_portProbeDetails_to_aws_guardduty_service_action_port_probe_action_port_probe_details_fb369eea
       field: json.service.action.portProbeAction.portProbeDetails
       target_field: aws.guardduty.service.action.port_probe_action.port_probe_details
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_rdsLoginAttemptAction_remoteIpDetails_city_cityName_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_city_name_e2b5f27e
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.city.cityName
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.city.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_rdsLoginAttemptAction_remoteIpDetails_country_countryCode_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_country_code_812d6635
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.country.countryCode
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.country.code
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_rdsLoginAttemptAction_remoteIpDetails_country_countryName_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_country_name_8a0b98b5
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.country.countryName
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.country.name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_rdsLoginAttemptAction_remoteIpDetails_geoLocation_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_geo_location_fdfcd67a
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.geoLocation
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.geo_location
       ignore_missing: true
   - convert:
+      tag: convert_json_service_action_rdsLoginAttemptAction_remoteIpDetails_ipAddressV4_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_ip_address_v4_dafb99f0
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.ipAddressV4
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.ip_address_v4
       type: ip
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ed666b3b
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_related_ip_8042b884
       field: related.ip
       value: '{{{aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.rds_login_attempt_action?.remote_ip_details?.ip_address_v4 != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_service_action_rdsLoginAttemptAction_remoteIpDetails_organization_asn_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_organization_asn_0f444543
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.organization.asn
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.organization.asn
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_rdsLoginAttemptAction_remoteIpDetails_organization_asnOrg_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_organization_asnorg_1fa94d1b
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.organization.asnOrg
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.organization.asnorg
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_rdsLoginAttemptAction_remoteIpDetails_organization_isp_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_organization_isp_04360b93
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.organization.isp
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.organization.isp
       ignore_missing: true
   - rename:
+      tag: rename_json_service_action_rdsLoginAttemptAction_remoteIpDetails_organization_org_to_aws_guardduty_service_action_rds_login_attempt_action_remote_ip_details_organization_org_04ea26a7
       field: json.service.action.rdsLoginAttemptAction.remoteIpDetails.organization.org
       target_field: aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.organization.org
       ignore_missing: true
   - rename:
+      tag: rename_json_service_additionalInfo_to_aws_guardduty_service_additional_info_ddc63025
       field: json.service.additionalInfo
       target_field: aws.guardduty.service.additional_info
       ignore_missing: true
   - convert:
+      tag: convert_json_service_archived_to_aws_guardduty_service_archived_9ca029b0
       field: json.service.archived
       target_field: aws.guardduty.service.archived
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_20a408cf
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_service_count_to_aws_guardduty_service_count_4efaa3c8
       field: json.service.count
       target_field: aws.guardduty.service.count
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_467c2175
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_detectorId_to_aws_guardduty_service_detector_id_132e494f
       field: json.service.detectorId
       target_field: aws.guardduty.service.detector_id
       ignore_missing: true
   - date:
+      tag: date_json_service_ebsVolumeScanDetails_scanCompletedAt_to_aws_guardduty_service_ebs_volume_scan_details_scan_completed_at_2625c888
       field: json.service.ebsVolumeScanDetails.scanCompletedAt
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.completed_at
       formats:
@@ -1599,71 +1876,87 @@ processors:
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanCompletedAt != null
       on_failure:
         - append:
+            tag: append_error_message_a58791a9
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_service_ebsVolumeScanDetails_scanDetections_highestSeverityThreatDetails_count_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_highest_severity_threat_details_count_95ce94a2
       field: json.service.ebsVolumeScanDetails.scanDetections.highestSeverityThreatDetails.count
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.highest_severity_threat_details.count
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0e5852d1
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_ebsVolumeScanDetails_scanDetections_highestSeverityThreatDetails_severity_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_highest_severity_threat_details_severity_2c4068ae
       field: json.service.ebsVolumeScanDetails.scanDetections.highestSeverityThreatDetails.severity
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.highest_severity_threat_details.severity
       ignore_missing: true
   - rename:
+      tag: rename_json_service_ebsVolumeScanDetails_scanDetections_highestSeverityThreatDetails_threatName_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_highest_severity_threat_details_threat_name_49c7a17f
       field: json.service.ebsVolumeScanDetails.scanDetections.highestSeverityThreatDetails.threatName
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.highest_severity_threat_details.threat_name
       ignore_missing: true
   - convert:
+      tag: convert_json_service_ebsVolumeScanDetails_scanDetections_scannedItemCount_files_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_scanned_item_count_files_f1a18931
       field: json.service.ebsVolumeScanDetails.scanDetections.scannedItemCount.files
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.scanned_item_count.files
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_36f96d3c
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_service_ebsVolumeScanDetails_scanDetections_scannedItemCount_totalGb_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_scanned_item_count_total_gb_1d9cf176
       field: json.service.ebsVolumeScanDetails.scanDetections.scannedItemCount.totalGb
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.scanned_item_count.total_gb
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5d328329
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_service_ebsVolumeScanDetails_scanDetections_scannedItemCount_volumes_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_scanned_item_count_volumes_7ac12249
       field: json.service.ebsVolumeScanDetails.scanDetections.scannedItemCount.volumes
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.scanned_item_count.volumes
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9a520dc8
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_itemCount_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threat_detected_by_name_item_count_9a021199
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.itemCount
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threat_detected_by_name.item_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_48a02ee8
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_shortened_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threat_detected_by_name_shortened_15f0e16c
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.shortened
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threat_detected_by_name.shortened
       type: boolean
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bfdd26e1
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_threatNames_3772409d
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanDetections?.threatDetectedByName?.threatNames instanceof List
       processor:
@@ -1676,6 +1969,7 @@ processors:
               target_field: _ingest._value.file.name
               ignore_missing: true
   - foreach:
+      tag: foreach_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_threatNames_3bc6d5f5
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanDetections?.threatDetectedByName?.threatNames instanceof List
       processor:
@@ -1688,6 +1982,7 @@ processors:
               target_field: _ingest._value.file.path
               ignore_missing: true
   - foreach:
+      tag: foreach_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_threatNames_07304072
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanDetections?.threatDetectedByName?.threatNames instanceof List
       processor:
@@ -1700,6 +1995,7 @@ processors:
               value: '{{{_ingest._value.hash}}}'
               allow_duplicates: false
   - foreach:
+      tag: foreach_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_threatNames_48a50560
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanDetections?.threatDetectedByName?.threatNames instanceof List
       processor:
@@ -1712,6 +2008,7 @@ processors:
               target_field: _ingest._value.volume_arn
               ignore_missing: true
   - foreach:
+      tag: foreach_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_threatNames_85182200
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanDetections?.threatDetectedByName?.threatNames instanceof List
       processor:
@@ -1720,6 +2017,7 @@ processors:
           target_field: _ingest._value.file_paths
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_threatNames_ea510234
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanDetections?.threatDetectedByName?.threatNames instanceof List
       processor:
@@ -1733,6 +2031,7 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_threatNames_0d84732a
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanDetections?.threatDetectedByName?.threatNames instanceof List
       processor:
@@ -1741,32 +2040,39 @@ processors:
             - _ingest._value.itemCount
           ignore_missing: true
   - rename:
+      tag: rename_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_threatNames_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threat_detected_by_name_threat_names_321f74d3
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threat_detected_by_name.threat_names
       ignore_missing: true
   - convert:
+      tag: convert_json_service_ebsVolumeScanDetails_scanDetections_threatDetectedByName_uniqueThreatNameCount_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threat_detected_by_name_unique_threat_name_count_3e98a3cf
       field: json.service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.uniqueThreatNameCount
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threat_detected_by_name.unique_threat_name_count
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_072d106a
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_service_ebsVolumeScanDetails_scanDetections_threatsDetectedItemCount_files_to_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threats_detected_item_count_files_b421743e
       field: json.service.ebsVolumeScanDetails.scanDetections.threatsDetectedItemCount.files
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threats_detected_item_count.files
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ab0c2999
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_ebsVolumeScanDetails_scanId_to_aws_guardduty_service_ebs_volume_scan_details_scan_id_53329e8f
       field: json.service.ebsVolumeScanDetails.scanId
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.id
       ignore_missing: true
   - date:
+      tag: date_json_service_ebsVolumeScanDetails_scanStartedAt_to_aws_guardduty_service_ebs_volume_scan_details_scan_started_at_40194f94
       field: json.service.ebsVolumeScanDetails.scanStartedAt
       target_field: aws.guardduty.service.ebs_volume_scan_details.scan.started_at
       formats:
@@ -1776,17 +2082,21 @@ processors:
       if: ctx.json?.service?.ebsVolumeScanDetails?.scanStartedAt != null
       on_failure:
         - append:
+            tag: append_error_message_df48f295
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_ebsVolumeScanDetails_sources_to_aws_guardduty_service_ebs_volume_scan_details_sources_3be7de1d
       field: json.service.ebsVolumeScanDetails.sources
       target_field: aws.guardduty.service.ebs_volume_scan_details.sources
       ignore_missing: true
   - rename:
+      tag: rename_json_service_ebsVolumeScanDetails_triggerFindingId_to_aws_guardduty_service_ebs_volume_scan_details_trigger_finding_id_53d851bf
       field: json.service.ebsVolumeScanDetails.triggerFindingId
       target_field: aws.guardduty.service.ebs_volume_scan_details.trigger_finding_id
       ignore_missing: true
   - date:
+      tag: date_json_service_eventFirstSeen_to_aws_guardduty_service_event_first_seen_97f7a6e3
       field: json.service.eventFirstSeen
       target_field: aws.guardduty.service.event.first_seen
       formats:
@@ -1796,9 +2106,11 @@ processors:
       if: ctx.json?.service?.eventFirstSeen != null
       on_failure:
         - append:
+            tag: append_error_message_5c3d39c2
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_service_eventLastSeen_to_aws_guardduty_service_event_last_seen_b0600769
       field: json.service.eventLastSeen
       target_field: aws.guardduty.service.event.last_seen
       formats:
@@ -1808,9 +2120,11 @@ processors:
       if: ctx.json?.service?.eventLastSeen != null
       on_failure:
         - append:
+            tag: append_error_message_af8911fa
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_service_evidence_threatIntelligenceDetails_d00b13fc
       field: json.service.evidence.threatIntelligenceDetails
       if: ctx.json?.service?.evidence?.threatIntelligenceDetails instanceof List
       processor:
@@ -1819,6 +2133,7 @@ processors:
           target_field: _ingest._value.threat.list_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_service_evidence_threatIntelligenceDetails_4ee0ec43
       field: json.service.evidence.threatIntelligenceDetails
       if: ctx.json?.service?.evidence?.threatIntelligenceDetails instanceof List
       processor:
@@ -1827,55 +2142,68 @@ processors:
           target_field: _ingest._value.threat.names
           ignore_missing: true
   - rename:
+      tag: rename_json_service_evidence_threatIntelligenceDetails_to_aws_guardduty_service_evidence_threat_intelligence_details_aa63dd1a
       field: json.service.evidence.threatIntelligenceDetails
       target_field: aws.guardduty.service.evidence.threat_intelligence_details
       ignore_missing: true
   - rename:
+      tag: rename_json_service_featureName_to_aws_guardduty_service_feature_name_7a2fb81d
       field: json.service.featureName
       target_field: aws.guardduty.service.feature_name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_resourceRole_to_aws_guardduty_service_resource_role_43be9c19
       field: json.service.resourceRole
       target_field: aws.guardduty.service.resource_role
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_addressFamily_to_aws_guardduty_service_runtime_details_context_address_family_388bd440
       field: json.service.runtimeDetails.context.addressFamily
       target_field: aws.guardduty.service.runtime_details.context.address_family
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_commandLineExample_to_aws_guardduty_service_runtime_details_context_command_line_example_93fdd483
       field: json.service.runtimeDetails.context.commandLineExample
       target_field: aws.guardduty.service.runtime_details.context.command_line_example
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_fileSystemType_to_aws_guardduty_service_runtime_details_context_file_system_type_518febe9
       field: json.service.runtimeDetails.context.fileSystemType
       target_field: aws.guardduty.service.runtime_details.context.file_system_type
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_flags_to_aws_guardduty_service_runtime_details_context_flags_552b1d9b
       field: json.service.runtimeDetails.context.flags
       target_field: aws.guardduty.service.runtime_details.context.flags
       ignore_missing: true
   - convert:
+      tag: convert_json_service_runtimeDetails_context_ianaProtocolNumber_to_aws_guardduty_service_runtime_details_context_iana_protocol_number_d6e2598a
       field: json.service.runtimeDetails.context.ianaProtocolNumber
       target_field: aws.guardduty.service.runtime_details.context.iana_protocol_number
       type: string
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3521c525
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_runtimeDetails_context_ldPreloadValue_to_aws_guardduty_service_runtime_details_context_ld_preload_e344a9d5
       field: json.service.runtimeDetails.context.ldPreloadValue
       target_field: aws.guardduty.service.runtime_details.context.ld_preload
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_libraryPath_to_aws_guardduty_service_runtime_details_context_library_path_5a63410a
       field: json.service.runtimeDetails.context.libraryPath
       target_field: aws.guardduty.service.runtime_details.context.library_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_memoryRegions_to_aws_guardduty_service_runtime_details_context_memory_regions_3ce00fd0
       field: json.service.runtimeDetails.context.memoryRegions
       target_field: aws.guardduty.service.runtime_details.context.memory_regions
       ignore_missing: true
   - date:
+      tag: date_json_service_runtimeDetails_context_modifiedAt_to_aws_guardduty_service_runtime_details_context_modified_at_d093de10
       field: json.service.runtimeDetails.context.modifiedAt
       target_field: aws.guardduty.service.runtime_details.context.modified_at
       formats:
@@ -1885,134 +2213,166 @@ processors:
       if: ctx.json?.service?.runtimeDetails?.context?.modifiedAt != null
       on_failure:
         - append:
+            tag: append_error_message_998425db
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_runtimeDetails_context_modifyingProcess_to_aws_guardduty_service_runtime_details_context_modifying_process_3285ae48
       field: json.service.runtimeDetails.context.modifyingProcess
       target_field: aws.guardduty.service.runtime_details.context.modifying_process
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_moduleFilePath_to_aws_guardduty_service_runtime_details_context_module_file_path_5e27d8fb
       field: json.service.runtimeDetails.context.moduleFilePath
       target_field: aws.guardduty.service.runtime_details.context.module_file_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_moduleName_to_aws_guardduty_service_runtime_details_context_module_name_2378912a
       field: json.service.runtimeDetails.context.moduleName
       target_field: aws.guardduty.service.runtime_details.context.module_name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_moduleSha256_to_aws_guardduty_service_runtime_details_context_module_sha256_0ff38552
       field: json.service.runtimeDetails.context.moduleSha256
       target_field: aws.guardduty.service.runtime_details.context.module_sha256
       ignore_missing: true
   - append:
+      tag: append_related_hash_f4be7daa
       field: related.hash
       value: '{{{aws.guardduty.service.runtime_details.context.module_sha256}}}'
       if: ctx.aws?.guardduty?.service?.runtime_details?.context?.module_sha256 != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_service_runtimeDetails_context_mountSource_to_aws_guardduty_service_runtime_details_context_mount_source_1cd7467a
       field: json.service.runtimeDetails.context.mountSource
       target_field: aws.guardduty.service.runtime_details.context.mount_source
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_mountTarget_to_aws_guardduty_service_runtime_details_context_mount_target_779b5cfe
       field: json.service.runtimeDetails.context.mountTarget
       target_field: aws.guardduty.service.runtime_details.context.mount_target
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_releaseAgentPath_to_aws_guardduty_service_runtime_details_context_release_agent_path_a74a8383
       field: json.service.runtimeDetails.context.releaseAgentPath
       target_field: aws.guardduty.service.runtime_details.context.release_agent_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_runcBinaryPath_to_aws_guardduty_service_runtime_details_context_runc_binary_path_65abb079
       field: json.service.runtimeDetails.context.runcBinaryPath
       target_field: aws.guardduty.service.runtime_details.context.runc_binary_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_scriptPath_to_aws_guardduty_service_runtime_details_context_script_path_3a8f0c4e
       field: json.service.runtimeDetails.context.scriptPath
       target_field: aws.guardduty.service.runtime_details.context.script_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_serviceName_to_aws_guardduty_service_runtime_details_context_service_name_fb2d1e36
       field: json.service.runtimeDetails.context.serviceName
       target_field: aws.guardduty.service.runtime_details.context.service_name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_shellHistoryFilePath_to_aws_guardduty_service_runtime_details_context_shell_history_file_path_8f0e96c2
       field: json.service.runtimeDetails.context.shellHistoryFilePath
       target_field: aws.guardduty.service.runtime_details.context.shell_history_file_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_socketPath_to_aws_guardduty_service_runtime_details_context_socket_path_f181f3f2
       field: json.service.runtimeDetails.context.socketPath
       target_field: aws.guardduty.service.runtime_details.context.socket_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_targetProcess_to_aws_guardduty_service_runtime_details_context_target_process_888281a4
       field: json.service.runtimeDetails.context.targetProcess
       target_field: aws.guardduty.service.runtime_details.context.target_process
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_threatFilePath_to_aws_guardduty_service_runtime_details_context_threat_file_path_9b4e1327
       field: json.service.runtimeDetails.context.threatFilePath
       target_field: aws.guardduty.service.runtime_details.context.threat_file_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_toolCategory_to_aws_guardduty_service_runtime_details_context_tool_category_4f0eba40
       field: json.service.runtimeDetails.context.toolCategory
       target_field: aws.guardduty.service.runtime_details.context.tool_category
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_context_toolName_to_aws_guardduty_service_runtime_details_context_tool_name_9e36525e
       field: json.service.runtimeDetails.context.toolName
       target_field: aws.guardduty.service.runtime_details.context.tool_name
       ignore_missing: true
   - convert:
+      tag: convert_json_service_runtimeDetails_process_euid_to_aws_guardduty_service_runtime_details_process_euid_3a9e2743
       field: json.service.runtimeDetails.process.euid
       target_field: aws.guardduty.service.runtime_details.process.euid
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9daf9e48
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_runtimeDetails_process_executablePath_to_aws_guardduty_service_runtime_details_process_executable_path_19522772
       field: json.service.runtimeDetails.process.executablePath
       target_field: aws.guardduty.service.runtime_details.process.executable_path
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_process_executableSha256_to_aws_guardduty_service_runtime_details_process_executable_sha256_f260ed42
       field: json.service.runtimeDetails.process.executableSha256
       target_field: aws.guardduty.service.runtime_details.process.executable_sha256
       ignore_missing: true
   - append:
+      tag: append_related_hash_2bfd4a92
       field: related.hash
       value: '{{{aws.guardduty.service.runtime_details.process.executable_sha256}}}'
       if: ctx.aws?.guardduty?.service?.runtime_details?.process?.executable_sha256 != null
       allow_duplicates: false
   - rename:
+      tag: rename_json_service_runtimeDetails_process_lineage_to_aws_guardduty_service_runtime_details_process_lineage_0d8b5337
       field: json.service.runtimeDetails.process.lineage
       target_field: aws.guardduty.service.runtime_details.process.lineage
       ignore_missing: true
   - rename:
+      tag: rename_json_service_runtimeDetails_process_name_to_aws_guardduty_service_runtime_details_process_name_65edaf75
       field: json.service.runtimeDetails.process.name
       target_field: aws.guardduty.service.runtime_details.process.name
       ignore_missing: true
   - convert:
+      tag: convert_json_service_runtimeDetails_process_namespacePid_to_aws_guardduty_service_runtime_details_process_namespace_pid_9077017c
       field: json.service.runtimeDetails.process.namespacePid
       target_field: aws.guardduty.service.runtime_details.process.namespace_pid
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_241df5e5
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_runtimeDetails_process_parentUuid_to_aws_guardduty_service_runtime_details_process_parent_uuid_673e2f5a
       field: json.service.runtimeDetails.process.parentUuid
       target_field: aws.guardduty.service.runtime_details.process.parent_uuid
       ignore_missing: true
   - convert:
+      tag: convert_json_service_runtimeDetails_process_pid_to_aws_guardduty_service_runtime_details_process_pid_3825c7e3
       field: json.service.runtimeDetails.process.pid
       target_field: aws.guardduty.service.runtime_details.process.pid
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b15faf80
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_runtimeDetails_process_pwd_to_aws_guardduty_service_runtime_details_process_pwd_5a23d56b
       field: json.service.runtimeDetails.process.pwd
       target_field: aws.guardduty.service.runtime_details.process.pwd
       ignore_missing: true
   - date:
+      tag: date_json_service_runtimeDetails_process_startTime_to_aws_guardduty_service_runtime_details_process_start_time_6b8d1c9f
       field: json.service.runtimeDetails.process.startTime
       target_field: aws.guardduty.service.runtime_details.process.start_time
       formats:
@@ -2022,63 +2382,78 @@ processors:
       if: ctx.json?.service?.runtimeDetails?.process?.startTime != null
       on_failure:
         - append:
+            tag: append_error_message_ae6e4f36
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_runtimeDetails_process_user_to_aws_guardduty_service_runtime_details_process_user_b3796891
       field: json.service.runtimeDetails.process.user
       target_field: aws.guardduty.service.runtime_details.process.user
       ignore_missing: true
   - convert:
+      tag: convert_json_service_runtimeDetails_process_userId_to_aws_guardduty_service_runtime_details_process_user_id_3b9bf15a
       field: json.service.runtimeDetails.process.userId
       target_field: aws.guardduty.service.runtime_details.process.user_id
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_01f9c007
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_service_runtimeDetails_process_uuid_to_aws_guardduty_service_runtime_details_process_uuid_f33aa639
       field: json.service.runtimeDetails.process.uuid
       target_field: aws.guardduty.service.runtime_details.process.uuid
       ignore_missing: true
   - rename:
+      tag: rename_json_service_serviceName_to_aws_guardduty_service_service_name_189ac26b
       field: json.service.serviceName
       target_field: aws.guardduty.service.service_name
       ignore_missing: true
   - rename:
+      tag: rename_json_service_userFeedback_to_aws_guardduty_service_user_feedback_c92c9b4f
       field: json.service.userFeedback
       target_field: aws.guardduty.service.user_feedback
       ignore_missing: true
   - convert:
+      tag: convert_json_severity_to_aws_guardduty_severity_code_7415835e
       field: json.severity
       target_field: aws.guardduty.severity.code
       type: double
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f2f35039
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_aws_guardduty_severity_value_108812a6
       field: aws.guardduty.severity.value
       value: 'High'
       if: ctx.aws?.guardduty?.severity?.code != null && ctx.aws.guardduty.severity.code <= 8.9 && ctx.aws.guardduty.severity.code >= 7.0
   - set:
+      tag: set_aws_guardduty_severity_value_11f328d4
       field: aws.guardduty.severity.value
       value: 'Medium'
       if: ctx.aws?.guardduty?.severity?.code != null && ctx.aws.guardduty.severity.code <= 6.9 && ctx.aws.guardduty.severity.code >= 4.0
   - set:
+      tag: set_aws_guardduty_severity_value_dd25e583
       field: aws.guardduty.severity.value
       value: 'Low'
       if: ctx.aws?.guardduty?.severity?.code != null && ctx.aws.guardduty.severity.code <= 3.9 && ctx.aws.guardduty.severity.code >= 1.0
   - rename:
+      tag: rename_json_title_to_aws_guardduty_title_9a6db728
       field: json.title
       target_field: aws.guardduty.title
       ignore_missing: true
   - rename:
+      tag: rename_json_type_to_aws_guardduty_type_a59c2c4e
       field: json.type
       target_field: aws.guardduty.type
       ignore_missing: true
   - date:
+      tag: date_json_updatedAt_to_aws_guardduty_updated_at_709b31c4
       field: json.updatedAt
       target_field: aws.guardduty.updated_at
       formats:
@@ -2088,33 +2463,41 @@ processors:
       if: ctx.json?.updatedAt != null
       on_failure:
         - append:
+            tag: append_error_message_9be5e133
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_timestamp_2196b16e
       field: '@timestamp'
       copy_from: aws.guardduty.updated_at
       ignore_empty_value: true
   - set:
+      tag: set_message_461bddf4
       field: message
       copy_from: aws.guardduty.description
       ignore_empty_value: true
   - set:
+      tag: set_cloud_account_id_327da7f3
       field: cloud.account.id
       copy_from: aws.guardduty.account_id
       ignore_empty_value: true
   - set:
+      tag: set_cloud_provider_8c031903
       field: cloud.provider
       copy_from: aws.guardduty.partition
       ignore_empty_value: true
   - set:
+      tag: set_cloud_region_89761e40
       field: cloud.region
       copy_from: aws.guardduty.region
       ignore_empty_value: true
   - set:
+      tag: set_cloud_service_name_cff50960
       field: cloud.service.name
       copy_from: aws.guardduty.service.service_name
       ignore_empty_value: true
   - foreach:
+      tag: foreach_aws_guardduty_resource_ecs_cluster_details_task_details_containers_40593a54
       field: aws.guardduty.resource.ecs_cluster_details.task_details.containers
       if: ctx.aws?.guardduty?.resource?.ecs_cluster_details?.task_details?.containers instanceof List
       processor:
@@ -2123,6 +2506,7 @@ processors:
           value: '{{{_ingest._value.id}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_resource_ecs_cluster_details_task_details_containers_5e27d44c
       field: aws.guardduty.resource.ecs_cluster_details.task_details.containers
       if: ctx.aws?.guardduty?.resource?.ecs_cluster_details?.task_details?.containers instanceof List
       processor:
@@ -2131,6 +2515,7 @@ processors:
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_resource_ecs_cluster_details_task_details_containers_887004a8
       field: aws.guardduty.resource.ecs_cluster_details.task_details.containers
       if: ctx.aws?.guardduty?.resource?.ecs_cluster_details?.task_details?.containers instanceof List
       processor:
@@ -2139,36 +2524,43 @@ processors:
           value: '{{{_ingest._value.container_runtime}}}'
           allow_duplicates: false
   - append:
+      tag: append_source_address_025090e5
       field: source.address
       value: '{{{aws.guardduty.service.action.aws_api_call_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.aws_api_call_action?.remote_ip_details?.ip_address_v4 != null
       allow_duplicates: false
   - append:
+      tag: append_source_address_bd4993bb
       field: source.address
       value: '{{{aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.kubernetes_api_call_action?.remote_ip_details?.ip_address_v4 != null
       allow_duplicates: false
   - append:
+      tag: append_source_address_5e1ffad0
       field: source.address
       value: '{{{aws.guardduty.service.action.network_connection_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.connection_direction != null && ctx.aws.guardduty.service.action.network_connection_action.connection_direction.toLowerCase() == 'inbound'
       allow_duplicates: false
   - append:
+      tag: append_destination_address_0316b508
       field: destination.address
       value: '{{{aws.guardduty.service.action.network_connection_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.connection_direction != null && ctx.aws.guardduty.service.action.network_connection_action.connection_direction.toLowerCase() == 'outbound'
       allow_duplicates: false
   - append:
+      tag: append_source_address_28747f58
       field: source.address
       value: '{{{aws.guardduty.service.action.network_connection_action.local_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.connection_direction != null && ctx.aws.guardduty.service.action.network_connection_action.connection_direction.toLowerCase() == 'outbound'
       allow_duplicates: false
   - append:
+      tag: append_destination_address_80e3defa
       field: destination.address
       value: '{{{aws.guardduty.service.action.network_connection_action.local_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.connection_direction != null && ctx.aws.guardduty.service.action.network_connection_action.connection_direction.toLowerCase() == 'inbound'
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_5f1eae10
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List
       processor:
@@ -2177,26 +2569,31 @@ processors:
           value: '{{{_ingest._value.remote_ip_details.ip_address_v4}}}'
           allow_duplicates: false
   - append:
+      tag: append_source_address_790e0815
       field: source.address
       value: '{{{aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.ip_address_v4}}}'
       if: ctx.aws?.guardduty?.service?.action?.rds_login_attempt_action?.remote_ip_details?.ip_address_v4 != null
       allow_duplicates: false
   - append:
+      tag: append_source_as_number_96d6d5d7
       field: source.as.number
       value: '{{{aws.guardduty.service.action.aws_api_call_action.remote_ip_details.organization.asn}}}'
       if: ctx.aws?.guardduty?.service?.action?.aws_api_call_action?.remote_ip_details?.organization?.asn != null
       allow_duplicates: false
   - append:
+      tag: append_source_as_number_ac60164f
       field: source.as.number
       value: '{{{aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.organization.asn}}}'
       if: ctx.aws?.guardduty?.service?.action?.kubernetes_api_call_action?.remote_ip_details?.organization?.asn != null
       allow_duplicates: false
   - append:
+      tag: append_source_as_number_97a08d47
       field: source.as.number
       value: '{{{aws.guardduty.service.action.network_connection_action.remote_ip_details.organization.asn}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.remote_ip_details?.organization?.asn != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_ddf0d8ab
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List
       processor:
@@ -2205,11 +2602,13 @@ processors:
           value: '{{{_ingest._value.remote_ip_details.organization.asn}}}'
           allow_duplicates: false
   - append:
+      tag: append_source_as_number_b5763e89
       field: source.as.number
       value: '{{{aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.organization.asn}}}'
       if: ctx.aws?.guardduty?.service?.action?.rds_login_attempt_action?.remote_ip_details?.organization?.asn != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_source_as_number_96d7c560
       field: source.as.number
       if: ctx.source?.as?.number instanceof List
       processor:
@@ -2224,21 +2623,25 @@ processors:
                 field: error.message
                 value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_source_as_organization_name_4d453676
       field: source.as.organization.name
       value: '{{{aws.guardduty.service.action.aws_api_call_action.remote_ip_details.organization.asnorg}}}'
       if: ctx.aws?.guardduty?.service?.action?.aws_api_call_action?.remote_ip_details?.organization?.asnorg != null
       allow_duplicates: false
   - append:
+      tag: append_source_as_organization_name_86e68d10
       field: source.as.organization.name
       value: '{{{aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.organization.asnorg}}}'
       if: ctx.aws?.guardduty?.service?.action?.kubernetes_api_call_action?.remote_ip_details?.organization?.asnorg != null
       allow_duplicates: false
   - append:
+      tag: append_source_as_organization_name_ba18f49e
       field: source.as.organization.name
       value: '{{{aws.guardduty.service.action.network_connection_action.remote_ip_details.organization.asnorg}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.remote_ip_details?.organization?.asnorg != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_6892028c
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List
       processor:
@@ -2247,26 +2650,31 @@ processors:
           value: '{{{_ingest._value.remote_ip_details.organization.asnorg}}}'
           allow_duplicates: false
   - append:
+      tag: append_source_as_organization_name_e4ad1e2c
       field: source.as.organization.name
       value: '{{{aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.organization.asnorg}}}'
       if: ctx.aws?.guardduty?.service?.action?.rds_login_attempt_action?.remote_ip_details?.organization?.asnorg != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_city_name_2b23026a
       field: source.geo.city_name
       value: '{{{aws.guardduty.service.action.aws_api_call_action.remote_ip_details.city.name}}}'
       if: ctx.aws?.guardduty?.service?.action?.aws_api_call_action?.remote_ip_details?.city?.name != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_city_name_827b7062
       field: source.geo.city_name
       value: '{{{aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.city.name}}}'
       if: ctx.aws?.guardduty?.service?.action?.kubernetes_api_call_action?.remote_ip_details?.city?.name != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_city_name_b2dec98a
       field: source.geo.city_name
       value: '{{{aws.guardduty.service.action.network_connection_action.remote_ip_details.city.name}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.remote_ip_details?.city?.name != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_48e84c15
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List
       processor:
@@ -2275,26 +2683,31 @@ processors:
           value: '{{{_ingest._value.remote_ip_details.city.name}}}'
           allow_duplicates: false
   - append:
+      tag: append_source_geo_city_name_848e8e7e
       field: source.geo.city_name
       value: '{{{aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.city.name}}}'
       if: ctx.aws?.guardduty?.service?.action?.rds_login_attempt_action?.remote_ip_details?.city?.name != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_country_iso_code_c3acfe0f
       field: source.geo.country_iso_code
       value: '{{{aws.guardduty.service.action.aws_api_call_action.remote_ip_details.country.code}}}'
       if: ctx.aws?.guardduty?.service?.action?.aws_api_call_action?.remote_ip_details?.country?.code != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_country_iso_code_ecfe925b
       field: source.geo.country_iso_code
       value: '{{{aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.country.code}}}'
       if: ctx.aws?.guardduty?.service?.action?.kubernetes_api_call_action?.remote_ip_details?.country?.code != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_country_iso_code_800ae6a7
       field: source.geo.country_iso_code
       value: '{{{aws.guardduty.service.action.network_connection_action.remote_ip_details.country.code}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.remote_ip_details?.country?.code != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_7eb36abb
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List
       processor:
@@ -2303,26 +2716,31 @@ processors:
           value: '{{{_ingest._value.remote_ip_details.country.code}}}'
           allow_duplicates: false
   - append:
+      tag: append_source_geo_country_iso_code_1912a90d
       field: source.geo.country_iso_code
       value: '{{{aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.country.code}}}'
       if: ctx.aws?.guardduty?.service?.action?.rds_login_attempt_action?.remote_ip_details?.country?.code != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_country_name_8596277b
       field: source.geo.country_name
       value: '{{{aws.guardduty.service.action.aws_api_call_action.remote_ip_details.country.name}}}'
       if: ctx.aws?.guardduty?.service?.action?.aws_api_call_action?.remote_ip_details?.country?.name != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_country_name_14f13f7f
       field: source.geo.country_name
       value: '{{{aws.guardduty.service.action.kubernetes_api_call_action.remote_ip_details.country.name}}}'
       if: ctx.aws?.guardduty?.service?.action?.kubernetes_api_call_action?.remote_ip_details?.country?.name != null
       allow_duplicates: false
   - append:
+      tag: append_source_geo_country_name_0b43562b
       field: source.geo.country_name
       value: '{{{aws.guardduty.service.action.network_connection_action.remote_ip_details.country.name}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.remote_ip_details?.country?.name != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_9f9fc7ed
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List
       processor:
@@ -2331,11 +2749,13 @@ processors:
           value: '{{{_ingest._value.remote_ip_details.country.name}}}'
           allow_duplicates: false
   - append:
+      tag: append_source_geo_country_name_e0b02655
       field: source.geo.country_name
       value: '{{{aws.guardduty.service.action.rds_login_attempt_action.remote_ip_details.country.name}}}'
       if: ctx.aws?.guardduty?.service?.action?.rds_login_attempt_action?.remote_ip_details?.country?.name != null
       allow_duplicates: false
   - script:
+      tag: script_1fe93b8c
       description: Map source.geo.location field.
       lang: painless
       source: |
@@ -2365,43 +2785,53 @@ processors:
         }
         ctx.source.geo.location = locationList;
   - set:
+      tag: set_dns_question_name_e9d10d46
       field: dns.question.name
       copy_from: aws.guardduty.service.action.dns_request_action.domain
       ignore_empty_value: true
   - set:
+      tag: set_event_action_dea792c8
       field: event.action
       copy_from: aws.guardduty.service.action.type
       ignore_empty_value: true
   - set:
+      tag: set_event_created_f1a03683
       field: event.created
       copy_from: aws.guardduty.created_at
       ignore_empty_value: true
   - set:
+      tag: set_event_end_97d8df89
       field: event.end
       copy_from: aws.guardduty.service.event.last_seen
       ignore_empty_value: true
   - set:
+      tag: set_event_id_48c61827
       field: event.id
       copy_from: aws.guardduty.id
       ignore_empty_value: true
   - set:
+      tag: set_event_provider_11f60cee
       field: event.provider
       copy_from: aws.guardduty.service.action.aws_api_call_action.service_name
       ignore_empty_value: true
   - convert:
+      tag: convert_json_severity_to_event_severity_649b84d8
       field: json.severity
       target_field: event.severity
       type: long
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_373c1d2d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_event_start_bae70594
       field: event.start
       copy_from: aws.guardduty.service.event.first_seen
       ignore_empty_value: true
   - foreach:
+      tag: foreach_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threat_detected_by_name_threat_names_572ecb13
       field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threat_detected_by_name.threat_names
       if: ctx.aws?.guardduty?.service?.ebs_volume_scan_details?.scan?.detections?.threat_detected_by_name?.threat_names instanceof List
       processor:
@@ -2414,6 +2844,7 @@ processors:
               value: '{{{_ingest._value.hash}}}'
               allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threat_detected_by_name_threat_names_f6934dbe
       field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threat_detected_by_name.threat_names
       if: ctx.aws?.guardduty?.service?.ebs_volume_scan_details?.scan?.detections?.threat_detected_by_name?.threat_names instanceof List
       processor:
@@ -2426,6 +2857,7 @@ processors:
               value: '{{{_ingest._value.file.name}}}'
               allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threat_detected_by_name_threat_names_7f9a8a32
       field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threat_detected_by_name.threat_names
       if: ctx.aws?.guardduty?.service?.ebs_volume_scan_details?.scan?.detections?.threat_detected_by_name?.threat_names instanceof List
       processor:
@@ -2438,83 +2870,103 @@ processors:
               value: '{{{_ingest._value.file.path}}}'
               allow_duplicates: false
   - set:
+      tag: set_cloud_instance_id_cb773dbc
       field: cloud.instance.id
       copy_from: aws.guardduty.resource.instance_details.instance.id
       ignore_empty_value: true
   - set:
+      tag: set_host_id_c1e92b0c
       field: host.id
       copy_from: aws.guardduty.resource.instance_details.instance.id
       ignore_empty_value: true
   - set:
+      tag: set_host_os_platform_224c633b
       field: host.os.platform
       copy_from: aws.guardduty.resource.instance_details.platform
       ignore_empty_value: true
   - set:
+      tag: set_cloud_machine_type_50c01a28
       field: cloud.machine.type
       copy_from: aws.guardduty.resource.instance_details.instance.type
       ignore_empty_value: true
   - set:
+      tag: set_host_type_c3ce41b4
       field: host.type
       copy_from: aws.guardduty.resource.instance_details.instance.type
       ignore_empty_value: true
   - set:
+      tag: set_network_iana_number_a07c9085
       field: network.iana_number
       copy_from: aws.guardduty.service.runtime_details.context.iana_protocol_number
       ignore_empty_value: true
   - lowercase:
+      tag: lowercase_aws_guardduty_service_action_network_connection_action_connection_direction_to_network_direction_d48d3d83
       field: aws.guardduty.service.action.network_connection_action.connection_direction
       target_field: network.direction
       ignore_missing: true
   - append:
+      tag: append_network_transport_fe6a323e
       field: network.transport
       value: '{{{aws.guardduty.service.action.network_connection_action.transport}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.transport != null
       allow_duplicates: false
   - append:
+      tag: append_network_transport_bce3262c
       field: network.transport
       value: '{{{aws.guardduty.service.action.dns_request_action.protocol}}}'
       if: ctx.aws?.guardduty?.service?.action?.dns_request_action?.protocol != null
       allow_duplicates: false
   - lowercase:
+      tag: lowercase_network_transport_bc8c1c12
       field: network.transport
       ignore_missing: true
   - set:
+      tag: set_orchestrator_namespace_85ce9dac
       field: orchestrator.namespace
       copy_from: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.name_space
       ignore_empty_value: true
   - set:
+      tag: set_orchestrator_resource_name_c5589ee7
       field: orchestrator.resource.name
       copy_from: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.name
       ignore_empty_value: true
   - set:
+      tag: set_orchestrator_resource_type_8be5e5a9
       field: orchestrator.resource.type
       copy_from: aws.guardduty.resource.kubernetes_details.kubernetes_workload_details.type
       ignore_empty_value: true
   - set:
+      tag: set_process_executable_9a11707d
       field: process.executable
       copy_from: aws.guardduty.service.runtime_details.process.executable_path
       ignore_empty_value: true
   - set:
+      tag: set_process_name_69372935
       field: process.name
       copy_from: aws.guardduty.service.runtime_details.process.name
       ignore_empty_value: true
   - set:
+      tag: set_process_pid_fa8723e9
       field: process.pid
       copy_from: aws.guardduty.service.runtime_details.process.pid
       ignore_empty_value: true
   - set:
+      tag: set_process_start_0a38b689
       field: process.start
       copy_from: aws.guardduty.service.runtime_details.process.start_time
       ignore_empty_value: true
   - set:
+      tag: set_process_working_directory_46187695
       field: process.working_directory
       copy_from: aws.guardduty.service.runtime_details.process.pwd
       ignore_empty_value: true
   - set:
+      tag: set_rule_name_1de38b88
       field: rule.name
       copy_from: aws.guardduty.type
       ignore_empty_value: true
   - grok:
+      tag: grok_rule_name_fbddbe6d
       field: rule.name
       patterns:
         - '%{RULESET:rule.ruleset}'
@@ -2522,6 +2974,7 @@ processors:
         RULESET: '%{WORD:rule.category}:%{WORD}'
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_8a86f521
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List
       processor:
@@ -2530,6 +2983,7 @@ processors:
           value: '{{{_ingest._value.local_ip_details.ip_address_v4}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_action_kubernetes_api_call_action_source_ips_99817c23
       field: aws.guardduty.service.action.kubernetes_api_call_action.source_ips
       if: ctx.aws?.guardduty?.service?.action?.kubernetes_api_call_action?.source_ips instanceof List
       processor:
@@ -2538,11 +2992,13 @@ processors:
           value: '{{{_ingest._value}}}'
           allow_duplicates: false
   - append:
+      tag: append_source_port_6e87170d
       field: source.port
       value: '{{{aws.guardduty.service.action.network_connection_action.local_port_details.port.value}}}'
       if: ctx.aws?.guardduty?.service?.action?.network_connection_action?.local_port_details?.port?.value != null
       allow_duplicates: false
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_cb744793
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List
       processor:
@@ -2551,6 +3007,7 @@ processors:
           value: '{{{_ingest._value.local_port_details.port.value}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_source_port_4104da61
       field: source.port
       if: ctx.source?.port instanceof List
       processor:
@@ -2559,46 +3016,56 @@ processors:
           type: long
           ignore_failure: true
   - set:
+      tag: set_threat_indicator_file_path_cbf265e7
       field: threat.indicator.file.path
       copy_from: aws.guardduty.service.runtime_details.context.threat_file_path
       ignore_empty_value: true
   - set:
+      tag: set_threat_software_name_0aec4896
       field: threat.software.name
       copy_from: aws.guardduty.service.runtime_details.context.tool_name
       ignore_empty_value: true
   - append:
+      tag: append_user_id_2badb8ee
       field: user.id
       value: '{{{aws.guardduty.resource.access_key_details.principal_id}}}'
       if: ctx.aws?.guardduty?.resource?.access_key_details?.principal_id != null
       allow_duplicates: false
   - append:
+      tag: append_user_id_3e10bb07
       field: user.id
       value: '{{{aws.guardduty.resource.kubernetes_details.kubernetes_user_details.uid}}}'
       if: ctx.aws?.guardduty?.resource?.kubernetes_details?.kubernetes_user_details?.uid != null
       allow_duplicates: false
   - append:
+      tag: append_user_name_30703801
       field: user.name
       value: '{{{aws.guardduty.resource.access_key_details.user.name}}}'
       if: ctx.aws?.guardduty?.resource?.access_key_details?.user?.name != null
       allow_duplicates: false
   - append:
+      tag: append_user_name_85fe9ac3
       field: user.name
       value: '{{{aws.guardduty.resource.kubernetes_details.kubernetes_user_details.user_name}}}'
       if: ctx.aws?.guardduty?.resource?.kubernetes_details?.kubernetes_user_details?.user_name != null
       allow_duplicates: false
   - append:
+      tag: append_user_name_af6ca9c6
       field: user.name
       value: '{{{aws.guardduty.resource.rdsdb_user_details.user}}}'
       if: ctx.aws?.guardduty?.resource?.rdsdb_user_details?.user != null
       allow_duplicates: false
   - set:
+      tag: set_user_roles_155b686f
       field: user.roles
       copy_from: aws.guardduty.resource.kubernetes_details.kubernetes_user_details.groups
       ignore_empty_value: true
   - remove:
+      tag: remove_json_29cdffdc
       field: json
       ignore_missing: true
   - remove:
+      tag: remove_5a31f510
       if: ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields'))
       field:
         - aws.guardduty.account_id
@@ -2671,6 +3138,7 @@ processors:
         - aws.guardduty.updated_at
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_guardduty_resource_ecs_cluster_details_task_details_containers_4814dbfa
       field: aws.guardduty.resource.ecs_cluster_details.task_details.containers
       if: ctx.aws?.guardduty?.resource?.ecs_cluster_details?.task_details?.containers instanceof List && (ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields')))
       processor:
@@ -2681,6 +3149,7 @@ processors:
             - _ingest._value.name
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_guardduty_service_action_port_probe_action_port_probe_details_ca397f92
       field: aws.guardduty.service.action.port_probe_action.port_probe_details
       if: ctx.aws?.guardduty?.service?.action?.port_probe_action?.port_probe_details instanceof List && (ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields')))
       processor:
@@ -2697,6 +3166,7 @@ processors:
             - _ingest._value.remote_ip_details.organization.asnorg
           ignore_missing: true
   - foreach:
+      tag: foreach_aws_guardduty_service_ebs_volume_scan_details_scan_detections_threat_detected_by_name_threat_names_a77c90d3
       field: aws.guardduty.service.ebs_volume_scan_details.scan.detections.threat_detected_by_name.threat_names
       if: ctx.aws?.guardduty?.service?.ebs_volume_scan_details?.scan?.detections?.threat_detected_by_name?.threat_names instanceof List && (ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields')))
       processor:
@@ -2711,6 +3181,7 @@ processors:
                 - _ingest._value.hash
               ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |
@@ -2728,6 +3199,7 @@ processors:
         }
         dropEmptyFields(ctx);
   - append:
+      tag: append_event_kind_d2f25e35
       field: event.kind
       value: pipeline_error
       if: ctx.error?.message != null
@@ -2741,4 +3213,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/inspector/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/inspector/elasticsearch/ingest_pipeline/default.yml
@@ -66,6 +66,7 @@ processors:
       target_field: json
       on_failure:
         - append:
+            tag: append_error_message_cea45f41
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
@@ -85,6 +86,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_0a49e009
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -144,6 +146,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_efe324d2
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -188,6 +191,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e73b9b49
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -208,6 +212,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f1246d44
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -233,6 +238,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0588064c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -246,6 +252,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_011cf6a6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -300,6 +307,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_d63716e9
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -315,6 +323,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_935ed3f4
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -335,6 +344,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fd9ed83c
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -378,9 +388,11 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_f82c7841
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_networkReachabilityDetails_networkPath_steps_3f0e7034
       field: json.networkReachabilityDetails.networkPath.steps
       if: ctx.json?.networkReachabilityDetails?.networkPath?.steps instanceof List
       processor:
@@ -390,6 +402,7 @@ processors:
           target_field: _ingest._value.component.id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_networkReachabilityDetails_networkPath_steps_1bdfbe9b
       field: json.networkReachabilityDetails.networkPath.steps
       if: ctx.json?.networkReachabilityDetails?.networkPath?.steps instanceof List
       processor:
@@ -399,6 +412,7 @@ processors:
           target_field: _ingest._value.component.type
           ignore_missing: true
   - foreach:
+      tag: foreach_json_networkReachabilityDetails_networkPath_steps_29f74ce0
       field: json.networkReachabilityDetails.networkPath.steps
       if: ctx.json?.networkReachabilityDetails?.networkPath?.steps instanceof List
       processor:
@@ -420,6 +434,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_634e7220
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - convert:
@@ -430,9 +445,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_15b1ed18
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_cvss_a6d89ede
       field: json.packageVulnerabilityDetails.cvss
       if: ctx.json?.packageVulnerabilityDetails?.cvss instanceof List
       processor:
@@ -450,6 +467,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_cvss_1a44209d
       field: json.packageVulnerabilityDetails.cvss
       if: ctx.json?.packageVulnerabilityDetails?.cvss instanceof List
       processor:
@@ -458,6 +476,7 @@ processors:
           tag: remove_packageVulnerabilityDetails_cvss_baseScore
           ignore_missing: true
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_cvss_1130ad25
       field: json.packageVulnerabilityDetails.cvss
       if: ctx.json?.packageVulnerabilityDetails?.cvss instanceof List
       processor:
@@ -473,7 +492,7 @@ processors:
       ignore_missing: true
   - rename:
       field: json.networkReachabilityDetails.networkPath.steps
-      tag: rename_networkReachabilityDetails_networkPath_steps
+      tag: rename_json_networkReachabilityDetails_networkPath_steps_to_aws_inspector_network_reachability_details_network_path_steps_4b117ba7
       target_field: aws.inspector.network_reachability_details.network_path.steps
       ignore_missing: true
   - rename:
@@ -494,9 +513,11 @@ processors:
       keep_original: true
       on_failure:
         - remove:
+            tag: remove_json_packageVulnerabilityDetails_sourceUrl_2131d595
             field: json.packageVulnerabilityDetails.sourceUrl
             ignore_missing: true
         - append:
+            tag: append_error_message_6134a7d6
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - date:
@@ -510,6 +531,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_4b43e61a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -533,9 +555,11 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_67ca7c47
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_vulnerablePackages_16913f8c
       field: json.packageVulnerabilityDetails.vulnerablePackages
       if: ctx.json?.packageVulnerabilityDetails?.vulnerablePackages instanceof List
       processor:
@@ -545,6 +569,7 @@ processors:
           target_field: _ingest._value.file_path
           ignore_missing: true
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_vulnerablePackages_8a1f2869
       field: json.packageVulnerabilityDetails.vulnerablePackages
       if: ctx.json?.packageVulnerabilityDetails?.vulnerablePackages instanceof List
       processor:
@@ -554,6 +579,7 @@ processors:
           target_field: _ingest._value.fixed_in_version
           ignore_missing: true
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_vulnerablePackages_ef960ebc
       field: json.packageVulnerabilityDetails.vulnerablePackages
       if: ctx.json?.packageVulnerabilityDetails?.vulnerablePackages instanceof List
       processor:
@@ -563,6 +589,7 @@ processors:
           target_field: _ingest._value.package_manager
           ignore_missing: true
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_vulnerablePackages_fc41ed43
       field: json.packageVulnerabilityDetails.vulnerablePackages
       if: ctx.json?.packageVulnerabilityDetails?.vulnerablePackages instanceof List
       processor:
@@ -572,6 +599,7 @@ processors:
           target_field: _ingest._value.source_lambda_layer_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_vulnerablePackages_00a54da8
       field: json.packageVulnerabilityDetails.vulnerablePackages
       if: ctx.json?.packageVulnerabilityDetails?.vulnerablePackages instanceof List
       processor:
@@ -581,6 +609,7 @@ processors:
           target_field: _ingest._value.source_layer_hash
           ignore_missing: true
   - foreach:
+      tag: foreach_json_packageVulnerabilityDetails_vulnerablePackages_9dedba0f
       field: json.packageVulnerabilityDetails.vulnerablePackages
       if: ctx.json?.packageVulnerabilityDetails?.vulnerablePackages instanceof List
       processor:
@@ -601,6 +630,7 @@ processors:
       copy_from: aws.inspector.package_vulnerability_details.vulnerable_packages
       ignore_empty_value: true
   - foreach:
+      tag: foreach_aws_inspector_package_vulnerability_details_vulnerable_packages_06d5f6ad
       field: aws.inspector.package_vulnerability_details.vulnerable_packages
       if: ctx.aws?.inspector?.package_vulnerability_details?.vulnerable_packages instanceof List
       processor:
@@ -610,6 +640,7 @@ processors:
           value: '{{{_ingest._value.arch}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_inspector_package_vulnerability_details_vulnerable_packages_230e1c93
       field: aws.inspector.package_vulnerability_details.vulnerable_packages
       if: ctx.aws?.inspector?.package_vulnerability_details?.vulnerable_packages instanceof List
       processor:
@@ -619,6 +650,7 @@ processors:
           value: '{{{_ingest._value.name}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_inspector_package_vulnerability_details_vulnerable_packages_5a1f8aa9
       field: aws.inspector.package_vulnerability_details.vulnerable_packages
       if: ctx.aws?.inspector?.package_vulnerability_details?.vulnerable_packages instanceof List
       processor:
@@ -628,6 +660,7 @@ processors:
           value: '{{{_ingest._value.version}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_inspector_package_vulnerability_details_vulnerable_packages_55903e77
       field: aws.inspector.package_vulnerability_details.vulnerable_packages
       if: ctx.aws?.inspector?.package_vulnerability_details?.vulnerable_packages instanceof List
       processor:
@@ -637,6 +670,7 @@ processors:
           value: '{{{_ingest._value.file_path}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_aws_inspector_package_vulnerability_details_vulnerable_packages_26dbe747
       field: aws.inspector.package_vulnerability_details.vulnerable_packages
       if: ctx.aws?.inspector?.package_vulnerability_details?.vulnerable_packages instanceof List
       processor:
@@ -658,12 +692,15 @@ processors:
       keep_original: true
       on_failure:
         - remove:
+            tag: remove_json_remediation_recommendation_Url_ced20895
             field: json.remediation.recommendation.Url
             ignore_missing: true
         - append:
+            tag: append_error_message_c4a03341
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resources_ac2134b6
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -673,6 +710,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.iam_instance_profile_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_b64133a2
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -682,6 +720,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.image_id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_bd8946bb
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -691,6 +730,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.ipv4_addresses
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_43e262ed
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -709,6 +749,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resources_630cb948
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -722,6 +763,7 @@ processors:
               value: '{{{_ingest._value}}}'
               allow_duplicates: false
   - foreach:
+      tag: foreach_json_resources_55a02249
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -731,6 +773,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.ipv6_addresses
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_43afa091
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -749,6 +792,7 @@ processors:
                     field: error.message
                     value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resources_bba66bcc
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -762,6 +806,7 @@ processors:
               value: '{{{_ingest._value}}}'
               allow_duplicates: false
   - foreach:
+      tag: foreach_json_resources_bb559ca6
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -771,6 +816,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.key_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_e506ea1a
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -787,6 +833,7 @@ processors:
                 field: _ingest._value.details.awsEc2Instance.launchedAt
                 ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_ae04f354
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -796,6 +843,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.platform
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_fd9b49a8
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -805,6 +853,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.subnet_id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_0b8fdb2f
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -814,6 +863,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.type
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_392ada08
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -823,6 +873,7 @@ processors:
           target_field: _ingest._value.details.aws.ec2_instance.vpc_id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_8b993cb4
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -832,6 +883,7 @@ processors:
           target_field: _ingest._value.details.aws.ecr_container_image.architecture
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_b0a0e420
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -841,6 +893,7 @@ processors:
           target_field: _ingest._value.details.aws.ecr_container_image.author
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_6d35ff4a
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -850,6 +903,7 @@ processors:
           target_field: _ingest._value.details.aws.ecr_container_image.image.hash
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_ec8dabdb
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -859,6 +913,7 @@ processors:
           value: '{{{_ingest._value.details.aws.ecr_container_image.image.hash}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_resources_42c3b875
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -868,6 +923,7 @@ processors:
           target_field: _ingest._value.details.aws.ecr_container_image.image.tags
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_65925e83
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -885,6 +941,7 @@ processors:
                 field: error.message
                 value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_resources_a9455749
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -901,6 +958,7 @@ processors:
                 field: _ingest._value.details.awsEcrContainerImage.lastInUseAt
                 ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_3b57b024
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -910,6 +968,7 @@ processors:
           target_field: _ingest._value.details.aws.ecr_container_image.platform
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_e9ccb3fb
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -926,6 +985,7 @@ processors:
                 field: _ingest._value.details.awsEcrContainerImage.pushedAt
                 ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_2715cf38
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -935,6 +995,7 @@ processors:
           target_field: _ingest._value.details.aws.ecr_container_image.registry
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_f6c8b8c1
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -944,6 +1005,7 @@ processors:
           target_field: _ingest._value.details.aws.ecr_container_image.repository_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_82d9a3d5
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -953,6 +1015,7 @@ processors:
           target_field: _ingest._value.details.awsLambdaFunction.code_sha256
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_e5abebac
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -962,6 +1025,7 @@ processors:
           value: '{{{_ingest._value.details.awsLambdaFunction.code_sha256}}}'
           allow_duplicates: false
   - foreach:
+      tag: foreach_json_resources_ee9fa493
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -971,6 +1035,7 @@ processors:
           target_field: _ingest._value.details.awsLambdaFunction.execution_role_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_2fc5e528
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -980,6 +1045,7 @@ processors:
           target_field: _ingest._value.details.awsLambdaFunction.function_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_f4f4115c
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -996,6 +1062,7 @@ processors:
                 field: _ingest._value.details.awsLambdaFunction.lastModifiedAt
                 ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_bd31e481
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1005,6 +1072,7 @@ processors:
           target_field: _ingest._value.details.awsLambdaFunction.package_type
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_b1fa8fbe
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1014,6 +1082,7 @@ processors:
           target_field: _ingest._value.details.awsLambdaFunction.vpc_config.security_group_ids
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_88e6abe9
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1023,6 +1092,7 @@ processors:
           target_field: _ingest._value.details.awsLambdaFunction.vpc_config.subnet_ids
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_24dd8d44
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1032,6 +1102,7 @@ processors:
           target_field: _ingest._value.details.awsLambdaFunction.vpc_config.vpc_id
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_24fa5676
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1045,6 +1116,7 @@ processors:
           tag: remove_resources_fields
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_6918858c
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1054,6 +1126,7 @@ processors:
           target_field: _ingest._value.details.aws.lambda_function
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_86dc252e
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1063,6 +1136,7 @@ processors:
           target_field: _ingest._value.details.code_repository.integration_arn
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_a204a363
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1072,6 +1146,7 @@ processors:
           target_field: _ingest._value.details.code_repository.project_name
           ignore_missing: true
   - foreach:
+      tag: foreach_json_resources_1cd3a1d2
       field: json.resources
       if: ctx.json?.resources instanceof List
       processor:
@@ -1145,6 +1220,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_1b3fbfea
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - script:
@@ -1211,6 +1287,7 @@ processors:
         }
       on_failure:
         - append:
+            tag: append_error_message_c134000a
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
@@ -1295,6 +1372,7 @@ processors:
       value: pipeline_error
       if: ctx.error?.message != null
   - append:
+      tag: append_tags_9fe66b2c
       field: tags
       value: preserve_original_event
       allow_duplicates: false
@@ -1305,7 +1383,7 @@ on_failure:
       value: |-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'
   - set:
       field: event.kind
       tag: set_pipeline_error_to_event_kind

--- a/packages/aws/data_stream/kafka_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/kafka_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -3,21 +3,26 @@ description: "Pipeline for Amazon MSK metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - rename:
+      tag: rename_aws_dimensions_Cluster_Name_to_aws_dimensions_ClusterName_c395738e
       field: aws.dimensions.Cluster Name
       target_field: aws.dimensions.ClusterName
       ignore_missing: true
   - rename:
+      tag: rename_aws_dimensions_Consumer_Group_to_aws_dimensions_ConsumerGroup_8f2fbc2a
       field: aws.dimensions.Consumer Group
       target_field: aws.dimensions.ConsumerGroup
       ignore_missing: true
   - rename:
+      tag: rename_aws_dimensions_Broker_ID_to_aws_dimensions_BrokerID_22ec9d9a
       field: aws.dimensions.Broker ID
       target_field: aws.dimensions.BrokerID
       ignore_missing: true
   - rename:
+      tag: rename_aws_dimensions_Client_Authentication_to_aws_dimensions_ClientAuthentication_05f2be7c
       field: aws.dimensions.Client Authentication
       target_field: aws.dimensions.ClientAuthentication
       ignore_missing: true
@@ -30,4 +35,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/kinesis/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/kinesis/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,11 @@ description: "Pipeline for Kinesis metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
@@ -19,4 +21,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/lambda/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/lambda/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,11 @@ description: "Pipeline for Lambda metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
@@ -19,4 +21,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-json.yml
+++ b/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-json.yml
@@ -2,12 +2,14 @@
 description: Pipeline for parsing AWS lambda logs in JSON format
 processors:
 - json:
+    tag: json_event_original_to_parsed_10ffb5ce
     field: event.original
     target_field: parsed
     ignore_failure: true
 
 # 1. Powertools structured logs (timestamp field)
 - date:
+    tag: date_parsed_timestamp_to_timestamp_97a41d9d
     if: "ctx.parsed?.timestamp != null"
     field: parsed.timestamp
     target_field: "@timestamp"
@@ -16,6 +18,7 @@ processors:
 
 # 2. Platform report logs (time field)
 - date:
+    tag: date_parsed_time_to_timestamp_fba879f2
     if: "ctx.parsed?.time != null"
     field: parsed.time
     target_field: "@timestamp"
@@ -24,6 +27,7 @@ processors:
 
 # 3. EMF metrics (_aws.Timestamp)
 - date:
+    tag: date_parsed__aws_Timestamp_to_timestamp_c68149cc
     if: "ctx.parsed?._aws?.Timestamp != null"
     field: parsed._aws.Timestamp
     target_field: "@timestamp"
@@ -32,33 +36,39 @@ processors:
 
 # Flatten important fields from each log type
 - set:
+    tag: set_aws_lambda_message_6544ba09
     field: aws.lambda.message
     if: "ctx.parsed?.record != null"
     copy_from: parsed.record
     ignore_failure: true
 
 - set:
+    tag: set_aws_lambda_message_3f326ec3
     field: aws.lambda.message
     if: "ctx.parsed?._aws != null"
     copy_from: parsed._aws
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_service_to_service_name_9caaaff4
     field: parsed.service
     target_field: service.name
     ignore_missing: true
 
 - rename:
+    tag: rename_parsed_level_to_log_level_862eec37
     field: parsed.level
     target_field: log.level
     ignore_missing: true
 
 - rename:
+    tag: rename_parsed_requestId_to_aws_lambda_request_id_18110ea2
     field: parsed.requestId
     target_field: aws.lambda.request_id
     ignore_missing: true
 
 - script:
+    tag: script_2a9075b4
     description: "Join stackTrace arrays into single multiline strings if present"
     if: "ctx.parsed instanceof Map"
     lang: painless
@@ -87,24 +97,28 @@ processors:
         }
 
 - rename:
+    tag: rename_parsed_record_functionArn_to_aws_lambda_arn_51703cf5
     field: parsed.record.functionArn
     target_field: aws.lambda.arn
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_requestId_to_aws_lambda_request_id_6a2d1562
     field: parsed.record.requestId
     target_field: aws.lambda.request_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_version_to_aws_lambda_version_7761b889
     field: parsed.record.version
     target_field: aws.lambda.version
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_status_to_aws_lambda_status_6b8d9e09
     field: parsed.record.status
     target_field: aws.lambda.status
     ignore_missing: true
@@ -134,90 +148,105 @@ processors:
 
 # Rename Lambda tracing fields
 - rename:
+    tag: rename_parsed_record_tracing_spanId_to_aws_lambda_tracing_span_id_256aad3c
     field: parsed.record.tracing.spanId
     target_field: aws.lambda.tracing.span_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_tracing_type_to_aws_lambda_tracing_type_39b45bd1
     field: parsed.record.tracing.type
     target_field: aws.lambda.tracing.type
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_tracing_value_to_aws_lambda_tracing_value_02ced129
     field: parsed.record.tracing.value
     target_field: aws.lambda.tracing.value
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_errorType_to_aws_lambda_error_type_88145965
     field: parsed.record.errorType
     target_field: aws.lambda.error.type
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_initializationType_to_aws_lambda_initialization_type_8046ddac
     field: parsed.record.initializationType
     target_field: aws.lambda.initialization_type
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_phase_to_aws_lambda_phase_308d50fd
     field: parsed.record.phase
     target_field: aws.lambda.phase
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_functionVersion_to_aws_lambda_version_8e78bc89
     field: parsed.record.functionVersion
     target_field: aws.lambda.version
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_functionName_to_aws_lambda_name_d0f84de3
     field: parsed.record.functionName
     target_field: aws.lambda.name
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_instanceId_to_aws_lambda_instance_id_b44195fe
     field: parsed.record.instanceId
     target_field: aws.lambda.instance_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_runtimeVersion_to_aws_lambda_runtime_version_b94b16e6
     field: parsed.record.runtimeVersion
     target_field: aws.lambda.runtime_version
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_runtimeVersionArn_to_aws_lambda_runtime_version_arn_0196eb2d
     field: parsed.record.runtimeVersionArn
     target_field: aws.lambda.runtime_version_arn
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_name_to_aws_lambda_extension_name_747c0f88
     field: parsed.record.name
     target_field: aws.lambda.extension.name
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_state_to_aws_lambda_extension_state_6295bd98
     field: parsed.record.state
     target_field: aws.lambda.extension.state
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_events_to_aws_lambda_extension_events_209e02f0
     field: parsed.record.events
     target_field: aws.lambda.extension.events
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_record_spans_to_aws_lambda_spans_26360141
     field: parsed.record.spans
     target_field: aws.lambda.spans
     ignore_missing: true
@@ -225,6 +254,7 @@ processors:
 
 # General fields
 - rename:
+    tag: rename_parsed_time_to_timestamp_e2d4f43a
     field: parsed.time
     target_field: "@timestamp"
     ignore_missing: true
@@ -232,84 +262,98 @@ processors:
     if: "ctx['@timestamp'] == null"
 
 - rename:
+    tag: rename_parsed_errorMessage_to_aws_lambda_error_message_90435096
     field: parsed.errorMessage
     target_field: aws.lambda.error.message
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_errorType_to_aws_lambda_error_type_41dc6cfe
     field: parsed.errorType
     target_field: aws.lambda.error.type
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_logger_to_log_logger_b2926610
     field: parsed.logger
     target_field: log.logger
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_stack_trace_flattened_to_aws_lambda_error_stack_trace_eb4f5110
     field: parsed.stack_trace_flattened
     target_field: aws.lambda.error.stack_trace
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_message_stack_trace_flattened_to_aws_lambda_error_stack_trace_e41d1f23
     field: parsed.message.stack_trace_flattened
     target_field: aws.lambda.error.stack_trace
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_message_errorType_to_aws_lambda_error_type_f7d435cb
     field: parsed.message.errorType
     target_field: aws.lambda.error.type
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_message_errorMessage_to_aws_lambda_error_message_33dc35cf
     field: parsed.message.errorMessage
     target_field: aws.lambda.error.message
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_time_to_timestamp_f0516457
     field: parsed.time
     target_field: "@timestamp"
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_timestamp_to_timestamp_6bf3188c
     field: parsed.timestamp
     target_field: "@timestamp"
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_type_to_aws_lambda_event_type_dc18588f
     field: parsed.type
     target_field: aws.lambda.event_type
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_cold_start_to_aws_lambda_cold_start_66f6c8a6
     field: parsed.cold_start
     target_field: aws.lambda.cold_start
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_correlation_id_to_aws_lambda_correlation_id_f0351420
     field: parsed.correlation_id
     target_field: aws.lambda.correlation_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_function_arn_to_aws_lambda_arn_f7c9939d
     field: parsed.function_arn
     target_field: aws.lambda.arn
     ignore_missing: true
     ignore_failure: true
 
 - convert:
+    tag: convert_parsed_function_memory_size_to_aws_lambda_metrics_memory_size_mb_88c72c01
     field: parsed.function_memory_size
     target_field: aws.lambda.metrics.memory_size_mb
     type: long
@@ -317,24 +361,28 @@ processors:
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_function_name_to_aws_lambda_name_13b2aecb
     field: parsed.function_name
     target_field: aws.lambda.name
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_function_request_id_to_aws_lambda_request_id_c469f1db
     field: parsed.function_request_id
     target_field: aws.lambda.request_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_location_to_aws_lambda_error_location_66753596
     field: parsed.location
     target_field: aws.lambda.error.location
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_message_to_aws_lambda_message_7c4e8659
     field: parsed.message
     target_field: aws.lambda.message
     ignore_missing: true
@@ -342,76 +390,89 @@ processors:
     if: "ctx.parsed?.message instanceof Map"
 
 - set:
+    tag: set_message_43c20b27
     field: message
     copy_from: parsed.message
     if: "ctx.parsed?.message != null && !(ctx.parsed.message instanceof Map)"
 
 - set:
+    tag: set_message_40e593a2
     field: message
     copy_from: event.original
     if: "ctx.message == null && ctx.aws?.lambda?.message == null"
 
 - rename:
+    tag: rename_parsed_users_to_aws_lambda_users_2cbd7f64
     field: parsed.users
     target_field: aws.lambda.users
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_tracing_xray_trace_id_to_aws_lambda_xray_trace_id_7af1af24
     field: parsed.tracing.xray_trace_id
     target_field: aws.lambda.xray_trace_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_ColdStart_to_aws_lambda_cold_start_int_a9f07947
     field: parsed.ColdStart
     target_field: aws.lambda.cold_start_int
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_FunctionName_to_aws_lambda_name_bc1732fa
     field: parsed.FunctionName
     target_field: aws.lambda.name
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_Service_to_aws_lambda_service_name_b05c7e13
     field: parsed.Service
     target_field: aws.lambda.service.name
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_executionEnvironment_to_aws_lambda_execution_environment_69e303a9
     field: parsed.executionEnvironment
     target_field: aws.lambda.execution_environment
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_functionVersion_to_aws_lambda_version_0ce7aa40
     field: parsed.functionVersion
     target_field: aws.lambda.version
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_logStreamId_to_aws_lambda_log_stream_id_cd3a949e
     field: parsed.logStreamId
     target_field: aws.lambda.log_stream_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_traceId_to_aws_lambda_trace_id_43e71591
     field: parsed.traceId
     target_field: aws.lambda.trace_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_AWSRequestId_to_aws_lambda_aws_request_id_1dfaf9e4
     field: parsed.AWSRequestId
     target_field: aws.lambda.aws_request_id
     ignore_missing: true
     ignore_failure: true
 
 - rename:
+    tag: rename_parsed_to_aws_lambda_message_7d198649
     field: parsed
     target_field: aws.lambda.message
     ignore_missing: true
@@ -419,16 +480,19 @@ processors:
     if: "ctx.parsed instanceof Map && !(ctx.parsed.containsKey('record') || ctx.parsed.containsKey('_aws') || ctx.parsed.containsKey('time') )"
 
 - remove:
+    tag: remove_parsed_d594d21c
     field: parsed
     ignore_missing: true
     ignore_failure: true
 
 - remove:
+    tag: remove_parsed__aws_5349e56c
     field: parsed._aws
     ignore_missing: true
     ignore_failure: true
 
 - script:
+    tag: script_4bd31a4f
     description: Drops null/empty values recursively
     lang: painless
     source: |
@@ -455,4 +519,4 @@ on_failure:
     value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-plaintext.yml
+++ b/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/aws-lambda-plaintext.yml
@@ -2,6 +2,7 @@
 description: "Parse AWS Lambda logs with fallback to raw message"
 processors:
   - grok:
+      tag: grok_event_original_0de36c41
       field: event.original
       pattern_definitions:
         GREEDYMULTILINE: "(.|\n|\t)*"
@@ -27,10 +28,11 @@ processors:
       ignore_failure: true
 
   - date:
+      tag: date_timestamp_to_timestamp_7eb435f0
       if: ctx.timestamp != null
       field: timestamp
       target_field: "@timestamp"
-      formats: 
+      formats:
         - "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         - "yyyy-MM-dd HH:mm:ss"
         - "yyyy/MM/dd HH:mm:ss"
@@ -38,18 +40,21 @@ processors:
       ignore_failure: true
 
   - set:
+      tag: set_timestamp_ca92eb85
       if: "ctx['@timestamp'] == null"
       field: "@timestamp"
       value: "{{_ingest.timestamp}}"
       ignore_failure: true
 
   - set:
+      tag: set_message_aacbc6b8
       field: message
       copy_from: event.original
       if: "ctx.message == null || ctx.message == ''"
       ignore_failure: true
 
   - remove:
+      tag: remove_timestamp_fade496d
       field: timestamp
       ignore_missing: true
       ignore_failure: true
@@ -62,4 +67,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
           {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-          {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+          {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/lambda_logs/elasticsearch/ingest_pipeline/default.yml
@@ -2,37 +2,46 @@
 description: Pipeline for AWS Lambda logs.
 processors:
     - rename:
+        tag: rename_message_to_event_original_b273fe21
         field: message
         target_field: event.original
         if: 'ctx.event?.original == null'
         description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
     - remove:
+        tag: remove_message_2ee3a7d4
         field: message
         ignore_missing: true
         if: ctx.event?.original != null
         description: 'The `message` field is no longer required if the document has an `event.original` field.'
     - set:
+        tag: set_ecs_version_0f7334bb
         field: ecs.version
         value: 8.11.0
     - set:
+        tag: set_cloud_service_name_cb418706
         field: cloud.service.name
         value: aws_lambda
     - set:
+        tag: set_cloud_provider_208bdd6b
         field: cloud.provider
         value: aws
     - grok:
+        tag: grok_event_original_fc1a0163
         field: event.original
         patterns:
         - '^%{CHAR:first_char}'
         pattern_definitions:
             CHAR: .
     - pipeline:
+        tag: pipeline_35b524a9
         if: ctx.first_char != '{'
         name: '{{ IngestPipeline "aws-lambda-plaintext" }}'
     - pipeline:
+        tag: pipeline_d8833c14
         if: ctx.first_char == '{'
         name: '{{ IngestPipeline "aws-lambda-json" }}'
     - remove:
+        tag: remove_first_char_c4836df3
         field: first_char
         ignore_missing: true
         description: 'Removes the `first_char` field used to determine the log format.'
@@ -45,4 +54,4 @@ on_failure:
     value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/natgateway/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/natgateway/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,11 @@ description: "Pipeline for NAT Gateway metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
@@ -19,4 +21,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/rds/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/rds/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,11 @@ description: "Pipeline for RDS metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - script:
+      tag: script_8d7bbae6
       lang: painless
       description: This script converts aws.rds.metrics.CPUUtilization.avg from percentage to decimal.
       source: |
@@ -13,278 +15,342 @@ processors:
             ctx.aws.rds.metrics.CPUUtilization.avg = ctx.aws.rds.metrics.CPUUtilization.avg / 100;
         }
   - rename:
+      tag: rename_aws_rds_metrics_BurstBalance_avg_to_aws_rds_burst_balance_pct_90530f8d
       field: aws.rds.metrics.BurstBalance.avg
       target_field: aws.rds.burst_balance.pct
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_CPUUtilization_avg_to_aws_rds_cpu_total_pct_36658ab8
       field: aws.rds.metrics.CPUUtilization.avg
       target_field: aws.rds.cpu.total.pct
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_CPUCreditUsage_avg_to_aws_rds_cpu_credit_usage_301b99b4
       field: aws.rds.metrics.CPUCreditUsage.avg
       target_field: aws.rds.cpu.credit_usage
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_CPUCreditBalance_avg_to_aws_rds_cpu_credit_balance_19f826d4
       field: aws.rds.metrics.CPUCreditBalance.avg
       target_field: aws.rds.cpu.credit_balance
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_DatabaseConnections_avg_to_aws_rds_database_connections_2b34658e
       field: aws.rds.metrics.DatabaseConnections.avg
       target_field: aws.rds.database_connections
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_DiskQueueDepth_avg_to_aws_rds_disk_queue_depth_38e3e7df
       field: aws.rds.metrics.DiskQueueDepth.avg
       target_field: aws.rds.disk_queue_depth
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_FailedSQLServerAgentJobsCount_avg_to_aws_rds_failed_sql_server_agent_jobs_f5668ba8
       field: aws.rds.metrics.FailedSQLServerAgentJobsCount.avg
       target_field: aws.rds.failed_sql_server_agent_jobs
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_FreeableMemory_avg_to_aws_rds_freeable_memory_bytes_3d8aca49
       field: aws.rds.metrics.FreeableMemory.avg
       target_field: aws.rds.freeable_memory.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_FreeStorageSpace_avg_to_aws_rds_free_storage_bytes_035183a3
       field: aws.rds.metrics.FreeStorageSpace.avg
       target_field: aws.rds.free_storage.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_MaximumUsedTransactionIDs_avg_to_aws_rds_maximum_used_transaction_ids_94a0ee2a
       field: aws.rds.metrics.MaximumUsedTransactionIDs.avg
       target_field: aws.rds.maximum_used_transaction_ids
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_OldestReplicationSlotLag_avg_to_aws_rds_oldest_replication_slot_lag_mb_d4787ee1
       field: aws.rds.metrics.OldestReplicationSlotLag.avg
       target_field: aws.rds.oldest_replication_slot_lag.mb
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_ReadIOPS_avg_to_aws_rds_read_iops_3625c54b
       field: aws.rds.metrics.ReadIOPS.avg
       target_field: aws.rds.read.iops
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_CommitThroughput_avg_to_aws_rds_throughput_commit_783a6247
       field: aws.rds.metrics.CommitThroughput.avg
       target_field: aws.rds.throughput.commit
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_DeleteThroughput_avg_to_aws_rds_throughput_delete_9a176acf
       field: aws.rds.metrics.DeleteThroughput.avg
       target_field: aws.rds.throughput.delete
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_DDLThroughput_avg_to_aws_rds_throughput_ddl_2e330eaf
       field: aws.rds.metrics.DDLThroughput.avg
       target_field: aws.rds.throughput.ddl
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_DMLThroughput_avg_to_aws_rds_throughput_dml_c44c206b
       field: aws.rds.metrics.DMLThroughput.avg
       target_field: aws.rds.throughput.dml
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_InsertThroughput_avg_to_aws_rds_throughput_insert_80456373
       field: aws.rds.metrics.InsertThroughput.avg
       target_field: aws.rds.throughput.insert
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_NetworkThroughput_avg_to_aws_rds_throughput_network_c7b36567
       field: aws.rds.metrics.NetworkThroughput.avg
       target_field: aws.rds.throughput.network
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_NetworkReceiveThroughput_avg_to_aws_rds_throughput_network_receive_b5789e2e
       field: aws.rds.metrics.NetworkReceiveThroughput.avg
       target_field: aws.rds.throughput.network_receive
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_NetworkTransmitThroughput_avg_to_aws_rds_throughput_network_transmit_a6019ece
       field: aws.rds.metrics.NetworkTransmitThroughput.avg
       target_field: aws.rds.throughput.network_transmit
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_ReadThroughput_avg_to_aws_rds_throughput_read_b2bb78f9
       field: aws.rds.metrics.ReadThroughput.avg
       target_field: aws.rds.throughput.read
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_SelectThroughput_avg_to_aws_rds_throughput_select_debcd5ed
       field: aws.rds.metrics.SelectThroughput.avg
       target_field: aws.rds.throughput.select
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_UpdateThroughput_avg_to_aws_rds_throughput_update_0cc3203f
       field: aws.rds.metrics.UpdateThroughput.avg
       target_field: aws.rds.throughput.update
       ignore_missing: true
   - rename:
-      field: aws.rds.metrics.FreeStorageSpace.avg
-      target_field: aws.rds.free_storage.bytes
-      ignore_missing: true
-  - rename:
+      tag: rename_aws_rds_metrics_WriteThroughput_avg_to_aws_rds_throughput_write_2920ae1f
       field: aws.rds.metrics.WriteThroughput.avg
       target_field: aws.rds.throughput.write
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_CommitLatency_avg_to_aws_rds_latency_commit_fafd88a1
       field: aws.rds.metrics.CommitLatency.avg
       target_field: aws.rds.latency.commit
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_DDLLatency_avg_to_aws_rds_latency_ddl_4b1c0d9d
       field: aws.rds.metrics.DDLLatency.avg
       target_field: aws.rds.latency.ddl
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_DMLLatency_avg_to_aws_rds_latency_dml_1ed16d41
       field: aws.rds.metrics.DMLLatency.avg
       target_field: aws.rds.latency.dml
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_InsertLatency_avg_to_aws_rds_latency_insert_2004ea69
       field: aws.rds.metrics.InsertLatency.avg
       target_field: aws.rds.latency.insert
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_ReadLatency_avg_to_aws_rds_latency_read_5e20162f
       field: aws.rds.metrics.ReadLatency.avg
       target_field: aws.rds.latency.read
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_SelectLatency_avg_to_aws_rds_latency_select_bc6b6a37
       field: aws.rds.metrics.SelectLatency.avg
       target_field: aws.rds.latency.select
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_UpdateLatency_avg_to_aws_rds_latency_update_86c8c791
       field: aws.rds.metrics.UpdateLatency.avg
       target_field: aws.rds.latency.update
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_WriteLatency_avg_to_aws_rds_latency_write_258532c5
       field: aws.rds.metrics.WriteLatency.avg
       target_field: aws.rds.latency.write
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_DeleteLatency_avg_to_aws_rds_latency_delete_3451b0c9
       field: aws.rds.metrics.DeleteLatency.avg
       target_field: aws.rds.latency.delete
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_ReplicaLag_avg_to_aws_rds_replica_lag_sec_ee824813
       field: aws.rds.metrics.ReplicaLag.avg
       target_field: aws.rds.replica_lag.sec
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_BinLogDiskUsage_avg_to_aws_rds_disk_usage_bin_log_bytes_71023bee
       field: aws.rds.metrics.BinLogDiskUsage.avg
       target_field: aws.rds.disk_usage.bin_log.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_ReplicationSlotDiskUsage_avg_to_aws_rds_disk_usage_replication_slot_mb_50bff192
       field: aws.rds.metrics.ReplicationSlotDiskUsage.avg
       target_field: aws.rds.disk_usage.replication_slot.mb
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_TransactionLogsDiskUsage_avg_to_aws_rds_disk_usage_transaction_logs_mb_67d9deb2
       field: aws.rds.metrics.TransactionLogsDiskUsage.avg
       target_field: aws.rds.disk_usage.transaction_logs.mb
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_SwapUsage_avg_to_aws_rds_swap_usage_bytes_d4fd3aa1
       field: aws.rds.metrics.SwapUsage.avg
       target_field: aws.rds.swap_usage.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_TransactionLogsGeneration_avg_to_aws_rds_transaction_logs_generation_ca29e891
       field: aws.rds.metrics.TransactionLogsGeneration.avg
       target_field: aws.rds.transaction_logs_generation
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_WriteIOPS_avg_to_aws_rds_write_iops_09d7d065
       field: aws.rds.metrics.WriteIOPS.avg
       target_field: aws.rds.write.iops
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_Queries_avg_to_aws_rds_queries_ed8957a3
       field: aws.rds.metrics.Queries.avg
       target_field: aws.rds.queries
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_Deadlocks_avg_to_aws_rds_deadlocks_8fe57437
       field: aws.rds.metrics.Deadlocks.avg
       target_field: aws.rds.deadlocks
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_VolumeBytesUsed_avg_to_aws_rds_volume_used_bytes_c4abfa0e
       field: aws.rds.metrics.VolumeBytesUsed.avg
       target_field: aws.rds.volume_used.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_FreeLocalStorage_avg_to_aws_rds_free_local_storage_bytes_ed049768
       field: aws.rds.metrics.FreeLocalStorage.avg
       target_field: aws.rds.free_local_storage.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_ActiveTransactions_avg_to_aws_rds_transactions_active_fd54d63d
       field: aws.rds.metrics.ActiveTransactions.avg
       target_field: aws.rds.transactions.active
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_BlockedTransactions_avg_to_aws_rds_transactions_blocked_d70d9b13
       field: aws.rds.metrics.BlockedTransactions.avg
       target_field: aws.rds.transactions.blocked
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_LoginFailures_avg_to_aws_rds_login_failures_ae692924
       field: aws.rds.metrics.LoginFailures.avg
       target_field: aws.rds.login_failures
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_AuroraBinlogReplicaLag_avg_to_aws_rds_aurora_bin_log_replica_lag_e2606dbf
       field: aws.rds.metrics.AuroraBinlogReplicaLag.avg
       target_field: aws.rds.aurora_bin_log_replica_lag
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_aurora_bin_log_replica_lag_avg_to_aws_rds_aurora_global_db_replicated_write_io_bytes_7c0a3bac
       field: aws.rds.metrics.aurora_bin_log_replica_lag.avg
       target_field: aws.rds.aurora_global_db.replicated_write_io.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_AuroraGlobalDBDataTransferBytes_avg_to_aws_rds_aurora_global_db_data_transfer_bytes_d8f7e75e
       field: aws.rds.metrics.AuroraGlobalDBDataTransferBytes.avg
       target_field: aws.rds.aurora_global_db.data_transfer.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_AuroraGlobalDBReplicationLag_avg_to_aws_rds_aurora_global_db_replication_lag_ms_a7e8e534
       field: aws.rds.metrics.AuroraGlobalDBReplicationLag.avg
       target_field: aws.rds.aurora_global_db.replication_lag.ms
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_AuroraReplicaLag_avg_to_aws_rds_aurora_replica_lag_ms_f4e2b194
       field: aws.rds.metrics.AuroraReplicaLag.avg
       target_field: aws.rds.aurora_replica.lag.ms
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_AuroraReplicaLagMaximum_avg_to_aws_rds_aurora_replica_lag_max_ms_e65f09b3
       field: aws.rds.metrics.AuroraReplicaLagMaximum.avg
       target_field: aws.rds.aurora_replica.lag_max.ms
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_AuroraReplicaLagMinimum_avg_to_aws_rds_aurora_replica_lag_min_ms_8c36ef77
       field: aws.rds.metrics.AuroraReplicaLagMinimum.avg
       target_field: aws.rds.aurora_replica.lag_min.ms
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_BacktrackChangeRecordsCreationRate_avg_to_aws_rds_backtrack_change_records_creation_rate_ad6f22dc
       field: aws.rds.metrics.BacktrackChangeRecordsCreationRate.avg
       target_field: aws.rds.backtrack_change_records.creation_rate
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_BacktrackChangeRecordsStored_avg_to_aws_rds_backtrack_change_records_stored_9d5d5465
       field: aws.rds.metrics.BacktrackChangeRecordsStored.avg
       target_field: aws.rds.backtrack_change_records.stored
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_BacktrackWindowActual_avg_to_aws_rds_backtrack_window_actual_399261d8
       field: aws.rds.metrics.BacktrackWindowActual.avg
       target_field: aws.rds.backtrack_window.actual
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_BacktrackWindowAlert_avg_to_aws_rds_backtrack_window_alert_83c91c1c
       field: aws.rds.metrics.BacktrackWindowAlert.avg
       target_field: aws.rds.backtrack_window.alert
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_BackupRetentionPeriodStorageUsed_avg_to_aws_rds_storage_used_backup_retention_period_bytes_0a3cc2f3
       field: aws.rds.metrics.BackupRetentionPeriodStorageUsed.avg
       target_field: aws.rds.storage_used.backup_retention_period.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_SnapshotStorageUsed_avg_to_aws_rds_storage_used_snapshot_bytes_03d1dc0d
       field: aws.rds.metrics.SnapshotStorageUsed.avg
       target_field: aws.rds.storage_used.snapshot.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_BufferCacheHitRatio_avg_to_aws_rds_cache_hit_ratio_buffer_34122891
       field: aws.rds.metrics.BufferCacheHitRatio.avg
       target_field: aws.rds.cache_hit_ratio.buffer
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_ResultSetCacheHitRatio_avg_to_aws_rds_cache_hit_ratio_result_set_12b7b3f8
       field: aws.rds.metrics.ResultSetCacheHitRatio.avg
       target_field: aws.rds.cache_hit_ratio.result_set
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_EngineUptime_avg_to_aws_rds_engine_uptime_sec_446af869
       field: aws.rds.metrics.EngineUptime.avg
       target_field: aws.rds.engine_uptime.sec
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_VolumeReadIOPs_avg_to_aws_rds_volume_read_iops_0b0607a5
       field: aws.rds.metrics.VolumeReadIOPs.avg
       target_field: aws.rds.volume.read.iops
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_VolumeWriteIOPs_avg_to_aws_rds_volume_write_iops_78fd3b35
       field: aws.rds.metrics.VolumeWriteIOPs.avg
       target_field: aws.rds.volume.write.iops
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_RDSToAuroraPostgreSQLReplicaLag_avg_to_aws_rds_rds_to_aurora_postgresql_replica_lag_sec_4c48eb8f
       field: aws.rds.metrics.RDSToAuroraPostgreSQLReplicaLag.avg
       target_field: aws.rds.rds_to_aurora_postgresql_replica_lag.sec
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_TotalBackupStorageBilled_avg_to_aws_rds_backup_storage_billed_total_bytes_8819e391
       field: aws.rds.metrics.TotalBackupStorageBilled.avg
       target_field: aws.rds.backup_storage_billed_total.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_rds_metrics_AuroraVolumeBytesLeftTotal_avg_to_aws_rds_aurora_volume_left_total_bytes_004b7308
       field: aws.rds.metrics.AuroraVolumeBytesLeftTotal.avg
       target_field: aws.rds.aurora_volume_left_total.bytes
       ignore_missing: true
@@ -297,4 +363,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/redshift/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/redshift/elasticsearch/ingest_pipeline/default.yml
@@ -3,18 +3,22 @@ description: "Ingest Pipeline for Amazon Redshift metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
       ignore_empty_value: true
   - rename:
+      tag: rename_aws_dimensions_service_class_to_aws_dimensions_service_class_edbfad29
       field: aws.dimensions.service class
       target_field: aws.dimensions.service_class
       ignore_missing: true
   - remove:
+      tag: remove_ae7047b7
       field:
         - aws.dimensions.service class
       ignore_missing: true
@@ -27,4 +31,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/route53_public_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/route53_public_logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,32 +3,40 @@ description: Pipeline for AWS Route53 Logs
 
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - set:
+      tag: set_cloud_provider_208bdd6b
       field: cloud.provider
       value: aws
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - append:
+      tag: append_event_category_7afdca3c
       field: event.category
       value: network
   - append:
+      tag: append_event_type_7ca1b382
       field: event.type
       value: protocol
   - rename:
+      tag: rename_message_to_event_original_c74b1d7e
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
+      tag: grok_event_original_a6b208c8
       field: event.original
       patterns:
         - '%{BASE10NUM} %{TIMESTAMP_ISO8601:_tmp.timestamp} %{DATA:aws.route53.hosted_zone_id} %{DATA:_tmp.question} %{WORD:dns.question.type} %{WORD:dns.response_code} %{WORD:network.transport} %{EDGE_LOCATION:aws.route53.edge_location} %{IP:source.address} (%{SUBNET:aws.route53.edns_client_subnet}|-)'
@@ -36,62 +44,76 @@ processors:
         EDGE_LOCATION: '[A-Z]{3}\d+(-[A-Z]+\d+)?'
         SUBNET: '%{IP}/[0-9]+'
   - date:
+      tag: date__tmp_timestamp_to_timestamp_b4a5e43c
       field: _tmp.timestamp
       target_field: '@timestamp'
       ignore_failure: true
       formats:
         - ISO8601
   - set:
+      tag: set_event_outcome_60bb549d
       field: event.outcome
       value: success
       if: ctx.dns?.response_code == "NOERROR"
   - set:
+      tag: set_event_outcome_25111b1a
       field: event.outcome
       value: failure
       if: ctx.dns?.response_code != "NOERROR"
   - registered_domain:
+      tag: registered_domain__tmp_question_to_dns_question_2c9f6754
       field: _tmp.question
       target_field: dns.question
       ignore_missing: true
       if: '!ctx._tmp?.question.endsWith("in-addr.arpa")'
   - rename:
+      tag: rename_dns_question_domain_to_dns_question_name_88a92ba9
       field: dns.question.domain
       target_field: dns.question.name
       ignore_missing: true
   - convert:
+      tag: convert_source_address_to_source_ip_48c76f83
       field: source.address
       target_field: source.ip
       type: ip
       ignore_missing: true
   - lowercase:
+      tag: lowercase_network_transport_bc8c1c12
       field: network.transport
       ignore_missing: true
   - set:
+      tag: set_network_protocol_96a840d1
       field: network.protocol
       value: dns
   - set:
+      tag: set_network_type_b7f5a7f1
       field: network.type
       value: ipv4
       if: 'ctx.source?.ip != null && ctx.source?.ip.contains(".")'
   - set:
+      tag: set_network_type_9ad17ef3
       field: network.type
       value: ipv6
       if: 'ctx.source?.ip != null && ctx.source?.ip.contains(":")'
   - set:
+      tag: set_network_iana_number_c83eed1a
       field: network.iana_number
       value: '6'
       if: ctx.network?.transport == "tcp"
   - set:
+      tag: set_network_iana_number_c552b054
       field: network.iana_number
       value: '17'
       if: ctx.network?.transport == "udp"
   # IP Geolocation Lookup
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   # IP Autonomous System (AS) Lookup
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -100,22 +122,27 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - append:
+      tag: append_related_ip_9f6befce
       field: related.ip
       value: "{{source.ip}}"
       if: ctx.source?.ip != null
   - append:
+      tag: append_related_hosts_28a2d1ad
       field: related.hosts
       value: "{{dns.question.name}}"
       if: ctx.dns?.question?.name != null
   - remove:
+      tag: remove_3f4f84fc
       field:
         - _tmp
       ignore_missing: true
@@ -128,4 +155,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/route53_resolver_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/route53_resolver_logs/elasticsearch/ingest_pipeline/default.yml
@@ -3,87 +3,107 @@ description: Pipeline for AWS Route53 Resolver Logs
 
 processors:
 - set:
+    tag: set_ecs_version_0f7334bb
     field: ecs.version
     value: '8.11.0'
 - rename:
+    tag: rename_message_to_event_original_c74b1d7e
     field: message
     target_field: event.original
     ignore_missing: true
     if: 'ctx.event?.original == null'
     description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
 - remove:
+    tag: remove_message_2ee3a7d4
     field: message
     ignore_missing: true
     if: 'ctx.event?.original != null'
     description: 'The `message` field is no longer required if the document has an `event.original` field.'
 - json:
+    tag: json_event_original_to_json_5e54dc16
     field: event.original
     target_field: json
 - set:
+    tag: set_cloud_provider_208bdd6b
     field: cloud.provider
     value: aws
 - rename:
+    tag: rename_json_account_id_to_cloud_account_id_509873b4
     field: json.account_id
     target_field: cloud.account.id
     ignore_missing: true
 - date:
+    tag: date_json_query_timestamp_to_timestamp_66d7d0f9
     field: json.query_timestamp
     target_field: '@timestamp'
     ignore_failure: true
     formats:
     - ISO8601
 - set:
+    tag: set_cloud_region_de27450e
     field: cloud.region
     copy_from: json.region
     ignore_empty_value: true
 - rename:
+    tag: rename_json_vpc_id_to_aws_vpc_id_a3655fc5
     field: json.vpc_id
     target_field: aws.vpc_id
     ignore_missing: true
 - rename:
+    tag: rename_json_srcids_instance_to_aws_instance_id_79e6accb
     field: json.srcids.instance
     target_field: aws.instance_id
     ignore_missing: true
 - set:
+    tag: set_cloud_instance_id_4f85b4b6
     field: cloud.instance.id
     copy_from: aws.instance_id
     ignore_empty_value: true
 - gsub:
+    tag: gsub_json_query_name_da62d22f
     field: json.query_name
     pattern: \.$
     replacement: ""
     ignore_missing: true
 - registered_domain:
+    tag: registered_domain_json_query_name_to_dns_question_f61e1e47
     field: json.query_name
     target_field: dns.question
     ignore_missing: true
     if: '!ctx.json?.query_name.endsWith("in-addr.arpa") && !ctx.json?.query_name.endsWith("ip6.arpa")'
 - rename:
+    tag: rename_dns_question_domain_to_dns_question_name_88a92ba9
     field: dns.question.domain
     target_field: dns.question.name
     ignore_missing: true
 - rename:
+    tag: rename_json_query_name_to_dns_question_name_5aa1d19f
     field: json.query_name
     target_field: dns.question.name
     ignore_missing: true
     if: ctx.dns?.question?.name == null
 - rename:
+    tag: rename_json_query_class_to_dns_question_class_277190a2
     field: json.query_class
     target_field: dns.question.class
     ignore_missing: true
 - rename:
+    tag: rename_json_query_type_to_dns_question_type_d1d1d692
     field: json.query_type
     target_field: dns.question.type
     ignore_missing: true
 - rename:
+    tag: rename_json_rcode_to_dns_response_code_c3e755b7
     field: json.rcode
     target_field: dns.response_code
     ignore_missing: true
 - rename:
+    tag: rename_json_answers_to_dns_answers_c7e6574d
     field: json.answers
     target_field: dns.answers
     ignore_missing: true
 - script:
+    tag: script_907e04a4
     lang: painless
     ignore_failure: true
     if: ctx.dns?.answers != null && ctx.dns?.answers instanceof List
@@ -125,44 +145,54 @@ processors:
       }
       ctx.dns.answers = answers;
 - rename:
+    tag: rename_json_transport_to_network_transport_b7a2472e
     field: json.transport
     target_field: network.transport
     ignore_missing: true
 - lowercase:
+    tag: lowercase_network_transport_bc8c1c12
     field: network.transport
     ignore_missing: true
 - set:
+    tag: set_network_iana_number_c83eed1a
     field: network.iana_number
     value: '6'
     if: ctx.network?.transport == "tcp"
 - set:
+    tag: set_network_iana_number_c552b054
     field: network.iana_number
     value: '17'
     if: ctx.network?.transport == "udp"
 - set:
+    tag: set_network_protocol_96a840d1
     field: network.protocol
     value: dns
 - convert:
+    tag: convert_json_srcport_to_source_port_1b64f3ea
     field: json.srcport
     target_field: source.port
     type: long
     ignore_missing: true
 - rename:
+    tag: rename_json_srcaddr_to_source_address_cf73df8a
     field: json.srcaddr
     target_field: source.address
     ignore_missing: true
 - convert:
+    tag: convert_source_address_to_source_ip_48c76f83
     field: source.address
     target_field: source.ip
     type: ip
     ignore_missing: true
 # IP Geolocation Lookup
 - geoip:
+    tag: geoip_source_ip_to_source_geo_da2e41b2
     field: source.ip
     target_field: source.geo
     ignore_missing: true
 # IP Autonomous System (AS) Lookup
 - geoip:
+    tag: geoip_source_ip_to_source_as_28d69883
     database_file: GeoLite2-ASN.mmdb
     field: source.ip
     target_field: source.as
@@ -171,55 +201,69 @@ processors:
     - organization_name
     ignore_missing: true
 - rename:
+    tag: rename_source_as_asn_to_source_as_number_a917047d
     field: source.as.asn
     target_field: source.as.number
     ignore_missing: true
 - rename:
+    tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
     field: source.as.organization_name
     target_field: source.as.organization.name
     ignore_missing: true
 - set:
+    tag: set_network_type_b7f5a7f1
     field: network.type
     value: ipv4
     if: 'ctx.source?.ip != null && ctx.source?.ip.contains(".")'
 - set:
+    tag: set_network_type_9ad17ef3
     field: network.type
     value: ipv6
     if: 'ctx.source?.ip != null && ctx.source?.ip.contains(":")'
 - rename:
+    tag: rename_json_firewall_rule_action_to_aws_route53_firewall_action_fbf4eb34
     field: json.firewall_rule_action
     target_field: aws.route53.firewall.action
     ignore_missing: true
 - rename:
+    tag: rename_json_firewall_rule_group_id_to_aws_route53_firewall_rule_group_id_53242fb8
     field: json.firewall_rule_group_id
     target_field: aws.route53.firewall.rule_group.id
     ignore_missing: true
 - rename:
+    tag: rename_json_firewall_domain_list_id_to_aws_route53_firewall_domain_list_id_7f72257c
     field: json.firewall_domain_list_id
     target_field: aws.route53.firewall.domain_list.id
     ignore_missing: true
 - set:
+    tag: set_event_kind_de80643c
     field: event.kind
     value: event
 - append:
+    tag: append_event_category_7afdca3c
     field: event.category
     value: network
 - append:
+    tag: append_event_type_7ca1b382
     field: event.type
     value: protocol
 - set:
+    tag: set_event_outcome_60bb549d
     field: event.outcome
     value: success
     if: ctx.dns?.response_code == "NOERROR"
 - set:
+    tag: set_event_outcome_25111b1a
     field: event.outcome
     value: failure
     if: ctx.dns?.response_code != "NOERROR"
 - append:
+    tag: append_related_ip_9f6befce
     field: related.ip
     value: "{{source.ip}}"
     if: ctx.source?.ip != null
 - script:
+    tag: script_a9e45180
     lang: painless
     ignore_failure: true
     if: ctx.dns?.question?.name != null && ctx.dns?.question?.type == "PTR"
@@ -253,14 +297,17 @@ processors:
         ctx.related.ip.add(ip);
       }   
 - append:
+    tag: append_related_hosts_0aeadd21
     field: related.hosts
     value: "{{dns.question.name}}"
     if: ctx.dns?.question?.name != null && ctx.dns?.question?.type != "PTR"
 - remove:
+    tag: remove_e5a80934
     field:
     - json
     ignore_missing: true
 - script:
+    tag: script_4d6993cb
     lang: painless
     description: This script processor iterates over the whole document to remove fields with null values.
     source: |
@@ -294,4 +341,4 @@ on_failure:
     value: >-
       Processor '{{{ _ingest.on_failure_processor_type }}}'
       {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-      {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+      {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/s3_daily_storage/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/s3_daily_storage/elasticsearch/ingest_pipeline/default.yml
@@ -3,26 +3,32 @@ description: "Pipeline for S3 daily storage metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
       ignore_empty_value: true
   - rename:
+      tag: rename_aws_s3_metrics_NumberOfObjects_avg_to_aws_s3_daily_storage_number_of_objects_1e8d69e3
       field: aws.s3.metrics.NumberOfObjects.avg
       target_field: aws.s3_daily_storage.number_of_objects
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_BucketSizeBytes_avg_to_aws_s3_daily_storage_bucket_size_bytes_7dcee011
       field: aws.s3.metrics.BucketSizeBytes.avg
       target_field: aws.s3_daily_storage.bucket.size.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_dimensions_BucketName_to_aws_s3_bucket_name_377e3325
       field: aws.dimensions.BucketName
       target_field: aws.s3.bucket.name
       ignore_missing: true
   - remove:
+      tag: remove_30570c1b
       field:
         - aws.s3.metrics
       if: ctx.agent?.type != "firehose"
@@ -36,4 +42,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/s3_request/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/s3_request/elasticsearch/ingest_pipeline/default.yml
@@ -3,90 +3,112 @@ description: "Pipeline for S3 request metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
       ignore_empty_value: true
   - rename:
+      tag: rename_aws_s3_metrics_AllRequests_sum_to_aws_s3_request_requests_total_ef72d2c3
       field: aws.s3.metrics.AllRequests.sum
       target_field: aws.s3_request.requests.total
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_GetRequests_sum_to_aws_s3_request_requests_get_6aba47e6
       field: aws.s3.metrics.GetRequests.sum
       target_field: aws.s3_request.requests.get
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_PutRequests_sum_to_aws_s3_request_requests_put_f80854c4
       field: aws.s3.metrics.PutRequests.sum
       target_field: aws.s3_request.requests.put
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_DeleteRequests_sum_to_aws_s3_request_requests_delete_b5e0fbe8
       field: aws.s3.metrics.DeleteRequests.sum
       target_field: aws.s3_request.requests.delete
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_HeadRequests_sum_to_aws_s3_request_requests_head_88d4b7b0
       field: aws.s3.metrics.HeadRequests.sum
       target_field: aws.s3_request.requests.head
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_PostRequests_sum_to_aws_s3_request_requests_post_af040874
       field: aws.s3.metrics.PostRequests.sum
       target_field: aws.s3_request.requests.post
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_SelectRequests_sum_to_aws_s3_request_requests_select_f54599f0
       field: aws.s3.metrics.SelectRequests.sum
       target_field: aws.s3_request.requests.select
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_SelectScannedBytes_avg_to_aws_s3_request_requests_select_scanned_bytes_1b1b4bdc
       field: aws.s3.metrics.SelectScannedBytes.avg
       target_field: aws.s3_request.requests.select_scanned.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_SelectReturnedBytes_avg_to_aws_s3_request_requests_select_returned_bytes_56bd0fec
       field: aws.s3.metrics.SelectReturnedBytes.avg
       target_field: aws.s3_request.requests.select_returned.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_ListRequests_sum_to_aws_s3_request_requests_list_11b02b4c
       field: aws.s3.metrics.ListRequests.sum
       target_field: aws.s3_request.requests.list
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_BytesDownloaded_avg_to_aws_s3_request_downloaded_bytes_41e74135
       field: aws.s3.metrics.BytesDownloaded.avg
       target_field: aws.s3_request.downloaded.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_BytesUploaded_avg_to_aws_s3_request_uploaded_bytes_10c10c17
       field: aws.s3.metrics.BytesUploaded.avg
       target_field: aws.s3_request.uploaded.bytes
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_BytesDownloaded_sum_to_aws_s3_request_downloaded_bytes_per_period_1504560a
       field: aws.s3.metrics.BytesDownloaded.sum
       target_field: aws.s3_request.downloaded.bytes_per_period
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_BytesUploaded_sum_to_aws_s3_request_uploaded_bytes_per_period_110bee5c
       field: aws.s3.metrics.BytesUploaded.sum
       target_field: aws.s3_request.uploaded.bytes_per_period
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_4xxErrors_avg_to_aws_s3_request_errors_4xx_d8047c6f
       field: aws.s3.metrics.4xxErrors.avg
       target_field: aws.s3_request.errors.4xx
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_5xxErrors_avg_to_aws_s3_request_errors_5xx_9d6dd6bd
       field: aws.s3.metrics.5xxErrors.avg
       target_field: aws.s3_request.errors.5xx
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_FirstByteLatency_avg_to_aws_s3_request_latency_first_byte_ms_180386fe
       field: aws.s3.metrics.FirstByteLatency.avg
       target_field: aws.s3_request.latency.first_byte.ms
       ignore_missing: true
   - rename:
+      tag: rename_aws_s3_metrics_TotalRequestLatency_avg_to_aws_s3_request_latency_total_request_ms_8896ad92
       field: aws.s3.metrics.TotalRequestLatency.avg
       target_field: aws.s3_request.latency.total_request.ms
       ignore_missing: true
   - rename:
+      tag: rename_aws_dimensions_BucketName_to_aws_s3_bucket_name_377e3325
       field: aws.dimensions.BucketName
       target_field: aws.s3.bucket.name
       ignore_missing: true
   - remove:
+      tag: remove_30570c1b
       field:
         - aws.s3.metrics
       if: ctx.agent?.type != "firehose"
@@ -100,4 +122,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/s3access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/s3access/elasticsearch/ingest_pipeline/default.yml
@@ -3,26 +3,32 @@ description: "Pipeline for S3 server access logs"
 
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - set:
+      tag: set_event_category_5c638872
       field: event.category
       value: ["web"]
   - append:
+      tag: append_event_type_8860cef4
       field: event.type
       value: ["access"]
   - rename:
+      tag: rename_message_to_event_original_c74b1d7e
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - grok:
+      tag: grok_event_original_7ad250cb
       field: event.original
       patterns:
         - >-
@@ -44,12 +50,14 @@ processors:
         S3ACLREQUIRED: "(-|Yes)"
         S3REGION: "[a-zA-Z][a-zA-Z0-9-]*"
   - grok:
+      tag: grok_aws_s3access_host_header_764d68d8
       field: aws.s3access.host_header
       ignore_missing: true
       ignore_failure: true
       patterns:
-        - ^%{DATA}s3\.%{DATA:cloud.region}\.%{DATA}$        
+        - ^%{DATA}s3\.%{DATA:cloud.region}\.%{DATA}$
   - script:
+      tag: script_7e38081f
       description: Drops null/empty values recursively
       lang: painless
       source: |
@@ -67,17 +75,20 @@ processors:
         }
         drop(ctx);
   - grok:
+      tag: grok_aws_s3access_request_uri_0b8af0c7
       field: aws.s3access.request_uri
       ignore_failure: true
       patterns:
         - '%{NOTSPACE:http.request.method} %{NOTSPACE:_temp_.url} [hH][tT][tT][pP]/%{NOTSPACE:http.version}'
   - uri_parts:
+      tag: uri_parts__temp__url_to_url_3c83809d
       field: _temp_.url
       target_field: url
       keep_original: true
       ignore_failure: true
       if: ctx._temp_?.url != null
   - append:
+      tag: append_related_user_cf7ba215
       field: related.user
       value: '{{aws.s3access.bucket_owner}}'
       allow_duplicates: false
@@ -86,75 +97,92 @@ processors:
   # Parse the date included in s3 access logs
   #
   - date:
+      tag: date__temp__s3access_time_to_timestamp_fafd8423
       field: _temp_.s3access_time
       target_field: '@timestamp'
       ignore_failure: true
       formats:
         - dd/MMM/yyyy:H:m:s Z
   - set:
+      tag: set_client_ip_84b371bb
       field: client.ip
       value: '{{aws.s3access.remote_ip}}'
       ignore_empty_value: true
   - append:
+      tag: append_related_ip_c0021ce9
       field: related.ip
       value: '{{aws.s3access.remote_ip}}'
       allow_duplicates: false
       if: ctx?.aws?.s3access?.remote_ip != null
   - set:
+      tag: set_client_address_15254d82
       field: client.address
       value: '{{aws.s3access.remote_ip}}'
       ignore_empty_value: true
   - geoip:
+      tag: geoip_aws_s3access_remote_ip_to_client_geo_69de0b8f
       field: aws.s3access.remote_ip
       target_field: client.geo
       if: ctx?.aws?.s3access?.remote_ip != null
   - set:
+      tag: set_geo_c11a7622
       field: geo
       copy_from: client.geo
       ignore_empty_value: true
   - set:
+      tag: set_client_user_id_8d848e48
       field: client.user.id
       value: '{{aws.s3access.requester}}'
       ignore_empty_value: true
   - set:
+      tag: set_event_id_9b7edba7
       field: event.id
       value: '{{aws.s3access.request_id}}'
       ignore_empty_value: true
   - set:
+      tag: set_event_action_f3ec7326
       field: event.action
       value: '{{aws.s3access.operation}}'
       ignore_empty_value: true
   - set:
+      tag: set_http_response_status_code_bb3a1d8b
       field: http.response.status_code
       value: '{{aws.s3access.http_status}}'
       ignore_empty_value: true
   - convert:
+      tag: convert_http_response_status_code_4ce392ee
       field: http.response.status_code
       type: long
       if: ctx?.http?.response?.status_code != null
   - set:
+      tag: set_event_outcome_71325d9b
       field: event.outcome
       value: failure
       if: ctx?.aws?.s3access?.error_code != null
   - set:
+      tag: set_event_code_d7aeb7ec
       field: event.code
       value: '{{aws.s3access.error_code}}'
       ignore_empty_value: true
   - set:
+      tag: set_event_outcome_84ea7090
       field: event.outcome
       value: success
       if: ctx?.aws?.s3access?.error_code == null
   - convert:
+      tag: convert_aws_s3access_bytes_sent_to_http_response_body_bytes_eeb33760
       field: aws.s3access.bytes_sent
       target_field: http.response.body.bytes
       type: long
       ignore_failure: true
   - convert:
+      tag: convert_aws_s3access_total_time_to_event_duration_c161728e
       field: aws.s3access.total_time
       target_field: event.duration
       type: long
       ignore_failure: true
   - script:
+      tag: script_b8d80e18
       lang: painless
       if: ctx.event?.duration != null
       params:
@@ -162,17 +190,21 @@ processors:
       source: >-
         ctx.event.duration *= params.MS_TO_NS;
   - set:
+      tag: set_http_request_referrer_5a3e0b30
       field: http.request.referrer
       value: '{{aws.s3access.referrer}}'
       ignore_empty_value: true
   - user_agent:
+      tag: user_agent_aws_s3access_user_agent_af05d986
       if: ctx?.aws?.s3access?.user_agent != null
       field: aws.s3access.user_agent
   - set:
+      tag: set_tls_cipher_1c33ee6d
       field: tls.cipher
       value: '{{aws.s3access.cipher_suite}}'
       ignore_empty_value: true
   - script:
+      tag: script_3583b6c1
       lang: painless
       if: ctx.aws?.s3access?.tls_version != null
       source: >-
@@ -183,30 +215,37 @@ processors:
         ctx.tls.version = parts[1];
         ctx.tls.version_protocol = parts[0]
   - set:
+      tag: set_aws_s3access_access_point_arn_9ed8f5f2
       field: aws.s3access.access_point_arn
       value: '{{aws.s3access.access_point_arn}}'
       ignore_empty_value: true
   - set:
+      tag: set_aws_s3access_aclrequired_dc250588
       field: aws.s3access.aclrequired
       value: '{{aws.s3access.aclrequired}}'
       ignore_empty_value: true
   - set:
+      tag: set_aws_s3access_source_region_72630762
       field: aws.s3access.source_region
       value: '{{aws.s3access.source_region}}'
       ignore_empty_value: true
   - set:
+      tag: set_cloud_provider_208bdd6b
       field: cloud.provider
       value: aws
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   #
   # Remove temporary fields
   #
   - remove:
+      tag: remove__temp__fc21405e
       field: _temp_
       ignore_missing: true
   - script:
+      tag: script_fa6ab501
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |
@@ -239,4 +278,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/securityhub_findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/securityhub_findings/elasticsearch/ingest_pipeline/default.yml
@@ -13,9 +13,11 @@ processors:
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - set:
+      tag: set_event_kind_871e09cf
       field: event.kind
       value: state
   - append:
@@ -29,20 +31,24 @@ processors:
       tag: append_event_category
       allow_duplicates: false
   - rename:
+      tag: rename_message_to_event_original_56a77271
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - fingerprint:
+      tag: fingerprint_d2518c19
       fields:
         - json.UpdatedAt
         - json.Id
@@ -58,33 +64,41 @@ processors:
       value: aws
       tag: set_cloud_provider
   - rename:
+      tag: rename_json_Action_ActionType_to_aws_securityhub_findings_action_type_ccb5b183
       field: json.Action.ActionType
       target_field: aws.securityhub_findings.action.type
       ignore_missing: true
   - set:
+      tag: set_event_action_224b26a1
       field: event.action
       copy_from: aws.securityhub_findings.action.type
       ignore_failure: true
   - lowercase:
+      tag: lowercase_event_action_9334b869
       field: event.action
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_AffectedResources_to_aws_securityhub_findings_action_aws_api_call_affected_resources_8439c8a6
       field: json.Action.AwsApiCallAction.AffectedResources
       target_field: aws.securityhub_findings.action.aws_api_call.affected_resources
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_Api_to_aws_securityhub_findings_action_aws_api_call_api_472d1b27
       field: json.Action.AwsApiCallAction.Api
       target_field: aws.securityhub_findings.action.aws_api_call.api
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_CallerType_to_aws_securityhub_findings_action_aws_api_call_caller_type_88d6efbb
       field: json.Action.AwsApiCallAction.CallerType
       target_field: aws.securityhub_findings.action.aws_api_call.caller.type
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_DomainDetails_Domain_to_aws_securityhub_findings_action_aws_api_call_domain_details_domain_54f8c820
       field: json.Action.AwsApiCallAction.DomainDetails.Domain
       target_field: aws.securityhub_findings.action.aws_api_call.domain_details.domain
       ignore_missing: true
   - date:
+      tag: date_json_Action_AwsApiCallAction_FirstSeen_to_aws_securityhub_findings_action_aws_api_call_first_seen_8484e185
       field: json.Action.AwsApiCallAction.FirstSeen
       if: ctx.json?.Action?.AwsApiCallAction?.FirstSeen != null && ctx.json?.Action?.AwsApiCallAction?.FirstSeen != ''
       target_field: aws.securityhub_findings.action.aws_api_call.first_seen
@@ -93,9 +107,11 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_b25fa624
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_Action_AwsApiCallAction_LastSeen_to_aws_securityhub_findings_action_aws_api_call_last_seen_db993bb5
       field: json.Action.AwsApiCallAction.LastSeen
       if: ctx.json?.Action?.AwsApiCallAction?.LastSeen != null && ctx.json?.Action?.AwsApiCallAction?.LastSeen != ''
       target_field: aws.securityhub_findings.action.aws_api_call.last_seen
@@ -104,21 +120,26 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_dff877ac
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_City_CityName_to_aws_securityhub_findings_action_aws_api_call_remote_ip_city_name_1a335a3d
       field: json.Action.AwsApiCallAction.RemoteIpDetails.City.CityName
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.city.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Country_CountryCode_to_aws_securityhub_findings_action_aws_api_call_remote_ip_country_code_a84a65ec
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Country.CountryCode
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.country.code
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Country_CountryName_to_aws_securityhub_findings_action_aws_api_call_remote_ip_country_name_b6ab617c
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Country.CountryName
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.country.name
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_AwsApiCallAction_RemoteIpDetails_GeoLocation_Lat_to_aws_securityhub_findings_action_aws_api_call_remote_ip_geolocation_latitude_d4d94bcc
       field: json.Action.AwsApiCallAction.RemoteIpDetails.GeoLocation.Lat
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.geolocation.latitude
       if: ctx.json?.Action?.AwsApiCallAction?.RemoteIpDetails?.GeoLocation?.Lat != ''
@@ -126,9 +147,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_614d949b
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_AwsApiCallAction_RemoteIpDetails_GeoLocation_Lon_to_aws_securityhub_findings_action_aws_api_call_remote_ip_geolocation_longitude_922c6311
       field: json.Action.AwsApiCallAction.RemoteIpDetails.GeoLocation.Lon
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.geolocation.longitude
       if: ctx.json?.Action?.AwsApiCallAction?.RemoteIpDetails?.GeoLocation?.Lon != ''
@@ -136,9 +159,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a5a012a8
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_AwsApiCallAction_RemoteIpDetails_IpAddressV4_to_aws_securityhub_findings_action_aws_api_call_remote_ip_ip_address_v4_c4c308eb
       field: json.Action.AwsApiCallAction.RemoteIpDetails.IpAddressV4
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.ip.address_v4
       if: ctx.json?.Action?.AwsApiCallAction?.RemoteIpDetails?.IpAddressV4 != ''
@@ -146,9 +171,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b5cb2ea0
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_AwsApiCallAction_RemoteIpDetails_Organization_Asn_to_aws_securityhub_findings_action_aws_api_call_remote_ip_organization_asn_419016d5
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Organization.Asn
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.organization.asn
       if: ctx.json?.Action?.AwsApiCallAction?.RemoteIpDetails?.Organization?.Asn != ''
@@ -156,25 +183,31 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3d0db9b2
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Organization_AsnOrg_to_aws_securityhub_findings_action_aws_api_call_remote_ip_organization_asn_organization_ff580110
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Organization.AsnOrg
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.organization.asn_organization
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Organization_Isp_to_aws_securityhub_findings_action_aws_api_call_remote_ip_organization_internet_service_provider_3de91cc9
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Organization.Isp
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.organization.internet_service_provider
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Organization_Org_to_aws_securityhub_findings_action_aws_api_call_remote_ip_organization_internet_provider_78fd718b
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Organization.Org
       target_field: aws.securityhub_findings.action.aws_api_call.remote_ip.organization.internet_provider
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_ServiceName_to_aws_securityhub_findings_action_aws_api_call_service_name_951a02bd
       field: json.Action.AwsApiCallAction.ServiceName
       target_field: aws.securityhub_findings.action.aws_api_call.service.name
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_DnsRequestAction_Blocked_to_aws_securityhub_findings_action_dns_request_blocked_9fa15697
       field: json.Action.DnsRequestAction.Blocked
       target_field: aws.securityhub_findings.action.dns_request.blocked
       if: ctx.json?.Action?.DnsRequestAction?.Blocked != ''
@@ -182,17 +215,21 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_99dfe1d2
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_DnsRequestAction_Domain_to_aws_securityhub_findings_action_dns_request_domain_56217044
       field: json.Action.DnsRequestAction.Domain
       target_field: aws.securityhub_findings.action.dns_request.domain
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_DnsRequestAction_Protocol_to_aws_securityhub_findings_action_dns_request_protocol_39b29874
       field: json.Action.DnsRequestAction.Protocol
       target_field: aws.securityhub_findings.action.dns_request.protocol
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_Blocked_to_aws_securityhub_findings_action_network_connection_blocked_1e897361
       field: json.Action.NetworkConnectionAction.Blocked
       target_field: aws.securityhub_findings.action.network_connection.blocked
       if: ctx.json?.Action?.NetworkConnectionAction?.Blocked != ''
@@ -200,13 +237,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_064ef302
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_ConnectionDirection_to_aws_securityhub_findings_action_network_connection_direction_33a9c9fe
       field: json.Action.NetworkConnectionAction.ConnectionDirection
       target_field: aws.securityhub_findings.action.network_connection.direction
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_LocalPortDetails_Port_to_aws_securityhub_findings_action_network_connection_local_port_number_d80d113b
       field: json.Action.NetworkConnectionAction.LocalPortDetails.Port
       target_field: aws.securityhub_findings.action.network_connection.local.port.number
       if: ctx.json?.Action?.NetworkConnectionAction?.LocalPortDetails?.Port != ''
@@ -214,29 +254,36 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e703adb4
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_LocalPortDetails_PortName_to_aws_securityhub_findings_action_network_connection_local_port_name_f4c7701d
       field: json.Action.NetworkConnectionAction.LocalPortDetails.PortName
       target_field: aws.securityhub_findings.action.network_connection.local.port.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_Protocol_to_aws_securityhub_findings_action_network_connection_protocol_6b7cadac
       field: json.Action.NetworkConnectionAction.Protocol
       target_field: aws.securityhub_findings.action.network_connection.protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_City_CityName_to_aws_securityhub_findings_action_network_connection_remote_ip_city_name_538607bc
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.City.CityName
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.city.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Country_CountryCode_to_aws_securityhub_findings_action_network_connection_remote_ip_country_code_bc59aca7
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Country.CountryCode
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.country.code
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Country_CountryName_to_aws_securityhub_findings_action_network_connection_remote_ip_country_name_605c5293
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Country.CountryName
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.country.name
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemoteIpDetails_GeoLocation_Lat_to_aws_securityhub_findings_action_network_connection_remote_ip_geolocation_latitude_fbddabe4
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.GeoLocation.Lat
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.geolocation.latitude
       if: ctx.json?.Action?.NetworkConnectionAction?.RemoteIpDetails?.GeoLocation?.Lat != ''
@@ -244,9 +291,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1dada8e3
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemoteIpDetails_GeoLocation_Lon_to_aws_securityhub_findings_action_network_connection_remote_ip_geolocation_longitude_9a011dcd
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.GeoLocation.Lon
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.geolocation.longitude
       if: ctx.json?.Action?.NetworkConnectionAction?.RemoteIpDetails?.GeoLocation?.Lon != ''
@@ -254,9 +303,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_73fa1b84
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemoteIpDetails_IpAddressV4_to_aws_securityhub_findings_action_network_connection_remote_ip_ip_address_v4_090c196b
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.IpAddressV4
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.ip.address_v4
       if: ctx.json?.Action?.NetworkConnectionAction?.RemoteIpDetails?.IpAddressV4 != ''
@@ -264,9 +315,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5edcced4
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemoteIpDetails_Organization_Asn_to_aws_securityhub_findings_action_network_connection_remote_ip_organization_asn_d6d39543
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Organization.Asn
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.organization.asn
       if: ctx.json?.Action?.NetworkConnectionAction?.RemoteIpDetails?.Organization?.Asn != ''
@@ -274,21 +327,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d2c5077c
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Organization_AsnOrg_to_aws_securityhub_findings_action_network_connection_remote_ip_organization_asn_organization_5176b42d
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Organization.AsnOrg
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.organization.asn_organization
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Organization_Isp_to_aws_securityhub_findings_action_network_connection_remote_ip_organization_internet_service_provider_1085c3dc
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Organization.Isp
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.organization.internet_service_provider
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Organization_Org_to_aws_securityhub_findings_action_network_connection_remote_ip_organization_internet_provider_a586aae6
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Organization.Org
       target_field: aws.securityhub_findings.action.network_connection.remote_ip.organization.internet_provider
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemotePortDetails_Port_to_aws_securityhub_findings_action_network_connection_remote_port_number_36226cde
       field: json.Action.NetworkConnectionAction.RemotePortDetails.Port
       target_field: aws.securityhub_findings.action.network_connection.remote.port.number
       if: ctx.json?.Action?.NetworkConnectionAction?.RemotePortDetails?.Port != ''
@@ -296,13 +354,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4280c517
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemotePortDetails_PortName_to_aws_securityhub_findings_action_network_connection_remote_port_name_6b4e5335
       field: json.Action.NetworkConnectionAction.RemotePortDetails.PortName
       target_field: aws.securityhub_findings.action.network_connection.remote.port.name
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_PortProbeAction_Blocked_to_aws_securityhub_findings_action_port_probe_blocked_b63398ae
       field: json.Action.PortProbeAction.Blocked
       target_field: aws.securityhub_findings.action.port_probe.blocked
       if: ctx.json?.Action?.PortProbeAction?.Blocked != ''
@@ -310,9 +371,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6306fe1d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_3837ae38
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -327,6 +390,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_c21dcf2d
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -341,6 +405,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_532ff1ea
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -350,6 +415,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_19cd5987
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -359,6 +425,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_236490ce
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -368,6 +435,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_52ead486
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -377,6 +445,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_52adc118
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -391,6 +460,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_4a9f5cb9
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -405,6 +475,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_da903888
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -419,6 +490,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_409e8475
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -433,6 +505,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_708fe002
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -442,6 +515,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_73bed45d
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -451,6 +525,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_250a673f
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -460,6 +535,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_be4eade7
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         remove:
@@ -471,26 +547,32 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - rename:
+      tag: rename_json_Action_PortProbeAction_PortProbeDetails_to_aws_securityhub_findings_action_port_probe_details_5a9eee55
       field: json.Action.PortProbeAction.PortProbeDetails
       target_field: aws.securityhub_findings.action.port_probe.details
       ignore_missing: true
   - rename:
+      tag: rename_json_AwsAccountId_to_aws_securityhub_findings_aws_account_id_f8eafd49
       field: json.AwsAccountId
       target_field: aws.securityhub_findings.aws_account_id
       ignore_missing: true
   - set:
+      tag: set_cloud_account_id_33e087bf
       field: cloud.account.id
       copy_from: aws.securityhub_findings.aws_account_id
       ignore_failure: true
   - rename:
+      tag: rename_json_CompanyName_to_aws_securityhub_findings_company_name_7c5b6857
       field: json.CompanyName
       target_field: aws.securityhub_findings.company.name
       ignore_missing: true
   - set:
+      tag: set_organization_name_e3359fcd
       field: organization.name
       copy_from: aws.securityhub_findings.company.name
       ignore_failure: true
   - rename:
+      tag: rename_json_Compliance_RelatedRequirements_to_aws_securityhub_findings_compliance_related_requirements_05f3f774
       field: json.Compliance.RelatedRequirements
       target_field: aws.securityhub_findings.compliance.related_requirements
       ignore_missing: true
@@ -505,6 +587,7 @@ processors:
           tag: append_related_requirements_rule_ruleset
           allow_duplicates: false
   - rename:
+      tag: rename_json_Compliance_Status_to_aws_securityhub_findings_compliance_status_e71f9029
       field: json.Compliance.Status
       target_field: aws.securityhub_findings.compliance.status
       ignore_missing: true
@@ -544,6 +627,7 @@ processors:
       value: unknown
       if: ctx.event?.outcome == null
   - foreach:
+      tag: foreach_json_Compliance_StatusReasons_9b221651
       field: json.Compliance.StatusReasons
       processor:
         rename:
@@ -553,6 +637,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Compliance?.StatusReasons != null && ctx.json?.Compliance?.StatusReasons instanceof List
   - foreach:
+      tag: foreach_json_Compliance_StatusReasons_0c940320
       field: json.Compliance.StatusReasons
       processor:
         rename:
@@ -562,10 +647,12 @@ processors:
       ignore_failure: true
       if: ctx.json?.Compliance?.StatusReasons != null && ctx.json?.Compliance?.StatusReasons instanceof List
   - rename:
+      tag: rename_json_Compliance_StatusReasons_to_aws_securityhub_findings_compliance_status_reasons_e0bdf718
       field: json.Compliance.StatusReasons
       target_field: aws.securityhub_findings.compliance.status_reasons
       ignore_missing: true
   - convert:
+      tag: convert_json_Confidence_to_aws_securityhub_findings_confidence_42ec0260
       field: json.Confidence
       target_field: aws.securityhub_findings.confidence
       if: ctx.json?.Confidence != ''
@@ -573,9 +660,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2f4de80f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_CreatedAt_to_aws_securityhub_findings_created_at_01694099
       field: json.CreatedAt
       if: ctx.json?.CreatedAt != null && ctx.json?.CreatedAt != ''
       target_field: aws.securityhub_findings.created_at
@@ -584,6 +673,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_64457c04
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
@@ -596,6 +686,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_5d8b19e7
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -604,6 +695,7 @@ processors:
       tag: set_timestamp
       ignore_empty_value: true
   - convert:
+      tag: convert_json_Criticality_to_aws_securityhub_findings_criticality_35758b8d
       field: json.Criticality
       target_field: aws.securityhub_findings.criticality
       if: ctx.json?.Criticality != ''
@@ -611,9 +703,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_62c45738
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Description_to_aws_securityhub_findings_description_27be9cd5
       field: json.Description
       target_field: aws.securityhub_findings.description
       ignore_missing: true
@@ -623,6 +717,7 @@ processors:
       copy_from: aws.securityhub_findings.description
       ignore_empty_value: true
   - convert:
+      tag: convert_json_FindingProviderFields_Confidence_to_aws_securityhub_findings_provider_fields_confidence_301d3826
       field: json.FindingProviderFields.Confidence
       target_field: aws.securityhub_findings.provider_fields.confidence
       if: ctx.json?.FindingProviderFields?.Confidence != ''
@@ -630,9 +725,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6e5f2f6b
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_FindingProviderFields_Criticality_to_aws_securityhub_findings_provider_fields_criticality_62ad14e9
       field: json.FindingProviderFields.Criticality
       target_field: aws.securityhub_findings.provider_fields.criticality
       if: ctx.json?.FindingProviderFields?.Criticality != ''
@@ -640,9 +737,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_593a6d6a
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_FindingProviderFields_RelatedFindings_c5e5b651
       field: json.FindingProviderFields.RelatedFindings
       processor:
         rename:
@@ -652,6 +751,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.FindingProviderFields?.RelatedFindings != null && ctx.json?.FindingProviderFields?.RelatedFindings instanceof List
   - foreach:
+      tag: foreach_json_FindingProviderFields_RelatedFindings_c8042321
       field: json.FindingProviderFields.RelatedFindings
       processor:
         rename:
@@ -661,18 +761,22 @@ processors:
       ignore_failure: true
       if: ctx.json?.FindingProviderFields?.RelatedFindings != null && ctx.json?.FindingProviderFields?.RelatedFindings instanceof List
   - rename:
+      tag: rename_json_FindingProviderFields_RelatedFindings_to_aws_securityhub_findings_provider_fields_related_findings_3593ac62
       field: json.FindingProviderFields.RelatedFindings
       target_field: aws.securityhub_findings.provider_fields.related_findings
       ignore_missing: true
   - rename:
+      tag: rename_json_FindingProviderFields_Severity_Label_to_aws_securityhub_findings_provider_fields_severity_label_84bc66af
       field: json.FindingProviderFields.Severity.Label
       target_field: aws.securityhub_findings.provider_fields.severity.label
       ignore_missing: true
   - rename:
+      tag: rename_json_FindingProviderFields_Severity_Original_to_aws_securityhub_findings_provider_fields_severity_original_d9c6aab3
       field: json.FindingProviderFields.Severity.Original
       target_field: aws.securityhub_findings.provider_fields.severity.original
       ignore_missing: true
   - convert:
+      tag: convert_json_FindingProviderFields_Severity_Normalized_to_aws_securityhub_findings_provider_fields_severity_normalized_a6698cba
       field: json.FindingProviderFields.Severity.Normalized
       target_field: aws.securityhub_findings.provider_fields.severity.normalized
       if: ctx.json?.FindingProviderFields?.Severity?.Normalized != ''
@@ -680,9 +784,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_211b47f7
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_FindingProviderFields_Severity_Product_to_aws_securityhub_findings_provider_fields_severity_product_565ab084
       field: json.FindingProviderFields.Severity.Product
       target_field: aws.securityhub_findings.provider_fields.severity.product
       if: ctx.json?.FindingProviderFields?.Severity?.Product != ''
@@ -690,13 +796,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6b841adb
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_FindingProviderFields_Types_to_aws_securityhub_findings_provider_fields_types_7ac55cd7
       field: json.FindingProviderFields.Types
       target_field: aws.securityhub_findings.provider_fields.types
       ignore_missing: true
   - date:
+      tag: date_json_FirstObservedAt_to_aws_securityhub_findings_first_observed_at_f22c8c5e
       field: json.FirstObservedAt
       if: ctx.json?.FirstObservedAt != null && ctx.json?.FirstObservedAt != ''
       target_field: aws.securityhub_findings.first_observed_at
@@ -705,9 +814,11 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_3fafaf39
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_GeneratorId_to_aws_securityhub_findings_generator_id_3dfea59f
       field: json.GeneratorId
       target_field: aws.securityhub_findings.generator.id
       ignore_missing: true
@@ -717,6 +828,7 @@ processors:
       copy_from: aws.securityhub_findings.generator.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Compliance_SecurityControlId_to_aws_securityhub_findings_compliance_security_control_id_f1b49969
       field: json.Compliance.SecurityControlId
       target_field: aws.securityhub_findings.compliance.security_control_id
       ignore_missing: true
@@ -727,14 +839,17 @@ processors:
       if: ctx.rule?.id == null
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Id_to_aws_securityhub_findings_id_f32ce363
       field: json.Id
       target_field: aws.securityhub_findings.id
       ignore_missing: true
   - set:
+      tag: set_event_id_98f64a99
       field: event.id
       copy_from: aws.securityhub_findings.id
       ignore_failure: true
   - date:
+      tag: date_json_LastObservedAt_to_aws_securityhub_findings_last_observed_at_c923185a
       field: json.LastObservedAt
       if: ctx.json?.LastObservedAt != null && ctx.json?.LastObservedAt != ''
       target_field: aws.securityhub_findings.last_observed_at
@@ -743,6 +858,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_ae76e441
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
@@ -755,6 +871,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_ad947772
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -763,6 +880,7 @@ processors:
       copy_from: aws.securityhub_findings.processed_at
       ignore_empty_value: true
   - foreach:
+      tag: foreach_json_Malware_18076c1e
       field: json.Malware
       processor:
         rename:
@@ -772,6 +890,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Malware != null && ctx.json?.Malware instanceof List
   - foreach:
+      tag: foreach_json_Malware_83b1baba
       field: json.Malware
       processor:
         rename:
@@ -781,6 +900,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Malware != null && ctx.json?.Malware instanceof List
   - foreach:
+      tag: foreach_json_Malware_872d434c
       field: json.Malware
       processor:
         rename:
@@ -790,6 +910,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Malware != null && ctx.json?.Malware instanceof List
   - foreach:
+      tag: foreach_json_Malware_e62418fc
       field: json.Malware
       processor:
         rename:
@@ -799,18 +920,22 @@ processors:
       ignore_failure: true
       if: ctx.json?.Malware != null && ctx.json?.Malware instanceof List
   - rename:
+      tag: rename_json_Malware_to_aws_securityhub_findings_malware_4e712349
       field: json.Malware
       target_field: aws.securityhub_findings.malware
       ignore_missing: true
   - rename:
+      tag: rename_json_Network_DestinationDomain_to_aws_securityhub_findings_network_destination_domain_035e637d
       field: json.Network.DestinationDomain
       target_field: aws.securityhub_findings.network.destination.domain
       ignore_missing: true
   - set:
+      tag: set_destination_domain_fea634a1
       field: destination.domain
       copy_from: aws.securityhub_findings.network.destination.domain
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_DestinationIpV4_to_aws_securityhub_findings_network_destination_ip_v4_66e13d93
       field: json.Network.DestinationIpV4
       target_field: aws.securityhub_findings.network.destination.ip.v4
       if: ctx.json?.Network?.DestinationIpV4 != ''
@@ -818,15 +943,18 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a76103e0
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_destination_ip_a75bc715
       field: destination.ip
       value: '{{{aws.securityhub_findings.network.destination.ip.v4}}}'
       if: ctx.aws?.securityhub_findings?.network?.destination?.ip?.v4 != null
       allow_duplicates: false
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_DestinationIpV6_to_aws_securityhub_findings_network_destination_ip_v6_c7e6a9d9
       field: json.Network.DestinationIpV6
       target_field: aws.securityhub_findings.network.destination.ip.v6
       if: ctx.json?.Network?.DestinationIpV6 != ''
@@ -834,15 +962,18 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b650620a
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_destination_ip_57f5c0a1
       field: destination.ip
       value: '{{{aws.securityhub_findings.network.destination.ip.v6}}}'
       if: ctx.aws?.securityhub_findings?.network?.destination?.ip?.v6 != null
       allow_duplicates: false
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_DestinationPort_to_aws_securityhub_findings_network_destination_port_346734f4
       field: json.Network.DestinationPort
       target_field: aws.securityhub_findings.network.destination.port
       if: ctx.json?.Network?.DestinationPort != ''
@@ -850,25 +981,31 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0046dc75
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_destination_port_eea43667
       field: destination.port
       copy_from: aws.securityhub_findings.network.destination.port
       ignore_failure: true
   - rename:
+      tag: rename_json_Network_Direction_to_aws_securityhub_findings_network_direction_7d021571
       field: json.Network.Direction
       target_field: aws.securityhub_findings.network.direction
       ignore_missing: true
   - set:
+      tag: set_network_direction_17f11860
       field: network.direction
       value: inbound
       if: "ctx.aws?.securityhub_findings?.network?.direction == 'IN'"
   - set:
+      tag: set_network_direction_b8aaa974
       field: network.direction
       value: outbound
       if: "ctx.aws?.securityhub_findings?.network?.direction == 'OUT'"
   - convert:
+      tag: convert_json_Network_OpenPortRange_Begin_to_aws_securityhub_findings_network_open_port_range_begin_38ed0927
       field: json.Network.OpenPortRange.Begin
       target_field: aws.securityhub_findings.network.open_port_range.begin
       if: ctx.json?.Network?.OpenPortRange?.Begin != ''
@@ -876,9 +1013,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_781a96da
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Network_OpenPortRange_End_to_aws_securityhub_findings_network_open_port_range_end_c0fcd627
       field: json.Network.OpenPortRange.End
       target_field: aws.securityhub_findings.network.open_port_range.end
       if: ctx.json?.Network?.OpenPortRange?.End != ''
@@ -886,28 +1025,35 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_943528d6
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Network_Protocol_to_aws_securityhub_findings_network_protocol_8a59dccd
       field: json.Network.Protocol
       target_field: aws.securityhub_findings.network.protocol
       ignore_missing: true
   - set:
+      tag: set_network_protocol_42dec1bd
       field: network.protocol
       copy_from: aws.securityhub_findings.network.protocol
       ignore_failure: true
   - lowercase:
+      tag: lowercase_network_protocol_49872259
       field: network.protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_Network_SourceDomain_to_aws_securityhub_findings_network_source_domain_9f3741ab
       field: json.Network.SourceDomain
       target_field: aws.securityhub_findings.network.source.domain
       ignore_missing: true
   - set:
+      tag: set_source_domain_9e070675
       field: source.domain
       copy_from: aws.securityhub_findings.network.source.domain
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_SourceIpV4_to_aws_securityhub_findings_network_source_ip_v4_2510ec4a
       field: json.Network.SourceIpV4
       target_field: aws.securityhub_findings.network.source.ip.v4
       if: ctx.json?.Network?.SourceIpV4 != ''
@@ -915,15 +1061,18 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_3dce855b
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_source_ip_20771e32
       field: source.ip
       value: '{{{aws.securityhub_findings.network.source.ip.v4}}}'
       if: ctx.aws?.securityhub_findings?.network?.source?.ip?.v4 != null
       allow_duplicates: false
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_SourceIpV6_to_aws_securityhub_findings_network_source_ip_v6_908e9f50
       field: json.Network.SourceIpV6
       target_field: aws.securityhub_findings.network.source.ip.v6
       if: ctx.json?.Network?.SourceIpV6 != ''
@@ -931,31 +1080,38 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fa373fd5
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_source_ip_a88c6a1a
       field: source.ip
       value: '{{{aws.securityhub_findings.network.source.ip.v6}}}'
       if: ctx.aws?.securityhub_findings?.network?.source?.ip?.v6 != null
       allow_duplicates: false
       ignore_failure: true
   - rename:
+      tag: rename_json_Network_SourceMac_to_aws_securityhub_findings_network_source_mac_d4f5018f
       field: json.Network.SourceMac
       target_field: aws.securityhub_findings.network.source.mac
       ignore_missing: true
   - gsub:
+      tag: gsub_aws_securityhub_findings_network_source_mac_a686617c
       field: aws.securityhub_findings.network.source.mac
       pattern: '[-:.]'
       replacement: '-'
       ignore_missing: true
   - uppercase:
+      tag: uppercase_aws_securityhub_findings_network_source_mac_b0e656a3
       field: aws.securityhub_findings.network.source.mac
       ignore_missing: true
   - set:
+      tag: set_source_mac_27d1a6d1
       field: source.mac
       copy_from: aws.securityhub_findings.network.source.mac
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_SourcePort_to_aws_securityhub_findings_network_source_port_cf79bce7
       field: json.Network.SourcePort
       target_field: aws.securityhub_findings.network.source.port
       if: ctx.json?.Network?.SourcePort != ''
@@ -963,13 +1119,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7e8b6480
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_port_aa43a689
       field: source.port
       copy_from: aws.securityhub_findings.network.source.port
       ignore_failure: true
   - foreach:
+      tag: foreach_json_NetworkPath_d16d69fa
       field: json.NetworkPath
       processor:
         rename:
@@ -979,6 +1138,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_bdd1d1d8
       field: json.NetworkPath
       processor:
         rename:
@@ -988,6 +1148,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_3782561c
       field: json.NetworkPath
       processor:
         rename:
@@ -997,6 +1158,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_d3dc83dd
       field: json.NetworkPath
       processor:
         foreach:
@@ -1016,6 +1178,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_4f963655
       field: json.NetworkPath
       processor:
         foreach:
@@ -1035,6 +1198,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_f7493631
       field: json.NetworkPath
       processor:
         foreach:
@@ -1050,6 +1214,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_13001d71
       field: json.NetworkPath
       processor:
         rename:
@@ -1059,6 +1224,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_dce80932
       field: json.NetworkPath
       processor:
         rename:
@@ -1068,6 +1234,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_b4a7c8a6
       field: json.NetworkPath
       processor:
         rename:
@@ -1077,6 +1244,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_242bcada
       field: json.NetworkPath
       processor:
         foreach:
@@ -1096,6 +1264,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_e93fd09a
       field: json.NetworkPath
       processor:
         foreach:
@@ -1115,6 +1284,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_21ad558c
       field: json.NetworkPath
       processor:
         foreach:
@@ -1130,6 +1300,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_1097a7f3
       field: json.NetworkPath
       processor:
         rename:
@@ -1139,6 +1310,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_33174c1a
       field: json.NetworkPath
       processor:
         rename:
@@ -1148,6 +1320,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_5c1690a5
       field: json.NetworkPath
       processor:
         foreach:
@@ -1167,6 +1340,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_b6476c1d
       field: json.NetworkPath
       processor:
         foreach:
@@ -1186,6 +1360,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_cc783169
       field: json.NetworkPath
       processor:
         foreach:
@@ -1201,6 +1376,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_3a332679
       field: json.NetworkPath
       processor:
         rename:
@@ -1210,6 +1386,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_5ab2fdc8
       field: json.NetworkPath
       processor:
         rename:
@@ -1219,6 +1396,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_0683485e
       field: json.NetworkPath
       processor:
         rename:
@@ -1228,6 +1406,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_2003d249
       field: json.NetworkPath
       processor:
         foreach:
@@ -1248,6 +1427,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_1b97f692
       field: json.NetworkPath
       processor:
         foreach:
@@ -1267,6 +1447,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_237ef0b4
       field: json.NetworkPath
       processor:
         foreach:
@@ -1282,6 +1463,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_63de8b8d
       field: json.NetworkPath
       processor:
         rename:
@@ -1291,14 +1473,17 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - rename:
+      tag: rename_json_NetworkPath_to_aws_securityhub_findings_network_path_97095d7e
       field: json.NetworkPath
       target_field: aws.securityhub_findings.network_path
       ignore_missing: true
   - rename:
+      tag: rename_json_Note_Text_to_aws_securityhub_findings_note_text_44700341
       field: json.Note.Text
       target_field: aws.securityhub_findings.note.text
       ignore_missing: true
   - date:
+      tag: date_json_Note_UpdatedAt_to_aws_securityhub_findings_note_updated_at_308d8e33
       field: json.Note.UpdatedAt
       if: ctx.json?.Note?.UpdatedAt != null && ctx.json?.Note?.UpdatedAt != ''
       target_field: aws.securityhub_findings.note.updated_at
@@ -1307,13 +1492,16 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_bb82e6fe
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Note_UpdatedBy_to_aws_securityhub_findings_note_updated_by_80704b96
       field: json.Note.UpdatedBy
       target_field: aws.securityhub_findings.note.updated_by
       ignore_missing: true
   - convert:
+      tag: convert_json_PatchSummary_FailedCount_to_aws_securityhub_findings_patch_summary_failed_count_dc8df8be
       field: json.PatchSummary.FailedCount
       target_field: aws.securityhub_findings.patch_summary.failed.count
       if: ctx.json?.PatchSummary?.FailedCount != ''
@@ -1321,13 +1509,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5bc060db
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_PatchSummary_Id_to_aws_securityhub_findings_patch_summary_id_8a73468e
       field: json.PatchSummary.Id
       target_field: aws.securityhub_findings.patch_summary.id
       ignore_missing: true
   - convert:
+      tag: convert_json_PatchSummary_InstalledCount_to_aws_securityhub_findings_patch_summary_installed_count_017efe97
       field: json.PatchSummary.InstalledCount
       target_field: aws.securityhub_findings.patch_summary.installed.count
       if: ctx.json?.PatchSummary?.InstalledCount != ''
@@ -1335,9 +1526,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6c19ff78
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_PatchSummary_InstalledOtherCount_to_aws_securityhub_findings_patch_summary_installed_other_count_55a46af1
       field: json.PatchSummary.InstalledOtherCount
       target_field: aws.securityhub_findings.patch_summary.installed.other.count
       if: ctx.json?.PatchSummary?.InstalledOtherCount != ''
@@ -1345,9 +1538,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_9cf71152
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_PatchSummary_InstalledPendingReboot_to_aws_securityhub_findings_patch_summary_installed_pending_reboot_db44fd4d
       field: json.PatchSummary.InstalledPendingReboot
       target_field: aws.securityhub_findings.patch_summary.installed.pending_reboot
       if: ctx.json?.PatchSummary?.InstalledPendingReboot != ''
@@ -1355,9 +1550,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_8890b1a8
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_PatchSummary_InstalledRejectedCount_to_aws_securityhub_findings_patch_summary_installed_rejected_count_3638048f
       field: json.PatchSummary.InstalledRejectedCount
       target_field: aws.securityhub_findings.patch_summary.installed.rejected.count
       if: ctx.json?.PatchSummary?.InstalledRejectedCount != ''
@@ -1365,9 +1562,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2e531376
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_PatchSummary_MissingCount_to_aws_securityhub_findings_patch_summary_missing_count_e7793e59
       field: json.PatchSummary.MissingCount
       target_field: aws.securityhub_findings.patch_summary.missing.count
       if: ctx.json?.PatchSummary?.MissingCount != ''
@@ -1375,13 +1574,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_65457b7a
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_PatchSummary_Operation_to_aws_securityhub_findings_patch_summary_operation_type_02025874
       field: json.PatchSummary.Operation
       target_field: aws.securityhub_findings.patch_summary.operation.type
       ignore_missing: true
   - date:
+      tag: date_json_PatchSummary_OperationEndTime_to_aws_securityhub_findings_patch_summary_operation_end_time_6d429fe6
       field: json.PatchSummary.OperationEndTime
       if: ctx.json?.PatchSummary?.OperationEndTime != null && ctx.json?.PatchSummary?.OperationEndTime != ''
       target_field: aws.securityhub_findings.patch_summary.operation.end_time
@@ -1390,9 +1592,11 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_825ebff7
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_PatchSummary_OperationStartTime_to_aws_securityhub_findings_patch_summary_operation_start_time_6379819a
       field: json.PatchSummary.OperationStartTime
       if: ctx.json?.PatchSummary?.OperationStartTime != null && ctx.json?.PatchSummary?.OperationStartTime != ''
       target_field: aws.securityhub_findings.patch_summary.operation.start_time
@@ -1401,13 +1605,16 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_7db00ee3
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_PatchSummary_RebootOption_to_aws_securityhub_findings_patch_summary_reboot_option_7584f629
       field: json.PatchSummary.RebootOption
       target_field: aws.securityhub_findings.patch_summary.reboot_option
       ignore_missing: true
   - date:
+      tag: date_json_Process_LaunchedAt_to_aws_securityhub_findings_process_launched_at_81ad95eb
       field: json.Process.LaunchedAt
       if: ctx.json?.Process?.LaunchedAt != null && ctx.json?.Process?.LaunchedAt != ''
       target_field: aws.securityhub_findings.process.launched_at
@@ -1416,21 +1623,26 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_c38b1c7e
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_process_start_3a4e8f93
       field: process.start
       copy_from: aws.securityhub_findings.process.launched_at
       ignore_failure: true
   - rename:
+      tag: rename_json_Process_Name_to_aws_securityhub_findings_process_name_3da71611
       field: json.Process.Name
       target_field: aws.securityhub_findings.process.name
       ignore_missing: true
   - set:
+      tag: set_process_name_27eb3331
       field: process.name
       copy_from: aws.securityhub_findings.process.name
       ignore_failure: true
   - convert:
+      tag: convert_json_Process_ParentPid_to_aws_securityhub_findings_process_parent_pid_0b9cf1a3
       field: json.Process.ParentPid
       target_field: aws.securityhub_findings.process.parent.pid
       if: ctx.json?.Process?.ParentPid != ''
@@ -1438,21 +1650,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6fc0a1da
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_process_parent_pid_4d7ccb91
       field: process.parent.pid
       copy_from: aws.securityhub_findings.process.parent.pid
       ignore_failure: true
   - rename:
+      tag: rename_json_Process_Path_to_aws_securityhub_findings_process_path_eb873a55
       field: json.Process.Path
       target_field: aws.securityhub_findings.process.path
       ignore_missing: true
   - set:
+      tag: set_process_executable_d26dca38
       field: process.executable
       copy_from: aws.securityhub_findings.process.path
       ignore_failure: true
   - convert:
+      tag: convert_json_Process_Pid_to_aws_securityhub_findings_process_pid_91bce07d
       field: json.Process.Pid
       target_field: aws.securityhub_findings.process.pid
       if: ctx.json?.Process?.Pid != ''
@@ -1460,13 +1677,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_48265d6e
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_process_pid_545f49f1
       field: process.pid
       copy_from: aws.securityhub_findings.process.pid
       ignore_failure: true
   - date:
+      tag: date_json_Process_TerminatedAt_to_aws_securityhub_findings_process_terminated_at_8902d61f
       field: json.Process.TerminatedAt
       if: ctx.json?.Process?.TerminatedAt != null && ctx.json?.Process?.TerminatedAt != ''
       target_field: aws.securityhub_findings.process.terminated_at
@@ -1475,29 +1695,36 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_d2615612
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_process_end_b5d22b7f
       field: process.end
       copy_from: aws.securityhub_findings.process.terminated_at
       ignore_failure: true
   - rename:
+      tag: rename_json_ProductArn_to_aws_securityhub_findings_product_arn_d405bc1f
       field: json.ProductArn
       target_field: aws.securityhub_findings.product.arn
       ignore_missing: true
   - rename:
+      tag: rename_json_ProductFields_to_aws_securityhub_findings_product_fields_6582ba87
       field: json.ProductFields
       target_field: aws.securityhub_findings.product.fields
       ignore_missing: true
   - rename:
+      tag: rename_json_ProductName_to_aws_securityhub_findings_product_name_7d81f7d7
       field: json.ProductName
       target_field: aws.securityhub_findings.product.name
       ignore_missing: true
   - rename:
+      tag: rename_json_RecordState_to_aws_securityhub_findings_record_state_d9fd63e8
       field: json.RecordState
       target_field: aws.securityhub_findings.record_state
       ignore_missing: true
   - rename:
+      tag: rename_json_Region_to_aws_securityhub_findings_region_68956dcd
       field: json.Region
       target_field: aws.securityhub_findings.region
       ignore_missing: true
@@ -1507,6 +1734,7 @@ processors:
       copy_from: aws.securityhub_findings.region
       ignore_empty_value: true
   - foreach:
+      tag: foreach_json_RelatedFindings_3e1a59fc
       field: json.RelatedFindings
       processor:
         rename:
@@ -1516,6 +1744,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.RelatedFindings != null && ctx.json?.RelatedFindings instanceof List
   - foreach:
+      tag: foreach_json_RelatedFindings_77b99b2a
       field: json.RelatedFindings
       processor:
         rename:
@@ -1525,14 +1754,17 @@ processors:
       ignore_failure: true
       if: ctx.json?.RelatedFindings != null && ctx.json?.RelatedFindings instanceof List
   - rename:
+      tag: rename_json_RelatedFindings_to_aws_securityhub_findings_related_findings_8eede454
       field: json.RelatedFindings
       target_field: aws.securityhub_findings.related_findings
       ignore_missing: true
   - rename:
+      tag: rename_json_Remediation_Recommendation_Text_to_aws_securityhub_findings_remediation_recommendation_text_6747ce2d
       field: json.Remediation.Recommendation.Text
       target_field: aws.securityhub_findings.remediation.recommendation.text
       ignore_missing: true
   - rename:
+      tag: rename_json_Remediation_Recommendation_Url_to_aws_securityhub_findings_remediation_recommendation_url_6ca71c8f
       field: json.Remediation.Recommendation.Url
       target_field: aws.securityhub_findings.remediation.recommendation.url
       ignore_missing: true
@@ -1548,6 +1780,7 @@ processors:
       if: ctx.aws?.securityhub_findings?.remediation?.recommendation?.url != null && ctx.aws.securityhub_findings.remediation.recommendation.text != null
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Resources_to_aws_securityhub_findings_resources_b9dbf1b1
       field: json.Resources
       target_field: aws.securityhub_findings.resources
       ignore_missing: true
@@ -1917,6 +2150,7 @@ processors:
           }
         }
   - convert:
+      tag: convert_json_Sample_to_aws_securityhub_findings_sample_f25d6b54
       field: json.Sample
       target_field: aws.securityhub_findings.sample
       if: ctx.json?.Sample != ''
@@ -1924,17 +2158,21 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a250ef1d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_SchemaVersion_to_aws_securityhub_findings_schema_version_e38936ed
       field: json.SchemaVersion
       target_field: aws.securityhub_findings.schema.version
       ignore_missing: true
   - rename:
+      tag: rename_json_Severity_Label_to_aws_securityhub_findings_severity_label_5115797f
       field: json.Severity.Label
       target_field: aws.securityhub_findings.severity.label
       ignore_missing: true
   - convert:
+      tag: convert_json_Severity_Normalized_to_aws_securityhub_findings_severity_normalized_7d4e00ce
       field: json.Severity.Normalized
       target_field: aws.securityhub_findings.severity.normalized
       if: ctx.json?.Severity?.Normalized != ''
@@ -1942,6 +2180,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1a7ade71
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
@@ -1952,13 +2191,16 @@ processors:
       type: long
       on_failure:
         - append:
+            tag: append_error_message_be1ff690
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Severity_Original_to_aws_securityhub_findings_severity_original_d5508139
       field: json.Severity.Original
       target_field: aws.securityhub_findings.severity.original
       ignore_missing: true
   - convert:
+      tag: convert_json_Severity_Product_to_aws_securityhub_findings_severity_product_3cdf5f44
       field: json.Severity.Product
       target_field: aws.securityhub_findings.severity.product
       if: ctx.json?.Severity?.Product != ''
@@ -1966,24 +2208,30 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_6b819b3d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_SourceUrl_to_aws_securityhub_findings_source_url_5af8a7dc
       field: json.SourceUrl
       target_field: aws.securityhub_findings.source_url
       ignore_missing: true
   - uri_parts:
+      tag: uri_parts_aws_securityhub_findings_source_url_3c502bf9
       field: aws.securityhub_findings.source_url
       if: ctx.aws?.securityhub_findings?.source_url != '' && ctx.aws?.securityhub_findings?.source_url != null
       on_failure:
         - append:
+            tag: append_error_message_67b98b74
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_url_full_bf65e319
       field: url.full
       value: '{{{url.original}}}'
       ignore_failure: true
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_2d212bcd
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -1993,6 +2241,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_e8528fcc
       field: json.ThreatIntelIndicators
       processor:
         date:
@@ -2005,6 +2254,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_8cc90a53
       field: json.ThreatIntelIndicators
       processor:
         remove:
@@ -2014,6 +2264,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_2e9164f3
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -2023,6 +2274,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_ad5cd248
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -2032,6 +2284,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_f1d323b5
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -2041,6 +2294,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_23d9c4b5
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -2050,6 +2304,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_b6f769ce
       field: json.ThreatIntelIndicators
       processor:
         set:
@@ -2059,6 +2314,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - script:
+      tag: script_fede25a4
       description: Map box field ThreatIntelIndicator to ECS field threat.indicator.type
       lang: painless
       params:
@@ -2102,10 +2358,12 @@ processors:
         } 
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - rename:
+      tag: rename_json_ThreatIntelIndicators_to_aws_securityhub_findings_threat_intel_indicators_abd47461
       field: json.ThreatIntelIndicators
       target_field: aws.securityhub_findings.threat_intel_indicators
       ignore_missing: true
   - rename:
+      tag: rename_json_Title_to_aws_securityhub_findings_title_7c6d2a4d
       field: json.Title
       target_field: aws.securityhub_findings.title
       ignore_missing: true
@@ -2115,18 +2373,22 @@ processors:
       copy_from: aws.securityhub_findings.title
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Types_to_aws_securityhub_findings_types_6190248d
       field: json.Types
       target_field: aws.securityhub_findings.types
       ignore_missing: true
   - rename:
+      tag: rename_json_UserDefinedFields_to_aws_securityhub_findings_user_defined_fields_d57d2ceb
       field: json.UserDefinedFields
       target_field: aws.securityhub_findings.user_defined_fields
       ignore_missing: true
   - rename:
+      tag: rename_json_VerificationState_to_aws_securityhub_findings_verification_state_6db403f8
       field: json.VerificationState
       target_field: aws.securityhub_findings.verification_state
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Vulnerabilities_17240f9e
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2146,6 +2408,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_5a0ab43e
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2165,6 +2428,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_bf70563b
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2179,6 +2443,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_97bc7c79
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2198,6 +2463,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_96ab6d00
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2212,6 +2478,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_a6376729
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2226,6 +2493,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_e6b5aa0b
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2240,6 +2508,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_25245e65
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2254,6 +2523,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_bd790766
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2268,6 +2538,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_b3591969
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2282,6 +2553,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_b6e12143
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2291,6 +2563,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_24c16547
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2300,6 +2573,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_c4a5957a
       field: json.Vulnerabilities
       processor:
         set:
@@ -2309,6 +2583,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_b6377fa4
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2318,6 +2593,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_77e83ed9
       field: json.Vulnerabilities
       processor:
         set:
@@ -2327,6 +2603,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_4ab2915c
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2336,6 +2613,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_8d1eba09
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2345,6 +2623,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_4f760f9b
       field: json.Vulnerabilities
       processor:
         set:
@@ -2354,6 +2633,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_7d175beb
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2363,6 +2643,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_ca92c915
       field: json.Vulnerabilities
       processor:
         date:
@@ -2375,6 +2656,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_1317e443
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2384,6 +2666,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_04152899
       field: json.Vulnerabilities
       processor:
         date:
@@ -2396,6 +2679,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_9d6098ca
       field: json.Vulnerabilities
       processor:
         remove:
@@ -2406,6 +2690,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_8bdce315
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2420,6 +2705,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_f06880e7
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2434,6 +2720,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_96026b91
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2448,6 +2735,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_4e26ca20
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2462,6 +2750,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_c9c47007
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2476,6 +2765,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_8c6cfe82
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2490,6 +2780,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_20a2be49
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2504,6 +2795,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_a62af8ed
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2518,6 +2810,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_0a574cec
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2527,34 +2820,41 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - rename:
+      tag: rename_json_Vulnerabilities_to_aws_securityhub_findings_vulnerabilities_2cdac8ed
       field: json.Vulnerabilities
       target_field: aws.securityhub_findings.vulnerabilities
       ignore_missing: true
   - rename:
+      tag: rename_json_Workflow_Status_to_aws_securityhub_findings_workflow_status_c29af441
       field: json.Workflow.Status
       target_field: aws.securityhub_findings.workflow.status
       ignore_missing: true
   - rename:
+      tag: rename_json_WorkflowState_to_aws_securityhub_findings_workflow_state_ecf76e0f
       field: json.WorkflowState
       target_field: aws.securityhub_findings.workflow.state
       ignore_missing: true
   - remove:
+      tag: remove_e5a80934
       field:
         - json
       ignore_missing: true
   - append:
+      tag: append_related_ip_144060b7
       field: related.ip
       value: '{{{aws.securityhub_findings.action.aws_api_call.remote_ip.ip.address_v4}}}'
       if: ctx.aws?.securityhub_findings?.action?.aws_api_call?.remote_ip?.ip?.address_v4 != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_ad86d72f
       field: related.ip
       value: '{{{aws.securityhub_findings.action.network_connection.remote_ip.ip.address_v4}}}'
       if: ctx.aws?.securityhub_findings?.action?.network_connection?.remote_ip?.ip?.address_v4 != null
       allow_duplicates: false
       ignore_failure: true
   - foreach:
+      tag: foreach_aws_securityhub_findings_action_port_probe_details_9b90fc36
       field: aws.securityhub_findings.action.port_probe.details
       processor:
         append:
@@ -2565,6 +2865,7 @@ processors:
       ignore_failure: true
       if: ctx.aws?.securityhub_findings?.action?.port_probe?.details != null && ctx.aws?.securityhub_findings?.action?.port_probe?.details instanceof List
   - foreach:
+      tag: foreach_aws_securityhub_findings_action_port_probe_details_a635271b
       field: aws.securityhub_findings.action.port_probe.details
       processor:
         append:
@@ -2575,30 +2876,35 @@ processors:
       ignore_failure: true
       if: ctx.aws?.securityhub_findings?.action?.port_probe?.details != null && ctx.aws?.securityhub_findings?.action?.port_probe?.details instanceof List
   - append:
+      tag: append_related_ip_9bdb8082
       field: related.ip
       value: '{{{aws.securityhub_findings.network.destination.ip.v4}}}'
       if: ctx.aws?.securityhub_findings?.network?.destination?.ip?.v4 != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_f5a85c0e
       field: related.ip
       value: '{{{aws.securityhub_findings.network.destination.ip.v6}}}'
       if: ctx.aws?.securityhub_findings?.network?.destination?.ip?.v6 != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_d85dfa88
       field: related.ip
       value: '{{{aws.securityhub_findings.network.source.ip.v4}}}'
       if: ctx.aws?.securityhub_findings?.network?.source?.ip?.v4 != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_2db9a640
       field: related.ip
       value: '{{{aws.securityhub_findings.network.source.ip.v6}}}'
       if: ctx.aws?.securityhub_findings?.network?.source?.ip?.v6 != null
       allow_duplicates: false
       ignore_failure: true
   - remove:
+      tag: remove_c696ed04
       if: ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields'))
       field:
         - aws.securityhub_findings.created_at
@@ -2624,6 +2930,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_findings_threat_intel_indicators_21a61e1a
       field: aws.securityhub_findings.threat_intel_indicators
       processor:
         remove:
@@ -2635,6 +2942,7 @@ processors:
           ignore_missing: true
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_findings_vulnerabilities_8f5de41c
       field: aws.securityhub_findings.vulnerabilities
       processor:
         remove:
@@ -2649,6 +2957,7 @@ processors:
           ignore_missing: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |
@@ -2674,4 +2983,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/securityhub_findings_full_posture/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/securityhub_findings_full_posture/elasticsearch/ingest_pipeline/default.yml
@@ -13,9 +13,11 @@ processors:
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - set:
+      tag: set_event_kind_871e09cf
       field: event.kind
       value: state
   - append:
@@ -29,20 +31,24 @@ processors:
       tag: append_event_category
       allow_duplicates: false
   - rename:
+      tag: rename_message_to_event_original_56a77271
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - fingerprint:
+      tag: fingerprint_d2518c19
       fields:
         - json.UpdatedAt
         - json.Id
@@ -58,33 +64,41 @@ processors:
       value: aws
       tag: set_cloud_provider
   - rename:
+      tag: rename_json_Action_ActionType_to_aws_securityhub_findings_full_posture_action_type_daeaf634
       field: json.Action.ActionType
       target_field: aws.securityhub_findings_full_posture.action.type
       ignore_missing: true
   - set:
+      tag: set_event_action_013b8a5e
       field: event.action
       copy_from: aws.securityhub_findings_full_posture.action.type
       ignore_failure: true
   - lowercase:
+      tag: lowercase_event_action_9334b869
       field: event.action
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_AffectedResources_to_aws_securityhub_findings_full_posture_action_aws_api_call_affected_resources_07d9c00b
       field: json.Action.AwsApiCallAction.AffectedResources
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.affected_resources
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_Api_to_aws_securityhub_findings_full_posture_action_aws_api_call_api_f9adec5a
       field: json.Action.AwsApiCallAction.Api
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.api
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_CallerType_to_aws_securityhub_findings_full_posture_action_aws_api_call_caller_type_18267cac
       field: json.Action.AwsApiCallAction.CallerType
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.caller.type
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_DomainDetails_Domain_to_aws_securityhub_findings_full_posture_action_aws_api_call_domain_details_domain_7f7eedc1
       field: json.Action.AwsApiCallAction.DomainDetails.Domain
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.domain_details.domain
       ignore_missing: true
   - date:
+      tag: date_json_Action_AwsApiCallAction_FirstSeen_to_aws_securityhub_findings_full_posture_action_aws_api_call_first_seen_d7b57296
       field: json.Action.AwsApiCallAction.FirstSeen
       if: ctx.json?.Action?.AwsApiCallAction?.FirstSeen != null && ctx.json?.Action?.AwsApiCallAction?.FirstSeen != ''
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.first_seen
@@ -93,9 +107,11 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_190d67d5
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_Action_AwsApiCallAction_LastSeen_to_aws_securityhub_findings_full_posture_action_aws_api_call_last_seen_702bbc50
       field: json.Action.AwsApiCallAction.LastSeen
       if: ctx.json?.Action?.AwsApiCallAction?.LastSeen != null && ctx.json?.Action?.AwsApiCallAction?.LastSeen != ''
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.last_seen
@@ -104,21 +120,26 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_bd75d2c3
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_City_CityName_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_city_name_36a3af44
       field: json.Action.AwsApiCallAction.RemoteIpDetails.City.CityName
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.city.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Country_CountryCode_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_country_code_14eb56e3
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Country.CountryCode
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.country.code
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Country_CountryName_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_country_name_2ac44ed3
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Country.CountryName
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.country.name
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_AwsApiCallAction_RemoteIpDetails_GeoLocation_Lat_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_geolocation_latitude_3485d26f
       field: json.Action.AwsApiCallAction.RemoteIpDetails.GeoLocation.Lat
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.geolocation.latitude
       if: ctx.json?.Action?.AwsApiCallAction?.RemoteIpDetails?.GeoLocation?.Lat != ''
@@ -126,9 +147,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_07cbf736
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_AwsApiCallAction_RemoteIpDetails_GeoLocation_Lon_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_geolocation_longitude_ceb3046c
       field: json.Action.AwsApiCallAction.RemoteIpDetails.GeoLocation.Lon
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.geolocation.longitude
       if: ctx.json?.Action?.AwsApiCallAction?.RemoteIpDetails?.GeoLocation?.Lon != ''
@@ -136,9 +159,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_051a87eb
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_AwsApiCallAction_RemoteIpDetails_IpAddressV4_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_ip_address_v4_e47e580c
       field: json.Action.AwsApiCallAction.RemoteIpDetails.IpAddressV4
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.ip.address_v4
       if: ctx.json?.Action?.AwsApiCallAction?.RemoteIpDetails?.IpAddressV4 != ''
@@ -146,9 +171,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bb08adc1
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_AwsApiCallAction_RemoteIpDetails_Organization_Asn_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_organization_asn_327bda3e
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Organization.Asn
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.organization.asn
       if: ctx.json?.Action?.AwsApiCallAction?.RemoteIpDetails?.Organization?.Asn != ''
@@ -156,25 +183,31 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2abbe38b
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Organization_AsnOrg_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_organization_asn_organization_6fc99169
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Organization.AsnOrg
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.organization.asn_organization
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Organization_Isp_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_organization_internet_service_provider_8d6f2a22
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Organization.Isp
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.organization.internet_service_provider
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_RemoteIpDetails_Organization_Org_to_aws_securityhub_findings_full_posture_action_aws_api_call_remote_ip_organization_internet_provider_324ad910
       field: json.Action.AwsApiCallAction.RemoteIpDetails.Organization.Org
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.organization.internet_provider
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_AwsApiCallAction_ServiceName_to_aws_securityhub_findings_full_posture_action_aws_api_call_service_name_2fa5d12e
       field: json.Action.AwsApiCallAction.ServiceName
       target_field: aws.securityhub_findings_full_posture.action.aws_api_call.service.name
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_DnsRequestAction_Blocked_to_aws_securityhub_findings_full_posture_action_dns_request_blocked_c1a4d0aa
       field: json.Action.DnsRequestAction.Blocked
       target_field: aws.securityhub_findings_full_posture.action.dns_request.blocked
       if: ctx.json?.Action?.DnsRequestAction?.Blocked != ''
@@ -182,17 +215,21 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4479fe55
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_DnsRequestAction_Domain_to_aws_securityhub_findings_full_posture_action_dns_request_domain_a7b1b863
       field: json.Action.DnsRequestAction.Domain
       target_field: aws.securityhub_findings_full_posture.action.dns_request.domain
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_DnsRequestAction_Protocol_to_aws_securityhub_findings_full_posture_action_dns_request_protocol_9d4d545f
       field: json.Action.DnsRequestAction.Protocol
       target_field: aws.securityhub_findings_full_posture.action.dns_request.protocol
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_Blocked_to_aws_securityhub_findings_full_posture_action_network_connection_blocked_facd05ce
       field: json.Action.NetworkConnectionAction.Blocked
       target_field: aws.securityhub_findings_full_posture.action.network_connection.blocked
       if: ctx.json?.Action?.NetworkConnectionAction?.Blocked != ''
@@ -200,13 +237,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4787767f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_ConnectionDirection_to_aws_securityhub_findings_full_posture_action_network_connection_direction_3a8f6b0f
       field: json.Action.NetworkConnectionAction.ConnectionDirection
       target_field: aws.securityhub_findings_full_posture.action.network_connection.direction
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_LocalPortDetails_Port_to_aws_securityhub_findings_full_posture_action_network_connection_local_port_number_e8bc8418
       field: json.Action.NetworkConnectionAction.LocalPortDetails.Port
       target_field: aws.securityhub_findings_full_posture.action.network_connection.local.port.number
       if: ctx.json?.Action?.NetworkConnectionAction?.LocalPortDetails?.Port != ''
@@ -214,29 +254,36 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4f368bb9
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_LocalPortDetails_PortName_to_aws_securityhub_findings_full_posture_action_network_connection_local_port_name_0d4fb666
       field: json.Action.NetworkConnectionAction.LocalPortDetails.PortName
       target_field: aws.securityhub_findings_full_posture.action.network_connection.local.port.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_Protocol_to_aws_securityhub_findings_full_posture_action_network_connection_protocol_aa5294a1
       field: json.Action.NetworkConnectionAction.Protocol
       target_field: aws.securityhub_findings_full_posture.action.network_connection.protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_City_CityName_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_city_name_347d8963
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.City.CityName
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.city.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Country_CountryCode_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_country_code_149a50ea
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Country.CountryCode
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.country.code
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Country_CountryName_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_country_name_e77027f2
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Country.CountryName
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.country.name
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemoteIpDetails_GeoLocation_Lat_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_geolocation_latitude_570161e7
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.GeoLocation.Lat
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.geolocation.latitude
       if: ctx.json?.Action?.NetworkConnectionAction?.RemoteIpDetails?.GeoLocation?.Lat != ''
@@ -244,9 +291,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_bf500a56
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemoteIpDetails_GeoLocation_Lon_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_geolocation_longitude_3aa8d0a0
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.GeoLocation.Lon
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.geolocation.longitude
       if: ctx.json?.Action?.NetworkConnectionAction?.RemoteIpDetails?.GeoLocation?.Lon != ''
@@ -254,9 +303,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c369ffc7
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemoteIpDetails_IpAddressV4_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_ip_address_v4_87901f94
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.IpAddressV4
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.ip.address_v4
       if: ctx.json?.Action?.NetworkConnectionAction?.RemoteIpDetails?.IpAddressV4 != ''
@@ -264,9 +315,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c12f50bd
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemoteIpDetails_Organization_Asn_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_organization_asn_135d7b38
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Organization.Asn
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.organization.asn
       if: ctx.json?.Action?.NetworkConnectionAction?.RemoteIpDetails?.Organization?.Asn != ''
@@ -274,21 +327,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0a80aa21
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Organization_AsnOrg_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_organization_asn_organization_afb18afe
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Organization.AsnOrg
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.organization.asn_organization
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Organization_Isp_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_organization_internet_service_provider_e93e6581
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Organization.Isp
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.organization.internet_service_provider
       ignore_missing: true
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemoteIpDetails_Organization_Org_to_aws_securityhub_findings_full_posture_action_network_connection_remote_ip_organization_internet_provider_ac383fc3
       field: json.Action.NetworkConnectionAction.RemoteIpDetails.Organization.Org
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote_ip.organization.internet_provider
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_NetworkConnectionAction_RemotePortDetails_Port_to_aws_securityhub_findings_full_posture_action_network_connection_remote_port_number_46a9223b
       field: json.Action.NetworkConnectionAction.RemotePortDetails.Port
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote.port.number
       if: ctx.json?.Action?.NetworkConnectionAction?.RemotePortDetails?.Port != ''
@@ -296,13 +354,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_d67eb2a0
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Action_NetworkConnectionAction_RemotePortDetails_PortName_to_aws_securityhub_findings_full_posture_action_network_connection_remote_port_name_1268b152
       field: json.Action.NetworkConnectionAction.RemotePortDetails.PortName
       target_field: aws.securityhub_findings_full_posture.action.network_connection.remote.port.name
       ignore_missing: true
   - convert:
+      tag: convert_json_Action_PortProbeAction_Blocked_to_aws_securityhub_findings_full_posture_action_port_probe_blocked_3ece0655
       field: json.Action.PortProbeAction.Blocked
       target_field: aws.securityhub_findings_full_posture.action.port_probe.blocked
       if: ctx.json?.Action?.PortProbeAction?.Blocked != ''
@@ -310,9 +371,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_39ec8f7c
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_3837ae38
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -327,6 +390,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_c21dcf2d
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -341,6 +405,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_532ff1ea
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -350,6 +415,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_19cd5987
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -359,6 +425,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_236490ce
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -368,6 +435,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_52ead486
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -377,6 +445,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_52adc118
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -391,6 +460,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_4a9f5cb9
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -405,6 +475,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_da903888
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -419,6 +490,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_409e8475
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         convert:
@@ -433,6 +505,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_708fe002
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -442,6 +515,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_73bed45d
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -451,6 +525,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_250a673f
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         rename:
@@ -460,6 +535,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - foreach:
+      tag: foreach_json_Action_PortProbeAction_PortProbeDetails_be4eade7
       field: json.Action.PortProbeAction.PortProbeDetails
       processor:
         remove:
@@ -471,26 +547,32 @@ processors:
       ignore_failure: true
       if: ctx.json?.Action?.PortProbeAction?.PortProbeDetails != null && ctx.json?.Action?.PortProbeAction?.PortProbeDetails instanceof List
   - rename:
+      tag: rename_json_Action_PortProbeAction_PortProbeDetails_to_aws_securityhub_findings_full_posture_action_port_probe_details_045eb2ce
       field: json.Action.PortProbeAction.PortProbeDetails
       target_field: aws.securityhub_findings_full_posture.action.port_probe.details
       ignore_missing: true
   - rename:
+      tag: rename_json_AwsAccountId_to_aws_securityhub_findings_full_posture_aws_account_id_be487dc2
       field: json.AwsAccountId
       target_field: aws.securityhub_findings_full_posture.aws_account_id
       ignore_missing: true
   - set:
+      tag: set_cloud_account_id_95972af6
       field: cloud.account.id
       copy_from: aws.securityhub_findings_full_posture.aws_account_id
       ignore_failure: true
   - rename:
+      tag: rename_json_CompanyName_to_aws_securityhub_findings_full_posture_company_name_f57b5a86
       field: json.CompanyName
       target_field: aws.securityhub_findings_full_posture.company.name
       ignore_missing: true
   - set:
+      tag: set_organization_name_5f7baba2
       field: organization.name
       copy_from: aws.securityhub_findings_full_posture.company.name
       ignore_failure: true
   - rename:
+      tag: rename_json_Compliance_RelatedRequirements_to_aws_securityhub_findings_full_posture_compliance_related_requirements_af2fdc63
       field: json.Compliance.RelatedRequirements
       target_field: aws.securityhub_findings_full_posture.compliance.related_requirements
       ignore_missing: true
@@ -505,6 +587,7 @@ processors:
           tag: append_related_requirements_rule_ruleset
           allow_duplicates: false
   - rename:
+      tag: rename_json_Compliance_Status_to_aws_securityhub_findings_full_posture_compliance_status_f978d15c
       field: json.Compliance.Status
       target_field: aws.securityhub_findings_full_posture.compliance.status
       ignore_missing: true
@@ -544,6 +627,7 @@ processors:
       value: unknown
       if: ctx.event?.outcome == null
   - foreach:
+      tag: foreach_json_Compliance_StatusReasons_9b221651
       field: json.Compliance.StatusReasons
       processor:
         rename:
@@ -553,6 +637,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Compliance?.StatusReasons != null && ctx.json?.Compliance?.StatusReasons instanceof List
   - foreach:
+      tag: foreach_json_Compliance_StatusReasons_0c940320
       field: json.Compliance.StatusReasons
       processor:
         rename:
@@ -562,10 +647,12 @@ processors:
       ignore_failure: true
       if: ctx.json?.Compliance?.StatusReasons != null && ctx.json?.Compliance?.StatusReasons instanceof List
   - rename:
+      tag: rename_json_Compliance_StatusReasons_to_aws_securityhub_findings_full_posture_compliance_status_reasons_602eb5df
       field: json.Compliance.StatusReasons
       target_field: aws.securityhub_findings_full_posture.compliance.status_reasons
       ignore_missing: true
   - convert:
+      tag: convert_json_Confidence_to_aws_securityhub_findings_full_posture_confidence_507c2887
       field: json.Confidence
       target_field: aws.securityhub_findings_full_posture.confidence
       if: ctx.json?.Confidence != ''
@@ -573,9 +660,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_5a2ee9fe
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_CreatedAt_to_aws_securityhub_findings_full_posture_created_at_187e2750
       field: json.CreatedAt
       if: ctx.json?.CreatedAt != null && ctx.json?.CreatedAt != ''
       target_field: aws.securityhub_findings_full_posture.created_at
@@ -584,6 +673,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_9ca0f1fb
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
@@ -596,6 +686,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_adb729fc
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -603,6 +694,7 @@ processors:
       value: "{{{_ingest.timestamp}}}"
       tag: set_timestamp
   - convert:
+      tag: convert_json_Criticality_to_aws_securityhub_findings_full_posture_criticality_693fc1fc
       field: json.Criticality
       target_field: aws.securityhub_findings_full_posture.criticality
       if: ctx.json?.Criticality != ''
@@ -610,9 +702,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_28c3f85f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Description_to_aws_securityhub_findings_full_posture_description_bac8422a
       field: json.Description
       target_field: aws.securityhub_findings_full_posture.description
       ignore_missing: true
@@ -622,6 +716,7 @@ processors:
       copy_from: aws.securityhub_findings_full_posture.description
       ignore_empty_value: true
   - convert:
+      tag: convert_json_FindingProviderFields_Confidence_to_aws_securityhub_findings_full_posture_provider_fields_confidence_9ce2bcfb
       field: json.FindingProviderFields.Confidence
       target_field: aws.securityhub_findings_full_posture.provider_fields.confidence
       if: ctx.json?.FindingProviderFields?.Confidence != ''
@@ -629,9 +724,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b0426020
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_FindingProviderFields_Criticality_to_aws_securityhub_findings_full_posture_provider_fields_criticality_90ef4822
       field: json.FindingProviderFields.Criticality
       target_field: aws.securityhub_findings_full_posture.provider_fields.criticality
       if: ctx.json?.FindingProviderFields?.Criticality != ''
@@ -639,9 +736,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_0ddd42bb
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - foreach:
+      tag: foreach_json_FindingProviderFields_RelatedFindings_c5e5b651
       field: json.FindingProviderFields.RelatedFindings
       processor:
         rename:
@@ -651,6 +750,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.FindingProviderFields?.RelatedFindings != null && ctx.json?.FindingProviderFields?.RelatedFindings instanceof List
   - foreach:
+      tag: foreach_json_FindingProviderFields_RelatedFindings_c8042321
       field: json.FindingProviderFields.RelatedFindings
       processor:
         rename:
@@ -660,18 +760,22 @@ processors:
       ignore_failure: true
       if: ctx.json?.FindingProviderFields?.RelatedFindings != null && ctx.json?.FindingProviderFields?.RelatedFindings instanceof List
   - rename:
+      tag: rename_json_FindingProviderFields_RelatedFindings_to_aws_securityhub_findings_full_posture_provider_fields_related_findings_31f7da8f
       field: json.FindingProviderFields.RelatedFindings
       target_field: aws.securityhub_findings_full_posture.provider_fields.related_findings
       ignore_missing: true
   - rename:
+      tag: rename_json_FindingProviderFields_Severity_Label_to_aws_securityhub_findings_full_posture_provider_fields_severity_label_27f92aa2
       field: json.FindingProviderFields.Severity.Label
       target_field: aws.securityhub_findings_full_posture.provider_fields.severity.label
       ignore_missing: true
   - rename:
+      tag: rename_json_FindingProviderFields_Severity_Original_to_aws_securityhub_findings_full_posture_provider_fields_severity_original_c580df4a
       field: json.FindingProviderFields.Severity.Original
       target_field: aws.securityhub_findings_full_posture.provider_fields.severity.original
       ignore_missing: true
   - convert:
+      tag: convert_json_FindingProviderFields_Severity_Normalized_to_aws_securityhub_findings_full_posture_provider_fields_severity_normalized_bc5cc1bb
       field: json.FindingProviderFields.Severity.Normalized
       target_field: aws.securityhub_findings_full_posture.provider_fields.severity.normalized
       if: ctx.json?.FindingProviderFields?.Severity?.Normalized != ''
@@ -679,9 +783,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b550d51c
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_FindingProviderFields_Severity_Product_to_aws_securityhub_findings_full_posture_provider_fields_severity_product_97ef4783
       field: json.FindingProviderFields.Severity.Product
       target_field: aws.securityhub_findings_full_posture.provider_fields.severity.product
       if: ctx.json?.FindingProviderFields?.Severity?.Product != ''
@@ -689,13 +795,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_c00f7eb2
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_FindingProviderFields_Types_to_aws_securityhub_findings_full_posture_provider_fields_types_b43960b4
       field: json.FindingProviderFields.Types
       target_field: aws.securityhub_findings_full_posture.provider_fields.types
       ignore_missing: true
   - date:
+      tag: date_json_FirstObservedAt_to_aws_securityhub_findings_full_posture_first_observed_at_ee1f7241
       field: json.FirstObservedAt
       if: ctx.json?.FirstObservedAt != null && ctx.json?.FirstObservedAt != ''
       target_field: aws.securityhub_findings_full_posture.first_observed_at
@@ -704,9 +813,11 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_2c2b348c
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_GeneratorId_to_aws_securityhub_findings_full_posture_generator_id_78270bea
       field: json.GeneratorId
       target_field: aws.securityhub_findings_full_posture.generator.id
       ignore_missing: true
@@ -716,6 +827,7 @@ processors:
       copy_from: aws.securityhub_findings_full_posture.generator.id
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Compliance_SecurityControlId_to_aws_securityhub_findings_full_posture_compliance_security_control_id_589fc60a
       field: json.Compliance.SecurityControlId
       target_field: aws.securityhub_findings_full_posture.compliance.security_control_id
       ignore_missing: true
@@ -726,14 +838,17 @@ processors:
       if: ctx.rule?.id == null
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Id_to_aws_securityhub_findings_full_posture_id_58a21558
       field: json.Id
       target_field: aws.securityhub_findings_full_posture.id
       ignore_missing: true
   - set:
+      tag: set_event_id_7b39e67c
       field: event.id
       copy_from: aws.securityhub_findings_full_posture.id
       ignore_failure: true
   - date:
+      tag: date_json_LastObservedAt_to_aws_securityhub_findings_full_posture_last_observed_at_31973917
       field: json.LastObservedAt
       if: ctx.json?.LastObservedAt != null && ctx.json?.LastObservedAt != ''
       target_field: aws.securityhub_findings_full_posture.last_observed_at
@@ -742,6 +857,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_c7a38a9a
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
@@ -754,6 +870,7 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_2bb20a31
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
@@ -762,6 +879,7 @@ processors:
       copy_from: aws.securityhub_findings_full_posture.processed_at
       ignore_empty_value: true
   - foreach:
+      tag: foreach_json_Malware_18076c1e
       field: json.Malware
       processor:
         rename:
@@ -771,6 +889,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Malware != null && ctx.json?.Malware instanceof List
   - foreach:
+      tag: foreach_json_Malware_83b1baba
       field: json.Malware
       processor:
         rename:
@@ -780,6 +899,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Malware != null && ctx.json?.Malware instanceof List
   - foreach:
+      tag: foreach_json_Malware_872d434c
       field: json.Malware
       processor:
         rename:
@@ -789,6 +909,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Malware != null && ctx.json?.Malware instanceof List
   - foreach:
+      tag: foreach_json_Malware_e62418fc
       field: json.Malware
       processor:
         rename:
@@ -798,18 +919,22 @@ processors:
       ignore_failure: true
       if: ctx.json?.Malware != null && ctx.json?.Malware instanceof List
   - rename:
+      tag: rename_json_Malware_to_aws_securityhub_findings_full_posture_malware_2fe55434
       field: json.Malware
       target_field: aws.securityhub_findings_full_posture.malware
       ignore_missing: true
   - rename:
+      tag: rename_json_Network_DestinationDomain_to_aws_securityhub_findings_full_posture_network_destination_domain_61f6410c
       field: json.Network.DestinationDomain
       target_field: aws.securityhub_findings_full_posture.network.destination.domain
       ignore_missing: true
   - set:
+      tag: set_destination_domain_4c203ac0
       field: destination.domain
       copy_from: aws.securityhub_findings_full_posture.network.destination.domain
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_DestinationIpV4_to_aws_securityhub_findings_full_posture_network_destination_ip_v4_f281d634
       field: json.Network.DestinationIpV4
       target_field: aws.securityhub_findings_full_posture.network.destination.ip.v4
       if: ctx.json?.Network?.DestinationIpV4 != ''
@@ -817,15 +942,18 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e33501fd
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_destination_ip_672b5e9b
       field: destination.ip
       value: '{{{aws.securityhub_findings_full_posture.network.destination.ip.v4}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.network?.destination?.ip?.v4 != null
       allow_duplicates: false
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_DestinationIpV6_to_aws_securityhub_findings_full_posture_network_destination_ip_v6_f1cb817e
       field: json.Network.DestinationIpV6
       target_field: aws.securityhub_findings_full_posture.network.destination.ip.v6
       if: ctx.json?.Network?.DestinationIpV6 != ''
@@ -833,15 +961,18 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_f86a3cc7
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_destination_ip_a34d9963
       field: destination.ip
       value: '{{{aws.securityhub_findings_full_posture.network.destination.ip.v6}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.network?.destination?.ip?.v6 != null
       allow_duplicates: false
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_DestinationPort_to_aws_securityhub_findings_full_posture_network_destination_port_792dabe1
       field: json.Network.DestinationPort
       target_field: aws.securityhub_findings_full_posture.network.destination.port
       if: ctx.json?.Network?.DestinationPort != ''
@@ -849,25 +980,31 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_27cd8976
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_destination_port_7c94e4ea
       field: destination.port
       copy_from: aws.securityhub_findings_full_posture.network.destination.port
       ignore_failure: true
   - rename:
+      tag: rename_json_Network_Direction_to_aws_securityhub_findings_full_posture_network_direction_9ac6840c
       field: json.Network.Direction
       target_field: aws.securityhub_findings_full_posture.network.direction
       ignore_missing: true
   - set:
+      tag: set_network_direction_2aa173b1
       field: network.direction
       value: inbound
       if: "ctx.aws?.securityhub_findings_full_posture?.network?.direction == 'IN'"
   - set:
+      tag: set_network_direction_970327b5
       field: network.direction
       value: outbound
       if: "ctx.aws?.securityhub_findings_full_posture?.network?.direction == 'OUT'"
   - convert:
+      tag: convert_json_Network_OpenPortRange_Begin_to_aws_securityhub_findings_full_posture_network_open_port_range_begin_10203b92
       field: json.Network.OpenPortRange.Begin
       target_field: aws.securityhub_findings_full_posture.network.open_port_range.begin
       if: ctx.json?.Network?.OpenPortRange?.Begin != ''
@@ -875,9 +1012,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_22676305
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_Network_OpenPortRange_End_to_aws_securityhub_findings_full_posture_network_open_port_range_end_1a46c98e
       field: json.Network.OpenPortRange.End
       target_field: aws.securityhub_findings_full_posture.network.open_port_range.end
       if: ctx.json?.Network?.OpenPortRange?.End != ''
@@ -885,28 +1024,35 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_e0c61d5d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Network_Protocol_to_aws_securityhub_findings_full_posture_network_protocol_8c40bff0
       field: json.Network.Protocol
       target_field: aws.securityhub_findings_full_posture.network.protocol
       ignore_missing: true
   - set:
+      tag: set_network_protocol_21433830
       field: network.protocol
       copy_from: aws.securityhub_findings_full_posture.network.protocol
       ignore_failure: true
   - lowercase:
+      tag: lowercase_network_protocol_49872259
       field: network.protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_Network_SourceDomain_to_aws_securityhub_findings_full_posture_network_source_domain_6d6bee2a
       field: json.Network.SourceDomain
       target_field: aws.securityhub_findings_full_posture.network.source.domain
       ignore_missing: true
   - set:
+      tag: set_source_domain_bd085fd0
       field: source.domain
       copy_from: aws.securityhub_findings_full_posture.network.source.domain
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_SourceIpV4_to_aws_securityhub_findings_full_posture_network_source_ip_v4_3e09c5d7
       field: json.Network.SourceIpV4
       target_field: aws.securityhub_findings_full_posture.network.source.ip.v4
       if: ctx.json?.Network?.SourceIpV4 != ''
@@ -914,15 +1060,18 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_ae526b08
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_source_ip_36f3c340
       field: source.ip
       value: '{{{aws.securityhub_findings_full_posture.network.source.ip.v4}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.network?.source?.ip?.v4 != null
       allow_duplicates: false
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_SourceIpV6_to_aws_securityhub_findings_full_posture_network_source_ip_v6_9520fa9d
       field: json.Network.SourceIpV6
       target_field: aws.securityhub_findings_full_posture.network.source.ip.v6
       if: ctx.json?.Network?.SourceIpV6 != ''
@@ -930,31 +1079,38 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_49fbd61e
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
+      tag: append_source_ip_45055624
       field: source.ip
       value: '{{{aws.securityhub_findings_full_posture.network.source.ip.v6}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.network?.source?.ip?.v6 != null
       allow_duplicates: false
       ignore_failure: true
   - rename:
+      tag: rename_json_Network_SourceMac_to_aws_securityhub_findings_full_posture_network_source_mac_8df846b2
       field: json.Network.SourceMac
       target_field: aws.securityhub_findings_full_posture.network.source.mac
       ignore_missing: true
   - gsub:
+      tag: gsub_aws_securityhub_findings_full_posture_network_source_mac_d4e74ecd
       field: aws.securityhub_findings_full_posture.network.source.mac
       pattern: '[-:.]'
       replacement: '-'
       ignore_missing: true
   - uppercase:
+      tag: uppercase_aws_securityhub_findings_full_posture_network_source_mac_e540c824
       field: aws.securityhub_findings_full_posture.network.source.mac
       ignore_missing: true
   - set:
+      tag: set_source_mac_6743405c
       field: source.mac
       copy_from: aws.securityhub_findings_full_posture.network.source.mac
       ignore_failure: true
   - convert:
+      tag: convert_json_Network_SourcePort_to_aws_securityhub_findings_full_posture_network_source_port_ab64dd08
       field: json.Network.SourcePort
       target_field: aws.securityhub_findings_full_posture.network.source.port
       if: ctx.json?.Network?.SourcePort != ''
@@ -962,13 +1118,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_83e92831
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_source_port_9781ee8c
       field: source.port
       copy_from: aws.securityhub_findings_full_posture.network.source.port
       ignore_failure: true
   - foreach:
+      tag: foreach_json_NetworkPath_d16d69fa
       field: json.NetworkPath
       processor:
         rename:
@@ -978,6 +1137,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_bdd1d1d8
       field: json.NetworkPath
       processor:
         rename:
@@ -987,6 +1147,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_3782561c
       field: json.NetworkPath
       processor:
         rename:
@@ -996,6 +1157,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_d3dc83dd
       field: json.NetworkPath
       processor:
         foreach:
@@ -1015,6 +1177,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_4f963655
       field: json.NetworkPath
       processor:
         foreach:
@@ -1034,6 +1197,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_f7493631
       field: json.NetworkPath
       processor:
         foreach:
@@ -1049,6 +1213,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_13001d71
       field: json.NetworkPath
       processor:
         rename:
@@ -1058,6 +1223,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_dce80932
       field: json.NetworkPath
       processor:
         rename:
@@ -1067,6 +1233,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_b4a7c8a6
       field: json.NetworkPath
       processor:
         rename:
@@ -1076,6 +1243,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_242bcada
       field: json.NetworkPath
       processor:
         foreach:
@@ -1095,6 +1263,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_e93fd09a
       field: json.NetworkPath
       processor:
         foreach:
@@ -1114,6 +1283,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_21ad558c
       field: json.NetworkPath
       processor:
         foreach:
@@ -1129,6 +1299,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_1097a7f3
       field: json.NetworkPath
       processor:
         rename:
@@ -1138,6 +1309,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_33174c1a
       field: json.NetworkPath
       processor:
         rename:
@@ -1147,6 +1319,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_5c1690a5
       field: json.NetworkPath
       processor:
         foreach:
@@ -1166,6 +1339,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_b6476c1d
       field: json.NetworkPath
       processor:
         foreach:
@@ -1185,6 +1359,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_cc783169
       field: json.NetworkPath
       processor:
         foreach:
@@ -1200,6 +1375,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_3a332679
       field: json.NetworkPath
       processor:
         rename:
@@ -1209,6 +1385,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_5ab2fdc8
       field: json.NetworkPath
       processor:
         rename:
@@ -1218,6 +1395,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_0683485e
       field: json.NetworkPath
       processor:
         rename:
@@ -1227,6 +1405,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_2003d249
       field: json.NetworkPath
       processor:
         foreach:
@@ -1247,6 +1426,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_1b97f692
       field: json.NetworkPath
       processor:
         foreach:
@@ -1266,6 +1446,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_237ef0b4
       field: json.NetworkPath
       processor:
         foreach:
@@ -1281,6 +1462,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - foreach:
+      tag: foreach_json_NetworkPath_63de8b8d
       field: json.NetworkPath
       processor:
         rename:
@@ -1290,14 +1472,17 @@ processors:
       ignore_failure: true
       if: ctx.json?.NetworkPath != null && ctx.json?.NetworkPath instanceof List
   - rename:
+      tag: rename_json_NetworkPath_to_aws_securityhub_findings_full_posture_network_path_efd85539
       field: json.NetworkPath
       target_field: aws.securityhub_findings_full_posture.network_path
       ignore_missing: true
   - rename:
+      tag: rename_json_Note_Text_to_aws_securityhub_findings_full_posture_note_text_a71a136c
       field: json.Note.Text
       target_field: aws.securityhub_findings_full_posture.note.text
       ignore_missing: true
   - date:
+      tag: date_json_Note_UpdatedAt_to_aws_securityhub_findings_full_posture_note_updated_at_5bf9f1f6
       field: json.Note.UpdatedAt
       if: ctx.json?.Note?.UpdatedAt != null && ctx.json?.Note?.UpdatedAt != ''
       target_field: aws.securityhub_findings_full_posture.note.updated_at
@@ -1306,13 +1491,16 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_6c418765
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Note_UpdatedBy_to_aws_securityhub_findings_full_posture_note_updated_by_23f8ed41
       field: json.Note.UpdatedBy
       target_field: aws.securityhub_findings_full_posture.note.updated_by
       ignore_missing: true
   - convert:
+      tag: convert_json_PatchSummary_FailedCount_to_aws_securityhub_findings_full_posture_patch_summary_failed_count_07cd176f
       field: json.PatchSummary.FailedCount
       target_field: aws.securityhub_findings_full_posture.patch_summary.failed.count
       if: ctx.json?.PatchSummary?.FailedCount != ''
@@ -1320,13 +1508,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_4b3a5c14
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_PatchSummary_Id_to_aws_securityhub_findings_full_posture_patch_summary_id_38e5fee1
       field: json.PatchSummary.Id
       target_field: aws.securityhub_findings_full_posture.patch_summary.id
       ignore_missing: true
   - convert:
+      tag: convert_json_PatchSummary_InstalledCount_to_aws_securityhub_findings_full_posture_patch_summary_installed_count_cb596cd0
       field: json.PatchSummary.InstalledCount
       target_field: aws.securityhub_findings_full_posture.patch_summary.installed.count
       if: ctx.json?.PatchSummary?.InstalledCount != ''
@@ -1334,9 +1525,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_1ab3a001
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_PatchSummary_InstalledOtherCount_to_aws_securityhub_findings_full_posture_patch_summary_installed_other_count_bd4f44f2
       field: json.PatchSummary.InstalledOtherCount
       target_field: aws.securityhub_findings_full_posture.patch_summary.installed.other.count
       if: ctx.json?.PatchSummary?.InstalledOtherCount != ''
@@ -1344,9 +1537,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b47f2767
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_PatchSummary_InstalledPendingReboot_to_aws_securityhub_findings_full_posture_patch_summary_installed_pending_reboot_be8a3cb0
       field: json.PatchSummary.InstalledPendingReboot
       target_field: aws.securityhub_findings_full_posture.patch_summary.installed.pending_reboot
       if: ctx.json?.PatchSummary?.InstalledPendingReboot != ''
@@ -1354,9 +1549,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2cb69f87
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_PatchSummary_InstalledRejectedCount_to_aws_securityhub_findings_full_posture_patch_summary_installed_rejected_count_a5036996
       field: json.PatchSummary.InstalledRejectedCount
       target_field: aws.securityhub_findings_full_posture.patch_summary.installed.rejected.count
       if: ctx.json?.PatchSummary?.InstalledRejectedCount != ''
@@ -1364,9 +1561,11 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_a1587eed
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
+      tag: convert_json_PatchSummary_MissingCount_to_aws_securityhub_findings_full_posture_patch_summary_missing_count_829654ca
       field: json.PatchSummary.MissingCount
       target_field: aws.securityhub_findings_full_posture.patch_summary.missing.count
       if: ctx.json?.PatchSummary?.MissingCount != ''
@@ -1374,13 +1573,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_241ff313
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_PatchSummary_Operation_to_aws_securityhub_findings_full_posture_patch_summary_operation_type_718260a3
       field: json.PatchSummary.Operation
       target_field: aws.securityhub_findings_full_posture.patch_summary.operation.type
       ignore_missing: true
   - date:
+      tag: date_json_PatchSummary_OperationEndTime_to_aws_securityhub_findings_full_posture_patch_summary_operation_end_time_136a9737
       field: json.PatchSummary.OperationEndTime
       if: ctx.json?.PatchSummary?.OperationEndTime != null && ctx.json?.PatchSummary?.OperationEndTime != ''
       target_field: aws.securityhub_findings_full_posture.patch_summary.operation.end_time
@@ -1389,9 +1591,11 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_514be620
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
+      tag: date_json_PatchSummary_OperationStartTime_to_aws_securityhub_findings_full_posture_patch_summary_operation_start_time_22b85da1
       field: json.PatchSummary.OperationStartTime
       if: ctx.json?.PatchSummary?.OperationStartTime != null && ctx.json?.PatchSummary?.OperationStartTime != ''
       target_field: aws.securityhub_findings_full_posture.patch_summary.operation.start_time
@@ -1400,13 +1604,16 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_a0a91fea
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_PatchSummary_RebootOption_to_aws_securityhub_findings_full_posture_patch_summary_reboot_option_dab689d2
       field: json.PatchSummary.RebootOption
       target_field: aws.securityhub_findings_full_posture.patch_summary.reboot_option
       ignore_missing: true
   - date:
+      tag: date_json_Process_LaunchedAt_to_aws_securityhub_findings_full_posture_process_launched_at_b6ab758a
       field: json.Process.LaunchedAt
       if: ctx.json?.Process?.LaunchedAt != null && ctx.json?.Process?.LaunchedAt != ''
       target_field: aws.securityhub_findings_full_posture.process.launched_at
@@ -1415,21 +1622,26 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_31702d7d
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_process_start_cc3be112
       field: process.start
       copy_from: aws.securityhub_findings_full_posture.process.launched_at
       ignore_failure: true
   - rename:
+      tag: rename_json_Process_Name_to_aws_securityhub_findings_full_posture_process_name_d113e498
       field: json.Process.Name
       target_field: aws.securityhub_findings_full_posture.process.name
       ignore_missing: true
   - set:
+      tag: set_process_name_1817bb0c
       field: process.name
       copy_from: aws.securityhub_findings_full_posture.process.name
       ignore_failure: true
   - convert:
+      tag: convert_json_Process_ParentPid_to_aws_securityhub_findings_full_posture_process_parent_pid_40ab8c66
       field: json.Process.ParentPid
       target_field: aws.securityhub_findings_full_posture.process.parent.pid
       if: ctx.json?.Process?.ParentPid != ''
@@ -1437,21 +1649,26 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_314cac45
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_process_parent_pid_9b582d9c
       field: process.parent.pid
       copy_from: aws.securityhub_findings_full_posture.process.parent.pid
       ignore_failure: true
   - rename:
+      tag: rename_json_Process_Path_to_aws_securityhub_findings_full_posture_process_path_1a708624
       field: json.Process.Path
       target_field: aws.securityhub_findings_full_posture.process.path
       ignore_missing: true
   - set:
+      tag: set_process_executable_0029ff51
       field: process.executable
       copy_from: aws.securityhub_findings_full_posture.process.path
       ignore_failure: true
   - convert:
+      tag: convert_json_Process_Pid_to_aws_securityhub_findings_full_posture_process_pid_0fe12de2
       field: json.Process.Pid
       target_field: aws.securityhub_findings_full_posture.process.pid
       if: ctx.json?.Process?.Pid != ''
@@ -1459,13 +1676,16 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_b1344067
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_process_pid_1e092430
       field: process.pid
       copy_from: aws.securityhub_findings_full_posture.process.pid
       ignore_failure: true
   - date:
+      tag: date_json_Process_TerminatedAt_to_aws_securityhub_findings_full_posture_process_terminated_at_865bd43c
       field: json.Process.TerminatedAt
       if: ctx.json?.Process?.TerminatedAt != null && ctx.json?.Process?.TerminatedAt != ''
       target_field: aws.securityhub_findings_full_posture.process.terminated_at
@@ -1474,29 +1694,36 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
       on_failure:
         - append:
+            tag: append_error_message_d0e0e6eb
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_process_end_f664d2b2
       field: process.end
       copy_from: aws.securityhub_findings_full_posture.process.terminated_at
       ignore_failure: true
   - rename:
+      tag: rename_json_ProductArn_to_aws_securityhub_findings_full_posture_product_arn_8b95f598
       field: json.ProductArn
       target_field: aws.securityhub_findings_full_posture.product.arn
       ignore_missing: true
   - rename:
+      tag: rename_json_ProductFields_to_aws_securityhub_findings_full_posture_product_fields_2df55c92
       field: json.ProductFields
       target_field: aws.securityhub_findings_full_posture.product.fields
       ignore_missing: true
   - rename:
+      tag: rename_json_ProductName_to_aws_securityhub_findings_full_posture_product_name_01270816
       field: json.ProductName
       target_field: aws.securityhub_findings_full_posture.product.name
       ignore_missing: true
   - rename:
+      tag: rename_json_RecordState_to_aws_securityhub_findings_full_posture_record_state_e415bc51
       field: json.RecordState
       target_field: aws.securityhub_findings_full_posture.record_state
       ignore_missing: true
   - rename:
+      tag: rename_json_Region_to_aws_securityhub_findings_full_posture_region_a0a39ad8
       field: json.Region
       target_field: aws.securityhub_findings_full_posture.region
       ignore_missing: true
@@ -1506,6 +1733,7 @@ processors:
       copy_from: aws.securityhub_findings_full_posture.region
       ignore_empty_value: true
   - foreach:
+      tag: foreach_json_RelatedFindings_3e1a59fc
       field: json.RelatedFindings
       processor:
         rename:
@@ -1515,6 +1743,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.RelatedFindings != null && ctx.json?.RelatedFindings instanceof List
   - foreach:
+      tag: foreach_json_RelatedFindings_77b99b2a
       field: json.RelatedFindings
       processor:
         rename:
@@ -1524,14 +1753,17 @@ processors:
       ignore_failure: true
       if: ctx.json?.RelatedFindings != null && ctx.json?.RelatedFindings instanceof List
   - rename:
+      tag: rename_json_RelatedFindings_to_aws_securityhub_findings_full_posture_related_findings_7404726f
       field: json.RelatedFindings
       target_field: aws.securityhub_findings_full_posture.related_findings
       ignore_missing: true
   - rename:
+      tag: rename_json_Remediation_Recommendation_Text_to_aws_securityhub_findings_full_posture_remediation_recommendation_text_d91c8228
       field: json.Remediation.Recommendation.Text
       target_field: aws.securityhub_findings_full_posture.remediation.recommendation.text
       ignore_missing: true
   - rename:
+      tag: rename_json_Remediation_Recommendation_Url_to_aws_securityhub_findings_full_posture_remediation_recommendation_url_bf617588
       field: json.Remediation.Recommendation.Url
       target_field: aws.securityhub_findings_full_posture.remediation.recommendation.url
       ignore_missing: true
@@ -1547,6 +1779,7 @@ processors:
       if: ctx.aws?.securityhub_findings_full_posture?.remediation?.recommendation?.url != null && ctx.aws.securityhub_findings_full_posture.remediation.recommendation.text != null
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Resources_to_aws_securityhub_findings_full_posture_resources_8ac394c4
       field: json.Resources
       target_field: aws.securityhub_findings_full_posture.resources
       ignore_missing: true
@@ -1916,6 +2149,7 @@ processors:
           }
         }
   - convert:
+      tag: convert_json_Sample_to_aws_securityhub_findings_full_posture_sample_426a9f05
       field: json.Sample
       target_field: aws.securityhub_findings_full_posture.sample
       if: ctx.json?.Sample != ''
@@ -1923,17 +2157,21 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_2a80cbae
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_SchemaVersion_to_aws_securityhub_findings_full_posture_schema_version_78ee4d9e
       field: json.SchemaVersion
       target_field: aws.securityhub_findings_full_posture.schema.version
       ignore_missing: true
   - rename:
+      tag: rename_json_Severity_Label_to_aws_securityhub_findings_full_posture_severity_label_88f30c2c
       field: json.Severity.Label
       target_field: aws.securityhub_findings_full_posture.severity.label
       ignore_missing: true
   - convert:
+      tag: convert_json_Severity_Normalized_to_aws_securityhub_findings_full_posture_severity_normalized_f525eba9
       field: json.Severity.Normalized
       target_field: aws.securityhub_findings_full_posture.severity.normalized
       if: ctx.json?.Severity?.Normalized != ''
@@ -1941,6 +2179,7 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_fe5d00d0
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - convert:
@@ -1951,13 +2190,16 @@ processors:
       type: long
       on_failure:
         - append:
+            tag: append_error_message_0f072524
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_Severity_Original_to_aws_securityhub_findings_full_posture_severity_original_2a72c462
       field: json.Severity.Original
       target_field: aws.securityhub_findings_full_posture.severity.original
       ignore_missing: true
   - convert:
+      tag: convert_json_Severity_Product_to_aws_securityhub_findings_full_posture_severity_product_a54cd555
       field: json.Severity.Product
       target_field: aws.securityhub_findings_full_posture.severity.product
       if: ctx.json?.Severity?.Product != ''
@@ -1965,24 +2207,30 @@ processors:
       ignore_missing: true
       on_failure:
         - append:
+            tag: append_error_message_7d366e56
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
+      tag: rename_json_SourceUrl_to_aws_securityhub_findings_full_posture_source_url_254fc93d
       field: json.SourceUrl
       target_field: aws.securityhub_findings_full_posture.source_url
       ignore_missing: true
   - uri_parts:
+      tag: uri_parts_aws_securityhub_findings_full_posture_source_url_2537d9fc
       field: aws.securityhub_findings_full_posture.source_url
       if: ctx.aws?.securityhub_findings_full_posture?.source_url != '' && ctx.aws?.securityhub_findings_full_posture?.source_url != null
       on_failure:
         - append:
+            tag: append_error_message_46e26d8f
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - set:
+      tag: set_url_full_bf65e319
       field: url.full
       value: '{{{url.original}}}'
       ignore_failure: true
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_2d212bcd
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -1992,6 +2240,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_e8528fcc
       field: json.ThreatIntelIndicators
       processor:
         date:
@@ -2004,6 +2253,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_8cc90a53
       field: json.ThreatIntelIndicators
       processor:
         remove:
@@ -2013,6 +2263,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_2e9164f3
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -2022,6 +2273,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_ad5cd248
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -2031,6 +2283,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_f1d323b5
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -2040,6 +2293,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_23d9c4b5
       field: json.ThreatIntelIndicators
       processor:
         rename:
@@ -2049,6 +2303,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - foreach:
+      tag: foreach_json_ThreatIntelIndicators_b6f769ce
       field: json.ThreatIntelIndicators
       processor:
         set:
@@ -2058,6 +2313,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - script:
+      tag: script_fede25a4
       description: Map box field ThreatIntelIndicator to ECS field threat.indicator.type
       lang: painless
       params:
@@ -2101,10 +2357,12 @@ processors:
         } 
       if: ctx.json?.ThreatIntelIndicators != null && ctx.json?.ThreatIntelIndicators instanceof List
   - rename:
+      tag: rename_json_ThreatIntelIndicators_to_aws_securityhub_findings_full_posture_threat_intel_indicators_96b7def6
       field: json.ThreatIntelIndicators
       target_field: aws.securityhub_findings_full_posture.threat_intel_indicators
       ignore_missing: true
   - rename:
+      tag: rename_json_Title_to_aws_securityhub_findings_full_posture_title_39cea6aa
       field: json.Title
       target_field: aws.securityhub_findings_full_posture.title
       ignore_missing: true
@@ -2114,18 +2372,22 @@ processors:
       copy_from: aws.securityhub_findings_full_posture.title
       ignore_empty_value: true
   - rename:
+      tag: rename_json_Types_to_aws_securityhub_findings_full_posture_types_379faecc
       field: json.Types
       target_field: aws.securityhub_findings_full_posture.types
       ignore_missing: true
   - rename:
+      tag: rename_json_UserDefinedFields_to_aws_securityhub_findings_full_posture_user_defined_fields_c2fa38ee
       field: json.UserDefinedFields
       target_field: aws.securityhub_findings_full_posture.user_defined_fields
       ignore_missing: true
   - rename:
+      tag: rename_json_VerificationState_to_aws_securityhub_findings_full_posture_verification_state_cef7f459
       field: json.VerificationState
       target_field: aws.securityhub_findings_full_posture.verification_state
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Vulnerabilities_17240f9e
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2145,6 +2407,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_5a0ab43e
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2164,6 +2427,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_bf70563b
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2178,6 +2442,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_97bc7c79
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2197,6 +2462,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_96ab6d00
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2211,6 +2477,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_a6376729
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2225,6 +2492,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_e6b5aa0b
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2239,6 +2507,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_25245e65
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2253,6 +2522,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_bd790766
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2267,6 +2537,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_b3591969
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2281,6 +2552,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_b6e12143
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2290,6 +2562,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_24c16547
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2299,6 +2572,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_c4a5957a
       field: json.Vulnerabilities
       processor:
         set:
@@ -2308,6 +2582,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_b6377fa4
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2317,6 +2592,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_77e83ed9
       field: json.Vulnerabilities
       processor:
         set:
@@ -2326,6 +2602,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_4ab2915c
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2335,6 +2612,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_8d1eba09
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2344,6 +2622,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_4f760f9b
       field: json.Vulnerabilities
       processor:
         set:
@@ -2353,6 +2632,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_7d175beb
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2362,6 +2642,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_ca92c915
       field: json.Vulnerabilities
       processor:
         date:
@@ -2374,6 +2655,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_1317e443
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2383,6 +2665,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_04152899
       field: json.Vulnerabilities
       processor:
         date:
@@ -2395,6 +2678,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_9d6098ca
       field: json.Vulnerabilities
       processor:
         remove:
@@ -2405,6 +2689,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_8bdce315
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2419,6 +2704,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_f06880e7
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2433,6 +2719,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_96026b91
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2447,6 +2734,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_4e26ca20
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2461,6 +2749,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_c9c47007
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2475,6 +2764,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_8c6cfe82
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2489,6 +2779,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_20a2be49
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2503,6 +2794,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_a62af8ed
       field: json.Vulnerabilities
       processor:
         foreach:
@@ -2517,6 +2809,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - foreach:
+      tag: foreach_json_Vulnerabilities_0a574cec
       field: json.Vulnerabilities
       processor:
         rename:
@@ -2526,34 +2819,41 @@ processors:
       ignore_failure: true
       if: ctx.json?.Vulnerabilities != null && ctx.json?.Vulnerabilities instanceof List
   - rename:
+      tag: rename_json_Vulnerabilities_to_aws_securityhub_findings_full_posture_vulnerabilities_1226723e
       field: json.Vulnerabilities
       target_field: aws.securityhub_findings_full_posture.vulnerabilities
       ignore_missing: true
   - rename:
+      tag: rename_json_Workflow_Status_to_aws_securityhub_findings_full_posture_workflow_status_ef1cf654
       field: json.Workflow.Status
       target_field: aws.securityhub_findings_full_posture.workflow.status
       ignore_missing: true
   - rename:
+      tag: rename_json_WorkflowState_to_aws_securityhub_findings_full_posture_workflow_state_d843c012
       field: json.WorkflowState
       target_field: aws.securityhub_findings_full_posture.workflow.state
       ignore_missing: true
   - remove:
+      tag: remove_e5a80934
       field:
         - json
       ignore_missing: true
   - append:
+      tag: append_related_ip_8801412d
       field: related.ip
       value: '{{{aws.securityhub_findings_full_posture.action.aws_api_call.remote_ip.ip.address_v4}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.action?.aws_api_call?.remote_ip?.ip?.address_v4 != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_2d403fcd
       field: related.ip
       value: '{{{aws.securityhub_findings_full_posture.action.network_connection.remote_ip.ip.address_v4}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.action?.network_connection?.remote_ip?.ip?.address_v4 != null
       allow_duplicates: false
       ignore_failure: true
   - foreach:
+      tag: foreach_aws_securityhub_findings_full_posture_action_port_probe_details_845ea2db
       field: aws.securityhub_findings_full_posture.action.port_probe.details
       processor:
         append:
@@ -2564,6 +2864,7 @@ processors:
       ignore_failure: true
       if: ctx.aws?.securityhub_findings_full_posture?.action?.port_probe?.details != null && ctx.aws?.securityhub_findings_full_posture?.action?.port_probe?.details instanceof List
   - foreach:
+      tag: foreach_aws_securityhub_findings_full_posture_action_port_probe_details_967d114e
       field: aws.securityhub_findings_full_posture.action.port_probe.details
       processor:
         append:
@@ -2574,30 +2875,35 @@ processors:
       ignore_failure: true
       if: ctx.aws?.securityhub_findings_full_posture?.action?.port_probe?.details != null && ctx.aws?.securityhub_findings_full_posture?.action?.port_probe?.details instanceof List
   - append:
+      tag: append_related_ip_84ad427c
       field: related.ip
       value: '{{{aws.securityhub_findings_full_posture.network.destination.ip.v4}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.network?.destination?.ip?.v4 != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_f3bb3388
       field: related.ip
       value: '{{{aws.securityhub_findings_full_posture.network.destination.ip.v6}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.network?.destination?.ip?.v6 != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_4974dbd6
       field: related.ip
       value: '{{{aws.securityhub_findings_full_posture.network.source.ip.v4}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.network?.source?.ip?.v4 != null
       allow_duplicates: false
       ignore_failure: true
   - append:
+      tag: append_related_ip_4d044bb2
       field: related.ip
       value: '{{{aws.securityhub_findings_full_posture.network.source.ip.v6}}}'
       if: ctx.aws?.securityhub_findings_full_posture?.network?.source?.ip?.v6 != null
       allow_duplicates: false
       ignore_failure: true
   - remove:
+      tag: remove_12fe459a
       if: ctx.tags == null || !(ctx.tags.contains('preserve_duplicate_custom_fields'))
       field:
         - aws.securityhub_findings_full_posture.created_at
@@ -2623,6 +2929,7 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_findings_full_posture_threat_intel_indicators_c1a3d5e9
       field: aws.securityhub_findings_full_posture.threat_intel_indicators
       processor:
         remove:
@@ -2634,6 +2941,7 @@ processors:
           ignore_missing: true
       ignore_missing: true
   - foreach:
+      tag: foreach_aws_securityhub_findings_full_posture_vulnerabilities_71ea5bd3
       field: aws.securityhub_findings_full_posture.vulnerabilities
       processor:
         remove:
@@ -2648,6 +2956,7 @@ processors:
           ignore_missing: true
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |
@@ -2673,4 +2982,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/securityhub_insights/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/securityhub_insights/elasticsearch/ingest_pipeline/default.yml
@@ -13,12 +13,15 @@ processors:
         Removes the fields added by Agentless as metadata,
         as they can collide with ECS fields.
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - set:
+      tag: set_event_type_ec95f7f2
       field: event.type
       value: [info]
   - set:
@@ -26,36 +29,44 @@ processors:
       value: AWS Security Hub CSPM
       tag: set_observer_vendor
   - rename:
+      tag: rename_message_to_event_original_56a77271
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
+      tag: json_event_original_to_json_cac66847
       field: event.original
       target_field: json
       ignore_failure: true
   - rename:
+      tag: rename_json_Filters_AwsAccountId_to_aws_securityhub_insights_filters_aws_account_id_7d9c5130
       field: json.Filters.AwsAccountId
       target_field: aws.securityhub_insights.filters.aws_account_id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_CompanyName_to_aws_securityhub_insights_filters_company_name_4b695968
       field: json.Filters.CompanyName
       target_field: aws.securityhub_insights.filters.company.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ComplianceStatus_to_aws_securityhub_insights_filters_compliance_status_029e914c
       field: json.Filters.ComplianceStatus
       target_field: aws.securityhub_insights.filters.compliance.status
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Confidence_to_aws_securityhub_insights_filters_confidence_d21eab9c
       field: json.Filters.Confidence
       target_field: aws.securityhub_insights.filters.confidence
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_CreatedAt_7990b1a8
       field: json.Filters.CreatedAt
       processor:
         rename:
@@ -65,6 +76,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.CreatedAt != null && ctx.json?.Filters?.CreatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_CreatedAt_73195d1a
       field: json.Filters.CreatedAt
       processor:
         rename:
@@ -74,6 +86,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.CreatedAt != null && ctx.json?.Filters?.CreatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_CreatedAt_23354fe8
       field: json.Filters.CreatedAt
       processor:
         date:
@@ -86,6 +99,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.CreatedAt != null && ctx.json?.Filters?.CreatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_CreatedAt_de1a2920
       field: json.Filters.CreatedAt
       processor:
         date:
@@ -98,6 +112,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.CreatedAt != null && ctx.json?.Filters?.CreatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_CreatedAt_3501ad7a
       field: json.Filters.CreatedAt
       processor:
         remove:
@@ -108,46 +123,57 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.CreatedAt != null && ctx.json?.Filters?.CreatedAt instanceof List
   - rename:
+      tag: rename_json_Filters_CreatedAt_to_aws_securityhub_insights_filters_created_at_fa003e79
       field: json.Filters.CreatedAt
       target_field: aws.securityhub_insights.filters.created_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Criticality_to_aws_securityhub_insights_filters_criticality_8c33f134
       field: json.Filters.Criticality
       target_field: aws.securityhub_insights.filters.criticality
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Description_to_aws_securityhub_insights_filters_description_e3450b80
       field: json.Filters.Description
       target_field: aws.securityhub_insights.filters.description
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_FindingProviderFieldsConfidence_to_aws_securityhub_insights_filters_finding_provider_fields_confidence_19ff433a
       field: json.Filters.FindingProviderFieldsConfidence
       target_field: aws.securityhub_insights.filters.finding_provider_fields.confidence
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_FindingProviderFieldsCriticality_to_aws_securityhub_insights_filters_finding_provider_fields_criticality_52864aa8
       field: json.Filters.FindingProviderFieldsCriticality
       target_field: aws.securityhub_insights.filters.finding_provider_fields.criticality
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_FindingProviderFieldsRelatedFindingsId_to_aws_securityhub_insights_filters_finding_provider_fields_related_findings_id_bfab5c87
       field: json.Filters.FindingProviderFieldsRelatedFindingsId
       target_field: aws.securityhub_insights.filters.finding_provider_fields.related_findings.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_FindingProviderFieldsRelatedFindingsProductArn_to_aws_securityhub_insights_filters_finding_provider_fields_related_findings_product_arn_467c9231
       field: json.Filters.FindingProviderFieldsRelatedFindingsProductArn
       target_field: aws.securityhub_insights.filters.finding_provider_fields.related_findings.product.arn
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_FindingProviderFieldsSeverityLabel_to_aws_securityhub_insights_filters_finding_provider_fields_severity_label_3833409a
       field: json.Filters.FindingProviderFieldsSeverityLabel
       target_field: aws.securityhub_insights.filters.finding_provider_fields.severity.label
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_FindingProviderFieldsSeverityOriginal_to_aws_securityhub_insights_filters_finding_provider_fields_severity_original_c593742e
       field: json.Filters.FindingProviderFieldsSeverityOriginal
       target_field: aws.securityhub_insights.filters.finding_provider_fields.severity.original
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_FindingProviderFieldsTypes_to_aws_securityhub_insights_filters_finding_provider_fields_types_fb2d68c0
       field: json.Filters.FindingProviderFieldsTypes
       target_field: aws.securityhub_insights.filters.finding_provider_fields.types
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_FirstObservedAt_383e75f6
       field: json.Filters.FirstObservedAt
       processor:
         rename:
@@ -157,6 +183,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.FirstObservedAt != null && ctx.json?.Filters?.FirstObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_FirstObservedAt_55516bc0
       field: json.Filters.FirstObservedAt
       processor:
         rename:
@@ -166,6 +193,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.FirstObservedAt != null && ctx.json?.Filters?.FirstObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_FirstObservedAt_32cf9a12
       field: json.Filters.FirstObservedAt
       processor:
         date:
@@ -178,6 +206,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.FirstObservedAt != null && ctx.json?.Filters?.FirstObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_FirstObservedAt_3cbd9812
       field: json.Filters.FirstObservedAt
       processor:
         date:
@@ -190,6 +219,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.FirstObservedAt != null && ctx.json?.Filters?.FirstObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_FirstObservedAt_fa3c0584
       field: json.Filters.FirstObservedAt
       processor:
         remove:
@@ -200,22 +230,27 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.FirstObservedAt != null && ctx.json?.Filters?.FirstObservedAt instanceof List
   - rename:
+      tag: rename_json_Filters_FirstObservedAt_to_aws_securityhub_insights_filters_first_observed_at_fa202d66
       field: json.Filters.FirstObservedAt
       target_field: aws.securityhub_insights.filters.first_observed_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_GeneratorId_to_aws_securityhub_insights_filters_generator_id_f46891a0
       field: json.Filters.GeneratorId
       target_field: aws.securityhub_insights.filters.generator.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Id_to_aws_securityhub_insights_filters_id_63ebe9d6
       field: json.Filters.Id
       target_field: aws.securityhub_insights.filters.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Keyword_to_aws_securityhub_insights_filters_keyword_c5877148
       field: json.Filters.Keyword
       target_field: aws.securityhub_insights.filters.keyword
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_LastObservedAt_7038e934
       field: json.Filters.LastObservedAt
       processor:
         rename:
@@ -225,6 +260,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.LastObservedAt != null && ctx.json?.Filters?.LastObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_LastObservedAt_ede31f46
       field: json.Filters.LastObservedAt
       processor:
         rename:
@@ -234,6 +270,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.LastObservedAt != null && ctx.json?.Filters?.LastObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_LastObservedAt_0a181104
       field: json.Filters.LastObservedAt
       processor:
         date:
@@ -246,6 +283,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.LastObservedAt != null && ctx.json?.Filters?.LastObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_LastObservedAt_b3620a6c
       field: json.Filters.LastObservedAt
       processor:
         date:
@@ -258,6 +296,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.LastObservedAt != null && ctx.json?.Filters?.LastObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_LastObservedAt_c160d15e
       field: json.Filters.LastObservedAt
       processor:
         remove:
@@ -268,74 +307,92 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.LastObservedAt != null && ctx.json?.Filters?.LastObservedAt instanceof List
   - rename:
+      tag: rename_json_Filters_LastObservedAt_to_aws_securityhub_insights_filters_last_observed_at_185c710c
       field: json.Filters.LastObservedAt
       target_field: aws.securityhub_insights.filters.last_observed_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_MalwareName_to_aws_securityhub_insights_filters_malware_name_560a52e8
       field: json.Filters.MalwareName
       target_field: aws.securityhub_insights.filters.malware.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_MalwarePath_to_aws_securityhub_insights_filters_malware_path_71977db8
       field: json.Filters.MalwarePath
       target_field: aws.securityhub_insights.filters.malware.path
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_MalwareState_to_aws_securityhub_insights_filters_malware_state_2d676798
       field: json.Filters.MalwareState
       target_field: aws.securityhub_insights.filters.malware.state
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_MalwareType_to_aws_securityhub_insights_filters_malware_type_96d84c3a
       field: json.Filters.MalwareType
       target_field: aws.securityhub_insights.filters.malware.type
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkDestinationDomain_to_aws_securityhub_insights_filters_network_destination_domain_453cfe1c
       field: json.Filters.NetworkDestinationDomain
       target_field: aws.securityhub_insights.filters.network.destination.domain
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkDestinationIpV4_to_aws_securityhub_insights_filters_network_destination_ip_v4_9f37f0bc
       field: json.Filters.NetworkDestinationIpV4
       target_field: aws.securityhub_insights.filters.network.destination.ip.v4
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkDestinationIpV6_to_aws_securityhub_insights_filters_network_destination_ip_v6_b4526c60
       field: json.Filters.NetworkDestinationIpV6
       target_field: aws.securityhub_insights.filters.network.destination.ip.v6
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkDestinationPort_to_aws_securityhub_insights_filters_network_destination_port_70b1e2ea
       field: json.Filters.NetworkDestinationPort
       target_field: aws.securityhub_insights.filters.network.destination.port
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkDirection_to_aws_securityhub_insights_filters_network_direction_1222eb02
       field: json.Filters.NetworkDirection
       target_field: aws.securityhub_insights.filters.network.direction
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkProtocol_to_aws_securityhub_insights_filters_network_protocol_695743fa
       field: json.Filters.NetworkProtocol
       target_field: aws.securityhub_insights.filters.network.protocol
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkSourceDomain_to_aws_securityhub_insights_filters_network_source_domain_0e324512
       field: json.Filters.NetworkSourceDomain
       target_field: aws.securityhub_insights.filters.network.source.domain
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkSourceIpV4_to_aws_securityhub_insights_filters_network_source_ip_v4_ce9edc24
       field: json.Filters.NetworkSourceIpV4
       target_field: aws.securityhub_insights.filters.network.source.ip.v4
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkSourceIpV6_to_aws_securityhub_insights_filters_network_source_ip_v6_a13c46f8
       field: json.Filters.NetworkSourceIpV6
       target_field: aws.securityhub_insights.filters.network.source.ip.v6
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkSourceMac_to_aws_securityhub_insights_filters_network_source_mac_7e493296
       field: json.Filters.NetworkSourceMac
       target_field: aws.securityhub_insights.filters.network.source.mac
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NetworkSourcePort_to_aws_securityhub_insights_filters_network_source_port_c8ad59fa
       field: json.Filters.NetworkSourcePort
       target_field: aws.securityhub_insights.filters.network.source.port
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NoteText_to_aws_securityhub_insights_filters_note_text_a049eea6
       field: json.Filters.NoteText
       target_field: aws.securityhub_insights.filters.note.text
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_NoteUpdatedAt_b18f5aeb
       field: json.Filters.NoteUpdatedAt
       processor:
         rename:
@@ -345,6 +402,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.NoteUpdatedAt != null && ctx.json?.Filters?.NoteUpdatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_NoteUpdatedAt_4d932739
       field: json.Filters.NoteUpdatedAt
       processor:
         rename:
@@ -354,6 +412,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.NoteUpdatedAt != null && ctx.json?.Filters?.NoteUpdatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_NoteUpdatedAt_484432b5
       field: json.Filters.NoteUpdatedAt
       processor:
         date:
@@ -366,6 +425,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.NoteUpdatedAt != null && ctx.json?.Filters?.NoteUpdatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_NoteUpdatedAt_fad04fb5
       field: json.Filters.NoteUpdatedAt
       processor:
         date:
@@ -378,6 +438,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.NoteUpdatedAt != null && ctx.json?.Filters?.NoteUpdatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_NoteUpdatedAt_236111b9
       field: json.Filters.NoteUpdatedAt
       processor:
         remove:
@@ -388,14 +449,17 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.NoteUpdatedAt != null && ctx.json?.Filters?.NoteUpdatedAt instanceof List
   - rename:
+      tag: rename_json_Filters_NoteUpdatedAt_to_aws_securityhub_insights_filters_note_updated_at_4073adf3
       field: json.Filters.NoteUpdatedAt
       target_field: aws.securityhub_insights.filters.note.updated_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_NoteUpdatedBy_to_aws_securityhub_insights_filters_note_updated_by_17c73d73
       field: json.Filters.NoteUpdatedBy
       target_field: aws.securityhub_insights.filters.note.updated_by
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_ProcessLaunchedAt_40077cf3
       field: json.Filters.ProcessLaunchedAt
       processor:
         rename:
@@ -405,6 +469,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessLaunchedAt != null && ctx.json?.Filters?.ProcessLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ProcessLaunchedAt_3bd97741
       field: json.Filters.ProcessLaunchedAt
       processor:
         rename:
@@ -414,6 +479,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessLaunchedAt != null && ctx.json?.Filters?.ProcessLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ProcessLaunchedAt_44097eed
       field: json.Filters.ProcessLaunchedAt
       processor:
         date:
@@ -426,6 +492,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessLaunchedAt != null && ctx.json?.Filters?.ProcessLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ProcessLaunchedAt_26a4f02d
       field: json.Filters.ProcessLaunchedAt
       processor:
         date:
@@ -438,6 +505,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessLaunchedAt != null && ctx.json?.Filters?.ProcessLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ProcessLaunchedAt_c6e6d581
       field: json.Filters.ProcessLaunchedAt
       processor:
         remove:
@@ -448,26 +516,32 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessLaunchedAt != null && ctx.json?.Filters?.ProcessLaunchedAt instanceof List
   - rename:
+      tag: rename_json_Filters_ProcessLaunchedAt_to_aws_securityhub_insights_filters_process_launched_at_afef394d
       field: json.Filters.ProcessLaunchedAt
       target_field: aws.securityhub_insights.filters.process.launched_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ProcessName_to_aws_securityhub_insights_filters_process_name_d1295940
       field: json.Filters.ProcessName
       target_field: aws.securityhub_insights.filters.process.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ProcessParentPid_to_aws_securityhub_insights_filters_process_parent_pid_d5ebf664
       field: json.Filters.ProcessParentPid
       target_field: aws.securityhub_insights.filters.process.parent.pid
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ProcessPath_to_aws_securityhub_insights_filters_process_path_e73c7244
       field: json.Filters.ProcessPath
       target_field: aws.securityhub_insights.filters.process.path
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ProcessPid_to_aws_securityhub_insights_filters_process_pid_5d364840
       field: json.Filters.ProcessPid
       target_field: aws.securityhub_insights.filters.process.pid
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_ProcessTerminatedAt_1ef7d40c
       field: json.Filters.ProcessTerminatedAt
       processor:
         rename:
@@ -477,6 +551,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessTerminatedAt != null && ctx.json?.Filters?.ProcessTerminatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ProcessTerminatedAt_eb39097e
       field: json.Filters.ProcessTerminatedAt
       processor:
         rename:
@@ -486,6 +561,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessTerminatedAt != null && ctx.json?.Filters?.ProcessTerminatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ProcessTerminatedAt_3439e70c
       field: json.Filters.ProcessTerminatedAt
       processor:
         date:
@@ -498,6 +574,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessTerminatedAt != null && ctx.json?.Filters?.ProcessTerminatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ProcessTerminatedAt_5eb4eff4
       field: json.Filters.ProcessTerminatedAt
       processor:
         date:
@@ -510,6 +587,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessTerminatedAt != null && ctx.json?.Filters?.ProcessTerminatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ProcessTerminatedAt_a9dc7616
       field: json.Filters.ProcessTerminatedAt
       processor:
         remove:
@@ -520,62 +598,77 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ProcessTerminatedAt != null && ctx.json?.Filters?.ProcessTerminatedAt instanceof List
   - rename:
+      tag: rename_json_Filters_ProcessTerminatedAt_to_aws_securityhub_insights_filters_process_terminated_at_efee7d27
       field: json.Filters.ProcessTerminatedAt
       target_field: aws.securityhub_insights.filters.process.terminated_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ProductArn_to_aws_securityhub_insights_filters_product_arn_0e9200b0
       field: json.Filters.ProductArn
       target_field: aws.securityhub_insights.filters.product.arn
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ProductFields_to_aws_securityhub_insights_filters_product_fields_82c8e51c
       field: json.Filters.ProductFields
       target_field: aws.securityhub_insights.filters.product.fields
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ProductName_to_aws_securityhub_insights_filters_product_name_08a71618
       field: json.Filters.ProductName
       target_field: aws.securityhub_insights.filters.product.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_RecommendationText_to_aws_securityhub_insights_filters_recommendation_text_134815b9
       field: json.Filters.RecommendationText
       target_field: aws.securityhub_insights.filters.recommendation_text
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_RecordState_to_aws_securityhub_insights_filters_record_state_1a7de2d3
       field: json.Filters.RecordState
       target_field: aws.securityhub_insights.filters.record_state
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Region_to_aws_securityhub_insights_filters_region_63957034
       field: json.Filters.Region
       target_field: aws.securityhub_insights.filters.region
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_RelatedFindingsId_to_aws_securityhub_insights_filters_related_findings_id_4d13d533
       field: json.Filters.RelatedFindingsId
       target_field: aws.securityhub_insights.filters.related_findings.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_RelatedFindingsProductArn_to_aws_securityhub_insights_filters_related_findings_product_arn_9deadc11
       field: json.Filters.RelatedFindingsProductArn
       target_field: aws.securityhub_insights.filters.related_findings.product.arn
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceIamInstanceProfileArn_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_iam_instance_profile_arn_9f3370ec
       field: json.Filters.ResourceAwsEc2InstanceIamInstanceProfileArn
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.iam_instance_profile.arn
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceImageId_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_image_id_b8694324
       field: json.Filters.ResourceAwsEc2InstanceImageId
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.image.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceIpV4Addresses_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_ip_v4_addresses_ecdd30d7
       field: json.Filters.ResourceAwsEc2InstanceIpV4Addresses
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.ip.v4_addresses
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceIpV6Addresses_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_ip_v6_addresses_43d18f23
       field: json.Filters.ResourceAwsEc2InstanceIpV6Addresses
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.ip.v6_addresses
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceKeyName_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_key_name_b5d8bb10
       field: json.Filters.ResourceAwsEc2InstanceKeyName
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.key.name
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsEc2InstanceLaunchedAt_e314785c
       field: json.Filters.ResourceAwsEc2InstanceLaunchedAt
       processor:
         rename:
@@ -585,6 +678,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt != null && ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsEc2InstanceLaunchedAt_b44da6ce
       field: json.Filters.ResourceAwsEc2InstanceLaunchedAt
       processor:
         rename:
@@ -594,6 +688,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt != null && ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsEc2InstanceLaunchedAt_cf7ab6dc
       field: json.Filters.ResourceAwsEc2InstanceLaunchedAt
       processor:
         date:
@@ -606,6 +701,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt != null && ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsEc2InstanceLaunchedAt_f53c5944
       field: json.Filters.ResourceAwsEc2InstanceLaunchedAt
       processor:
         date:
@@ -618,6 +714,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt != null && ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsEc2InstanceLaunchedAt_5b1c2506
       field: json.Filters.ResourceAwsEc2InstanceLaunchedAt
       processor:
         remove:
@@ -628,22 +725,27 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt != null && ctx.json?.Filters?.ResourceAwsEc2InstanceLaunchedAt instanceof List
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceLaunchedAt_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_launched_at_0a47404b
       field: json.Filters.ResourceAwsEc2InstanceLaunchedAt
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.launched_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceSubnetId_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_subnet_id_2c1909f0
       field: json.Filters.ResourceAwsEc2InstanceSubnetId
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.subnet.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceType_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_type_e9f23480
       field: json.Filters.ResourceAwsEc2InstanceType
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.type
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsEc2InstanceVpcId_to_aws_securityhub_insights_filters_resource_aws_ec2_instance_vpc_id_e77c1424
       field: json.Filters.ResourceAwsEc2InstanceVpcId
       target_field: aws.securityhub_insights.filters.resource.aws_ec2_instance.vpc.id
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsIamAccessKeyCreatedAt_4d1c1737
       field: json.Filters.ResourceAwsIamAccessKeyCreatedAt
       processor:
         rename:
@@ -653,6 +755,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt != null && ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsIamAccessKeyCreatedAt_1a456765
       field: json.Filters.ResourceAwsIamAccessKeyCreatedAt
       processor:
         rename:
@@ -662,6 +765,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt != null && ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsIamAccessKeyCreatedAt_80aa64b1
       field: json.Filters.ResourceAwsIamAccessKeyCreatedAt
       processor:
         date:
@@ -674,6 +778,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt != null && ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsIamAccessKeyCreatedAt_bb814411
       field: json.Filters.ResourceAwsIamAccessKeyCreatedAt
       processor:
         date:
@@ -686,6 +791,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt != null && ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceAwsIamAccessKeyCreatedAt_ea6fc82d
       field: json.Filters.ResourceAwsIamAccessKeyCreatedAt
       processor:
         remove:
@@ -696,42 +802,52 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt != null && ctx.json?.Filters?.ResourceAwsIamAccessKeyCreatedAt instanceof List
   - rename:
+      tag: rename_json_Filters_ResourceAwsIamAccessKeyCreatedAt_to_aws_securityhub_insights_filters_resource_aws_iam_access_key_created_at_9cbe108a
       field: json.Filters.ResourceAwsIamAccessKeyCreatedAt
       target_field: aws.securityhub_insights.filters.resource.aws_iam_access_key.created_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsIamAccessKeyPrincipalName_to_aws_securityhub_insights_filters_resource_aws_iam_access_key_principal_name_1cb3d833
       field: json.Filters.ResourceAwsIamAccessKeyPrincipalName
       target_field: aws.securityhub_insights.filters.resource.aws_iam_access_key.principal.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsIamAccessKeyStatus_to_aws_securityhub_insights_filters_resource_aws_iam_access_key_status_27bb8e05
       field: json.Filters.ResourceAwsIamAccessKeyStatus
       target_field: aws.securityhub_insights.filters.resource.aws_iam_access_key.status
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsIamAccessKeyUserName_to_aws_securityhub_insights_filters_resource_aws_iam_access_key_user_name_34f26a73
       field: json.Filters.ResourceAwsIamAccessKeyUserName
       target_field: aws.securityhub_insights.filters.resource.aws_iam_access_key.user.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsIamUserUserName_to_aws_securityhub_insights_filters_resource_aws_iam_user_user_name_ab3aad46
       field: json.Filters.ResourceAwsIamUserUserName
       target_field: aws.securityhub_insights.filters.resource.aws_iam_user.user.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsS3BucketOwnerId_to_aws_securityhub_insights_filters_resource_aws_s3_bucket_owner_id_3e754466
       field: json.Filters.ResourceAwsS3BucketOwnerId
       target_field: aws.securityhub_insights.filters.resource.aws_s3_bucket.owner.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceAwsS3BucketOwnerName_to_aws_securityhub_insights_filters_resource_aws_s3_bucket_owner_name_961e92ea
       field: json.Filters.ResourceAwsS3BucketOwnerName
       target_field: aws.securityhub_insights.filters.resource.aws_s3_bucket.owner.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceContainerImageId_to_aws_securityhub_insights_filters_resource_container_image_id_8ca97a7c
       field: json.Filters.ResourceContainerImageId
       target_field: aws.securityhub_insights.filters.resource.container.image.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceContainerImageName_to_aws_securityhub_insights_filters_resource_container_image_name_04c255d8
       field: json.Filters.ResourceContainerImageName
       target_field: aws.securityhub_insights.filters.resource.container.image.name
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_ResourceContainerLaunchedAt_e31051f1
       field: json.Filters.ResourceContainerLaunchedAt
       processor:
         rename:
@@ -741,6 +857,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceContainerLaunchedAt != null && ctx.json?.Filters?.ResourceContainerLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceContainerLaunchedAt_1da27c27
       field: json.Filters.ResourceContainerLaunchedAt
       processor:
         rename:
@@ -750,6 +867,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceContainerLaunchedAt != null && ctx.json?.Filters?.ResourceContainerLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceContainerLaunchedAt_0ea1862f
       field: json.Filters.ResourceContainerLaunchedAt
       processor:
         date:
@@ -762,6 +880,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceContainerLaunchedAt != null && ctx.json?.Filters?.ResourceContainerLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceContainerLaunchedAt_21990087
       field: json.Filters.ResourceContainerLaunchedAt
       processor:
         date:
@@ -774,6 +893,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceContainerLaunchedAt != null && ctx.json?.Filters?.ResourceContainerLaunchedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ResourceContainerLaunchedAt_05759ac3
       field: json.Filters.ResourceContainerLaunchedAt
       processor:
         remove:
@@ -784,62 +904,77 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ResourceContainerLaunchedAt != null && ctx.json?.Filters?.ResourceContainerLaunchedAt instanceof List
   - rename:
+      tag: rename_json_Filters_ResourceContainerLaunchedAt_to_aws_securityhub_insights_filters_resource_container_launched_at_ed0d3d5b
       field: json.Filters.ResourceContainerLaunchedAt
       target_field: aws.securityhub_insights.filters.resource.container.launched_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceContainerName_to_aws_securityhub_insights_filters_resource_container_name_8da057b6
       field: json.Filters.ResourceContainerName
       target_field: aws.securityhub_insights.filters.resource.container.name
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceDetailsOther_to_aws_securityhub_insights_filters_resource_details_other_a2be770b
       field: json.Filters.ResourceDetailsOther
       target_field: aws.securityhub_insights.filters.resource.details_other
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceId_to_aws_securityhub_insights_filters_resource_id_573229ca
       field: json.Filters.ResourceId
       target_field: aws.securityhub_insights.filters.resource.id
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourcePartition_to_aws_securityhub_insights_filters_resource_partition_7cf9bee6
       field: json.Filters.ResourcePartition
       target_field: aws.securityhub_insights.filters.resource.partition
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceRegion_to_aws_securityhub_insights_filters_resource_region_d3c1c1fe
       field: json.Filters.ResourceRegion
       target_field: aws.securityhub_insights.filters.resource.region
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceTags_to_aws_securityhub_insights_filters_resource_tags_e6bf5a2e
       field: json.Filters.ResourceTags
       target_field: aws.securityhub_insights.filters.resource.tags
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ResourceType_to_aws_securityhub_insights_filters_resource_type_1de8508e
       field: json.Filters.ResourceType
       target_field: aws.securityhub_insights.filters.resource.type
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Sample_to_aws_securityhub_insights_filters_sample_f868f35c
       field: json.Filters.Sample
       target_field: aws.securityhub_insights.filters.sample
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_SeverityLabel_to_aws_securityhub_insights_filters_severity_label_598340fa
       field: json.Filters.SeverityLabel
       target_field: aws.securityhub_insights.filters.severity.label
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_SeverityNormalized_to_aws_securityhub_insights_filters_severity_normalized_cc0552b0
       field: json.Filters.SeverityNormalized
       target_field: aws.securityhub_insights.filters.severity.normalized
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_SeverityProduct_to_aws_securityhub_insights_filters_severity_product_d5573ee8
       field: json.Filters.SeverityProduct
       target_field: aws.securityhub_insights.filters.severity.product
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_SourceUrl_to_aws_securityhub_insights_filters_source_url_eeef5ee7
       field: json.Filters.SourceUrl
       target_field: aws.securityhub_insights.filters.source_url
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ThreatIntelIndicatorCategory_to_aws_securityhub_insights_filters_threat_intel_indicator_category_d82b128c
       field: json.Filters.ThreatIntelIndicatorCategory
       target_field: aws.securityhub_insights.filters.threat_intel_indicator.category
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_ThreatIntelIndicatorLastObservedAt_aa5a0dff
       field: json.Filters.ThreatIntelIndicatorLastObservedAt
       processor:
         rename:
@@ -849,6 +984,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt != null && ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ThreatIntelIndicatorLastObservedAt_0212296d
       field: json.Filters.ThreatIntelIndicatorLastObservedAt
       processor:
         rename:
@@ -858,6 +994,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt != null && ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ThreatIntelIndicatorLastObservedAt_4a1c55a9
       field: json.Filters.ThreatIntelIndicatorLastObservedAt
       processor:
         date:
@@ -870,6 +1007,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt != null && ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ThreatIntelIndicatorLastObservedAt_70148249
       field: json.Filters.ThreatIntelIndicatorLastObservedAt
       processor:
         date:
@@ -882,6 +1020,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt != null && ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_ThreatIntelIndicatorLastObservedAt_204dd315
       field: json.Filters.ThreatIntelIndicatorLastObservedAt
       processor:
         remove:
@@ -892,34 +1031,42 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt != null && ctx.json?.Filters?.ThreatIntelIndicatorLastObservedAt instanceof List
   - rename:
+      tag: rename_json_Filters_ThreatIntelIndicatorLastObservedAt_to_aws_securityhub_insights_filters_threat_intel_indicator_last_observed_at_eb54c5be
       field: json.Filters.ThreatIntelIndicatorLastObservedAt
       target_field: aws.securityhub_insights.filters.threat_intel_indicator.last_observed_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ThreatIntelIndicatorSource_to_aws_securityhub_insights_filters_threat_intel_indicator_source_4efb6030
       field: json.Filters.ThreatIntelIndicatorSource
       target_field: aws.securityhub_insights.filters.threat_intel_indicator.source
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ThreatIntelIndicatorSourceUrl_to_aws_securityhub_insights_filters_threat_intel_indicator_source_url_5a6e8181
       field: json.Filters.ThreatIntelIndicatorSourceUrl
       target_field: aws.securityhub_insights.filters.threat_intel_indicator.source_url
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ThreatIntelIndicatorType_to_aws_securityhub_insights_filters_threat_intel_indicator_type_8e8e9890
       field: json.Filters.ThreatIntelIndicatorType
       target_field: aws.securityhub_insights.filters.threat_intel_indicator.type
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_ThreatIntelIndicatorValue_to_aws_securityhub_insights_filters_threat_intel_indicator_value_f658672c
       field: json.Filters.ThreatIntelIndicatorValue
       target_field: aws.securityhub_insights.filters.threat_intel_indicator.value
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Title_to_aws_securityhub_insights_filters_title_95601ccc
       field: json.Filters.Title
       target_field: aws.securityhub_insights.filters.title
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_Type_to_aws_securityhub_insights_filters_type_be3b63f4
       field: json.Filters.Type
       target_field: aws.securityhub_insights.filters.type
       ignore_missing: true
   - foreach:
+      tag: foreach_json_Filters_UpdatedAt_1397d65b
       field: json.Filters.UpdatedAt
       processor:
         rename:
@@ -929,6 +1076,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.UpdatedAt != null && ctx.json?.Filters?.UpdatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_UpdatedAt_e8e1aaa9
       field: json.Filters.UpdatedAt
       processor:
         rename:
@@ -938,6 +1086,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.UpdatedAt != null && ctx.json?.Filters?.UpdatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_UpdatedAt_2f220665
       field: json.Filters.UpdatedAt
       processor:
         date:
@@ -950,6 +1099,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.UpdatedAt != null && ctx.json?.Filters?.UpdatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_UpdatedAt_71fbcca5
       field: json.Filters.UpdatedAt
       processor:
         date:
@@ -962,6 +1112,7 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.UpdatedAt != null && ctx.json?.Filters?.UpdatedAt instanceof List
   - foreach:
+      tag: foreach_json_Filters_UpdatedAt_9b86f049
       field: json.Filters.UpdatedAt
       processor:
         remove:
@@ -972,42 +1123,52 @@ processors:
       ignore_failure: true
       if: ctx.json?.Filters?.UpdatedAt != null && ctx.json?.Filters?.UpdatedAt instanceof List
   - rename:
+      tag: rename_json_Filters_UpdatedAt_to_aws_securityhub_insights_filters_updated_at_29c6f55d
       field: json.Filters.UpdatedAt
       target_field: aws.securityhub_insights.filters.updated_at
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_UserDefinedFields_to_aws_securityhub_insights_filters_user_defined_fields_51f7e45a
       field: json.Filters.UserDefinedFields
       target_field: aws.securityhub_insights.filters.user_defined_fields
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_VerificationState_to_aws_securityhub_insights_filters_verification_state_877df380
       field: json.Filters.VerificationState
       target_field: aws.securityhub_insights.filters.verification.state
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_WorkflowState_to_aws_securityhub_insights_filters_workflow_state_43bd5cf0
       field: json.Filters.WorkflowState
       target_field: aws.securityhub_insights.filters.workflow.state
       ignore_missing: true
   - rename:
+      tag: rename_json_Filters_WorkflowStatus_to_aws_securityhub_insights_filters_workflow_status_5fc600dc
       field: json.Filters.WorkflowStatus
       target_field: aws.securityhub_insights.filters.workflow.status
       ignore_missing: true
   - rename:
+      tag: rename_json_GroupByAttribute_to_aws_securityhub_insights_group_by_attribute_59ad40a2
       field: json.GroupByAttribute
       target_field: aws.securityhub_insights.group_by_attribute
       ignore_missing: true
   - rename:
+      tag: rename_json_InsightArn_to_aws_securityhub_insights_insight_arn_4d0cc417
       field: json.InsightArn
       target_field: aws.securityhub_insights.insight_arn
       ignore_missing: true
   - rename:
+      tag: rename_json_Name_to_aws_securityhub_insights_name_8dc3d1e4
       field: json.Name
       target_field: aws.securityhub_insights.name
       ignore_missing: true
   - remove:
+      tag: remove_e5a80934
       field:
         - json
       ignore_missing: true
   - script:
+      tag: script_a3eb5add
       description: Drops null/empty values recursively.
       lang: painless
       source: |
@@ -1033,4 +1194,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/sqs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/sqs/elasticsearch/ingest_pipeline/default.yml
@@ -3,50 +3,62 @@ description: "Pipeline for SQS metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
       ignore_empty_value: true
   - rename:
+      tag: rename_aws_sqs_metrics_ApproximateAgeOfOldestMessage_max_to_aws_sqs_oldest_message_age_sec_c95b50a9
       field: aws.sqs.metrics.ApproximateAgeOfOldestMessage.max
       target_field: aws.sqs.oldest_message_age.sec
       ignore_missing: true
   - rename:
+      tag: rename_aws_sqs_metrics_ApproximateNumberOfMessagesDelayed_avg_to_aws_sqs_messages_delayed_ca6073c1
       field: aws.sqs.metrics.ApproximateNumberOfMessagesDelayed.avg
       target_field: aws.sqs.messages.delayed
       ignore_missing: true
   - rename:
+      tag: rename_aws_sqs_metrics_ApproximateNumberOfMessagesNotVisible_avg_to_aws_sqs_messages_not_visible_8a0a8f4e
       field: aws.sqs.metrics.ApproximateNumberOfMessagesNotVisible.avg
       target_field: aws.sqs.messages.not_visible
       ignore_missing: true
   - rename:
+      tag: rename_aws_sqs_metrics_ApproximateNumberOfMessagesVisible_avg_to_aws_sqs_messages_visible_1942dde5
       field: aws.sqs.metrics.ApproximateNumberOfMessagesVisible.avg
       target_field: aws.sqs.messages.visible
       ignore_missing: true
   - rename:
+      tag: rename_aws_sqs_metrics_NumberOfMessagesDeleted_sum_to_aws_sqs_messages_deleted_853d108e
       field: aws.sqs.metrics.NumberOfMessagesDeleted.sum
       target_field: aws.sqs.messages.deleted
       ignore_missing: true
   - rename:
+      tag: rename_aws_sqs_metrics_NumberOfMessagesReceived_sum_to_aws_sqs_messages_received_2f8e5010
       field: aws.sqs.metrics.NumberOfMessagesReceived.sum
       target_field: aws.sqs.messages.received
       ignore_missing: true
   - rename:
+      tag: rename_aws_sqs_metrics_NumberOfMessagesSent_sum_to_aws_sqs_messages_sent_64cf391a
       field: aws.sqs.metrics.NumberOfMessagesSent.sum
       target_field: aws.sqs.messages.sent
       ignore_missing: true
   - rename:
+      tag: rename_aws_sqs_metrics_NumberOfEmptyReceives_sum_to_aws_sqs_empty_receives_0684a641
       field: aws.sqs.metrics.NumberOfEmptyReceives.sum
       target_field: aws.sqs.empty_receives
       ignore_missing: true
   - rename:
+      tag: rename_aws_sqs_metrics_SentMessageSize_avg_to_aws_sqs_sent_message_size_bytes_dd16fb4e
       field: aws.sqs.metrics.SentMessageSize.avg
       target_field: aws.sqs.sent_message_size.bytes
       ignore_missing: true
   - remove:
+      tag: remove_8f371c74
       field:
         - aws.sqs.metrics
       if: ctx.agent?.type != "firehose"
@@ -60,4 +72,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/transitgateway/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/transitgateway/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,11 @@ description: "Pipeline for Transit Gateway metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
@@ -19,4 +21,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/usage/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/usage/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,11 @@ description: "Pipeline for Usage metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
@@ -19,4 +21,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
@@ -3,104 +3,126 @@ description: Pipeline for AWS VPC Flow Logs
 
 processors:
   - set:
+      tag: set_ecs_version_0f7334bb
       field: ecs.version
       value: '8.11.0'
   - dot_expander:
+      tag: dot_expander_*_0a223fd2
       field: "*"
   - rename:
+      tag: rename_message_to_event_original_c74b1d7e
       field: message
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
       description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
   - remove:
+      tag: remove_message_2ee3a7d4
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
       description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - set:
+      tag: set_event_type_8fd37e4e
       field: event.type
       value: [connection]
   - set:
+      tag: set_event_category_dbab8a4e
       field: event.category
       value: [network]
   - drop:
+      tag: drop_820c8200
       if: 'ctx.event?.original.startsWith("version") || ctx.event?.original.startsWith("instance-id")'
   - dissect:
+      tag: dissect_event_original_33687689
       field: event.original
       pattern: '{"message":"%{event.original}"}'
       ignore_failure: true
   - script:
+      tag: script_31bfbb6b
       lang: painless
       if: ctx.event?.original != null
       source: >-
         ctx._temp_ = new HashMap();
         ctx._temp_.message_token_count = ctx.event?.original.splitOnToken(" ").length;
   - dissect:
+      tag: dissect_event_original_fac58ae9
       field: event.original
       pattern: '%{aws.vpcflow.version} %{aws.vpcflow.account_id} %{aws.vpcflow.interface_id} %{aws.vpcflow.srcaddr} %{aws.vpcflow.dstaddr} %{aws.vpcflow.srcport} %{aws.vpcflow.dstport} %{aws.vpcflow.protocol} %{aws.vpcflow.packets} %{aws.vpcflow.bytes} %{aws.vpcflow.start} %{aws.vpcflow.end} %{aws.vpcflow.action} %{aws.vpcflow.log_status}'
       if: ctx?._temp_?.message_token_count == 14
   - dissect:
+      tag: dissect_event_original_d9e06c20
       field: event.original
       pattern: '%{aws.vpcflow.instance_id} %{aws.vpcflow.interface_id} %{aws.vpcflow.srcaddr} %{aws.vpcflow.dstaddr} %{aws.vpcflow.pkt_srcaddr} %{aws.vpcflow.pkt_dstaddr}'
       if: ctx?._temp_?.message_token_count == 6
   - dissect:
+      tag: dissect_event_original_f642e8e3
       field: event.original
       pattern: '%{aws.vpcflow.version} %{aws.vpcflow.interface_id} %{aws.vpcflow.account_id} %{aws.vpcflow.vpc_id} %{aws.vpcflow.subnet_id} %{aws.vpcflow.instance_id} %{aws.vpcflow.srcaddr} %{aws.vpcflow.dstaddr} %{aws.vpcflow.srcport} %{aws.vpcflow.dstport} %{aws.vpcflow.protocol} %{aws.vpcflow.tcp_flags} %{aws.vpcflow.type} %{aws.vpcflow.pkt_srcaddr} %{aws.vpcflow.pkt_dstaddr} %{aws.vpcflow.action} %{aws.vpcflow.log_status}'
       if: ctx?._temp_?.message_token_count == 17
   - dissect:
+      tag: dissect_event_original_33072e15
       field: event.original
       pattern: '%{aws.vpcflow.version} %{aws.vpcflow.vpc_id} %{aws.vpcflow.subnet_id} %{aws.vpcflow.instance_id} %{aws.vpcflow.interface_id} %{aws.vpcflow.account_id} %{aws.vpcflow.type} %{aws.vpcflow.srcaddr} %{aws.vpcflow.dstaddr} %{aws.vpcflow.srcport} %{aws.vpcflow.dstport} %{aws.vpcflow.pkt_srcaddr} %{aws.vpcflow.pkt_dstaddr} %{aws.vpcflow.protocol} %{aws.vpcflow.bytes} %{aws.vpcflow.packets} %{aws.vpcflow.start} %{aws.vpcflow.end} %{aws.vpcflow.action} %{aws.vpcflow.tcp_flags} %{aws.vpcflow.log_status}'
       if: ctx?._temp_?.message_token_count == 21
   - dissect:
+      tag: dissect_event_original_62589421
       field: event.original
       pattern: '%{aws.vpcflow.version} %{aws.vpcflow.account_id} %{aws.vpcflow.interface_id} %{aws.vpcflow.srcaddr} %{aws.vpcflow.dstaddr} %{aws.vpcflow.srcport} %{aws.vpcflow.dstport} %{aws.vpcflow.protocol} %{aws.vpcflow.packets} %{aws.vpcflow.bytes} %{aws.vpcflow.start} %{aws.vpcflow.end} %{aws.vpcflow.action} %{aws.vpcflow.log_status} %{aws.vpcflow.vpc_id} %{aws.vpcflow.subnet_id} %{aws.vpcflow.instance_id} %{aws.vpcflow.tcp_flags} %{aws.vpcflow.type} %{aws.vpcflow.pkt_srcaddr} %{aws.vpcflow.pkt_dstaddr} %{cloud.region} %{cloud.availability_zone} %{aws.vpcflow.sublocation.type} %{aws.vpcflow.sublocation.id} %{aws.vpcflow.pkt_src_service} %{aws.vpcflow.pkt_dst_service} %{network.direction} %{aws.vpcflow.traffic_path}'
       if: ctx?._temp_?.message_token_count == 29
   - dissect:
+      tag: dissect_event_original_46beaf82
       field: event.original
       description: default format for transit gateway vpc flow logs, covering versions v2 through v6.
       pattern: '%{aws.vpcflow.version} %{aws.vpcflow.resource_type} %{aws.vpcflow.account_id} %{aws.vpcflow.tgw_id} %{aws.vpcflow.tgw_attachment_id} %{aws.vpcflow.tgw_src_vpc_account_id} %{aws.vpcflow.tgw_dst_vpc_account_id} %{aws.vpcflow.tgw_src_vpc_id} %{aws.vpcflow.tgw_dst_vpc_id} %{aws.vpcflow.tgw_src_subnet_id} %{aws.vpcflow.tgw_dst_subnet_id} %{aws.vpcflow.tgw_src_eni} %{aws.vpcflow.tgw_dst_eni} %{aws.vpcflow.tgw_src_az_id} %{aws.vpcflow.tgw_dst_az_id} %{aws.vpcflow.tgw_pair_attachment_id} %{aws.vpcflow.srcaddr} %{aws.vpcflow.dstaddr} %{aws.vpcflow.srcport} %{aws.vpcflow.dstport} %{aws.vpcflow.protocol} %{aws.vpcflow.packets} %{aws.vpcflow.bytes} %{aws.vpcflow.start} %{aws.vpcflow.end} %{aws.vpcflow.log_status} %{aws.vpcflow.type} %{aws.vpcflow.packets_lost_no_route} %{aws.vpcflow.packets_lost_blackhole} %{aws.vpcflow.packets_lost_mtu_exceeded} %{aws.vpcflow.packets_lost_ttl_expired} %{aws.vpcflow.tcp_flags} %{cloud.region} %{network.direction} %{aws.vpcflow.pkt_src_service} %{aws.vpcflow.pkt_dst_service}'
       if: ctx?._temp_?.message_token_count == 36
   - dissect:
+      tag: dissect_event_original_ba6c5411
       field: event.original
       pattern: '%{aws.vpcflow.version} %{aws.vpcflow.account_id} %{aws.vpcflow.interface_id} %{aws.vpcflow.srcaddr} %{aws.vpcflow.dstaddr} %{aws.vpcflow.srcport} %{aws.vpcflow.dstport} %{aws.vpcflow.protocol} %{aws.vpcflow.packets} %{aws.vpcflow.bytes} %{aws.vpcflow.start} %{aws.vpcflow.end} %{aws.vpcflow.action} %{aws.vpcflow.log_status} %{aws.vpcflow.vpc_id} %{aws.vpcflow.subnet_id} %{aws.vpcflow.instance_id} %{aws.vpcflow.tcp_flags} %{aws.vpcflow.type} %{aws.vpcflow.pkt_srcaddr} %{aws.vpcflow.pkt_dstaddr} %{cloud.region} %{cloud.availability_zone} %{aws.vpcflow.sublocation.type} %{aws.vpcflow.sublocation.id} %{aws.vpcflow.pkt_src_service} %{aws.vpcflow.pkt_dst_service} %{network.direction} %{aws.vpcflow.traffic_path} %{aws.vpcflow.ecs_cluster_arn} %{aws.vpcflow.ecs_cluster_name} %{aws.vpcflow.ecs_container_instance_arn} %{aws.vpcflow.ecs_container_instance_id} %{aws.vpcflow.ecs_container_id} %{aws.vpcflow.ecs_second_container_id} %{aws.vpcflow.ecs_service_name} %{aws.vpcflow.ecs_task_definition_arn} %{aws.vpcflow.ecs_task_arn} %{aws.vpcflow.ecs_task_id}'
       if: ctx?._temp_?.message_token_count == 39
   - dissect:
+      tag: dissect_event_original_95c3b068
       field: event.original
       pattern: '%{aws.vpcflow.version} %{aws.vpcflow.account_id} %{aws.vpcflow.interface_id} %{aws.vpcflow.srcaddr} %{aws.vpcflow.dstaddr} %{aws.vpcflow.srcport} %{aws.vpcflow.dstport} %{aws.vpcflow.protocol} %{aws.vpcflow.packets} %{aws.vpcflow.bytes} %{aws.vpcflow.start} %{aws.vpcflow.end} %{aws.vpcflow.action} %{aws.vpcflow.log_status} %{aws.vpcflow.vpc_id} %{aws.vpcflow.subnet_id} %{aws.vpcflow.instance_id} %{aws.vpcflow.tcp_flags} %{aws.vpcflow.type} %{aws.vpcflow.pkt_srcaddr} %{aws.vpcflow.pkt_dstaddr} %{cloud.region} %{cloud.availability_zone} %{aws.vpcflow.sublocation.type} %{aws.vpcflow.sublocation.id} %{aws.vpcflow.pkt_src_service} %{aws.vpcflow.pkt_dst_service} %{network.direction} %{aws.vpcflow.traffic_path} %{aws.vpcflow.ecs_cluster_arn} %{aws.vpcflow.ecs_cluster_name} %{aws.vpcflow.ecs_container_instance_arn} %{aws.vpcflow.ecs_container_instance_id} %{aws.vpcflow.ecs_container_id} %{aws.vpcflow.ecs_second_container_id} %{aws.vpcflow.ecs_service_name} %{aws.vpcflow.ecs_task_definition_arn} %{aws.vpcflow.ecs_task_arn} %{aws.vpcflow.ecs_task_id} %{aws.vpcflow.reject_reason}'
       if: ctx?._temp_?.message_token_count == 40
   - fail:
+      tag: fail_c4acd9b4
       if: ctx?._temp_?.message_token_count != null && ctx?.aws?.vpcflow?.srcaddr == null
       message: >-
         Unsupported VPC Flow Log format: record has {{{_temp_.message_token_count}}} fields,
         which does not match any integration supported VPC flow log format.
         Use a custom ingest pipeline to parse this format.
-
   # Convert Unix epoch to timestamp
   - date:
+      tag: date_aws_vpcflow_end_to_timestamp_a04826cb
       field: aws.vpcflow.end
       target_field: '@timestamp'
       ignore_failure: true
       formats:
         - UNIX
   - date:
+      tag: date_aws_vpcflow_start_to_event_start_68b50594
       field: aws.vpcflow.start
       target_field: event.start
       ignore_failure: true
       formats:
         - UNIX
   - date:
+      tag: date_aws_vpcflow_end_to_event_end_b34fe330
       field: aws.vpcflow.end
       target_field: event.end
       ignore_failure: true
       formats:
         - UNIX
   - remove:
+      tag: remove_c95882b3
       field:
         - aws.vpcflow.start
         - aws.vpcflow.end
       ignore_missing: true
   - script:
+      tag: script_899f529c
       lang: painless
       ignore_failure: true
       if: ctx.aws != null
@@ -126,86 +148,106 @@ processors:
         }
         handleMap(ctx.aws);
   - set:
+      tag: set_event_outcome_ac92d4f9
       field: event.outcome
       value: success
       if: ctx.aws?.vpcflow?.action == "ACCEPT"
   - set:
+      tag: set_event_outcome_91c3214b
       field: event.outcome
       value: failure
       if: ctx.aws?.vpcflow?.action == "REJECT"
   - append:
+      tag: append_event_type_e95f735a
       field: event.type
       value: allowed
       if: ctx.aws?.vpcflow?.action == "ACCEPT"
   - append:
+      tag: append_event_type_bceb2fd0
       field: event.type
       value: denied
       if: ctx.aws?.vpcflow?.action == "REJECT"
   - set:
+      tag: set_event_action_3d174f4b
       field: event.action
       copy_from: aws.vpcflow.action
       ignore_empty_value: true
   - set:
+      tag: set_event_reason_7642d565
       field: event.reason
       copy_from: aws.vpcflow.reject_reason
       ignore_empty_value: true
   - rename:
+      tag: rename_aws_vpcflow_srcaddr_to_source_address_0ae0377a
       field: aws.vpcflow.srcaddr
       target_field: source.address
       ignore_missing: true
   - set:
+      tag: set_source_ip_e17d09df
       field: source.ip
       copy_from: source.address
       if: ctx.source?.address != null
   - convert:
+      tag: convert_aws_vpcflow_srcport_to_source_port_6449afbc
       field: aws.vpcflow.srcport
       target_field: source.port
       type: integer
       ignore_missing: true
   - rename:
+      tag: rename_aws_vpcflow_dstaddr_to_destination_address_562251ae
       field: aws.vpcflow.dstaddr
       target_field: destination.address
       ignore_missing: true
   - set:
+      tag: set_destination_ip_3d6f6004
       field: destination.ip
       copy_from: destination.address
       if: ctx.destination?.address != null
   - convert:
+      tag: convert_aws_vpcflow_dstport_to_destination_port_65df486e
       field: aws.vpcflow.dstport
       target_field: destination.port
       type: integer
       ignore_missing: true
   - rename:
+      tag: rename_aws_vpcflow_protocol_to_network_iana_number_4b33bb5d
       field: aws.vpcflow.protocol
       target_field: network.iana_number
       ignore_missing: true
   - convert:
+      tag: convert_aws_vpcflow_packets_to_source_packets_dcea5b6c
       field: aws.vpcflow.packets
       target_field: source.packets
       type: long
       ignore_missing: true
   - convert:
+      tag: convert_aws_vpcflow_bytes_to_source_bytes_12aa9fa8
       field: aws.vpcflow.bytes
       target_field: source.bytes
       type: long
       ignore_missing: true
   - set:
+      tag: set_network_bytes_d417039e
       field: network.bytes
       copy_from: source.bytes
       if: ctx.source?.bytes != null
   - set:
+      tag: set_network_packets_4ee14814
       field: network.packets
       copy_from: source.packets
       if: ctx.source?.packets != null
   - set:
+      tag: set_network_type_b7f5a7f1
       field: network.type
       value: ipv4
       if: 'ctx.source?.ip != null && ctx.source?.ip.contains(".")'
   - set:
+      tag: set_network_type_9ad17ef3
       field: network.type
       value: ipv6
       if: 'ctx.source?.ip != null && ctx.source?.ip.contains(":")'
   - script:
+      tag: script_aaef8fa9
       lang: painless
       ignore_failure: true
       if: ctx?.network?.iana_number != null
@@ -235,19 +277,23 @@ processors:
             ctx.network.transport = 'sctp';
         }
   - community_id:
+      tag: community_id_d2308e7a
       target_field: network.community_id
       ignore_failure: true
   # IP Geolocation Lookup
   - geoip:
+      tag: geoip_source_ip_to_source_geo_da2e41b2
       field: source.ip
       target_field: source.geo
       ignore_missing: true
   - geoip:
+      tag: geoip_destination_ip_to_destination_geo_ab5e2968
       field: destination.ip
       target_field: destination.geo
       ignore_missing: true
   # IP Autonomous System (AS) Lookup
   - geoip:
+      tag: geoip_source_ip_to_source_as_28d69883
       database_file: GeoLite2-ASN.mmdb
       field: source.ip
       target_field: source.as
@@ -256,6 +302,7 @@ processors:
         - organization_name
       ignore_missing: true
   - geoip:
+      tag: geoip_destination_ip_to_destination_as_8a007787
       database_file: GeoLite2-ASN.mmdb
       field: destination.ip
       target_field: destination.as
@@ -264,94 +311,117 @@ processors:
         - organization_name
       ignore_missing: true
   - rename:
+      tag: rename_source_as_asn_to_source_as_number_a917047d
       field: source.as.asn
       target_field: source.as.number
       ignore_missing: true
   - rename:
+      tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
       field: source.as.organization_name
       target_field: source.as.organization.name
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_asn_to_destination_as_number_3b459fcd
       field: destination.as.asn
       target_field: destination.as.number
       ignore_missing: true
   - rename:
+      tag: rename_destination_as_organization_name_to_destination_as_organization_name_814bd459
       field: destination.as.organization_name
       target_field: destination.as.organization.name
       ignore_missing: true
   # Generate related.ip field
   - append:
+      tag: append_related_ip_8c90798b
       if: 'ctx.source?.ip != null && ctx.destination?.ip != null'
       field: related.ip
       value: ["{{source.ip}}", "{{destination.ip}}"]
   - set:
+      tag: set_cloud_provider_208bdd6b
       field: cloud.provider
       value: aws
   - set:
+      tag: set_cloud_account_id_6f6cbfdb
       if: ctx.aws?.vpcflow?.account_id != null
       field: cloud.account.id
       copy_from: aws.vpcflow.account_id
   - set:
+      tag: set_cloud_instance_id_772217de
       if: 'ctx.aws?.vpcflow?.instance_id != null && ctx.aws.vpcflow.instance_id != "-"'
       field: cloud.instance.id
       copy_from: aws.vpcflow.instance_id
   - convert:
+     tag: convert_aws_vpcflow_packets_lost_no_route_061d1753
      field: aws.vpcflow.packets_lost_no_route
      type: long
      ignore_missing: true
      on_failure:
        - remove:
+           tag: remove_aws_vpcflow_packets_lost_no_route_81bf75db
            field: aws.vpcflow.packets_lost_no_route
   - convert:
+     tag: convert_aws_vpcflow_packets_lost_blackhole_990ff7b7
      field: aws.vpcflow.packets_lost_blackhole
      type: long
      ignore_missing: true
      on_failure:
        - remove:
+           tag: remove_aws_vpcflow_packets_lost_blackhole_e20c47a7
            field: aws.vpcflow.packets_lost_blackhole
   - convert:
+     tag: convert_aws_vpcflow_packets_lost_mtu_exceeded_431186f9
      field: aws.vpcflow.packets_lost_mtu_exceeded
      type: long
      ignore_missing: true
      on_failure:
        - remove:
+           tag: remove_aws_vpcflow_packets_lost_mtu_exceeded_ad3e2a80
            field: aws.vpcflow.packets_lost_mtu_exceeded
   - convert:
+     tag: convert_aws_vpcflow_packets_lost_ttl_expired_2acccd3b
      field: aws.vpcflow.packets_lost_ttl_expired
      type: long
      ignore_missing: true
      on_failure:
        - remove:
+           tag: remove_aws_vpcflow_packets_lost_ttl_expired_07fb73e4
            field: aws.vpcflow.packets_lost_ttl_expired
   - set:
+      tag: set_orchestrator_cluster_id_0537ed3d
       field: orchestrator.cluster.id
       copy_from: aws.vpcflow.ecs_cluster_arn
       if: ctx.aws?.vpcflow?.ecs_cluster_arn != '-'
       ignore_empty_value: true
   - set:
+      tag: set_orchestrator_cluster_name_1f38825d
       field: orchestrator.cluster.name
       copy_from: aws.vpcflow.ecs_cluster_name
       if: ctx.aws?.vpcflow?.ecs_cluster_name != '-'
       ignore_empty_value: true
   - set:
+      tag: set_orchestrator_resource_name_9fe69dab
       field: orchestrator.resource.name
       copy_from: aws.vpcflow.ecs_container_instance_arn
       if: ctx.aws?.vpcflow?.ecs_container_instance_arn != '-'
       ignore_empty_value: true
   - set:
+      tag: set_orchestrator_resource_id_1c8e301d
       field: orchestrator.resource.id
       copy_from: aws.vpcflow.ecs_container_instance_id
       if: ctx.aws?.vpcflow?.ecs_container_instance_id != '-'
       ignore_empty_value: true
   - set:
+      tag: set_service_name_13435814
       field: service.name
       copy_from: aws.vpcflow.ecs_service_name
       if: ctx.aws?.vpcflow?.ecs_service_name != '-'
       ignore_empty_value: true
   - set:
+      tag: set_event_kind_de80643c
       field: event.kind
       value: event
   - script:
+      tag: script_6e3f8fd4
       lang: painless
       ignore_failure: true
       if: "ctx.aws?.vpcflow?.tcp_flags != null"
@@ -382,6 +452,7 @@ processors:
           ctx.aws.vpcflow.tcp_flags_array.add('urg');
         }
   - remove:
+      tag: remove_b2d17f23
       field:
         - _temp_
         - aws.vpcflow.srcaddr
@@ -407,4 +478,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/vpn/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/vpn/elasticsearch/ingest_pipeline/default.yml
@@ -3,9 +3,11 @@ description: "Pipeline for VPN metrics"
 
 processors:
   - dot_expander:
+      tag: dot_expander_*_c2762c23
       field: "*"
       ignore_failure: true
   - set:
+      tag: set_cloud_account_name_20733914
       field: cloud.account.name
       copy_from: cloud.account.id
       override: false
@@ -19,4 +21,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/waf/elasticsearch/ingest_pipeline/default.yml
@@ -2,48 +2,59 @@
 description: "Pipeline for WAF logs"
 processors:
 - set:
+    tag: set_ecs_version_0f7334bb
     field: ecs.version
     value: '8.11.0'
 - set:
+    tag: set_event_category_d1482d04
     field: event.category
     value: ["web", "network"]
 - append:
+    tag: append_event_type_8860cef4
     field: event.type
     value: ["access"]
 - rename:
+    tag: rename_message_to_event_original_c74b1d7e
     field: message
     target_field: event.original
     ignore_missing: true
     if: 'ctx.event?.original == null'
     description: 'Renames the original `message` field to `event.original` to store a copy of the original message. The `event.original` field is not touched if the document already has one; it may happen when Logstash sends the document.'
 - remove:
+    tag: remove_message_2ee3a7d4
     field: message
     ignore_missing: true
     if: 'ctx.event?.original != null'
     description: 'The `message` field is no longer required if the document has an `event.original` field.'
 - json:
+    tag: json_event_original_to_json_5e54dc16
     field: event.original
     target_field: json
 - date:
+    tag: date_json_timestamp_to_timestamp_56edca7f
     field: json.timestamp
     target_field: '@timestamp'
     ignore_failure: true
     formats:
     - UNIX_MS
 - rename:
+    tag: rename_json_httpRequest_clientIp_to_source_ip_d91520cd
     field: json.httpRequest.clientIp
     target_field: source.ip
     ignore_missing: true
 - geoip:
+    tag: geoip_source_ip_to_source_geo_da2e41b2
     field: source.ip
     target_field: source.geo
     ignore_missing: true
 - rename:
+    tag: rename_json_httpRequest_country_to_source_geo_country_iso_code_e529e510
     field: json.httpRequest.country
     target_field: source.geo.country_iso_code
     ignore_missing: true
     if: ctx.source?.geo?.country_iso_code == null
 - geoip:
+    tag: geoip_source_ip_to_source_as_28d69883
     database_file: GeoLite2-ASN.mmdb
     field: source.ip
     target_field: source.as
@@ -52,15 +63,18 @@ processors:
     - organization_name
     ignore_missing: true
 - rename:
+    tag: rename_source_as_asn_to_source_as_number_a917047d
     field: source.as.asn
     target_field: source.as.number
     ignore_missing: true
 - rename:
+    tag: rename_json_ClientASN_to_source_as_number_ca8c111f
     field: json.ClientASN
     target_field: source.as.number
     ignore_missing: true
     if: ctx?.source?.as?.number == null
 - rename:
+    tag: rename_source_as_organization_name_to_source_as_organization_name_f1362d0b
     field: source.as.organization_name
     target_field: source.as.organization.name
     ignore_missing: true
@@ -72,6 +86,7 @@ processors:
     ignore_missing: true
     on_failure:
       - append:
+          tag: append_error_message_1aa4965d
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - date:
@@ -83,6 +98,7 @@ processors:
     if: ctx.json?.captchaResponse?.solveTimestamp != null && ctx.json.captchaResponse.solveTimestamp != ''
     on_failure:
       - append:
+          tag: append_error_message_42eab77f
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - rename:
@@ -98,6 +114,7 @@ processors:
     ignore_missing: true
     on_failure:
       - append:
+          tag: append_error_message_162ae230
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - date:
@@ -109,6 +126,7 @@ processors:
     if: ctx.json?.challengeResponse?.solveTimestamp != null && ctx.json.challengeResponse.solveTimestamp != ''
     on_failure:
       - append:
+          tag: append_error_message_25c78f2c
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - rename:
@@ -133,6 +151,7 @@ processors:
     target_field: url.registered_domain
     ignore_missing: true
 - rename:
+    tag: rename_json_httpRequest_requestId_to_http_request_id_9f01188d
     field: json.httpRequest.requestId
     target_field: http.request.id
     ignore_missing: true
@@ -149,6 +168,7 @@ processors:
     ignore_missing: true
     on_failure:
       - append:
+          tag: append_error_message_6edc1635
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - convert:
@@ -159,6 +179,7 @@ processors:
     ignore_missing: true
     on_failure:
       - append:
+          tag: append_error_message_b1dcefda
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - convert:
@@ -169,28 +190,35 @@ processors:
     ignore_missing: true
     on_failure:
       - append:
+          tag: append_error_message_e983b3a7
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - rename:
+    tag: rename_json_httpRequest_httpMethod_to_http_request_method_36be9aa0
     field: json.httpRequest.httpMethod
     target_field: http.request.method
     ignore_missing: true
 - dissect:
+    tag: dissect_json_httpRequest_httpVersion_3eaa461f
     field: json.httpRequest.httpVersion
     pattern: "%{network.protocol}/%{http.version}"
     ignore_failure: true
 - lowercase:
+    tag: lowercase_network_protocol_49872259
     field: network.protocol
     ignore_missing: true
 - set:
+    tag: set_network_transport_be847bd4
     field: network.transport
     value: tcp
     if: ctx?.network?.protocol != null && ctx?.network?.protocol == 'http'
 - rename:
+    tag: rename_json_httpRequest_args_to_url_query_f317ee93
     field: json.httpRequest.args
     target_field: url.query
     ignore_missing: true
 - rename:
+    tag: rename_json_httpRequest_uri_to_url_path_efbbbc4d
     field: json.httpRequest.uri
     target_field: url.path
     ignore_missing: true
@@ -215,22 +243,27 @@ processors:
     target_field: aws.waf.oversize_fields
     ignore_missing: true
 - rename:
+    tag: rename_json_terminatingRuleMatchDetails_to_aws_waf_terminating_rule_match_details_c9c5dba2
     field: json.terminatingRuleMatchDetails
     target_field: aws.waf.terminating_rule_match_details
     ignore_missing: true
 - rename:
+    tag: rename_json_ruleGroupList_to_aws_waf_rule_group_list_b00ab221
     field: json.ruleGroupList
     target_field: aws.waf.rule_group_list
     ignore_missing: true
 - rename:
+    tag: rename_json_rateBasedRuleList_to_aws_waf_rate_based_rule_list_d273b998
     field: json.rateBasedRuleList
     target_field: aws.waf.rate_based_rule_list
     ignore_missing: true
 - rename:
+    tag: rename_json_nonTerminatingMatchingRules_to_aws_waf_non_terminating_matching_rules_9e63f656
     field: json.nonTerminatingMatchingRules
     target_field: aws.waf.non_terminating_matching_rules
     ignore_missing: true
 - script:
+    tag: script_cb4c8e3d
     lang: painless
     source: >-
       if (ctx.json.httpRequest.headers != null) {
@@ -253,53 +286,66 @@ processors:
       }
     on_failure:
       - append:
+          tag: append_error_message_6eaadeb6
           field: error.message
           value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 - rename:
+    tag: rename_json_action_to_event_action_6ebb0784
     field: json.action
     target_field: event.action
     ignore_missing: true
 - append:
+    tag: append_related_ip_d7aecc5f
     field: related.ip
     value: '{{source.ip}}'
     allow_duplicates: false
     if: ctx.source?.ip != null
 - set:
+    tag: set_cloud_provider_208bdd6b
     field: cloud.provider
     value: aws
 - set:
+    tag: set_event_kind_de80643c
     field: event.kind
     value: event
 - append:
+    tag: append_event_type_7c253a3f
     field: event.type
     value: allowed
     if: ctx.event.action == "ALLOW"
 - append:
+    tag: append_event_type_c102eb1c
     field: event.type
     value: denied
     if: ctx.event.action == "BLOCK"
 - rename:
+    tag: rename_json_webaclId_to_aws_waf_arn_50c9c659
     field: json.webaclId
     target_field: aws.waf.arn
     ignore_missing: true
 - dissect:
+    tag: dissect_aws_waf_arn_751ee2c3
     field: aws.waf.arn
     pattern: "arn:%{}:%{cloud.service.name}:%{cloud.region}:%{cloud.account.id}:%{aws.waf.id}"
     ignore_failure: true
     ignore_missing: true
 - rename:
+    tag: rename_json_terminatingRuleId_to_rule_id_9b482d48
     field: json.terminatingRuleId
     target_field: rule.id
     ignore_missing: true
 - rename:
+    tag: rename_json_terminatingRuleType_to_rule_ruleset_d7b5d1b8
     field: json.terminatingRuleType
     target_field: rule.ruleset
     ignore_missing: true
 - rename:
+    tag: rename_json_httpSourceName_to_aws_waf_source_name_0d5e84e3
     field: json.httpSourceName
     target_field: aws.waf.source.name
     ignore_missing: true
 - rename:
+    tag: rename_json_httpSourceId_to_aws_waf_source_id_ab7d1b3f
     field: json.httpSourceId
     target_field: aws.waf.source.id
     ignore_missing: true
@@ -308,9 +354,11 @@ processors:
   # Remove temporary fields
   #
 - remove:
+    tag: remove_json_29cdffdc
     field: json
     ignore_missing: true
 - script:
+    tag: script_63b36254
     lang: painless
     description: This script processor iterates over the whole document to remove fields with null values.
     source: |
@@ -343,4 +391,4 @@ on_failure:
       value: >-
         Processor '{{{ _ingest.on_failure_processor_type }}}'
         {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
-        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+        {{{/_ingest.on_failure_processor_tag}}}in pipeline '{{{ _ingest.pipeline }}}' failed with message '{{{ _ingest.on_failure_message }}}'

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.20.2
+version: 6.20.3
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[aws] Add processor tags to ingest pipelines

Add `tag` fields to every processor in all AWS ingest pipelines using
`elastic-package modify --modifiers pipeline-tag`. Also update
`on_failure` error messages to include `_ingest.pipeline` per the
SVR00009 linter rule. Both are requirements that will be enforced when
the AWS package format_version is bumped to 3.6.0.

Also fix two pre-existing duplicate processors exposed by the tagging:
- cloudfront_logs/default.yml: duplicate x-edge-response-result-type rename
- rds/default.yml: duplicate FreeStorageSpace rename

Fixes cloudfront_logs/pipeline_process_ip.yml which was missing a
pipeline-level on_failure block (SVR00008/SVR00009).
```

_Created with Claude Code using Sonnet 4.6._

## Background

This PR pre-lands the ingest pipeline changes required by the
`elastic-package` linter when `format_version` is bumped to 3.6.0:

- **SVR00006**: every processor must have a `tag` field
- **SVR00008**: pipeline-level `on_failure` must set `event.kind: pipeline_error`
- **SVR00009**: pipeline-level `on_failure` error message must include `_ingest.pipeline`

By landing these changes separately, the upcoming format_version bump PR
will be smaller and easier to review. These changes are also safe to
backport since they have no functional effect at format_version 3.4.0.

The changes were generated with:
```
elastic-package modify --modifiers pipeline-tag
```
followed by manual fixes for the on_failure message template updates
and two duplicate processor removals that were surfaced by the tagging.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-command).

## Related

- https://github.com/elastic/integrations/pull/19278#pullrequestreview-4555025226
