### PR TITLE
[cisco_asa] Fix grok pattern for 737016 IPAA events without pool_name.

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add grok pattern to parse_737016 to handle IPAA pool-freeing events with Session ID but without pool name.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19910
 - version: "2.45.9"
   changes:
     - description: Add 'Users account has expired' to AAA rejection reasons in parse_113005 grok pattern.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.45.10"
+  changes:
+    - description: Add grok pattern to parse_737016 to handle IPAA pool-freeing events with Session ID but without pool name.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.45.9"
   changes:
     - description: Add 'Users account has expired' to AAA rejection reasons in parse_113005 grok pattern.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -192,3 +192,4 @@ May  5 18:40:50 dev-01: %ASA-6-305011: Built dynamic TCP translation from fw111:
 May  5 18:40:50 dev_01: %ASA-6-305011: Built dynamic TCP translation from fw111:10.10.10.10/61400 to out111:external-pool/61400
 <190>May 15 2026 12:54:07: %ASA-6-113015: AAA user authentication Rejected : reason = User was not found : local database : user = ;;alice-johnson(test user) : user IP = 203.0.113.20
 <166>:: %ASA-auth-6-113005: AAA user authentication Rejected : reason = Users account has expired : server = 198.51.100.10 : user = alice.johnson : user IP = 203.0.113.20
+<140>Jun 27 00:53:12 host-1.example.local : %ASA-6-737016: IPAA: Session=0x0e5fc000, Freeing local pool address 198.51.100.10

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -13537,6 +13537,65 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-06-27T00:53:12.000Z",
+            "cisco": {
+                "asa": {
+                    "pool_address": "198.51.100.10",
+                    "session_id": "0x0e5fc000"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737016",
+                "kind": "event",
+                "original": "<140>Jun 27 00:53:12 host-1.example.local : %ASA-6-737016: IPAA: Session=0x0e5fc000, Freeing local pool address 198.51.100.10",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "host-1.example.local"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "host-1.example.local",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "host-1.example.local"
+                ],
+                "ip": [
+                    "198.51.100.10"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1138,6 +1138,7 @@ processors:
       tag: parse_737016
       patterns:
         - '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Freeing local pool %{NOTSPACE:_temp_.cisco.pool_name} address %{NOTSPACE:_temp_.cisco.pool_address}$'
+        - '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Freeing local pool address %{NOTSPACE:_temp_.cisco.pool_address}$'
         - '^IPAA: Freeing local pool %{NOTSPACE:_temp_.cisco.pool_name} address %{NOTSPACE:_temp_.cisco.pool_address}$'
   - grok:
       field: message

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.45.9"
+version: "2.45.10"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

Added a new grok pattern to the parse_737016 processor in the ingest pipeline to handle IPAA pool-freeing events that contain a Session ID and pool address but omit the pool name field. The existing pattern expected the format 'Freeing local pool <pool_name> address <pool_address>', but some logs only have 'Freeing local pool address <pool_address>'. The new pattern handles this missing case, resolving the parsing failure indicated by the MISSING_CASE error. Test coverage was added to verify the new format is correctly parsed.

## Proposed commit message

```
[cisco_asa] Fix grok pattern for 737016 IPAA events without pool_name.
```

## Root cause

The grok processor for message ID 737016 has two patterns: one expecting Session prefix with pool_name, and one expecting no Session prefix. The sanitized event has a Session prefix but omits pool_name, matching neither pattern. The existing Pattern 1 tries to capture 'address' (the next word) as pool_name, then fails because the literal 'address' keyword follows instead.

## Approach

Add a third grok pattern to the parse_737016 processor to handle the IPAA pool-freeing event variant that includes a Session ID prefix but omits the pool_name field. The new pattern will match the structure 'Session=<id>, Freeing local pool address <address>' without requiring a pool_name token between 'pool' and 'address'. This matches the exact sanitized event structure that currently causes a grok match failure.

## Implementation

1. Step 1: Open packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml around line 1140 where the parse_737016 grok patterns are defined.
2. Step 2: Add a third pattern between the existing two patterns to handle Session with optional pool_name: '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Freeing local pool(?: %{NOTSPACE:_temp_.cisco.pool_name})? address %{NOTSPACE:_temp_.cisco.pool_address}$'
3. Step 3: Add a test fixture file test-737016-session-no-pool.log containing the sanitized event to verify the fix.
4. Step 4: Update test-additional-messages.log-expected.json to add expected output for the new test case, showing fields: _temp_.cisco.session_id, _temp_.cisco.pool_address (omit _temp_.cisco.pool_name).
5. Step 5: Run elastic-package test pipeline to verify all three 737016 patterns match their respective event variants without errors.

## Pipeline changes

- Add grok pattern to parse_737016: '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Freeing local pool(?: %{NOTSPACE:_temp_.cisco.pool_name})? address %{NOTSPACE:_temp_.cisco.pool_address}$' — handles Session-based events without explicit pool_name by using optional non-capturing group (?: ... )? to match zero or one occurrence of ' <pool_name>'

## Field / mapping changes

—

## Sanitized error message

`Processor 'grok' with tag 'parse_737016' in pipeline 'logs-cisco_asa.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
Jun 27 00:53:12 host-1.example.local : %ASA-6-737016: IPAA: Session=0x0e5fc000, Freeing local pool address 198.51.100.10
```

## Reviewer concerns

The new pattern is inserted at index 1 in the patterns list (after the original pattern). Verify that the pattern order is intentional and that both patterns are mutually exclusive or that the intended pattern matches first for all expected log variations.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors, ingest, test-fixture
- **Impact**: low

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_asa.log [MISSING_CASE]: Processor 'grok' with tag 'parse_737016' in pipeline 'logs-cisco_asa.log…
- **Pipeline case**: `2a2dedb0f00d997e`
