### PR TITLE
[cisco_asa] Add 'Users account has expired' to AAA rejection reasons.

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.9"
+  changes:
+    - description: Add 'Users account has expired' to AAA rejection reasons in parse_113005 grok pattern.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.45.8"
   changes:
     - description: Fix parse_315011 grok patterns to handle missing source IP address in SSH session messages.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add 'Users account has expired' to AAA rejection reasons in parse_113005 grok pattern.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19831
 - version: "2.45.8"
   changes:
     - description: Fix parse_315011 grok patterns to handle missing source IP address in SSH session messages.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -191,3 +191,4 @@ Apr 29 12:59:50.138340591: %ASA-6-302013: Built outbound TCP connection 89765432
 May  5 18:40:50 dev-01: %ASA-6-305011: Built dynamic TCP translation from fw111:SDC_Proxy/63986 to out111:81.2.69.144/63986
 May  5 18:40:50 dev_01: %ASA-6-305011: Built dynamic TCP translation from fw111:10.10.10.10/61400 to out111:external-pool/61400
 <190>May 15 2026 12:54:07: %ASA-6-113015: AAA user authentication Rejected : reason = User was not found : local database : user = ;;alice-johnson(test user) : user IP = 203.0.113.20
+<166>:: %ASA-auth-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 198.51.100.10 : user = alice.johnson : user IP = 203.0.113.20

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -13426,6 +13426,117 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "cisco": {
+                "asa": {
+                    "rejection_reason": "Users account has expired",
+                    "suffix": "auth"
+                }
+            },
+            "destination": {
+                "address": "198.51.100.10",
+                "as": {
+                    "number": 64501,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Amsterdam",
+                    "continent_name": "Europe",
+                    "country_iso_code": "NL",
+                    "country_name": "Netherlands",
+                    "location": {
+                        "lat": 52.37404,
+                        "lon": 4.88969
+                    },
+                    "region_iso_code": "NL-NH",
+                    "region_name": "North Holland"
+                },
+                "ip": "198.51.100.10"
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "logon-failed",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113005",
+                "kind": "event",
+                "original": "<166>:: %ASA-auth-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 198.51.100.10 : user = alice.johnson : user IP = 203.0.113.20",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "denied",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "::"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 166,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "::",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "::"
+                ],
+                "ip": [
+                    "203.0.113.20",
+                    "198.51.100.10"
+                ],
+                "user": [
+                    "alice.johnson"
+                ]
+            },
+            "source": {
+                "address": "203.0.113.20",
+                "as": {
+                    "number": 64502,
+                    "organization": {
+                        "name": "Documentation ASN"
+                    }
+                },
+                "geo": {
+                    "city_name": "Madrid",
+                    "continent_name": "Europe",
+                    "country_iso_code": "ES",
+                    "country_name": "Spain",
+                    "location": {
+                        "lat": 40.41639,
+                        "lon": -3.7025
+                    },
+                    "region_iso_code": "ES-M",
+                    "region_name": "Madrid"
+                },
+                "ip": "203.0.113.20",
+                "user": {
+                    "name": "alice.johnson"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -429,7 +429,7 @@ processors:
       - "AAA user %{AUTH} Rejected(%{SPACE})?: reason = %{REASON:_temp_.cisco.rejection_reason}(%{SPACE})?: server = %{IPORHOST:destination.address}(%{SPACE})?: user = ?(%{CISCO_USER:source.user.name}|)(%{SPACE})?: user IP = %{IPORNONE}"
       pattern_definitions:
         AUTH: (authentication|authorization)
-        REASON: (AAA failure|Account has been disabled|Invalid password|Password is expiring|Password has expired|Password malformed|Unspecified|Account has been locked out)
+        REASON: (AAA failure|Account has been disabled|Invalid password|Password is expiring|Password has expired|Password malformed|Unspecified|Account has been locked out|Users account has expired)
         USERNAME: "[a-zA-Z0-9._'-]+"
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
         IPORNONE: (%{IP:source.address}|None)

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.45.8"
+version: "2.45.9"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

Adds support for the 'Users account has expired' rejection reason to the parse_113005 grok pattern in the Cisco ASA ingest pipeline. This missing case was preventing proper parsing of authentication rejection logs with this specific reason. The fix updates the REASON pattern definition, includes a comprehensive test case with expected output, and bumps the package version to 2.45.9.

## Proposed commit message

```
[cisco_asa] Add 'Users account has expired' to AAA rejection reasons.
```

## Root cause

The REASON pattern in the parse_113005 grok processor is incomplete and does not include 'Users account has expired' as a valid rejection reason, even though Cisco ASA documents this as a valid AAA authentication failure reason. When an event contains this reason value, the grok pattern fails to match, causing the event to be routed to on_failure.

## Approach

Add 'Users account has expired' to the REASON pattern_definitions in the parse_113005 grok processor of the default pipeline. This rejection reason is documented by Cisco but was missing from the pattern, causing valid events to fail matching. The fix expands the pattern to include this vendor-documented rejection reason and adds a test fixture to prevent regression.

## Implementation

1. 1. Read packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml and locate the parse_113005 processor (line ~423-434)
2. 2. Update the REASON pattern_definitions on line ~431 to include 'Users account has expired' in the alternation list
3. 3. Add a new test case to packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log with the sanitized event
4. 4. Generate expected output for the new test case in the corresponding .log-expected.json file using elastic-package test
5. 5. Verify the grok pattern now matches the new rejection reason by running elastic-package test pipeline
6. 6. Update packages/cisco_asa/changelog.yml with a bugfix entry documenting the fix

## Pipeline changes

- Update REASON pattern in parse_113005 processor to include 'Users account has expired' as valid rejection reason value

## Field / mapping changes

—

## Sanitized error message

`Processor 'grok' with tag 'parse_113005' in pipeline 'logs-cisco_asa.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
<166>:: %ASA-auth-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 198.51.100.10 : user = alice.johnson : user IP = 203.0.113.20
```

## Reviewer concerns

The [clean] stage exited with code 1 during testing. While all functional tests (test-pipeline, test-static, test-system) pass successfully, the clean failure should be investigated to ensure there are no underlying package structure or artifact issues.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors, ecs, ingest, test-fixture
- **Impact**: medium

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_asa.log [MISSING_CASE]: Processor 'grok' with tag 'parse_113005' in pipeline 'logs-cisco_asa.log…
- **Pipeline case**: `5bee0242e4bbdea5`
