### PR TITLE
[Cyera] Update docs: new API token generation flow

### DIFF
--- a/packages/cyera/_dev/build/docs/README.md
+++ b/packages/cyera/_dev/build/docs/README.md
@@ -44,12 +44,27 @@ This integration installs [Elastic latest transforms](https://www.elastic.co/doc
 
 ### From Cyera
 
-While collecting data through the Cyera APIs, authentication is handled using a `Client ID` and `Client Secret`, which serve as the required credentials. Any requests made without credentials will be rejected by the Cyera APIs.
+The integration authenticates to the Cyera API using a `Client ID` and `Client Secret`, which serve as the required credentials. Any requests made without valid credentials are rejected by the Cyera APIs. Generate these credentials from the Cyera platform before you configure the integration.
 
-#### Obtain `Credentials`:
+#### Prerequisites
 
-- Generate a Cyera API client, retrieve the Client ID and Client Secret.
-- Confirm your Cyera API URL, a default is loaded in the configuration.
+- Cyera **Admin** role.
+- An active Cyera **DSPM** license.
+- Access to the partner integration page in the Cyera platform.
+
+#### Obtain credentials
+
+1. In Cyera, go to **Integrations** in the navigation menu.
+2. Find the **Elastic** integration card and select it to open the details.
+3. In the **API Token Generator** section, note the pre-filled **Token Description**.
+4. Select a **Token Expiration** from the menu (1, 7, 30, 90, or 365 days).
+5. Select **Generate Token**.
+6. The **Client ID** and **Client Secret** are displayed. These credentials are shown only once, so copy each value using the copy icon, or select **Download CSV** to save both.
+7. Confirm your Cyera **API URL**; a default is loaded in the integration configuration.
+
+Use the saved **Client ID** and **Client Secret** when you configure the integration in Kibana (refer to [Setup](#setup)).
+
+**Note:** After configuration, the initial sync may take up to 24 hours.
 
 ## How do I deploy this integration?
 

--- a/packages/cyera/changelog.yml
+++ b/packages/cyera/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Update documentation with the new Cyera API token generation flow.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19908
 - version: "0.7.1"
   changes:
     - description: Fix kibana.version constraint to use tilde ranges for intermediate version bounds.

--- a/packages/cyera/docs/README.md
+++ b/packages/cyera/docs/README.md
@@ -44,12 +44,27 @@ This integration installs [Elastic latest transforms](https://www.elastic.co/doc
 
 ### From Cyera
 
-While collecting data through the Cyera APIs, authentication is handled using a `Client ID` and `Client Secret`, which serve as the required credentials. Any requests made without credentials will be rejected by the Cyera APIs.
+The integration authenticates to the Cyera API using a `Client ID` and `Client Secret`, which serve as the required credentials. Any requests made without valid credentials are rejected by the Cyera APIs. Generate these credentials from the Cyera platform before you configure the integration.
 
-#### Obtain `Credentials`:
+#### Prerequisites
 
-- Generate a Cyera API client, retrieve the Client ID and Client Secret.
-- Confirm your Cyera API URL, a default is loaded in the configuration.
+- Cyera **Admin** role.
+- An active Cyera **DSPM** license.
+- Access to the partner integration page in the Cyera platform.
+
+#### Obtain credentials
+
+1. In Cyera, go to **Integrations** in the navigation menu.
+2. Find the **Elastic** integration card and select it to open the details.
+3. In the **API Token Generator** section, note the pre-filled **Token Description**.
+4. Select a **Token Expiration** from the menu (1, 7, 30, 90, or 365 days).
+5. Select **Generate Token**.
+6. The **Client ID** and **Client Secret** are displayed. These credentials are shown only once, so copy each value using the copy icon, or select **Download CSV** to save both.
+7. Confirm your Cyera **API URL**; a default is loaded in the integration configuration.
+
+Use the saved **Client ID** and **Client Secret** when you configure the integration in Kibana (refer to [Setup](#setup)).
+
+**Note:** After configuration, the initial sync may take up to 24 hours.
 
 ## How do I deploy this integration?
 

--- a/packages/cyera/manifest.yml
+++ b/packages/cyera/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cyera
 title: Cyera
-version: 0.7.1
+version: 0.8.0
 description: Collect logs from Cyera with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/docs-content/issues/7164.
Updates the Cyera integration docs to reflect Cyera's new streamlined API token generation flow.

- Replaces the high-level "Obtain Credentials" section with a step-by-step flow (API Token Generator, token expiration, "shown only once" warning, CSV download).
- Adds a Prerequisites subsection (Admin role, DSPM license, partner integration page access).
- Bumps package version to 0.8.0 and rebuilds the rendered README.



Made with [Cursor](https://cursor.com)