### PR TITLE
[aws] Add var_groups for credential type selection with Identity Federation

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,21 @@
 # newer versions go on top
+- version: "7.0.0"
+  changes:
+    - description: Reorganize AWS credentials configuration into a `Setup Access` selector with Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, Assume Role with External ID, and Shared Credentials options. Existing access keys, role ARN, and shared credential settings continue to function and are auto-mapped to the corresponding option.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19828
+    - description: Switch the GuardDuty httpjson stream from manual SigV4 HMAC signing to the native `auth.aws` block.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19828
+    - description: Store the `external_id` variable as a secret.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/19828
+    - description: Add `assume_role_duration`, `assume_role_expiry_window`, and `supports_identity_federation` variables.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19828
+    - description: Require Kibana and Elastic Agent ^9.4.0 (drop support for Kibana 8.x, Kibana 9.x below 9.4.0, and Elastic Agent below 9.4.0). The var_groups manifest feature and `auth.aws` runtime require this minimum.
+      type: breaking-change
+      link: https://github.com/elastic/integrations/pull/19828
 - version: "6.21.0"
   changes:
     - description: Poll Amazon Inspector findings on `updatedAt` instead of `lastObservedAt` so that findings AWS marks CLOSED or SUPPRESSED are collected and no longer remain stale in Elastic.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: "7.0.0"
   changes:
+    - description: Hide the CloudWatch, EBS, EC2, ECS, and S3 metric/log inputs when the Identity Federation setup access option is selected, since only the GuardDuty API input supports identity federation.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19828
     - description: Reorganize AWS credentials configuration into a `Setup Access` selector with Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, Assume Role with External ID, and Shared Credentials options. Existing access keys, role ARN, and shared credential settings continue to function and are auto-mapped to the corresponding option.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19828

--- a/packages/aws/data_stream/guardduty/_dev/test/policy/test-httpjson-agentless-cloud-connector.expected
+++ b/packages/aws/data_stream/guardduty/_dev/test/policy/test-httpjson-agentless-cloud-connector.expected
@@ -1,0 +1,84 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.4.0
+            name: aws
+      name: test-httpjson-agentless-cloud-connector-aws
+      streams:
+        - auth.aws:
+            external_id: ${SECRET_0}
+            role_arn: arn:aws:iam::123456789012:role/ElasticGuardDutyReadOnly
+            use_cloud_connectors: true
+          chain:
+            - step:
+                replace: $.nextToken
+                request.method: POST
+                request.ssl: null
+                request.timeout: 30s
+                request.transforms:
+                    - set:
+                        target: body.findingIds
+                        value: '[[toJSON .parent_last_response.body.findingIds]]'
+                        value_type: json
+                    - set:
+                        target: body.sortCriteria
+                        value: '{"attributeName":"updatedAt","orderBy":"ASC"}'
+                        value_type: json
+                request.url: https://guardduty.us-east-1.amazonaws.com/detector/12abc34d567e8fa901bc2d34e567f890/findings/get
+                response.split:
+                    target: body.findings
+          config_version: 2
+          cursor:
+            last_execution_datetime:
+                ignore_empty_value: true
+                value: '[[$f := (index .last_response.body "findings")]][[if $f]][[if (ne (len $f) 50)]][[.last_event.updatedAt]][[end]][[end]]'
+          data_stream:
+            dataset: aws.guardduty
+          interval: 5m
+          publisher_pipeline.disable_host: true
+          request.method: POST
+          request.ssl: null
+          request.timeout: 30s
+          request.transforms:
+            - set:
+                target: body.maxResults
+                value: 50
+                value_type: int
+            - set:
+                target: body.sortCriteria
+                value: '{"attributeName":"updatedAt","orderBy":"ASC"}'
+                value_type: json
+            - set:
+                default: '[[((now (parseDuration "-48h"))).UnixMilli]]'
+                target: body.findingCriteria.criterion.updatedAt.greaterThan
+                value: '[[((parseDate .cursor.last_execution_datetime)).UnixMilli]]'
+          request.url: https://guardduty.us-east-1.amazonaws.com/detector/12abc34d567e8fa901bc2d34e567f890/findings
+          response.pagination:
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: true
+                target: body.nextToken
+                value: '[[if (ne .last_response.body.nextToken "")]][[.last_response.body.nextToken]][[end]]'
+          tags:
+            - forwarded
+            - aws-guardduty
+      type: httpjson
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws.guardduty-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}

