### PR TITLE
Fix Kerberos ticket StatusDescription case-sensitivity in Security pipelines

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix Kerberos ticket StatusDescription not being populated when winlog.event_data.Status arrives in lower case in the Security event log ingest pipeline.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TODO
+      link: https://github.com/elastic/integrations/pull/19919
 - version: "2.20.0"
   changes:
     - description: Populate event.action and event.type for PAM authentication failure events across all modules.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: "2.20.1"
+  changes:
+    - description: Fix Kerberos ticket StatusDescription not being populated when winlog.event_data.Status arrives in lower case in the Security event log ingest pipeline.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TODO
 - version: "2.20.0"
   changes:
     - description: Populate event.action and event.type for PAM authentication failure events across all modules.

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -1381,7 +1381,9 @@ processors:
             !["4768", "4769", "4770", "4771", "4793"].contains(ctx.event.code)) {
           return;
         }
-        ctx.winlog.event_data.put("StatusDescription", params[ctx.winlog.event_data.Status.toUpperCase()]);
+        def status = ctx.winlog.event_data.Status;
+        def key = status.length() > 2 ? "0x" + status.substring(2).toUpperCase() : status;
+        ctx.winlog.event_data.put("StatusDescription", params[key]);
   - date:
       field: winlog.event_data.ClientCreationTime
       tag: date_clientcreationtime

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -1381,7 +1381,7 @@ processors:
             !["4768", "4769", "4770", "4771", "4793"].contains(ctx.event.code)) {
           return;
         }
-        ctx.winlog.event_data.put("StatusDescription", params[ctx.winlog.event_data.Status]);
+        ctx.winlog.event_data.put("StatusDescription", params[ctx.winlog.event_data.Status.toUpperCase()]);
   - date:
       field: winlog.event_data.ClientCreationTime
       tag: date_clientcreationtime

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.20.0"
+version: "2.20.1"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix Kerberos ticket StatusDescription not being populated when winlog.event_data.Status arrives in lower case in the forwarded Security event log ingest pipeline.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TODO
+      link: https://github.com/elastic/integrations/pull/19919
 - version: "3.8.3"
   changes:
     - description: Map Sysmon event 26 file delete hashes to `file.hash` instead of `process.hash`.

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.8.4"
+  changes:
+    - description: Fix Kerberos ticket StatusDescription not being populated when winlog.event_data.Status arrives in lower case in the forwarded Security event log ingest pipeline.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TODO
 - version: "3.8.3"
   changes:
     - description: Map Sysmon event 26 file delete hashes to `file.hash` instead of `process.hash`.

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
@@ -1092,7 +1092,7 @@ processors:
             !["4768", "4769", "4770", "4771"].contains(ctx.event.code)) {
           return;
         }
-        ctx.winlog.event_data.put("StatusDescription", params[ctx.winlog.event_data.Status]);
+        ctx.winlog.event_data.put("StatusDescription", params[ctx.winlog.event_data.Status.toUpperCase()]);
   - script:
       lang: painless
       ignore_failure: false

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/security_standard.yml
@@ -1092,7 +1092,9 @@ processors:
             !["4768", "4769", "4770", "4771"].contains(ctx.event.code)) {
           return;
         }
-        ctx.winlog.event_data.put("StatusDescription", params[ctx.winlog.event_data.Status.toUpperCase()]);
+        def status = ctx.winlog.event_data.Status;
+        def key = status.length() > 2 ? "0x" + status.substring(2).toUpperCase() : status;
+        ctx.winlog.event_data.put("StatusDescription", params[key]);
   - script:
       lang: painless
       ignore_failure: false

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 3.8.3
+version: 3.8.4
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Summary
- `winlog.event_data.Status` is matched case-sensitively against the Kerbero status code lookup table in both the `system` and `windows` (forwarded) Security ingest pipelines. Every key with a hex letter is upper case (e.g. `0x1B`), so a lower-case value like `0x1b` fails to match and `StatusDescription` is left null.
- Normalizes the lookup with `.toUpperCase()`, mirroring how the neighboring `TicketEncryptionType` processor already normalizes case.
- Bumps `system` to 2.20.1 and `windows` to 3.8.4 with changelog entries.

Reported by a customer in https://github.com/elastic/sdh-beats/issues/7310. The same processor logic is also duplicated in `elastic/beats` (winlogbeat); a companion fix is up at https://github.com/brian-mckinney/beats/tree/fix/kerberos-status-code-case-sensitivity.

## Test plan
- [ ] Verify pipeline simulate with a sample 4769 event where `Status` is `0x1b` (lower case) now populates `StatusDescription` as `KDC_ERR_MUST_USE_USER2USER`.
- [ ] Confirm existing pipeline tests still pass for both packages.