### PR TITLE
[aws_elb_metrics_otel] Add ML anomaly detection modules

### DIFF
--- a/packages/aws_elb_metrics_otel/changelog.yml
+++ b/packages/aws_elb_metrics_otel/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "0.10.0"
+  changes:
+    - description: Add ML anomaly detection modules for ALB target health (response time, unhealthy hosts) and request errors (5XX, rejected connections).
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19925
+    - description: Add ml_module to the Kibana asset tags.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19925
 - version: "0.9.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/aws_elb_metrics_otel/kibana/ml_module/aws_elb_metrics_otel-activity-ml.json
+++ b/packages/aws_elb_metrics_otel/kibana/ml_module/aws_elb_metrics_otel-activity-ml.json
@@ -1,0 +1,195 @@
+{
+    "id": "aws_elb_metrics_otel-activity-ml",
+    "type": "ml-module",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "attributes": {
+        "id": "aws_elb_metrics_otel-activity-ml",
+        "title": "AWS Application Load Balancer errors (OpenTelemetry)",
+        "description": "Detect anomalous rates of ALB 5XX responses and rejected connections (the per-bucket Sum statistic) streamed from CloudWatch via the OpenTelemetry firehose receiver. Modelled per load balancer against its own history, so error and rejection elevations that are abnormal for that resource are caught even when they stay below the fixed error-count alert thresholds.",
+        "type": "AWS metrics",
+        "logo": {
+            "icon": "logoAWSMono"
+        },
+        "defaultIndexPattern": "metrics-aws.elb.otel-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "Namespace": "AWS/ApplicationELB"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "LoadBalancer"
+                        }
+                    }
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
+            }
+        },
+        "jobs": [
+            {
+                "id": "aws_elb_request_error_anomaly",
+                "config": {
+                    "groups": [
+                        "aws",
+                        "elb",
+                        "otel"
+                    ],
+                    "description": "AWS ALB: detect load balancers producing unusual rates of ELB-generated 5XX, target 5XX, or rejected connections relative to their own history. The threshold-based alert rules cover hard error-count breaches; this job catches rate elevations that drift below any fixed threshold, with the load balancer, target group, region, and account surfaced as influencers for attribution.",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Anomalous ELB-generated 5XX rate",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count",
+                                "by_field_name": "LoadBalancer",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous target 5XX rate",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count",
+                                "by_field_name": "LoadBalancer",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous rejected-connection rate (listener saturation)",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/ApplicationELB/RejectedConnectionCount",
+                                "by_field_name": "LoadBalancer",
+                                "partition_field_name": "cloud.region"
+                            }
+                        ],
+                        "influencers": [
+                            "LoadBalancer",
+                            "TargetGroup",
+                            "cloud.region",
+                            "cloud.account.id"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "64mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": false,
+                        "annotations_enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-aws-elb-metrics-otel-activity-ml"
+                    }
+                }
+            }
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-aws_elb_request_error_anomaly",
+                "job_id": "aws_elb_request_error_anomaly",
+                "config": {
+                    "job_id": "aws_elb_request_error_anomaly",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "indices_options": {
+                        "allow_no_indices": true
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "stat": "Sum"
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "MetricName": [
+                                            "HTTPCode_ELB_5XX_Count",
+                                            "HTTPCode_Target_5XX_Count",
+                                            "RejectedConnectionCount"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                        "field": "LoadBalancer"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "composite": {
+                                "size": 1000,
+                                "sources": [
+                                    {
+                                        "date": {
+                                            "date_histogram": {
+                                                "field": "@timestamp",
+                                                "fixed_interval": "900s"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.region": {
+                                            "terms": {
+                                                "field": "cloud.region"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "LoadBalancer": {
+                                            "terms": {
+                                                "field": "LoadBalancer"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_ELB_5XX_Count"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/ApplicationELB/HTTPCode_Target_5XX_Count"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/ApplicationELB/RejectedConnectionCount": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/ApplicationELB/RejectedConnectionCount"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/aws_elb_metrics_otel/kibana/ml_module/aws_elb_metrics_otel-activity-ml.json
+++ b/packages/aws_elb_metrics_otel/kibana/ml_module/aws_elb_metrics_otel-activity-ml.json
@@ -7,13 +7,13 @@
     "references": [],
     "attributes": {
         "id": "aws_elb_metrics_otel-activity-ml",
-        "title": "AWS Application Load Balancer errors (OpenTelemetry)",
+        "title": "[AWS ELB OTel] Application Load Balancer error anomalies",
         "description": "Detect anomalous rates of ALB 5XX responses and rejected connections (the per-bucket Sum statistic) streamed from CloudWatch via the OpenTelemetry firehose receiver. Modelled per load balancer against its own history, so error and rejection elevations that are abnormal for that resource are caught even when they stay below the fixed error-count alert thresholds.",
         "type": "AWS metrics",
         "logo": {
             "icon": "logoAWSMono"
         },
-        "defaultIndexPattern": "metrics-aws.elb.otel-*",
+        "defaultIndexPattern": "metrics-aws.applicationelb.otel-*",
         "query": {
             "bool": {
                 "filter": [
@@ -47,7 +47,7 @@
                         "elb",
                         "otel"
                     ],
-                    "description": "AWS ALB: detect load balancers producing unusual rates of ELB-generated 5XX, target 5XX, or rejected connections relative to their own history. The threshold-based alert rules cover hard error-count breaches; this job catches rate elevations that drift below any fixed threshold, with the load balancer, target group, region, and account surfaced as influencers for attribution.",
+                    "description": "AWS ALB: detect load balancers producing unusual rates of ELB-generated 5XX, target 5XX, or rejected connections relative to their own history. The threshold-based alert rules cover hard error-count breaches; this job catches rate elevations that drift below any fixed threshold, with the load balancer, region, and account surfaced as influencers for attribution.",
                     "analysis_config": {
                         "bucket_span": "15m",
                         "summary_count_field_name": "doc_count",
@@ -76,7 +76,6 @@
                         ],
                         "influencers": [
                             "LoadBalancer",
-                            "TargetGroup",
                             "cloud.region",
                             "cloud.account.id"
                         ]
@@ -110,6 +109,7 @@
                     "indices_options": {
                         "allow_no_indices": true
                     },
+                    "frequency": "5m",
                     "query": {
                         "bool": {
                             "filter": [
@@ -144,7 +144,14 @@
                                         "date": {
                                             "date_histogram": {
                                                 "field": "@timestamp",
-                                                "fixed_interval": "900s"
+                                                "fixed_interval": "5m"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.account.id": {
+                                            "terms": {
+                                                "field": "cloud.account.id"
                                             }
                                         }
                                     },

--- a/packages/aws_elb_metrics_otel/kibana/ml_module/aws_elb_metrics_otel-metrics-ml.json
+++ b/packages/aws_elb_metrics_otel/kibana/ml_module/aws_elb_metrics_otel-metrics-ml.json
@@ -1,0 +1,182 @@
+{
+    "id": "aws_elb_metrics_otel-metrics-ml",
+    "type": "ml-module",
+    "migrationVersion": {
+        "search": "7.9.3"
+    },
+    "references": [],
+    "attributes": {
+        "id": "aws_elb_metrics_otel-metrics-ml",
+        "title": "AWS Application Load Balancer target health (OpenTelemetry)",
+        "description": "Detect anomalies in ALB target response time and unhealthy-host count streamed from CloudWatch via the OpenTelemetry firehose receiver. Each target group is modelled against its own history, so latency drift and intermittent host unhealthiness are caught before they cross the static alert thresholds.",
+        "type": "AWS metrics",
+        "logo": {
+            "icon": "logoAWSMono"
+        },
+        "defaultIndexPattern": "metrics-aws.elb.otel-*",
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "Namespace": "AWS/ApplicationELB"
+                        }
+                    },
+                    {
+                        "exists": {
+                            "field": "TargetGroup"
+                        }
+                    }
+                ],
+                "must_not": {
+                    "terms": {
+                        "_tier": [
+                            "data_frozen",
+                            "data_cold"
+                        ]
+                    }
+                }
+            }
+        },
+        "jobs": [
+            {
+                "id": "aws_elb_target_latency_anomaly",
+                "config": {
+                    "groups": [
+                        "aws",
+                        "elb",
+                        "otel"
+                    ],
+                    "description": "AWS ALB: detect target groups whose response time or unhealthy-host count has drifted unusually relative to that target group's own history - a backend slowing down or hosts flapping in and out of health. The static alert rules cover hard latency and unhealthy-host breaches; this job covers the sub-threshold drift, with the target group, load balancer, region, and account as influencers.",
+                    "analysis_config": {
+                        "bucket_span": "15m",
+                        "summary_count_field_name": "doc_count",
+                        "detectors": [
+                            {
+                                "detector_description": "Anomalous target response time (latency drift)",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime",
+                                "by_field_name": "TargetGroup",
+                                "partition_field_name": "cloud.region"
+                            },
+                            {
+                                "detector_description": "Anomalous unhealthy-host count",
+                                "function": "high_mean",
+                                "field_name": "metrics.amazonaws.com/AWS/ApplicationELB/UnHealthyHostCount",
+                                "by_field_name": "TargetGroup",
+                                "partition_field_name": "cloud.region"
+                            }
+                        ],
+                        "influencers": [
+                            "TargetGroup",
+                            "LoadBalancer",
+                            "cloud.region",
+                            "cloud.account.id"
+                        ]
+                    },
+                    "analysis_limits": {
+                        "model_memory_limit": "64mb"
+                    },
+                    "data_description": {
+                        "time_field": "@timestamp",
+                        "time_format": "epoch_ms"
+                    },
+                    "model_plot_config": {
+                        "enabled": false,
+                        "annotations_enabled": true
+                    },
+                    "custom_settings": {
+                        "created_by": "ml-module-aws-elb-metrics-otel-metrics-ml"
+                    }
+                }
+            }
+        ],
+        "datafeeds": [
+            {
+                "id": "datafeed-aws_elb_target_latency_anomaly",
+                "job_id": "aws_elb_target_latency_anomaly",
+                "config": {
+                    "job_id": "aws_elb_target_latency_anomaly",
+                    "indices": [
+                        "INDEX_PATTERN_NAME"
+                    ],
+                    "indices_options": {
+                        "allow_no_indices": true
+                    },
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "term": {
+                                        "stat": "Average"
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "MetricName": [
+                                            "TargetResponseTime",
+                                            "UnHealthyHostCount"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "exists": {
+                                        "field": "TargetGroup"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggregations": {
+                        "buckets": {
+                            "composite": {
+                                "size": 1000,
+                                "sources": [
+                                    {
+                                        "date": {
+                                            "date_histogram": {
+                                                "field": "@timestamp",
+                                                "fixed_interval": "900s"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.region": {
+                                            "terms": {
+                                                "field": "cloud.region"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "TargetGroup": {
+                                            "terms": {
+                                                "field": "TargetGroup"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "aggregations": {
+                                "@timestamp": {
+                                    "max": {
+                                        "field": "@timestamp"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/ApplicationELB/TargetResponseTime"
+                                    }
+                                },
+                                "metrics.amazonaws.com/AWS/ApplicationELB/UnHealthyHostCount": {
+                                    "avg": {
+                                        "field": "metrics.amazonaws.com/AWS/ApplicationELB/UnHealthyHostCount"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/aws_elb_metrics_otel/kibana/ml_module/aws_elb_metrics_otel-metrics-ml.json
+++ b/packages/aws_elb_metrics_otel/kibana/ml_module/aws_elb_metrics_otel-metrics-ml.json
@@ -7,13 +7,13 @@
     "references": [],
     "attributes": {
         "id": "aws_elb_metrics_otel-metrics-ml",
-        "title": "AWS Application Load Balancer target health (OpenTelemetry)",
+        "title": "[AWS ELB OTel] Application Load Balancer target health anomalies",
         "description": "Detect anomalies in ALB target response time and unhealthy-host count streamed from CloudWatch via the OpenTelemetry firehose receiver. Each target group is modelled against its own history, so latency drift and intermittent host unhealthiness are caught before they cross the static alert thresholds.",
         "type": "AWS metrics",
         "logo": {
             "icon": "logoAWSMono"
         },
-        "defaultIndexPattern": "metrics-aws.elb.otel-*",
+        "defaultIndexPattern": "metrics-aws.applicationelb.otel-*",
         "query": {
             "bool": {
                 "filter": [
@@ -103,6 +103,7 @@
                     "indices_options": {
                         "allow_no_indices": true
                     },
+                    "frequency": "5m",
                     "query": {
                         "bool": {
                             "filter": [
@@ -136,7 +137,21 @@
                                         "date": {
                                             "date_histogram": {
                                                 "field": "@timestamp",
-                                                "fixed_interval": "900s"
+                                                "fixed_interval": "5m"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "LoadBalancer": {
+                                            "terms": {
+                                                "field": "LoadBalancer"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "cloud.account.id": {
+                                            "terms": {
+                                                "field": "cloud.account.id"
                                             }
                                         }
                                     },

--- a/packages/aws_elb_metrics_otel/kibana/tags.yml
+++ b/packages/aws_elb_metrics_otel/kibana/tags.yml
@@ -3,13 +3,16 @@
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: ELB
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module
 - text: OpenTelemetry
   asset_types:
     - dashboard
     - alerting_rule_template
     - slo_template
+    - ml_module

--- a/packages/aws_elb_metrics_otel/manifest.yml
+++ b/packages/aws_elb_metrics_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.6.0
 name: aws_elb_metrics_otel
 title: "AWS ELB Metrics OpenTelemetry Assets"
-version: 0.9.0
+version: 0.10.0
 source:
   license: "Elastic-2.0"
 description: "AWS ELB Metrics OpenTelemetry Assets"


### PR DESCRIPTION
## What

Adds a machine-learning anomaly-detection module (`kibana/ml_module/`) to the **aws_elb_metrics_otel** integration, proposing anomaly detection as an addition alongside the integration's existing dashboards, alert rules, and SLO templates. Modeled on the `kubernetes_otel` ML module ([#19030](https://github.com/elastic/integrations/pull/19030)).

## Why — complements the threshold alerts, doesn't duplicate them

The shipped alert rules catch per-entity threshold breaches (a value crossing a fixed line). These ML jobs model each metric **per entity against its own history**, catching the *drift* those miss — e.g. a backend slowing down, hosts flapping in and out of health, or an error/rejection rate rising below the fixed count threshold. Each detector's description defers per-entity spikes to the alert rules, the same split `kubernetes_otel` uses. The detectors are drawn from the service's own signals and real failure modes — not tailored to any specific workflow.

## Jobs

- `aws_elb_target_latency_anomaly` — per `TargetGroup` (partition `cloud.region`): `high_mean` **TargetResponseTime** and **UnHealthyHostCount**.
- `aws_elb_request_error_anomaly` — per `LoadBalancer` (partition `cloud.region`), the per-bucket **Sum**: `high_mean` **HTTPCode_ELB_5XX_Count, HTTPCode_Target_5XX_Count, RejectedConnectionCount**.

Datafeeds are **composite-aggregated** — required, because these `metrics-aws.*.otel-*` indices contain `aggregate_metric_double` fields that a plain (non-aggregating) ML datafeed cannot read.

## Validation

Structural draft. The other services in this set were validated against live AWS OTel telemetry (baselines established; RDS scored 1.0 against a known incident); this one awaits a live load balancer to confirm field shape and detection.

Methodology, tooling, and the scoring harness: https://github.com/elastic/aws_otel_ml_draft

## Notes for reviewers (@elastic/obs-infraobs-integrations)

- **Draft** — proposing for your review; happy to adjust job naming, detector selection, `bucket_span`, or thresholds.
- Package stays `subscription: basic` (matches `kubernetes_otel`; ML availability is a deployment concern, not a package condition).
- Entity fields use the **raw CloudWatch dimensions** present in the indexed documents (`LoadBalancer` / `TargetGroup`), not the normalized fields the alert-rule `termField`s reference (those are not present in the documents).
- Unlike the other services, these jobs were **not validated against live data** (no load balancer was present in the test environment) — they are structurally consistent with the validated services and should be reviewed with that in mind.
