### PR TITLE
chore: use dedicated label for backport sync-changelog pull requests

### DIFF
--- a/dev/backports/changelog/sync.go
+++ b/dev/backports/changelog/sync.go
@@ -86,7 +86,7 @@ func CreateSyncPR(entriesTSV, workingBranch, backportPRNumber, backportBranch, p
 		"--base", "main",
 		"--head", workingBranch,
 		"--title", prTitle,
-		"--label", "automation",
+		"--label", "backport:sync-changelog",
 		"--reviewer", "elastic/ecosystem",
 		"--body", body,
 	)


### PR DESCRIPTION
## Proposed commit message

```
chore: use dedicated label for backport sync-changelog pull requests

Use `backport:sync-changelog` instead of `automation` for the pull
requests created by the sync-backport-changelog workflow.

The `automation` label is already used for unrelated purposes in this
repository (dependabot PRs and flaky-test issues), so filtering on it to
skip processing sync-changelog PRs would also incorrectly match those.
A dedicated label avoids the collision.
```

**WHY:** [elastic/integrations#19215](https://github.com/elastic/integrations/issues/19215) proposed labeling pull requests created by workflows with `automation`, so that other automation can skip processing them. However, `automation` is already applied to dependabot PRs (`.github/dependabot.yml`) and flaky-test issues (`dev/testsreporter/testsreporter.go`), so any future check for "does this PR have the `automation` label" would also match those unrelated PRs/issues.

**WHAT:**
- `dev/backports/changelog/sync.go`: change the label passed to `gh pr create` from `automation` to `backport:sync-changelog` when creating the changelog-sync PR.

**Note for reviewers:** the `backport:sync-changelog` label does not exist yet on `elastic/integrations` and needs to be created before this takes effect, otherwise `gh pr create --label` will fail.

## Author's Checklist

- [x] Create the `backport:sync-changelog` label on `elastic/integrations` before/alongside merging this PR

## How to test this PR locally

This change only affects the label passed to `gh pr create` in `dev/backports/changelog/sync.go`. It can be verified by running the existing unit tests:

```bash
go test ./dev/backports/changelog/...
```

To confirm end-to-end, trigger the `sync-backport-changelog` workflow (push a `changelog.yml` change to a `backport-*` branch) and check that the resulting PR is labeled `backport:sync-changelog` instead of `automation`.

## Related issues

- Relates #19215

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-5).
