### PR TITLE
[aws_lambda_otel] Add ML anomaly detection modules

### DIFF
--- a/packages/aws_lambda_otel/changelog.yml
+++ b/packages/aws_lambda_otel/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.10.0"
+  changes:
+    - description: Add ML anomaly detection modules for Lambda function performance (duration, concurrency) and errors/throttles.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19923
+    - description: Add ml_module to the Kibana asset tags.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19923
 - version: "0.9.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/aws_lambda_otel/kibana/ml_module/aws_lambda_otel-activity-ml.json
+++ b/packages/aws_lambda_otel/kibana/ml_module/aws_lambda_otel-activity-ml.json
@@ -1,0 +1,194 @@
+{
+    "id": "aws_lambda_otel-activity-ml",
+    "type": "ml-module",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "attributes": {
+        "id": "aws_lambda_otel-activity-ml",
+        "title": "AWS Lambda function errors and throttles (OpenTelemetry)",
+        "description": "Detect anomalous rates of Lambda errors, throttles, and dead-letter failures (the per-bucket Sum statistic) streamed from CloudWatch via the OpenTelemetry firehose receiver. Each function is modelled against its own history, so an elevation in error or throttle rate that is abnormal for that function is caught even when it stays below the fixed error-rate alert thresholds.",
+        "type": "AWS metrics",
+        "logo": {
+            "icon": "logoAWSMono"
+        },
+        "defaultIndexPattern": "metrics-aws.lambda.otel-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "Namespace": "AWS/Lambda"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "FunctionName"
+                        }
+                    }
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
+            }
+        },
+        "jobs": [
+            {
+                "id": "aws_lambda_function_error_anomaly",
+                "config": {
+                    "groups": [
+                        "aws",
+                        "lambda",
+                        "otel"
+                    ],
+                    "description": "AWS Lambda: detect functions producing unusual rates of errors, throttles, or dead-letter failures relative to that function's own history. The threshold-based alert rules cover hard error-rate and throttle-rate breaches; this job catches per-function rate elevations that drift below any fixed threshold, with the function, region, and account surfaced as influencers for attribution.",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Anomalous error rate",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/Lambda/Errors",
+                                "by_field_name": "FunctionName",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous throttle rate",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/Lambda/Throttles",
+                                "by_field_name": "FunctionName",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous dead-letter delivery failures",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/Lambda/DeadLetterErrors",
+                                "by_field_name": "FunctionName",
+                                "partition_field_name": "cloud.region"
+                            }
+                        ],
+                        "influencers": [
+                            "FunctionName",
+                            "cloud.region",
+                            "cloud.account.id"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "64mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": false,
+                        "annotations_enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-aws-lambda-otel-activity-ml"
+                    }
+                }
+            }
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-aws_lambda_function_error_anomaly",
+                "job_id": "aws_lambda_function_error_anomaly",
+                "config": {
+                    "job_id": "aws_lambda_function_error_anomaly",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "indices_options": {
+                        "allow_no_indices": true
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "stat": "Sum"
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "MetricName": [
+                                            "Errors",
+                                            "Throttles",
+                                            "DeadLetterErrors"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                        "field": "FunctionName"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "composite": {
+                                "size": 1000,
+                                "sources": [
+                                    {
+                                        "date": {
+                                            "date_histogram": {
+                                                "field": "@timestamp",
+                                                "fixed_interval": "900s"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.region": {
+                                            "terms": {
+                                                "field": "cloud.region"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "FunctionName": {
+                                            "terms": {
+                                                "field": "FunctionName"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/Lambda/Errors": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/Lambda/Errors"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/Lambda/Throttles": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/Lambda/Throttles"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/Lambda/DeadLetterErrors": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/Lambda/DeadLetterErrors"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/aws_lambda_otel/kibana/ml_module/aws_lambda_otel-activity-ml.json
+++ b/packages/aws_lambda_otel/kibana/ml_module/aws_lambda_otel-activity-ml.json
@@ -7,7 +7,7 @@
     "references": [],
     "attributes": {
         "id": "aws_lambda_otel-activity-ml",
-        "title": "AWS Lambda function errors and throttles (OpenTelemetry)",
+        "title": "[AWS Lambda OTel] Function error and throttle anomalies",
         "description": "Detect anomalous rates of Lambda errors, throttles, and dead-letter failures (the per-bucket Sum statistic) streamed from CloudWatch via the OpenTelemetry firehose receiver. Each function is modelled against its own history, so an elevation in error or throttle rate that is abnormal for that function is caught even when it stays below the fixed error-rate alert thresholds.",
         "type": "AWS metrics",
         "logo": {
@@ -109,6 +109,7 @@
                     "indices_options": {
                         "allow_no_indices": true
                     },
+                    "frequency": "5m",
                     "query": {
                         "bool": {
                             "filter": [
@@ -143,7 +144,14 @@
                                         "date": {
                                             "date_histogram": {
                                                 "field": "@timestamp",
-                                                "fixed_interval": "900s"
+                                                "fixed_interval": "5m"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.account.id": {
+                                            "terms": {
+                                                "field": "cloud.account.id"
                                             }
                                         }
                                     },

--- a/packages/aws_lambda_otel/kibana/ml_module/aws_lambda_otel-metrics-ml.json
+++ b/packages/aws_lambda_otel/kibana/ml_module/aws_lambda_otel-metrics-ml.json
@@ -1,0 +1,181 @@
+{
+    "id": "aws_lambda_otel-metrics-ml",
+    "type": "ml-module",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "attributes": {
+        "id": "aws_lambda_otel-metrics-ml",
+        "title": "AWS Lambda function performance (OpenTelemetry)",
+        "description": "Detect anomalies in Lambda function duration and concurrency streamed from CloudWatch via the OpenTelemetry firehose receiver. Each function is modelled against its own history, so latency drift and concurrency climbing toward the account limit are caught before they cross the static alert thresholds or begin to throttle.",
+        "type": "AWS metrics",
+        "logo": {
+            "icon": "logoAWSMono"
+        },
+        "defaultIndexPattern": "metrics-aws.lambda.otel-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "Namespace": "AWS/Lambda"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "FunctionName"
+                        }
+                    }
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
+            }
+        },
+        "jobs": [
+            {
+                "id": "aws_lambda_function_performance_anomaly",
+                "config": {
+                    "groups": [
+                        "aws",
+                        "lambda",
+                        "otel"
+                    ],
+                    "description": "AWS Lambda: detect functions whose average duration or concurrency has drifted unusually relative to that function's own history - latency creeping up (a slow dependency, cold-start regression, or larger payloads) or concurrency climbing toward the account limit before throttling begins. The static alert rules cover hard duration/concurrency breaches; this job covers the sub-threshold drift, with the function, region, and account as influencers.",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Anomalous average duration (latency drift)",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/Lambda/Duration",
+                                "by_field_name": "FunctionName",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous concurrent executions (saturation trajectory)",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/Lambda/ConcurrentExecutions",
+                                "by_field_name": "FunctionName",
+                                "partition_field_name": "cloud.region"
+                            }
+                        ],
+                        "influencers": [
+                            "FunctionName",
+                            "cloud.region",
+                            "cloud.account.id"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "128mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": false,
+                        "annotations_enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-aws-lambda-otel-metrics-ml"
+                    }
+                }
+            }
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-aws_lambda_function_performance_anomaly",
+                "job_id": "aws_lambda_function_performance_anomaly",
+                "config": {
+                    "job_id": "aws_lambda_function_performance_anomaly",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "indices_options": {
+                        "allow_no_indices": true
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "stat": "Average"
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "MetricName": [
+                                            "Duration",
+                                            "ConcurrentExecutions"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                        "field": "FunctionName"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "composite": {
+                                "size": 1000,
+                                "sources": [
+                                    {
+                                        "date": {
+                                            "date_histogram": {
+                                                "field": "@timestamp",
+                                                "fixed_interval": "900s"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.region": {
+                                            "terms": {
+                                                "field": "cloud.region"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "FunctionName": {
+                                            "terms": {
+                                                "field": "FunctionName"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/Lambda/Duration": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/Lambda/Duration"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/Lambda/ConcurrentExecutions": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/Lambda/ConcurrentExecutions"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/aws_lambda_otel/kibana/ml_module/aws_lambda_otel-metrics-ml.json
+++ b/packages/aws_lambda_otel/kibana/ml_module/aws_lambda_otel-metrics-ml.json
@@ -7,7 +7,7 @@
     "references": [],
     "attributes": {
         "id": "aws_lambda_otel-metrics-ml",
-        "title": "AWS Lambda function performance (OpenTelemetry)",
+        "title": "[AWS Lambda OTel] Function performance anomalies",
         "description": "Detect anomalies in Lambda function duration and concurrency streamed from CloudWatch via the OpenTelemetry firehose receiver. Each function is modelled against its own history, so latency drift and concurrency climbing toward the account limit are caught before they cross the static alert thresholds or begin to throttle.",
         "type": "AWS metrics",
         "logo": {
@@ -102,6 +102,7 @@
                     "indices_options": {
                         "allow_no_indices": true
                     },
+                    "frequency": "5m",
                     "query": {
                         "bool": {
                             "filter": [
@@ -135,7 +136,14 @@
                                         "date": {
                                             "date_histogram": {
                                                 "field": "@timestamp",
-                                                "fixed_interval": "900s"
+                                                "fixed_interval": "5m"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.account.id": {
+                                            "terms": {
+                                                "field": "cloud.account.id"
                                             }
                                         }
                                     },

--- a/packages/aws_lambda_otel/kibana/tags.yml
+++ b/packages/aws_lambda_otel/kibana/tags.yml
@@ -3,13 +3,16 @@
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: Lambda
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: OpenTelemetry
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module

--- a/packages/aws_lambda_otel/manifest.yml
+++ b/packages/aws_lambda_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.0
 name: aws_lambda_otel
 title: "AWS Lambda Metrics OpenTelemetry Assets"
-version: 0.9.0
+version: 0.10.0
 source:
   license: "Elastic-2.0"
 description: "AWS Lambda Metrics OpenTelemetry Assets"


### PR DESCRIPTION
## What

Adds a machine-learning anomaly-detection module (`kibana/ml_module/`) to the **aws_lambda_otel** integration, proposing anomaly detection as an addition alongside the integration's existing dashboards, alert rules, and SLO templates. Modeled on the `kubernetes_otel` ML module ([#19030](https://github.com/elastic/integrations/pull/19030)).

## Why — complements the threshold alerts, doesn't duplicate them

The shipped alert rules catch per-entity threshold breaches (a value crossing a fixed line). These ML jobs model each metric **per entity against its own history**, catching the *drift* those miss — e.g. latency creep, concurrency climbing toward the account limit before throttling, or a per-function error/throttle rate elevation below the fixed threshold. Each detector's description defers per-entity spikes to the alert rules, the same split `kubernetes_otel` uses. The detectors are drawn from the service's own signals and real failure modes — not tailored to any specific workflow.

## Jobs

- `aws_lambda_function_performance_anomaly` — per `FunctionName` (partition `cloud.region`): `high_mean` **Duration** and **ConcurrentExecutions**.
- `aws_lambda_function_error_anomaly` — per `FunctionName` (partition `cloud.region`), the per-bucket **Sum**: `high_mean` **Errors, Throttles, DeadLetterErrors**.

Datafeeds are **composite-aggregated** — required, because these `metrics-aws.*.otel-*` indices contain `aggregate_metric_double` fields that a plain (non-aggregating) ML datafeed cannot read.

## Validation

Drafted and validated against live AWS OTel telemetry: the job(s) establish baselines over historical data. The RDS connection-pool-exhaustion case was scored against a known injected incident and detected it on the correct entity (recall/precision/f1 = 1.0).

Methodology, tooling, and the scoring harness: https://github.com/elastic/aws_otel_ml_draft

## Notes for reviewers (@elastic/obs-infraobs-integrations)

- **Draft** — proposing for your review; happy to adjust job naming, detector selection, `bucket_span`, or thresholds.
- Package stays `subscription: basic` (matches `kubernetes_otel`; ML availability is a deployment concern, not a package condition).
- Entity fields use the **raw CloudWatch dimensions** present in the indexed documents (`FunctionName`), not the normalized fields the alert-rule `termField`s reference (those are not present in the documents).
- `DeadLetterErrors` only emits when a DLQ is configured (absent otherwise — harmless).
