### PR TITLE
cyera,extrahop,ironscales,island_browser,jupiter_one,proofpoint_on_demand,sentinel_one,websocket: fix redundant caret ranges in kibana.version constraints

### DIFF
--- a/packages/cyera/changelog.yml
+++ b/packages/cyera/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.1"
+  changes:
+    - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19872
 - version: "0.7.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/cyera/manifest.yml
+++ b/packages/cyera/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.3.2
 name: cyera
 title: Cyera
-version: 0.7.0
+version: 0.7.1
 description: Collect logs from Cyera with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: '^8.19.7 || ^9.1.7 || ^9.2.1 || ^9.3.0'
+    version: '^8.19.7 || ~9.1.7 || ~9.2.1 || ^9.3.0'
   elastic:
     subscription: basic
 icons:

--- a/packages/extrahop/changelog.yml
+++ b/packages/extrahop/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19872
 - version: "0.3.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/extrahop/manifest.yml
+++ b/packages/extrahop/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.3.2
 name: extrahop
 title: ExtraHop
-version: 0.3.0
+version: 0.3.1
 description: Collect logs from ExtraHop RevealX 360 with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: ^8.18.5 || ^8.19.2  || ^9.0.5  || ^9.1.2
+    version: ~8.18.5 || ^8.19.2 || ~9.0.5 || ^9.1.2
   elastic:
     subscription: basic
 screenshots:

--- a/packages/ironscales/changelog.yml
+++ b/packages/ironscales/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.3"
+  changes:
+    - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19872
 - version: "0.2.2"
   changes:
     - description: Skip incidents that return 404 or 410 instead of aborting the entire collection.

--- a/packages/ironscales/manifest.yml
+++ b/packages/ironscales/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.3.2
 name: ironscales
 title: IRONSCALES
-version: 0.2.2
+version: 0.2.3
 description: Collect logs from IRONSCALES with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: ^8.19.8 || ^9.1.8 || ^9.2.2 || ^9.3.0
+    version: ^8.19.8 || ~9.1.8 || ~9.2.2 || ^9.3.0
   elastic:
     subscription: basic
 screenshots:

--- a/packages/island_browser/changelog.yml
+++ b/packages/island_browser/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19872
 - version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/island_browser/manifest.yml
+++ b/packages/island_browser/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.3.2
 name: island_browser
 title: Island Browser
-version: 1.1.0
+version: 1.1.1
 description: Collect logs from Island Browser with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: ^8.18.8 || ^8.19.5  || ^9.0.8  || ^9.1.5
+    version: ~8.18.8 || ^8.19.5 || ~9.0.8 || ^9.1.5
   elastic:
     subscription: basic
 icons:

--- a/packages/jupiter_one/changelog.yml
+++ b/packages/jupiter_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19872
 - version: "1.1.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/jupiter_one/manifest.yml
+++ b/packages/jupiter_one/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.3.2
 name: jupiter_one
 title: JupiterOne
-version: 1.1.0
+version: 1.1.1
 description: Collect logs from JupiterOne with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: ^8.19.10 || ^9.1.10 || ^9.2.4 || ^9.3.1 || ^9.4.0
+    version: ^8.19.10 || ~9.1.10 || ~9.2.4 || ~9.3.1 || ^9.4.0
   elastic:
     subscription: basic
 icons:

--- a/packages/proofpoint_on_demand/changelog.yml
+++ b/packages/proofpoint_on_demand/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.2"
+  changes:
+    - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19872
 - version: "1.10.1"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/proofpoint_on_demand/manifest.yml
+++ b/packages/proofpoint_on_demand/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.1.4
 name: proofpoint_on_demand
 title: Proofpoint On Demand
-version: "1.10.1"
+version: "1.10.2"
 description: Collect logs from Proofpoint On Demand with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: "^8.19.16 || ^9.3.5 || ^9.4.0"
+    version: "^8.19.16 || ~9.3.5 || ^9.4.0"
   elastic:
     subscription: basic
 icons:

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.2"
+  changes:
+    - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19872
 - version: "2.8.1"
   changes:
     - description: Fix unified alert pipeline mapping `parentName` to `process.parent.command_line` instead of `process.parent.name`.

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: sentinel_one
 title: SentinelOne
-version: "2.8.1"
+version: "2.8.2"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - edr_xdr
 conditions:
   kibana:
-    version: ^8.19.13 || ^9.2.7 || ^9.3.2
+    version: ^8.19.13 || ~9.2.7 || ^9.3.2
 screenshots:
   - src: /img/sentinel-one-activities-dashboard.png
     title: SentinelOne Activity Dashboard

--- a/packages/websocket/changelog.yml
+++ b/packages/websocket/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19872
 - version: "1.0.1"
   changes:
     - description: Fix broken links for Websocket integration.

--- a/packages/websocket/manifest.yml
+++ b/packages/websocket/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: websocket
 title: Custom Websocket logs
-version: "1.0.1"
+version: "1.0.2"
 description: Collect custom events from a socket server with Elastic agent.
 type: input
 categories:
@@ -10,7 +10,7 @@ categories:
   - network
 conditions:
   kibana:
-    version: "^8.16.3 || ^8.17.1 || ^9.0.0"
+    version: "~8.16.3 || ^8.17.1 || ^9.0.0"
   elastic:
     subscription: "basic"
 policy_templates:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
cyera,extrahop,ironscales,island_browser,jupiter_one,proofpoint_on_demand,sentinel_one,websocket: fix redundant caret ranges in kibana.version constraints

Intermediate semver ranges used ^ (caret) instead of ~ (tilde),
making subsequent ranges within the same major version redundant.
For example ^9.2.7 || ^9.3.2 is equivalent to just ^9.2.7 because
caret covers >=9.2.7 <10.0.0. The intended constraint was
~9.2.7 || ^9.3.2, using tilde to restrict the intermediate range
to >=9.2.7 <9.3.0.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #19870

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
