### PR TITLE
Sync Datastream Categories with Policy Template Categories

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -2,7 +2,7 @@
 - version: "6.20.4"
   changes:
     - description: Add security category to the Transit Gateway data stream to match its policy template categories.
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/19911
 - version: "6.20.3"
   changes:

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.20.4"
+  changes:
+    - description: Add security category to the Transit Gateway data stream to match its policy template categories.
+      type: bug
+      link: https://github.com/elastic/integrations/pull/19911
 - version: "6.20.3"
   changes:
     - description: Add processor tags to all ingest pipeline processors to satisfy elastic-package linter requirements for format_version 3.6.0 and above.

--- a/packages/aws/data_stream/transitgateway/manifest.yml
+++ b/packages/aws/data_stream/transitgateway/manifest.yml
@@ -3,6 +3,7 @@ categories:
   - aws
   - network
   - observability
+  - security
 type: metrics
 elasticsearch:
   index_mode: "time_series"

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.20.3
+version: 6.20.4
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,5 +1,9 @@
 # newer versions go on top
-
+- version: "2.50.2"
+  changes:
+    - description: Add security category to the Load Balancing and VPC Flow data streams to match their policy template categories.
+      type: bug
+      link: https://github.com/elastic/integrations/pull/19911
 - version: "2.50.1"
   changes:
     - description: Fix JSON credentials escaping.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.50.2"
   changes:
     - description: Add security category to the Load Balancing and VPC Flow data streams to match their policy template categories.
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/19911
 - version: "2.50.1"
   changes:

--- a/packages/gcp/data_stream/loadbalancing_logs/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_logs/manifest.yml
@@ -4,6 +4,7 @@ categories:
   - cloud
   - google_cloud
   - observability
+  - security
 streams:
   - input: gcp-pubsub
     vars:

--- a/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
+++ b/packages/gcp/data_stream/loadbalancing_metrics/manifest.yml
@@ -3,6 +3,7 @@ categories:
   - cloud
   - google_cloud
   - observability
+  - security
 type: metrics
 streams:
   - input: gcp/metrics

--- a/packages/gcp/data_stream/vpcflow/manifest.yml
+++ b/packages/gcp/data_stream/vpcflow/manifest.yml
@@ -5,6 +5,7 @@ categories:
   - google_cloud
   - network
   - observability
+  - security
 streams:
   - input: gcp-pubsub
     vars:

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.50.1"
+version: "2.50.2"
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
 icons:

--- a/packages/tencent_cloud/changelog.yml
+++ b/packages/tencent_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.2.1
+  changes:
+    - description: Add security category to the CLB and COS data streams to match their policy template categories.
+      type: bug
+      link: https://github.com/elastic/integrations/pull/19911
 - version: 0.2.0
   changes:
     - description: Add new datastream - scf, cos and clb

--- a/packages/tencent_cloud/changelog.yml
+++ b/packages/tencent_cloud/changelog.yml
@@ -2,7 +2,7 @@
 - version: 0.2.1
   changes:
     - description: Add security category to the CLB and COS data streams to match their policy template categories.
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/19911
 - version: 0.2.0
   changes:

--- a/packages/tencent_cloud/data_stream/clb/manifest.yml
+++ b/packages/tencent_cloud/data_stream/clb/manifest.yml
@@ -1,6 +1,7 @@
 title: Tencent Cloud CLB Logs
 categories:
   - observability
+  - security
 type: logs
 streams:
   - input: aws-s3

--- a/packages/tencent_cloud/data_stream/cos/manifest.yml
+++ b/packages/tencent_cloud/data_stream/cos/manifest.yml
@@ -1,6 +1,7 @@
 title: Tencent Cloud COS Access Logs
 categories:
   - observability
+  - security
 type: logs
 streams:
   - input: aws-s3

--- a/packages/tencent_cloud/manifest.yml
+++ b/packages/tencent_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: tencent_cloud
 title: Tencent Cloud
-version: 0.2.0
+version: 0.2.1
 
 description: 从腾讯云的 COS 中采集基础设施日志
 


### PR DESCRIPTION

## Proposed commit message
Adds security to datastream categories to keep it in sync with existing policy template security category. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [ ] ~I have added an entry to my package's `changelog.yml` file.~
- [ ] ~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~
- [ ] ~I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) ~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
https://github.com/elastic/integrations/pull/17523

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
