### PR TITLE
[netbox] Add missing default for disable_keep_alive var

### DIFF
--- a/packages/netbox/changelog.yml
+++ b/packages/netbox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Set the default value of the disable_keep_alive variable to false to fix package policy validation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/19889
 - version: "0.1.0"
   changes:
     - description: Initial draft of the package

--- a/packages/netbox/manifest.yml
+++ b/packages/netbox/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.1
 name: netbox
 title: "NetBox"
-version: 0.1.0
+version: 0.1.1
 source:
   license: "Elastic-2.0"
 description: "Collect logs from NetBox with Elastic Agent"
@@ -88,6 +88,7 @@ policy_templates:
             description: Controls whether HTTP keep-alives are disabled.
             type: bool
             multi: false
+            default: false
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic


### PR DESCRIPTION
## Proposed commit message

```
[netbox] Add missing default for disable_keep_alive var

The disable_keep_alive variable in the httpjson input was declared as
required: true and show_user: false but with no default value. Because
the variable is hidden from the user and the system tests do not supply
it explicitly, Fleet rejects the package policy with:

  inputs.httpjson.vars.disable_keep_alive: ["Disable HTTP Keep-Alives is required"]

Add default: false (the canonical pattern used by okta and 1password)
so Fleet can satisfy the required constraint without user input.

Closes #18665, #18666, #18667, #18668, #18727, #18728
```

Assisted-by: Claude Opus 4.8 (planning) and Sonnet 4.6.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [x] Both `netbox.devices` and `netbox.ips` system tests pass locally after the fix.

## How to test this PR locally

```
cd packages/netbox
elastic-package stack up -d
elastic-package test system
elastic-package stack down
```

Both data streams should show PASS. Before the fix both fail at policy creation with the `disable_keep_alive is required` error.

## Related issues

- Closes #18665
- Closes #18666
- Closes #18667
- Closes #18668
- Closes #18727
- Closes #18728
- Duplicate https://github.com/elastic/integrations/pull/18679 (didn't see this one until Mario linked it)