### PR TITLE
Disable unowned AI GitHub Actions workflows

### DIFF
--- a/.github/workflows/sweep-dashboard-data-scope.yml
+++ b/.github/workflows/sweep-dashboard-data-scope.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
       title-prefix: "[dashboard-data-scope]"

--- a/.github/workflows/sweep-field-mapping-conflicts.yml
+++ b/.github/workflows/sweep-field-mapping-conflicts.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
       title-prefix: "[field-mapping-conflicts]"

--- a/.github/workflows/sweep-httpjson-pagination.yml
+++ b/.github/workflows/sweep-httpjson-pagination.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
       title-prefix: "[httpjson-pagination]"

--- a/.github/workflows/sweep-ingest-pipeline-safety.yml
+++ b/.github/workflows/sweep-ingest-pipeline-safety.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
       title-prefix: "[ingest-pipeline-safety]"

--- a/.github/workflows/sweep-pipeline-error-handling.yml
+++ b/.github/workflows/sweep-pipeline-error-handling.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-quality-audit.lock.yml@v0
     with:
       title-prefix: "[pipeline-error-handling]"

--- a/.github/workflows/trigger-breaking-change-detector.yml
+++ b/.github/workflows/trigger-breaking-change-detector.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-breaking-change-detector.lock.yml@v0
     with:
       additional-instructions: |

--- a/.github/workflows/trigger-bug-hunter.yml
+++ b/.github/workflows/trigger-bug-hunter.yml
@@ -13,4 +13,7 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — this workflow has no current owner. Re-enabling
+    # requires removing this line via a reviewed PR, so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-bug-hunter.lock.yml@v0

--- a/.github/workflows/trigger-docs-patrol.yml
+++ b/.github/workflows/trigger-docs-patrol.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@v0
     with:
       title-prefix: "[docs-patrol]"

--- a/.github/workflows/trigger-duplicate-issue-detector.yml
+++ b/.github/workflows/trigger-duplicate-issue-detector.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@v0
     with:
       detect-related-issues: false

--- a/.github/workflows/trigger-issue-triage.yml
+++ b/.github/workflows/trigger-issue-triage.yml
@@ -15,9 +15,13 @@ jobs:
   run:
     # Access control is enforced by the upstream reusable workflow pre_activation
     # check (required roles: admin, maintainer, write).
-    if: >-
-      github.event.action == 'opened' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'claude-plz-triage')
+    #
+    # Disabled 2026-07-02 — no current owner. To re-enable, remove `if: false`
+    # and restore the original activation condition below via a reviewed PR:
+    #   if: >-
+    #     github.event.action == 'opened' ||
+    #     (github.event.action == 'labeled' && github.event.label.name == 'claude-plz-triage')
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v0
     with:
       setup-commands: |

--- a/.github/workflows/trigger-mention-in-issue.yml
+++ b/.github/workflows/trigger-mention-in-issue.yml
@@ -15,9 +15,13 @@ jobs:
   run:
     # Access control is enforced by the upstream reusable workflow pre_activation
     # check (required roles: admin, maintainer, write).
-    if: >-
-      github.event.issue.pull_request == null &&
-      (startsWith(github.event.comment.body, '/ai') || contains(github.event.comment.body, '@claude'))
+    #
+    # Disabled 2026-07-02 — no current owner. To re-enable, remove `if: false`
+    # and restore the original activation condition below via a reviewed PR:
+    #   if: >-
+    #     github.event.issue.pull_request == null &&
+    #     (startsWith(github.event.comment.body, '/ai') || contains(github.event.comment.body, '@claude'))
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-issue.lock.yml@v0
     with:
       setup-commands: |

--- a/.github/workflows/trigger-mention-in-pr.yml
+++ b/.github/workflows/trigger-mention-in-pr.yml
@@ -17,9 +17,13 @@ jobs:
   run:
     # Access control is enforced by the upstream reusable workflow pre_activation
     # check (required roles: admin, maintainer, write).