--- a/packages/aws/data_stream/guardduty/_dev/test/policy/test-httpjson-agentless-cloud-connector.yml
+++ b/packages/aws/data_stream/guardduty/_dev/test/policy/test-httpjson-agentless-cloud-connector.yml
@@ -1,0 +1,15 @@
+vars:
+  role_arn: arn:aws:iam::123456789012:role/ElasticGuardDutyReadOnly
+  external_id: guardduty-external-id
+  supports_identity_federation: true
+  default_region: us-east-1
+data_stream:
+  vars:
+    interval: 5m
+    initial_interval: 48h
+    detector_id: 12abc34d567e8fa901bc2d34e567f890
+    aws_region: us-east-1
+    tld: amazonaws.com
+    http_client_timeout: 30s
+    preserve_original_event: false
+    preserve_duplicate_custom_fields: false

--- a/packages/aws/data_stream/guardduty/_dev/test/policy/test-httpjson-legacy-credentials.expected
+++ b/packages/aws/data_stream/guardduty/_dev/test/policy/test-httpjson-legacy-credentials.expected
@@ -1,0 +1,101 @@
+inputs:
+    - data_stream:
+        namespace: ep
+      meta:
+        package:
+            agentVersion: ^9.4.0
+            name: aws
+      name: test-httpjson-legacy-credentials-aws
+      streams:
+        - auth.aws:
+            access_key_id: ${SECRET_0}
+            secret_access_key: ${SECRET_1}
+          chain:
+            - step:
+                replace: $.nextToken
+                request.method: POST
+                request.proxy_url: https://user:P%40ssword%23@192.0.2.10:8080
+                request.ssl:
+                    enabled: true
+                    verification_mode: none
+                request.timeout: 30s
+                request.transforms:
+                    - set:
+                        target: body.findingIds
+                        value: '[[toJSON .parent_last_response.body.findingIds]]'
+                        value_type: json
+                    - set:
+                        target: body.sortCriteria
+                        value: '{"attributeName":"updatedAt","orderBy":"ASC"}'
+                        value_type: json
+                request.url: https://guardduty.us-east-1.amazonaws.com/detector/12abc34d567e8fa901bc2d34e567f890/findings/get
+                response.split:
+                    target: body.findings
+          config_version: 2
+          cursor:
+            last_execution_datetime:
+                ignore_empty_value: true
+                value: '[[$f := (index .last_response.body "findings")]][[if $f]][[if (ne (len $f) 50)]][[.last_event.updatedAt]][[end]][[end]]'
+          data_stream:
+            dataset: aws.guardduty
+          interval: 5m
+          processors:
+            - add_fields:
+                fields:
+                    env: test
+                    name: guardduty
+                target: project
+          publisher_pipeline.disable_host: true
+          request.method: POST
+          request.proxy_url: https://user:P%40ssword%23@192.0.2.10:8080
+          request.ssl:
+            enabled: true
+            verification_mode: none
+          request.timeout: 30s
+          request.tracer.filename: ../../logs/httpjson/http-request-trace-*.ndjson
+          request.tracer.maxbackups: 5
+          request.transforms:
+            - set:
+                target: body.maxResults
+                value: 50
+                value_type: int
+            - set:
+                target: body.sortCriteria
+                value: '{"attributeName":"updatedAt","orderBy":"ASC"}'
+                value_type: json
+            - set:
+                default: '[[((now (parseDuration "-48h"))).UnixMilli]]'
+                target: body.findingCriteria.criterion.updatedAt.greaterThan
+                value: '[[((parseDate .cursor.last_execution_datetime)).UnixMilli]]'
+          request.url: https://guardduty.us-east-1.amazonaws.com/detector/12abc34d567e8fa901bc2d34e567f890/findings
+          response.pagination:
+            - set:
+                do_not_log_failure: true
+                fail_on_template_error: true
+                target: body.nextToken
+                value: '[[if (ne .last_response.body.nextToken "")]][[.last_response.body.nextToken]][[end]]'
+          tags:
+            - preserve_original_event
+            - preserve_duplicate_custom_fields
+            - forwarded
+            - aws-guardduty
+            - test-policy
+      type: httpjson
+      use_output: default
+output_permissions:
+    default:
+        _elastic_agent_checks:
+            cluster:
+                - monitor
+        _elastic_agent_monitoring:
+            indices: []
+        uuid-for-permissions-on-related-indices:
+            indices:
+                - names:
+                    - logs-aws.guardduty-ep
+                  privileges:
+                    - auto_configure
+                    - create_doc
+secret_references:
+    - {}
+    - {}

