### PR TITLE
[aws_rds_otel] Add ML anomaly detection module

### DIFF
--- a/packages/aws_rds_otel/changelog.yml
+++ b/packages/aws_rds_otel/changelog.yml
@@ -4,6 +4,9 @@
     - description: Add ML anomaly detection module for RDS instance resource metrics (connections, CPU, latency, memory, disk queue).
       type: enhancement
       link: https://github.com/elastic/integrations/pull/19920
+    - description: Add ml_module to the Kibana asset tags.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19920
 - version: "0.10.1"
   changes:
     - description: Fix Databases by status, Database count over time, and Databases table panels breaking when no data is available

--- a/packages/aws_rds_otel/changelog.yml
+++ b/packages/aws_rds_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Add ML anomaly detection module for RDS instance resource metrics (connections, CPU, latency, memory, disk queue).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19920
 - version: "0.10.1"
   changes:
     - description: Fix Databases by status, Database count over time, and Databases table panels breaking when no data is available

--- a/packages/aws_rds_otel/kibana/ml_module/aws_rds_otel-metrics-ml.json
+++ b/packages/aws_rds_otel/kibana/ml_module/aws_rds_otel-metrics-ml.json
@@ -1,0 +1,233 @@
+{
+    "id": "aws_rds_otel-metrics-ml",
+    "type": "ml-module",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "attributes": {
+        "id": "aws_rds_otel-metrics-ml",
+        "title": "AWS RDS instance resources (OpenTelemetry)",
+        "description": "Detect anomalies in RDS instance resource metrics (connections, CPU, latency, memory, disk queue) streamed from CloudWatch via the OpenTelemetry firehose receiver. Each metric is modelled per DB instance against that instance's own history, so slow drift below the fixed alert thresholds is caught before it becomes an outage.",
+        "type": "AWS metrics",
+        "logo": {
+            "icon": "logoAWSMono"
+        },
+        "defaultIndexPattern": "metrics-aws.rds.otel-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "Namespace": "AWS/RDS"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "DBInstanceIdentifier"
+                        }
+                    }
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
+            }
+        },
+        "jobs": [
+            {
+                "id": "aws_rds_instance_resource_anomaly",
+                "config": {
+                    "groups": [
+                        "aws",
+                        "rds",
+                        "otel"
+                    ],
+                    "description": "AWS RDS: detect DB instances whose resource usage has drifted unusually relative to that instance's own history - a connection count climbing toward the pool ceiling, latency creeping up, freeable memory sinking, or disk queue building. Catches slow trajectories that stay below the static threshold-based alert rules until they tip into an incident. Per-instance threshold breaches are covered by the alert rules; this job covers the sub-threshold drift, with the instance, region, and account surfaced as influencers for attribution.",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Anomalous DB connection count (pool-exhaustion trajectory)",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/RDS/DatabaseConnections",
+                                "by_field_name": "DBInstanceIdentifier",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous CPU utilization",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/RDS/CPUUtilization",
+                                "by_field_name": "DBInstanceIdentifier",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous read latency",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/RDS/ReadLatency",
+                                "by_field_name": "DBInstanceIdentifier",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous write latency",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/RDS/WriteLatency",
+                                "by_field_name": "DBInstanceIdentifier",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous drop in freeable memory (memory-pressure trajectory)",
+                                "function": "low_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/RDS/FreeableMemory",
+                                "by_field_name": "DBInstanceIdentifier",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous disk queue depth (I/O saturation building)",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/RDS/DiskQueueDepth",
+                                "by_field_name": "DBInstanceIdentifier",
+                                "partition_field_name": "cloud.region"
+                            }
+                        ],
+                        "influencers": [
+                            "DBInstanceIdentifier",
+                            "cloud.region",
+                            "cloud.account.id"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "128mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": false,
+                        "annotations_enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-aws-rds-otel-metrics-ml"
+                    }
+                }
+            }
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-aws_rds_instance_resource_anomaly",
+                "job_id": "aws_rds_instance_resource_anomaly",
+                "config": {
+                    "job_id": "aws_rds_instance_resource_anomaly",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "indices_options": {
+                        "allow_no_indices": true
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "stat": "Average"
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "MetricName": [
+                                            "DatabaseConnections",
+                                            "CPUUtilization",
+                                            "ReadLatency",
+                                            "WriteLatency",
+                                            "FreeableMemory",
+                                            "DiskQueueDepth"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                        "field": "DBInstanceIdentifier"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "composite": {
+                                "size": 1000,
+                                "sources": [
+                                    {
+                                        "date": {
+                                            "date_histogram": {
+                                                "field": "@timestamp",
+                                                "fixed_interval": "900s"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.region": {
+                                            "terms": {
+                                                "field": "cloud.region"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "DBInstanceIdentifier": {
+                                            "terms": {
+                                                "field": "DBInstanceIdentifier"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/RDS/DatabaseConnections": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/RDS/DatabaseConnections"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/RDS/CPUUtilization": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/RDS/CPUUtilization"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/RDS/ReadLatency": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/RDS/ReadLatency"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/RDS/WriteLatency": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/RDS/WriteLatency"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/RDS/FreeableMemory": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/RDS/FreeableMemory"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/RDS/DiskQueueDepth": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/RDS/DiskQueueDepth"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/aws_rds_otel/kibana/ml_module/aws_rds_otel-metrics-ml.json
+++ b/packages/aws_rds_otel/kibana/ml_module/aws_rds_otel-metrics-ml.json
@@ -7,7 +7,7 @@
     "references": [],
     "attributes": {
         "id": "aws_rds_otel-metrics-ml",
-        "title": "AWS RDS instance resources (OpenTelemetry)",
+        "title": "[AWS RDS OTel] Instance resource anomalies",
         "description": "Detect anomalies in RDS instance resource metrics (connections, CPU, latency, memory, disk queue) streamed from CloudWatch via the OpenTelemetry firehose receiver. Each metric is modelled per DB instance against that instance's own history, so slow drift below the fixed alert thresholds is caught before it becomes an outage.",
         "type": "AWS metrics",
         "logo": {
@@ -130,6 +130,7 @@
                     "indices_options": {
                         "allow_no_indices": true
                     },
+                    "frequency": "5m",
                     "query": {
                         "bool": {
                             "filter": [
@@ -167,7 +168,14 @@
                                         "date": {
                                             "date_histogram": {
                                                 "field": "@timestamp",
-                                                "fixed_interval": "900s"
+                                                "fixed_interval": "5m"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.account.id": {
+                                            "terms": {
+                                                "field": "cloud.account.id"
                                             }
                                         }
                                     },

--- a/packages/aws_rds_otel/kibana/tags.yml
+++ b/packages/aws_rds_otel/kibana/tags.yml
@@ -3,13 +3,16 @@
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: RDS
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: OpenTelemetry
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module

--- a/packages/aws_rds_otel/manifest.yml
+++ b/packages/aws_rds_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.0
 name: aws_rds_otel
 title: "AWS RDS Metrics OpenTelemetry Assets"
-version: 0.10.1
+version: 0.11.0
 source:
   license: "Elastic-2.0"
 description: "AWS RDS Metrics OpenTelemetry Assets"


### PR DESCRIPTION
## What

Adds a machine-learning anomaly-detection module (`kibana/ml_module/`) to the **aws_rds_otel** integration, proposing anomaly detection as an addition alongside the integration's existing dashboards, alert rules, and SLO templates. Modeled on the `kubernetes_otel` ML module ([#19030](https://github.com/elastic/integrations/pull/19030)).

## Why — complements the threshold alerts, doesn't duplicate them

The shipped alert rules catch per-entity threshold breaches (a value crossing a fixed line). These ML jobs model each metric **per entity against its own history**, catching the *drift* those miss — e.g. a connection count climbing toward the pool ceiling, or latency and freeable memory creeping past baseline but below the fixed floor. Each detector's description defers per-entity spikes to the alert rules, the same split `kubernetes_otel` uses. The detectors are drawn from the service's own signals and real failure modes — not tailored to any specific workflow.

## Jobs

- `aws_rds_instance_resource_anomaly` — `high_mean`/`low_mean` per `DBInstanceIdentifier` (partition `cloud.region`) on **DatabaseConnections, CPUUtilization, ReadLatency, WriteLatency, FreeableMemory (low), DiskQueueDepth**.

Datafeeds are **composite-aggregated** — required, because these `metrics-aws.*.otel-*` indices contain `aggregate_metric_double` fields that a plain (non-aggregating) ML datafeed cannot read.

## Validation

Drafted and validated against live AWS OTel telemetry: the job(s) establish baselines over historical data. The RDS connection-pool-exhaustion case was scored against a known injected incident and detected it on the correct entity (recall/precision/f1 = 1.0).

Methodology, tooling, and the scoring harness: https://github.com/elastic/aws_otel_ml_draft

## Notes for reviewers (@elastic/obs-infraobs-integrations)

- **Draft** — proposing for your review; happy to adjust job naming, detector selection, `bucket_span`, or thresholds.
- Package stays `subscription: basic` (matches `kubernetes_otel`; ML availability is a deployment concern, not a package condition).
- Entity fields use the **raw CloudWatch dimensions** present in the indexed documents (`DBInstanceIdentifier`), not the normalized fields the alert-rule `termField`s reference (those are not present in the documents).
- Open tuning item: the low-variance detectors (`DiskQueueDepth`, `ReadLatency`) can over-fire on idle instances — a candidate for `bucket_span` / multi-bucket tuning.