-    if: >-
-      (startsWith(github.event.comment.body, '/ai') || contains(github.event.comment.body, '@claude')) &&
-      (github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment')
+    #
+    # Disabled 2026-07-02 — no current owner. To re-enable, remove `if: false`
+    # and restore the original activation condition below via a reviewed PR:
+    #   if: >-
+    #     (startsWith(github.event.comment.body, '/ai') || contains(github.event.comment.body, '@claude')) &&
+    #     (github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment')
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@v0
     with:
       setup-commands: |

--- a/.github/workflows/trigger-newbie-contributor-patrol.yml
+++ b/.github/workflows/trigger-newbie-contributor-patrol.yml
@@ -12,4 +12,7 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-newbie-contributor-patrol.lock.yml@v0

--- a/.github/workflows/trigger-pr-review.yml
+++ b/.github/workflows/trigger-pr-review.yml
@@ -12,10 +12,13 @@ permissions:
 
 jobs:
   run:
-    if: >-
-      (contains(fromJSON('["Copilot","dependabot[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)) &&
-      github.event.pull_request.draft == false &&
-      !contains(github.event.pull_request.labels.*.name, 'no-pr-review')
+    # Disabled 2026-07-02 — no current owner. To re-enable, remove `if: false`
+    # and restore the original activation condition below via a reviewed PR:
+    #   if: >-
+    #     (contains(fromJSON('["Copilot","dependabot[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)) &&
+    #     github.event.pull_request.draft == false &&
+    #     !contains(github.event.pull_request.labels.*.name, 'no-pr-review')
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review.lock.yml@v0
     with:
       intensity: aggressive

--- a/.github/workflows/trigger-stale-issues.yml
+++ b/.github/workflows/trigger-stale-issues.yml
@@ -12,4 +12,7 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-stale-issues.lock.yml@v0

--- a/.github/workflows/trigger-text-auditor.yml
+++ b/.github/workflows/trigger-text-auditor.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   run:
+    # Disabled 2026-07-02 — no current owner. Re-enable by removing this
+    # `if: false` line via a reviewed PR so the change is visible.
+    if: false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-text-auditor.lock.yml@v0
     with:
       title-prefix: "[text-auditor]"


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
ci: disable unowned AI GitHub Actions workflows

The sweep-* and trigger-* workflows wrap reusable workflows from
elastic/ai-github-actions. They were set up by a contributor who has
since left, and no team currently owns them.

Left running unowned, they generate noise that no one is triaging:
100+ AI-authored issues opened since March with no team labels, issues
filed against deprecated integrations, and issues created when the bots
themselves error out. Disable them to stop the noise until ownership is
decided — rather than deleting them, since deletion would lose the
config and history and a team may want to adopt and re-enable them.

Disable via a source-level `if: false` on the `run` job (not the
Actions UI toggle) so that re-enabling requires a reviewed PR and is
visible in git history — a silent flip-back-on isn't possible.

Disabled 16 workflows:
  sweep-dashboard-data-scope, sweep-field-mapping-conflicts,
  sweep-httpjson-pagination, sweep-ingest-pipeline-safety,
  sweep-pipeline-error-handling, trigger-breaking-change-detector,
  trigger-bug-hunter, trigger-docs-patrol,
  trigger-duplicate-issue-detector, trigger-issue-triage,
  trigger-mention-in-issue, trigger-mention-in-pr,
  trigger-newbie-contributor-patrol, trigger-pr-review,
  trigger-text-auditor, trigger-stale-issues

For the 12 single-job workflows, `if: false` plus a comment was added
directly to the `run` job.

For the 4 workflows that already had an `if:` activation condition
(trigger-issue-triage, trigger-mention-in-issue, trigger-mention-in-pr,
trigger-pr-review), YAML permits only one `if:` key per job, so the
original condition was moved into a comment above the job and replaced
with `if: false`. The comment preserves the exact original expression
so it can be restored verbatim on re-enable.

Excluded (intentionally not disabled):
  - trigger-package-tests-security-ml: actively maintained by the
    security-ml team (and uses elastic/ci-gh-actions, not
    elastic/ai-github-actions).
  - trigger-pr-actions-detective: has an extra step-level job
    (actions/github-script) before the reusable-workflow call, so it
    needs separate handling rather than a blanket if: false.

Note: workflows still trigger on their existing events/schedules but
the job is skipped, producing empty "skipped" runs. This is the
accepted trade-off for keeping the disabled state in source.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
