### PR TITLE
[TrendAI Deep Security] Map CEF Name to trendmicro.deep_security.malware.name for anti-malware events

### DIFF
--- a/packages/trendmicro/changelog.yml
+++ b/packages/trendmicro/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Map CEF Name to trendmicro.deep_security.malware.name for anti-malware events.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19873
 - version: "2.8.2"
   changes:
     - description: Update product name to TrendAI in documentation

--- a/packages/trendmicro/changelog.yml
+++ b/packages/trendmicro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.0"
+  changes:
+    - description: Map CEF Name to trendmicro.deep_security.malware.name for anti-malware events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.8.2"
   changes:
     - description: Update product name to TrendAI in documentation

--- a/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-trendmicro.json
+++ b/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-trendmicro.json
@@ -251,6 +251,40 @@
                 "port": 65535,
                 "mac": "11-AA-00-00-AA-00"
             }
+        },
+        {
+            "@timestamp": "2024-04-18T02:35:59.000Z",
+            "event": {
+                "code": "4000010",
+                "severity": 6,
+                "original": "<134>Apr 18 02:35:59 host-01.example.local CEF:0|Trend Micro|Deep Security Agent|20.0.1073|4000010|PUA.XML.GhostBuilder.SM|6|cn1=42 cn1Label=Host ID dvchost=workstation-01.example.local TrendMicroDsTenant=Primary TrendMicroDsTenantId=0 act=Quarantine"
+            },
+            "message": "PUA.XML.GhostBuilder.SM",
+            "cef": {
+                "name": "PUA.XML.GhostBuilder.SM",
+                "severity": "6",
+                "version": "0",
+                "device": {
+                    "vendor": "Trend Micro",
+                    "product": "Deep Security Agent",
+                    "version": "20.0.1073",
+                    "event_class_id": "4000010"
+                },
+                "extensions": {
+                    "deviceCustomNumber1": 42,
+                    "deviceCustomNumber1Label": "Host ID",
+                    "deviceHostName": "workstation-01.example.local",
+                    "deviceAction": "Quarantine",
+                    "TrendMicroDsTenant": "Primary",
+                    "TrendMicroDsTenantId": "0"
+                }
+            },
+            "observer": {
+                "product": "Deep Security Agent",
+                "version": "20.0.1073",
+                "hostname": "workstation-01.example.local",
+                "vendor": "Trend Micro"
+            }
         }
     ]
 }

