### PR TITLE
[infoblox_bloxone_ddi][jamf_pro] Add agentless deployment

### DIFF
--- a/packages/infoblox_bloxone_ddi/_dev/build/docs/README.md
+++ b/packages/infoblox_bloxone_ddi/_dev/build/docs/README.md
@@ -4,6 +4,11 @@ The [Infoblox BloxOne DDI](https://www.infoblox.com/products/bloxone-ddi/) integ
 
 Use the Infoblox BloxOne DDI integration to collects and parses data from the REST APIs and then visualize that data in Kibana.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The Infoblox BloxOne DDI integration collects logs for three types of events: DHCP lease, DNS data and DNS config.

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.22.0"
   changes:
     - description: Prevent updating fleet health status to degraded when pagination completes.

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19900
 - version: "1.22.0"
   changes:
     - description: Prevent updating fleet health status to degraded when pagination completes.

--- a/packages/infoblox_bloxone_ddi/data_stream/dhcp_lease/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_bloxone_ddi/data_stream/dhcp_lease/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/infoblox_bloxone_ddi/data_stream/dns_config/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_bloxone_ddi/data_stream/dns_config/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/infoblox_bloxone_ddi/data_stream/dns_data/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_bloxone_ddi/data_stream/dns_data/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,12 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      tag: remove_message
+      ignore_missing: true
+      if: ctx.event?.original != null
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/infoblox_bloxone_ddi/docs/README.md
+++ b/packages/infoblox_bloxone_ddi/docs/README.md
@@ -4,6 +4,11 @@ The [Infoblox BloxOne DDI](https://www.infoblox.com/products/bloxone-ddi/) integ
 
 Use the Infoblox BloxOne DDI integration to collects and parses data from the REST APIs and then visualize that data in Kibana.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
+
 ## Data streams
 
 The Infoblox BloxOne DDI integration collects logs for three types of events: DHCP lease, DNS data and DNS config.

--- a/packages/infoblox_bloxone_ddi/manifest.yml
+++ b/packages/infoblox_bloxone_ddi/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.2"
+format_version: "3.3.2"
 name: infoblox_bloxone_ddi
 title: Infoblox BloxOne DDI
-version: "1.22.0"
+version: "1.23.0"
 description: Collect logs from Infoblox BloxOne DDI with Elastic Agent.
 type: integration
 categories:
@@ -25,6 +25,15 @@ policy_templates:
   - name: infoblox_bloxone_ddi
     title: Infoblox BloxOne DDI
     description: Collect logs from Infoblox BloxOne DDI.
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: httpjson
         title: Collect Infoblox BloxOne DDI logs via API

--- a/packages/jamf_pro/_dev/build/docs/README.md
+++ b/packages/jamf_pro/_dev/build/docs/README.md
@@ -2,6 +2,10 @@
 
 Jamf Pro is a comprehensive management solution designed to help organizations deploy, configure, secure, and manage Apple devices. This integration enables organizations to seamlessly monitor and protect their Mac fleet through Elastic, providing a unified view of security events across all endpoints and facilitating a more effective response to threats. This integration encompasses both event and inventory data ingestion from Jamf Pro.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
 
 ## Data streams
 

--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Enable Agentless deployment.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.2.0"
   changes:
     - description: Add support for ECS entity fields.

--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -3,8 +3,7 @@
   changes:
     - description: Enable Agentless deployment.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
-- version: "1.2.0"
+      link: https://github.com/elastic/integrations/pull/19900
   changes:
     - description: Add support for ECS entity fields.
       type: enhancement

--- a/packages/jamf_pro/changelog.yml
+++ b/packages/jamf_pro/changelog.yml
@@ -4,6 +4,7 @@
     - description: Enable Agentless deployment.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19900
+- version: "1.2.0"
   changes:
     - description: Add support for ECS entity fields.
       type: enhancement

--- a/packages/jamf_pro/docs/README.md
+++ b/packages/jamf_pro/docs/README.md
@@ -2,6 +2,10 @@
 
 Jamf Pro is a comprehensive management solution designed to help organizations deploy, configure, secure, and manage Apple devices. This integration enables organizations to seamlessly monitor and protect their Mac fleet through Elastic, providing a unified view of security events across all endpoints and facilitating a more effective response to threats. This integration encompasses both event and inventory data ingestion from Jamf Pro.
 
+## Agentless Enabled Integration
+
+Agentless integrations allow you to collect data without having to manage Elastic Agent in your cloud. They make manual agent deployment unnecessary, so you can focus on your data instead of the agent that collects it. For more information, refer to [Agentless integrations](https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html) and the [Agentless integrations FAQ](https://www.elastic.co/guide/en/serverless/current/agentless-integration-troubleshooting.html).
+Agentless deployments are only supported in Elastic Serverless and Elastic Cloud environments.  This functionality is in beta and is subject to change. Beta features are not subject to the support SLA of official GA features.
 
 ## Data streams
 

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.1.5
+format_version: 3.3.2
 name: jamf_pro
 title: "Jamf Pro"
-version: "1.2.0"
+version: "1.3.0"
 source:
   license: "Elastic-2.0"
 description: "Collect logs and inventory data from Jamf Pro with Elastic Agent"
@@ -11,7 +11,7 @@ categories:
   - custom
 conditions:
   kibana:
-    version: "^8.15.0 || ^9.0.0"
+    version: "^8.19.2 || ^9.0.5"
   elastic:
     subscription: "basic"
 screenshots:
@@ -44,6 +44,15 @@ policy_templates:
   - name: general_settings
     title: Jamf Pro settings
     description: Jamf Pro related settings
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        release: beta
+        organization: security
+        division: engineering
+        team: security-service-integrations
     inputs:
       - type: cel
         title: Inventory Settings

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -77,6 +77,8 @@ policy_templates:
       - type: http_endpoint
         title: Events
         description: Receiving Jamf Pro events.
+        deployment_modes:
+          - default
         vars:
           - name: ssl
             type: yaml

--- a/packages/jamf_pro/manifest.yml
+++ b/packages/jamf_pro/manifest.yml
@@ -77,8 +77,6 @@ policy_templates:
       - type: http_endpoint
         title: Events
         description: Receiving Jamf Pro events.
-        deployment_modes:
-          - default
         vars:
           - name: ssl
             type: yaml


### PR DESCRIPTION
## Proposed commit message

```
add agentless support and update kibana version constraint for infoblox_bloxone_ddi and jamf_pro
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/infoblox_bloxone_ddi and integrations/packages/jamf_pro directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

- Closes #19820
- Closes #19821