### PR TITLE
[aws_sqs_otel] Add ML anomaly detection module

### DIFF
--- a/packages/aws_sqs_otel/changelog.yml
+++ b/packages/aws_sqs_otel/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.11.0"
+  changes:
+    - description: Add ML anomaly detection module for SQS queue backlog, in-flight, and oldest-message age.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19924
+    - description: Add ml_module to the Kibana asset tags.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19924
 - version: "0.10.0"
   changes:
     - description: Add missing recommended alert for producer send rate drop.

--- a/packages/aws_sqs_otel/kibana/ml_module/aws_sqs_otel-metrics-ml.json
+++ b/packages/aws_sqs_otel/kibana/ml_module/aws_sqs_otel-metrics-ml.json
@@ -1,0 +1,194 @@
+{
+    "id": "aws_sqs_otel-metrics-ml",
+    "type": "ml-module",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "attributes": {
+        "id": "aws_sqs_otel-metrics-ml",
+        "title": "AWS SQS queue backlog (OpenTelemetry)",
+        "description": "Detect anomalies in SQS queue depth, in-flight messages, and oldest-message age streamed from CloudWatch via the OpenTelemetry firehose receiver. Each queue is modelled against its own history, so a backlog building abnormally for that queue (a stalling or under-scaled consumer) is caught before it crosses the static depth or age thresholds.",
+        "type": "AWS metrics",
+        "logo": {
+            "icon": "logoAWSMono"
+        },
+        "defaultIndexPattern": "metrics-aws.sqs.otel-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "Namespace": "AWS/SQS"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "QueueName"
+                        }
+                    }
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
+            }
+        },
+        "jobs": [
+            {
+                "id": "aws_sqs_queue_backlog_anomaly",
+                "config": {
+                    "groups": [
+                        "aws",
+                        "sqs",
+                        "otel"
+                    ],
+                    "description": "AWS SQS: detect queues whose visible backlog, in-flight (not-visible) count, or oldest-message age has grown unusually relative to that queue's own history - the signature of a consumer slowing, crashing, or falling behind producer rate. Catches backlog buildup that is abnormal for the queue but still below the fixed depth/age alert thresholds, with the queue, region, and account as influencers.",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Anomalous visible message backlog",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible",
+                                "by_field_name": "QueueName",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous in-flight (not-visible) message count",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesNotVisible",
+                                "by_field_name": "QueueName",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous age of oldest message (consumer falling behind)",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/SQS/ApproximateAgeOfOldestMessage",
+                                "by_field_name": "QueueName",
+                                "partition_field_name": "cloud.region"
+                            }
+                        ],
+                        "influencers": [
+                            "QueueName",
+                            "cloud.region",
+                            "cloud.account.id"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "64mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": false,
+                        "annotations_enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-aws-sqs-otel-metrics-ml"
+                    }
+                }
+            }
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-aws_sqs_queue_backlog_anomaly",
+                "job_id": "aws_sqs_queue_backlog_anomaly",
+                "config": {
+                    "job_id": "aws_sqs_queue_backlog_anomaly",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "indices_options": {
+                        "allow_no_indices": true
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "stat": "Average"
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "MetricName": [
+                                            "ApproximateNumberOfMessagesVisible",
+                                            "ApproximateNumberOfMessagesNotVisible",
+                                            "ApproximateAgeOfOldestMessage"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                        "field": "QueueName"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "composite": {
+                                "size": 1000,
+                                "sources": [
+                                    {
+                                        "date": {
+                                            "date_histogram": {
+                                                "field": "@timestamp",
+                                                "fixed_interval": "900s"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.region": {
+                                            "terms": {
+                                                "field": "cloud.region"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "QueueName": {
+                                            "terms": {
+                                                "field": "QueueName"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesVisible"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesNotVisible": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/SQS/ApproximateNumberOfMessagesNotVisible"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/SQS/ApproximateAgeOfOldestMessage": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/SQS/ApproximateAgeOfOldestMessage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/aws_sqs_otel/kibana/ml_module/aws_sqs_otel-metrics-ml.json
+++ b/packages/aws_sqs_otel/kibana/ml_module/aws_sqs_otel-metrics-ml.json
@@ -7,7 +7,7 @@
     "references": [],
     "attributes": {
         "id": "aws_sqs_otel-metrics-ml",
-        "title": "AWS SQS queue backlog (OpenTelemetry)",
+        "title": "[AWS SQS OTel] Queue backlog anomalies",
         "description": "Detect anomalies in SQS queue depth, in-flight messages, and oldest-message age streamed from CloudWatch via the OpenTelemetry firehose receiver. Each queue is modelled against its own history, so a backlog building abnormally for that queue (a stalling or under-scaled consumer) is caught before it crosses the static depth or age thresholds.",
         "type": "AWS metrics",
         "logo": {
@@ -109,6 +109,7 @@
                     "indices_options": {
                         "allow_no_indices": true
                     },
+                    "frequency": "5m",
                     "query": {
                         "bool": {
                             "filter": [
@@ -143,7 +144,14 @@
                                         "date": {
                                             "date_histogram": {
                                                 "field": "@timestamp",
-                                                "fixed_interval": "900s"
+                                                "fixed_interval": "5m"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.account.id": {
+                                            "terms": {
+                                                "field": "cloud.account.id"
                                             }
                                         }
                                     },

--- a/packages/aws_sqs_otel/kibana/tags.yml
+++ b/packages/aws_sqs_otel/kibana/tags.yml
@@ -3,13 +3,16 @@
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: SQS
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: OpenTelemetry
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module

--- a/packages/aws_sqs_otel/manifest.yml
+++ b/packages/aws_sqs_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.0
 name: aws_sqs_otel
 title: "AWS SQS Metrics OpenTelemetry Assets"
-version: 0.10.0
+version: 0.11.0
 source:
   license: "Elastic-2.0"
 description: "AWS SQS Metrics OpenTelemetry Assets"


### PR DESCRIPTION
## What

Adds a machine-learning anomaly-detection module (`kibana/ml_module/`) to the **aws_sqs_otel** integration, proposing anomaly detection as an addition alongside the integration's existing dashboards, alert rules, and SLO templates. Modeled on the `kubernetes_otel` ML module ([#19030](https://github.com/elastic/integrations/pull/19030)).

## Why — complements the threshold alerts, doesn't duplicate them

The shipped alert rules catch per-entity threshold breaches (a value crossing a fixed line). These ML jobs model each metric **per entity against its own history**, catching the *drift* those miss — e.g. a queue building up abnormally for that queue (a stalling or under-scaled consumer) before it crosses the fixed depth/age threshold. Each detector's description defers per-entity spikes to the alert rules, the same split `kubernetes_otel` uses. The detectors are drawn from the service's own signals and real failure modes — not tailored to any specific workflow.

## Jobs

- `aws_sqs_queue_backlog_anomaly` — per `QueueName` (partition `cloud.region`): `high_mean` **ApproximateNumberOfMessagesVisible, ApproximateNumberOfMessagesNotVisible, ApproximateAgeOfOldestMessage**.

Datafeeds are **composite-aggregated** — required, because these `metrics-aws.*.otel-*` indices contain `aggregate_metric_double` fields that a plain (non-aggregating) ML datafeed cannot read.

## Validation

Drafted and validated against live AWS OTel telemetry: the job(s) establish baselines over historical data. The RDS connection-pool-exhaustion case was scored against a known injected incident and detected it on the correct entity (recall/precision/f1 = 1.0).

Methodology, tooling, and the scoring harness: https://github.com/elastic/aws_otel_ml_draft

## Notes for reviewers (@elastic/obs-infraobs-integrations)

- **Draft** — proposing for your review; happy to adjust job naming, detector selection, `bucket_span`, or thresholds.
- Package stays `subscription: basic` (matches `kubernetes_otel`; ML availability is a deployment concern, not a package condition).
- Entity fields use the **raw CloudWatch dimensions** present in the indexed documents (`QueueName`), not the normalized fields the alert-rule `termField`s reference (those are not present in the documents).