--- a/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-trendmicro.json-expected.json
+++ b/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-trendmicro.json-expected.json
@@ -205,7 +205,7 @@
             }
         },
         {
-            "@timestamp": "2025-01-19T13:36:47.000Z",
+            "@timestamp": "2026-01-19T13:36:47.000Z",
             "destination": {
                 "geo": {
                     "city_name": "London",
@@ -347,7 +347,7 @@
             }
         },
         {
-            "@timestamp": "2025-01-19T13:36:47.000Z",
+            "@timestamp": "2026-01-19T13:36:47.000Z",
             "destination": {
                 "geo": {
                     "city_name": "London",
@@ -469,6 +469,9 @@
                     "deviceHostName": "2K19-va.test.local",
                     "event_category": "anti-malware-event",
                     "event_class_id": "4000001",
+                    "malware": {
+                        "name": "Disallow Web Proxy Autodiscovery Protocol"
+                    },
                     "name": "Disallow Web Proxy Autodiscovery Protocol",
                     "severity": 6,
                     "signature_id": 4000001,
@@ -483,6 +486,77 @@
                         "ds_packet_data": "PUaBgwAAAAAQAABHdwYWQEdGVzdAVsb2NhbAAAAQABAAAGAAEAAVF5AEABYQxyb290LXNlcnZlcnMDbmV0AAVuc3RsZAx2ZXJpc2lnbi1ncnMDY29tAHij+HwAAAcIAAADhAAJOoAAAVGA",
                         "ds_tenant": "814726098539",
                         "ds_tenant_id": "16005"
+                    },
+                    "version": "0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2026-04-18T02:35:59.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "quarantine",
+                "category": [
+                    "malware"
+                ],
+                "code": "4000010",
+                "kind": "alert",
+                "original": "<134>Apr 18 02:35:59 host-01.example.local CEF:0|Trend Micro|Deep Security Agent|20.0.1073|4000010|PUA.XML.GhostBuilder.SM|6|cn1=42 cn1Label=Host ID dvchost=workstation-01.example.local TrendMicroDsTenant=Primary TrendMicroDsTenantId=0 act=Quarantine",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "id": "42"
+            },
+            "log": {
+                "syslog": {
+                    "priority": 134
+                }
+            },
+            "message": "PUA.XML.GhostBuilder.SM",
+            "observer": {
+                "hostname": "workstation-01.example.local",
+                "product": "Deep Security Agent",
+                "vendor": "Trend Micro",
+                "version": "20.0.1073"
+            },
+            "related": {
+                "hosts": [
+                    "42"
+                ]
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "trendmicro": {
+                "deep_security": {
+                    "action": "Quarantine",
+                    "device": {
+                        "custom_number1": {
+                            "label": "Host ID",
+                            "value": "42"
+                        },
+                        "product": "Deep Security Agent",
+                        "vendor": "Trend Micro",
+                        "version": "20.0.1073"
+                    },
+                    "deviceHostName": "workstation-01.example.local",
+                    "event_category": "anti-malware-event",
+                    "event_class_id": "4000010",
+                    "malware": {
+                        "name": "PUA.XML.GhostBuilder.SM"
+                    },
+                    "name": "PUA.XML.GhostBuilder.SM",
+                    "severity": 6,
+                    "signature_id": 4000010,
+                    "trendmicro": {
+                        "ds_tenant": "Primary",
+                        "ds_tenant_id": "0"
                     },
                     "version": "0"
                 }

--- a/packages/trendmicro/data_stream/deep_security/elasticsearch/ingest_pipeline/malware-event.yml
+++ b/packages/trendmicro/data_stream/deep_security/elasticsearch/ingest_pipeline/malware-event.yml
@@ -5,6 +5,11 @@ processors:
       field: trendmicro.deep_security.event_category
       tag: set_deep_security_event_category
       value: anti-malware-event
+  - set:
+      field: trendmicro.deep_security.malware.name
+      tag: set_deep_security_malware_name_from_deep_security_name
+      copy_from: trendmicro.deep_security.name
+      ignore_empty_value: true
   - script:
       lang: painless
       tag: script_to_set_ecs_categorization_in_malware_pipeline

--- a/packages/trendmicro/data_stream/deep_security/fields/fields.yml
+++ b/packages/trendmicro/data_stream/deep_security/fields/fields.yml
@@ -166,6 +166,12 @@
         - name: filename
           type: keyword
           description: The file name that was accessed.
+        - name: malware
+          type: group
+          fields:
+            - name: name
+              type: keyword
+              description: The name of the malware that was found.
         - name: message
           type: keyword
           description: A list of changed attribute names.

--- a/packages/trendmicro/docs/README.md
+++ b/packages/trendmicro/docs/README.md
@@ -186,6 +186,7 @@ An example event for `deep_security` looks as following:
 | trendmicro.deep_security.file.size | The file size in bytes. | long |
 | trendmicro.deep_security.file_path | The location of the malware file. | keyword |
 | trendmicro.deep_security.filename | The file name that was accessed. | keyword |
+| trendmicro.deep_security.malware.name | The name of the malware that was found. | keyword |
 | trendmicro.deep_security.message | A list of changed attribute names. | keyword |
 | trendmicro.deep_security.model | The product name of the device. | keyword |
 | trendmicro.deep_security.name | CEF event containing message. | keyword |

--- a/packages/trendmicro/manifest.yml
+++ b/packages/trendmicro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: trendmicro
 title: TrendAI Deep Security
-version: "2.8.2"
+version: "2.9.0"
 description: Collect logs from TrendAI Deep Security with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
trendmicro: map CEF Name to dedicated malware name field for anti-malware events

Map the CEF Name value to trendmicro.deep_security.malware.name for anti-malware
events so malware and threat classifications remain searchable when deviceAction
overwrites event.action and duplicate-field cleanup removes trendmicro.deep_security.name.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

## Related issues

- Closes #18660