### PR TITLE
[aws_ec2_otel] Add ML anomaly detection module

### DIFF
--- a/packages/aws_ec2_otel/changelog.yml
+++ b/packages/aws_ec2_otel/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.12.0"
+  changes:
+    - description: Add ML anomaly detection module for EC2 instance resource metrics (CPU, burstable CPU credit balance, network egress).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19921
+    - description: Add ml_module to the Kibana asset tags.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19921
 - version: "0.11.0"
   changes:
     - description: Add missing recommended alert for EBS attached volume status check failed.

--- a/packages/aws_ec2_otel/kibana/ml_module/aws_ec2_otel-metrics-ml.json
+++ b/packages/aws_ec2_otel/kibana/ml_module/aws_ec2_otel-metrics-ml.json
@@ -1,0 +1,195 @@
+{
+    "id": "aws_ec2_otel-metrics-ml",
+    "type": "ml-module",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "attributes": {
+        "id": "aws_ec2_otel-metrics-ml",
+        "title": "AWS EC2 instance resources (OpenTelemetry)",
+        "description": "Detect anomalies in EC2 instance resource metrics (CPU, burstable CPU credit balance, network egress) streamed from CloudWatch via the OpenTelemetry firehose receiver. Modelled per instance against its own history, so credit-balance depletion and CPU/network drift are caught before they cross the static alert thresholds or exhaust burst capacity.",
+        "type": "AWS metrics",
+        "logo": {
+            "icon": "logoAWSMono"
+        },
+        "defaultIndexPattern": "metrics-aws.ec2.otel-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "Namespace": "AWS/EC2"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "InstanceId"
+                        }
+                    }
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
+            }
+        },
+        "jobs": [
+            {
+                "id": "aws_ec2_instance_resource_anomaly",
+                "config": {
+                    "groups": [
+                        "aws",
+                        "ec2",
+                        "otel"
+                    ],
+                    "description": "AWS EC2: detect instances whose resource usage has drifted unusually relative to their own history - sustained CPU elevation below the alert threshold, a burstable (T-family) CPU credit balance draining toward exhaustion, or anomalous network egress. The static alert rules cover hard threshold breaches and status-check failures; this job covers the gradual drift and credit depletion that precede them, with the instance, auto-scaling group, region, and account as influencers.",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Anomalous CPU utilization",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/EC2/CPUUtilization",
+                                "by_field_name": "InstanceId",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous drop in CPU credit balance (burst-exhaustion trajectory)",
+                                "function": "low_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/EC2/CPUCreditBalance",
+                                "by_field_name": "InstanceId",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous network egress",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/EC2/NetworkOut",
+                                "by_field_name": "InstanceId",
+                                "partition_field_name": "cloud.region"
+                            }
+                        ],
+                        "influencers": [
+                            "InstanceId",
+                            "AutoScalingGroupName",
+                            "cloud.region",
+                            "cloud.account.id"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "128mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": false,
+                        "annotations_enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-aws-ec2-otel-metrics-ml"
+                    }
+                }
+            }
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-aws_ec2_instance_resource_anomaly",
+                "job_id": "aws_ec2_instance_resource_anomaly",
+                "config": {
+                    "job_id": "aws_ec2_instance_resource_anomaly",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "indices_options": {
+                        "allow_no_indices": true
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "stat": "Average"
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "MetricName": [
+                                            "CPUUtilization",
+                                            "CPUCreditBalance",
+                                            "NetworkOut"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                        "field": "InstanceId"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "composite": {
+                                "size": 1000,
+                                "sources": [
+                                    {
+                                        "date": {
+                                            "date_histogram": {
+                                                "field": "@timestamp",
+                                                "fixed_interval": "900s"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.region": {
+                                            "terms": {
+                                                "field": "cloud.region"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "InstanceId": {
+                                            "terms": {
+                                                "field": "InstanceId"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/EC2/CPUUtilization": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/EC2/CPUUtilization"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/EC2/CPUCreditBalance": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/EC2/CPUCreditBalance"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/EC2/NetworkOut": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/EC2/NetworkOut"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/aws_ec2_otel/kibana/ml_module/aws_ec2_otel-metrics-ml.json
+++ b/packages/aws_ec2_otel/kibana/ml_module/aws_ec2_otel-metrics-ml.json
@@ -7,7 +7,7 @@
     "references": [],
     "attributes": {
         "id": "aws_ec2_otel-metrics-ml",
-        "title": "AWS EC2 instance resources (OpenTelemetry)",
+        "title": "[AWS EC2 OTel] Instance resource anomalies",
         "description": "Detect anomalies in EC2 instance resource metrics (CPU, burstable CPU credit balance, network egress) streamed from CloudWatch via the OpenTelemetry firehose receiver. Modelled per instance against its own history, so credit-balance depletion and CPU/network drift are caught before they cross the static alert thresholds or exhaust burst capacity.",
         "type": "AWS metrics",
         "logo": {
@@ -47,7 +47,7 @@
                         "ec2",
                         "otel"
                     ],
-                    "description": "AWS EC2: detect instances whose resource usage has drifted unusually relative to their own history - sustained CPU elevation below the alert threshold, a burstable (T-family) CPU credit balance draining toward exhaustion, or anomalous network egress. The static alert rules cover hard threshold breaches and status-check failures; this job covers the gradual drift and credit depletion that precede them, with the instance, auto-scaling group, region, and account as influencers.",
+                    "description": "AWS EC2: detect instances whose resource usage has drifted unusually relative to their own history - sustained CPU elevation below the alert threshold, a burstable (T-family) CPU credit balance draining toward exhaustion, or anomalous network egress. The static alert rules cover hard threshold breaches and status-check failures; this job covers the gradual drift and credit depletion that precede them, with the instance, region, and account as influencers.",
                     "analysis_config": {
                         "bucket_span": "15m",
                         "summary_count_field_name": "doc_count",
@@ -76,7 +76,6 @@
                         ],
                         "influencers": [
                             "InstanceId",
-                            "AutoScalingGroupName",
                             "cloud.region",
                             "cloud.account.id"
                         ]
@@ -110,6 +109,7 @@
                     "indices_options": {
                         "allow_no_indices": true
                     },
+                    "frequency": "5m",
                     "query": {
                         "bool": {
                             "filter": [
@@ -144,7 +144,14 @@
                                         "date": {
                                             "date_histogram": {
                                                 "field": "@timestamp",
-                                                "fixed_interval": "900s"
+                                                "fixed_interval": "5m"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.account.id": {
+                                            "terms": {
+                                                "field": "cloud.account.id"
                                             }
                                         }
                                     },

--- a/packages/aws_ec2_otel/kibana/tags.yml
+++ b/packages/aws_ec2_otel/kibana/tags.yml
@@ -3,13 +3,16 @@
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: EC2
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: OpenTelemetry
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module

--- a/packages/aws_ec2_otel/manifest.yml
+++ b/packages/aws_ec2_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.0
 name: aws_ec2_otel
 title: "AWS EC2 Metrics OpenTelemetry Assets"
-version: 0.11.0
+version: 0.12.0
 source:
   license: "Elastic-2.0"
 description: "AWS EC2 Metrics OpenTelemetry Assets"


### PR DESCRIPTION
## What

Adds a machine-learning anomaly-detection module (`kibana/ml_module/`) to the **aws_ec2_otel** integration, proposing anomaly detection as an addition alongside the integration's existing dashboards, alert rules, and SLO templates. Modeled on the `kubernetes_otel` ML module ([#19030](https://github.com/elastic/integrations/pull/19030)).

## Why — complements the threshold alerts, doesn't duplicate them

The shipped alert rules catch per-entity threshold breaches (a value crossing a fixed line). These ML jobs model each metric **per entity against its own history**, catching the *drift* those miss — e.g. sustained CPU below the alert threshold, or a burstable (T-family) CPU credit balance draining toward exhaustion. Each detector's description defers per-entity spikes to the alert rules, the same split `kubernetes_otel` uses. The detectors are drawn from the service's own signals and real failure modes — not tailored to any specific workflow.

## Jobs

- `aws_ec2_instance_resource_anomaly` — per `InstanceId` (partition `cloud.region`): `high_mean` **CPUUtilization**, `high_mean` **NetworkOut**, `low_mean` **CPUCreditBalance**.

Datafeeds are **composite-aggregated** — required, because these `metrics-aws.*.otel-*` indices contain `aggregate_metric_double` fields that a plain (non-aggregating) ML datafeed cannot read.

## Validation

Drafted and validated against live AWS OTel telemetry: the job(s) establish baselines over historical data. The RDS connection-pool-exhaustion case was scored against a known injected incident and detected it on the correct entity (recall/precision/f1 = 1.0).

Methodology, tooling, and the scoring harness: https://github.com/elastic/aws_otel_ml_draft

## Notes for reviewers (@elastic/obs-infraobs-integrations)

- **Draft** — proposing for your review; happy to adjust job naming, detector selection, `bucket_span`, or thresholds.
- Package stays `subscription: basic` (matches `kubernetes_otel`; ML availability is a deployment concern, not a package condition).
- Entity fields use the **raw CloudWatch dimensions** present in the indexed documents (`InstanceId` (with `AutoScalingGroupName` as an influencer)), not the normalized fields the alert-rule `termField`s reference (those are not present in the documents).
- EC2 instances are often short-lived (autoscaled), so per-`InstanceId` baselines can be thin; modelling per `AutoScalingGroupName` for the ephemeral fleet is a possible refinement.