--- a/packages/aws/data_stream/guardduty/_dev/test/policy/test-httpjson-legacy-credentials.yml
+++ b/packages/aws/data_stream/guardduty/_dev/test/policy/test-httpjson-legacy-credentials.yml
@@ -1,0 +1,29 @@
+vars:
+  access_key_id: FAKE_AWS_ACCESS_KEY_ID_FOR_TESTS_ONLY
+  secret_access_key: FAKE_AWS_SECRET_ACCESS_KEY_FOR_TESTS_ONLY
+  default_region: us-east-1
+data_stream:
+  vars:
+    enable_request_tracer: true
+    interval: 5m
+    initial_interval: 48h
+    detector_id: 12abc34d567e8fa901bc2d34e567f890
+    aws_region: us-east-1
+    tld: amazonaws.com
+    http_client_timeout: 30s
+    proxy_url: https://user:P%40ssword%23@192.0.2.10:8080
+    ssl: |
+      enabled: true
+      verification_mode: none
+    preserve_original_event: true
+    preserve_duplicate_custom_fields: true
+    tags:
+      - forwarded
+      - aws-guardduty
+      - test-policy
+    processors: |
+      - add_fields:
+          target: project
+          fields:
+            name: guardduty
+            env: test

--- a/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
@@ -15,10 +15,8 @@ request.proxy_url: {{proxy_url}}
 {{#if ssl}}
 request.ssl: {{ssl}}
 {{/if}}
+
 request.transforms:
-  - set:
-      target: header.X-Amz-Date
-      value: '[[formatDate (now) "20060102T150405Z"]]'
   - set:
       target: body.maxResults
       value: 50
@@ -35,20 +33,12 @@ request.transforms:
       re-evaluates (now) on every pagination page, which can change the query and
       invalidate the NextToken. A CEL rewrite can reintroduce the upper bound safely
       since it can pin the value once per collection interval. --}}
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/guardduty/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "guardduty")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/guardduty/aws4_request") (hash "sha256" "POST\n" "/detector/{{detector_id}}/findings\n" "\n" "host:guardduty.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
 response.pagination:
   - set:
       target: body.nextToken
       value: '[[if (ne .last_response.body.nextToken "")]][[.last_response.body.nextToken]][[end]]'
       fail_on_template_error: true
       do_not_log_failure: true
-  - delete:
-      target: header.Authorization
-  - set:
-      target: header.Authorization
-      value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/guardduty/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "guardduty")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/guardduty/aws4_request") (hash "sha256" "POST\n" "/detector/{{detector_id}}/findings\n" "\n" "host:guardduty.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
 chain:
   - step:
       request.url: https://guardduty.{{aws_region}}.{{tld}}/detector/{{detector_id}}/findings/get
@@ -65,9 +55,6 @@ chain:
       request.method: POST
       request.transforms:
         - set:
-            target: header.X-Amz-Date
-            value: '[[formatDate (now) "20060102T150405Z"]]'
-        - set:
             target: body.findingIds
             value: '[[toJSON .parent_last_response.body.findingIds]]'
             value_type: json
@@ -75,9 +62,6 @@ chain:
             target: body.sortCriteria
             value: '{"attributeName":"updatedAt","orderBy":"ASC"}'
             value_type: json
-        - set:
-            target: header.Authorization
-            value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/guardduty/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "guardduty")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/guardduty/aws4_request") (hash "sha256" "POST\n" "/detector/{{detector_id}}/findings/get\n" "\n" "host:guardduty.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'
       response.split:
         target: body.findings
 cursor:
