### PR TITLE
[aws_ecs_otel] Add ML anomaly detection module

### DIFF
--- a/packages/aws_ecs_otel/changelog.yml
+++ b/packages/aws_ecs_otel/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.10.0"
+  changes:
+    - description: Add ML anomaly detection module for ECS service CPU and memory utilization.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19922
+    - description: Add ml_module to the Kibana asset tags.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19922
 - version: "0.9.0"
   changes:
     - description: Add missing recommended alerts for CPU and memory reservation high.

--- a/packages/aws_ecs_otel/kibana/ml_module/aws_ecs_otel-metrics-ml.json
+++ b/packages/aws_ecs_otel/kibana/ml_module/aws_ecs_otel-metrics-ml.json
@@ -1,0 +1,182 @@
+{
+    "id": "aws_ecs_otel-metrics-ml",
+    "type": "ml-module",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "attributes": {
+        "id": "aws_ecs_otel-metrics-ml",
+        "title": "AWS ECS service resources (OpenTelemetry)",
+        "description": "Detect anomalies in ECS service CPU and memory utilization streamed from CloudWatch via the OpenTelemetry firehose receiver. Memory is modelled per service (within its cluster) against its own history to catch slow leaks that affect a service's tasks before any single task crosses a hard threshold - the ECS analogue of per-workload memory modelling on Kubernetes.",
+        "type": "AWS metrics",
+        "logo": {
+            "icon": "logoAWSMono"
+        },
+        "defaultIndexPattern": "metrics-aws.ecs.otel-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "Namespace": "AWS/ECS"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "ServiceName"
+                        }
+                    }
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
+            }
+        },
+        "jobs": [
+            {
+                "id": "aws_ecs_service_resource_anomaly",
+                "config": {
+                    "groups": [
+                        "aws",
+                        "ecs",
+                        "otel"
+                    ],
+                    "description": "AWS ECS: detect services whose CPU or memory utilization has grown unusually relative to that service's own history, partitioned by cluster. Catches slow memory-leak trajectories that affect a service across task recycling before any individual task crosses a hard threshold, and sustained CPU drift. Per-service threshold breaches are covered by the alert rules; this job covers the sub-threshold drift, with the service, cluster, region, and account as influencers.",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Anomalous service memory utilization (leak trajectory)",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/ECS/MemoryUtilization",
+                                "by_field_name": "ServiceName",
+                                "partition_field_name": "ClusterName"
+                            },
+                            {
+                                "detector_description": "Anomalous service CPU utilization",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/ECS/CPUUtilization",
+                                "by_field_name": "ServiceName",
+                                "partition_field_name": "ClusterName"
+                            }
+                        ],
+                        "influencers": [
+                            "ServiceName",
+                            "ClusterName",
+                            "cloud.region",
+                            "cloud.account.id"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "64mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": false,
+                        "annotations_enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-aws-ecs-otel-metrics-ml"
+                    }
+                }
+            }
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-aws_ecs_service_resource_anomaly",
+                "job_id": "aws_ecs_service_resource_anomaly",
+                "config": {
+                    "job_id": "aws_ecs_service_resource_anomaly",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "indices_options": {
+                        "allow_no_indices": true
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "stat": "Average"
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "MetricName": [
+                                            "MemoryUtilization",
+                                            "CPUUtilization"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                        "field": "ServiceName"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "composite": {
+                                "size": 1000,
+                                "sources": [
+                                    {
+                                        "date": {
+                                            "date_histogram": {
+                                                "field": "@timestamp",
+                                                "fixed_interval": "900s"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "ClusterName": {
+                                            "terms": {
+                                                "field": "ClusterName"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "ServiceName": {
+                                            "terms": {
+                                                "field": "ServiceName"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/ECS/MemoryUtilization": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/ECS/MemoryUtilization"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/ECS/CPUUtilization": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/ECS/CPUUtilization"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/aws_ecs_otel/kibana/ml_module/aws_ecs_otel-metrics-ml.json
+++ b/packages/aws_ecs_otel/kibana/ml_module/aws_ecs_otel-metrics-ml.json
@@ -7,7 +7,7 @@
     "references": [],
     "attributes": {
         "id": "aws_ecs_otel-metrics-ml",
-        "title": "AWS ECS service resources (OpenTelemetry)",
+        "title": "[AWS ECS OTel] Service resource anomalies",
         "description": "Detect anomalies in ECS service CPU and memory utilization streamed from CloudWatch via the OpenTelemetry firehose receiver. Memory is modelled per service (within its cluster) against its own history to catch slow leaks that affect a service's tasks before any single task crosses a hard threshold - the ECS analogue of per-workload memory modelling on Kubernetes.",
         "type": "AWS metrics",
         "logo": {
@@ -103,6 +103,7 @@
                     "indices_options": {
                         "allow_no_indices": true
                     },
+                    "frequency": "5m",
                     "query": {
                         "bool": {
                             "filter": [
@@ -136,7 +137,21 @@
                                         "date": {
                                             "date_histogram": {
                                                 "field": "@timestamp",
-                                                "fixed_interval": "900s"
+                                                "fixed_interval": "5m"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.region": {
+                                            "terms": {
+                                                "field": "cloud.region"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.account.id": {
+                                            "terms": {
+                                                "field": "cloud.account.id"
                                             }
                                         }
                                     },

--- a/packages/aws_ecs_otel/kibana/tags.yml
+++ b/packages/aws_ecs_otel/kibana/tags.yml
@@ -2,11 +2,14 @@
   asset_types:
     - dashboard
     - alerting_rule_template
+    - ml_module
 - text: ECS
   asset_types:
     - dashboard
     - alerting_rule_template
+    - ml_module
 - text: OpenTelemetry
   asset_types:
     - dashboard
     - alerting_rule_template
+    - ml_module

--- a/packages/aws_ecs_otel/manifest.yml
+++ b/packages/aws_ecs_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.0
 name: aws_ecs_otel
 title: "AWS ECS Metrics OpenTelemetry Assets"
-version: 0.9.0
+version: 0.10.0
 source:
   license: "Elastic-2.0"
 description: "AWS ECS Metrics OpenTelemetry Assets"


### PR DESCRIPTION
## What

Adds a machine-learning anomaly-detection module (`kibana/ml_module/`) to the **aws_ecs_otel** integration, proposing anomaly detection as an addition alongside the integration's existing dashboards and alert rules. Modeled on the `kubernetes_otel` ML module ([#19030](https://github.com/elastic/integrations/pull/19030)).

## Why — complements the threshold alerts, doesn't duplicate them

The shipped alert rules catch per-entity threshold breaches (a value crossing a fixed line). These ML jobs model each metric **per entity against its own history**, catching the *drift* those miss — e.g. a slow memory leak across task recycling before any single task crosses a hard threshold. Each detector's description defers per-entity spikes to the alert rules, the same split `kubernetes_otel` uses. The detectors are drawn from the service's own signals and real failure modes — not tailored to any specific workflow.

## Jobs

- `aws_ecs_service_resource_anomaly` — per `ServiceName` (partition `ClusterName`): `high_mean` **MemoryUtilization** and **CPUUtilization**.

Datafeeds are **composite-aggregated** — required, because these `metrics-aws.*.otel-*` indices contain `aggregate_metric_double` fields that a plain (non-aggregating) ML datafeed cannot read.

## Validation

Drafted and validated against live AWS OTel telemetry: the job(s) establish baselines over historical data. The RDS connection-pool-exhaustion case was scored against a known injected incident and detected it on the correct entity (recall/precision/f1 = 1.0).

Methodology, tooling, and the scoring harness: https://github.com/elastic/aws_otel_ml_draft

## Notes for reviewers (@elastic/obs-infraobs-integrations)

- **Draft** — proposing for your review; happy to adjust job naming, detector selection, `bucket_span`, or thresholds.
- Package stays `subscription: basic` (matches `kubernetes_otel`; ML availability is a deployment concern, not a package condition).
- Entity fields use the **raw CloudWatch dimensions** present in the indexed documents (`ServiceName` + `ClusterName`), not the normalized fields the alert-rule `termField`s reference (those are not present in the documents).
- Open tuning item: ECS `MemoryUtilization` can be noisy on some services — a candidate for `bucket_span` tuning.