@@ -100,4 +84,35 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{processors}}
+{{/if}}
+auth.aws:
+{{#if access_key_id}}
+  access_key_id: {{access_key_id}}
+{{/if}}
+{{#if secret_access_key}}
+  secret_access_key: {{secret_access_key}}
+{{/if}}
+{{#if session_token}}
+  session_token: {{session_token}}
+{{/if}}
+{{#if shared_credential_file}}
+  shared_credential_file: {{shared_credential_file}}
+{{/if}}
+{{#if credential_profile_name}}
+  credential_profile_name: {{credential_profile_name}}
+{{/if}}
+{{#if role_arn}}
+  role_arn: {{role_arn}}
+{{/if}}
+{{#if external_id}}
+  external_id: {{external_id}}
+{{/if}}
+{{#if assume_role_duration}}
+  assume_role.duration: {{assume_role_duration}}
+{{/if}}
+{{#if assume_role_expiry_window}}
+  assume_role.expiry_window: {{assume_role_expiry_window}}
+{{/if}}
+{{#if supports_identity_federation}}
+  use_cloud_connectors: {{supports_identity_federation}}
 {{/if}}

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -257,10 +257,14 @@ policy_templates:
         title: Collect logs from CloudWatch
         description: Collecting logs using aws-cloudwatch input
         input_group: logs
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
       - type: aws/metrics
         title: Collect metrics from CloudWatch
         description: Collecting metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -356,6 +360,8 @@ policy_templates:
         title: Collect EBS metrics
         description: Collect EBS metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -392,10 +398,14 @@ policy_templates:
         title: Collect EC2 logs from CloudWatch
         description: Collecting logs from EC2 using aws-cloudwatch input
         input_group: logs
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
       - type: aws/metrics
         title: Collect EC2 metrics
         description: Collecting EC2 metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -428,6 +438,8 @@ policy_templates:
         title: Collect ECS metrics
         description: Collecting ECS metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -668,6 +680,8 @@ policy_templates:
         title: Collect S3 metrics
         description: Collecting S3 metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.6.0
+format_version: 3.6.1
 name: aws
 title: AWS
 version: 7.0.0

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.4.0
+format_version: 3.6.0
 name: aws
 title: AWS
-version: 6.21.0
+version: 7.0.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:
@@ -21,7 +21,10 @@ conditions:
   elastic:
     subscription: basic
   kibana:
-    version: "^8.19.4 || ^9.2.1"
+    version: "^9.4.0"
+  # auth.aws support in CEL and HTTPJSON inputs requires Elastic Agent 9.4.0+.
+  agent:
+    version: "^9.4.0"
 screenshots:
   - src: /img/metricbeat-aws-overview.png
     title: metricbeat aws overview
@@ -79,7 +82,22 @@ vars:
     multi: false
     required: false
     show_user: false
+    secret: true
     description: External ID to use when assuming a role in another account, see [the AWS documentation for use of external IDs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
+  - name: assume_role_duration
+    type: duration
+    title: Assume Role Duration
+    multi: false
+    required: false
+    show_user: false
+    description: Duration of the assumed role session.
+  - name: assume_role_expiry_window
+    type: duration
+    title: Assume Role Expiry Window
+    multi: false
+    required: false
+    show_user: false
+    description: Amount of time before the assumed role session expires during which credentials are refreshed.
   - name: default_region
     type: text
     title: Default AWS Region
@@ -95,6 +113,43 @@ vars:
     required: false
     show_user: false
     description: URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port>
+  - name: supports_identity_federation
+    type: bool
+    title: Supports Identity Federation
+    multi: false
+    required: false
+    show_user: false
+var_groups:
+  - name: credential_type
+    required: true
+    title: Setup Access
+    selector_title: Preferred method
+    options:
+      - name: identity_federation
+        title: Identity Federation
+        vars: [role_arn, external_id, supports_identity_federation]
+        hide_in_deployment_modes: [default]
+        provider: aws
+        iac_template_url: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cloud-connectors-guardduty-9.4.0.yml&param_ElasticResourceId=RESOURCE_ID
+      - name: direct_access_key
+        title: Direct Access Keys
+        vars: [access_key_id, secret_access_key]
+      - name: temporary_access_key
+        title: Temporary Access Keys
+        vars: [access_key_id, secret_access_key, session_token]
+        hide_in_deployment_modes: [agentless]
+      - name: assume_role
+        title: Assume Role
+        vars: [role_arn]
+        hide_in_deployment_modes: [agentless]
+      - name: assume_role_external_id
+        title: Assume Role with External ID
+        vars: [role_arn, external_id]
+        hide_in_deployment_modes: [agentless]
+      - name: shared_credentials
+        title: Shared Credentials
+        vars: [shared_credential_file, credential_profile_name]
+        hide_in_deployment_modes: [agentless]
 policy_templates:
   - name: awshealth
     title: AWS Health
@@ -108,6 +163,8 @@ policy_templates:
         title: Collect AWS Health metrics (experimental)
         description: Collect AWS Health metrics (experimental).
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -139,6 +196,8 @@ policy_templates:
         title: Collect billing metrics
         description: Collect billing metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -238,6 +297,8 @@ policy_templates:
       - type: cel
         title: Collect AWS Config logs via API
         description: Collecting AWS Config logs via API.
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     icons:
       - src: /img/logo-aws-config.svg
         title: AWS Config logo
@@ -261,6 +322,8 @@ policy_templates:
         title: Collect dynamodb metrics
         description: Collect dynamodb metrics
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -393,14 +456,20 @@ policy_templates:
         title: Collect ELB logs from S3
         description: Collecting logs from ELB using aws-s3 input
         input_group: logs
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
       - type: aws-cloudwatch
         title: Collect ELB logs from CloudWatch
         description: Collecting logs from ELB using aws-cloudwatch input
         input_group: logs
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
       - type: aws/metrics
         title: Collect ELB metrics
         description: Collecting ELB metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -453,10 +522,14 @@ policy_templates:
         title: Collect Lambda metrics
         description: Collect Lambda metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
       - type: aws-cloudwatch
         title: Collect lambda logs from CloudWatch
         description: Collecting AWS lambda logs using aws-cloudwatch input
         input_group: logs
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -555,6 +628,8 @@ policy_templates:
         title: Collect RDS metrics
         description: Collect RDS metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -651,6 +726,8 @@ policy_templates:
         title: Collect SNS metrics
         description: Collect SNS metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -682,6 +759,8 @@ policy_templates:
         title: Collect SQS metrics
         description: Collect SQS metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -713,6 +792,8 @@ policy_templates:
         title: Collect Transit Gateway metrics
         description: Collect Transit Gateway metrics using AWS CloudWatch
         input_group: metrics
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     deployment_modes:
       default:
         enabled: true
@@ -922,6 +1003,8 @@ policy_templates:
       - type: httpjson
         title: Collect AWS Security Hub CSPM logs via API
         description: Collecting AWS Security Hub CSPM logs via API.
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     screenshots:
       - src: /img/securityhub_cspm_findings_insights_dashboard.png
         title: Security Hub CSPM Findings and Insights dashboard screenshot
@@ -958,6 +1041,8 @@ policy_templates:
       - type: httpjson
         title: Collect Amazon Inspector logs via API
         description: Collecting Amazon Inspector logs via API.
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     screenshots:
       - src: /img/inspector-findings-overview-dashboard.png
         title: Inspector Findings Overview dashboard
@@ -1003,6 +1088,8 @@ policy_templates:
       - type: aws-s3
         title: Collect Amazon GuardDuty logs via AWS S3 or SQS
         description: Collecting Amazon GuardDuty logs via AWS S3 or SQS input.
+        hide_in_var_group_options:
+          credential_type: [identity_federation]
     screenshots:
       - src: /img/guardduty-findings-overview.png
         title: GuardDuty Findings Overview dashboard screenshot


### PR DESCRIPTION
## Proposed commit message

```
[aws] Add var_groups for credential type selection with Identity Federation

Bump format_version to 3.6.1 and version to 7.0.0. Reorganize AWS
credential configuration into a `Setup Access` var_groups selector with
six options: Identity Federation, Direct Access Keys, Temporary Access
Keys, Assume Role, Assume Role with External ID, and Shared Credentials.

Key changes:
- format_version: 3.4.0 → 3.6.1
- version: 6.20.3 → 7.0.0
- kibana.version: "^8.19.4 || ^9.2.1" → "^9.4.0"
- agent.version: "^9.4.0"
- var_groups: credential_type selector with 6 options
- external_id is now secret: true
- New vars: assume_role_duration, assume_role_expiry_window,
  supports_cloud_connectors
- hide_in_var_group_options for 13 inputs across services that don't
  support Identity Federation
- GuardDuty httpjson stream: switch to auth.aws: block and add Identity
  Federation policy tests
- Add conditions.agent.version: ^9.4.0 because guardduty now requires
  it.

Source: elastic/integrations#19278 (Omolola-Akinleye/integrations)

```

## Summary

This PR carries the var_groups / Identity Federation work from #19278 forward on top of the processor-tags pre-landing from #19824.

### What changed

- Bump `format_version` from 3.4.0 to 3.6.1 and package `version` from 6.20.3 to 7.0.0.
- Require Kibana and Elastic Agent `^9.4.0` for the `var_groups` UI feature and `auth.aws` runtime support.
- Add a `credential_type` var_groups selector with Identity Federation, Direct Access Keys, Temporary Access Keys, Assume Role, Assume Role with External ID, and Shared Credentials options.
- Add `assume_role_duration`, `assume_role_expiry_window`, and `supports_cloud_connectors` variables.
- Mark `external_id` as secret.
- Hide the Identity Federation option for inputs where that path has not yet been validated.
- Switch the GuardDuty httpjson stream from manual SigV4 HMAC signing to the native `auth.aws` block.
- Add GuardDuty Identity Federation and legacy credential policy test fixtures.
- Align Transit Gateway policy template categories with its metrics data stream.

### Related

- elastic/integrations#19278 remake of 18762 with major version bump, basis for this PR
- elastic/integrations#18762 original PR
- elastic/ingest-dev#8788 (internal)

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-command).