### PR TITLE
[cisco_aironet] Add grok pattern for LOG-6-Q_IND Radius override message

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.1"
+  changes:
+    - description: Add grok pattern for LOG-6-Q_IND Radius override messages
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.21.0"
   changes:
     - description: Add parsers for WLC9800-style log messages including AWIPS alarms, client exclusion, DOT1X/MAB/SESSION_MGR failures, FMANFP ACL logs, RADIUS audit, SSH, mobility, and administrative login events.

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add grok pattern for LOG-6-Q_IND Radius override messages
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19934
 - version: "1.21.0"
   changes:
     - description: Add parsers for WLC9800-style log messages including AWIPS alarms, client exclusion, DOT1X/MAB/SESSION_MGR failures, FMANFP ACL logs, RADIUS audit, SSH, mobility, and administrative login events.

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.21.1"
   changes:
     - description: Add grok pattern for LOG-6-Q_IND Radius override messages
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/19934
 - version: "1.21.0"
   changes:

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
@@ -38,3 +38,4 @@
 <4>6642: AP:abcd.9876.0123: *Jul  9 09:06:15.007: %DOT11-4-CCMP_REPLAY: Client 1234.efab.11ab had 1 AES-CCMP TSC replays
 <158>7779986: WLC001: 7842329: Oct 3 16:14:07.740 SGT: %APMGR_AWIPS_SYSLOG-6-APMGR_AWIPS_MESSAGE: Chassis 1 R0/0: wncd: AWIPS alarm:(TEST-AP-01) a1b2.c3d4.e5f6 Radio MAC a1b2.c3d4.e5f7 detected Airdrop Session (10021)
 <157>7781346: WLC001: 7843692: Oct 3 16:15:44.319 SGT: %SESSION_MGR-5-FAIL: Chassis 1 R0/6: wncd: Authorization failed or unapplied for client (de:fb:48:7c:4f:f7) on Interface capwap_12345678 AuditSessionID ABC123DEF456789012345678. Failure reason: Authc fail. Authc failure reason: Cred Fail.
+<46>host-1.example.local: *SISF BT Process: Jun 28 01:14:15.327: %LOG-6-Q_IND: [PA]apf_ms_radius_override.c:213 Radius overrides disabled, ignoring source 4

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
@@ -1560,6 +1560,46 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2026-06-28T01:14:15.327+08:00",
+            "cisco": {
+                "radius": {
+                    "source": 4,
+                    "status": "disabled"
+                }
+            },
+            "ecs": {
+                "version": "8.17.0"
+            },
+            "event": {
+                "action": "Q_IND",
+                "original": "<46>host-1.example.local: *SISF BT Process: Jun 28 01:14:15.327: %LOG-6-Q_IND: [PA]apf_ms_radius_override.c:213 Radius overrides disabled, ignoring source 4",
+                "provider": "LOG",
+                "severity": 6
+            },
+            "host": {
+                "name": "host-1.example.local"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 5
+                    },
+                    "priority": 46,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "message": "Radius overrides disabled, ignoring source 4",
+            "process": {
+                "name": "SISF BT Process"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -130,7 +130,7 @@ processors:
   # Adding information to event types
   - grok:
       tag: grok_message_c41fbfd3
-      description: SISF-6-ENTRY_CREATED, SISF-6-ENTRY_DELETED, SISF-6-ENTRY_CHANGED, LOG-6-Q_IND
+      description: SISF-6-ENTRY_CREATED, SISF-6-ENTRY_DELETED, SISF-6-ENTRY_CHANGED, LOG-6-Q_IND (SISF binding, username, and Radius override)
       field: message
       if: >-
         ctx._temp_?.reason == 'SISF-6-ENTRY_CREATED' ||
@@ -140,6 +140,7 @@ processors:
       patterns:
         - "A=%{IP:client.ip} V=%{INT} I=%{DATA:cisco.interface.type}:%{INT} P=%{INT} M=((%{MAC:client.mac})|$)"
         - "Username entry \\(%{DATA:user.name}\\)%{DATA}mobile %{MAC:client.mac}"
+        - "Radius overrides %{WORD:cisco.radius.status}(?:, ignoring source %{INT:cisco.radius.source:int})?"
       ignore_failure: false
   ###
   - grok:

--- a/packages/cisco_aironet/data_stream/log/fields/aironet-fields.yml
+++ b/packages/cisco_aironet/data_stream/log/fields/aironet-fields.yml
@@ -61,3 +61,9 @@
 - name: cisco.loadbalance.instance
   type: integer
   description: Load balancer instance number
+- name: cisco.radius.status
+  type: keyword
+  description: RADIUS status (enabled/disabled)
+- name: cisco.radius.source
+  type: short
+  description: RADIUS source identifier number

--- a/packages/cisco_aironet/docs/README.md
+++ b/packages/cisco_aironet/docs/README.md
@@ -312,6 +312,8 @@ The `log` data stream provides events from Cisco Aironet Wireless LAN Controller
 | cisco.interface.type | Cisco interface type | keyword |
 | cisco.loadbalance.instance | Load balancer instance number | integer |
 | cisco.radius.server | RADIUS server address and port string | keyword |
+| cisco.radius.source | RADIUS source identifier number | short |
+| cisco.radius.status | RADIUS status (enabled/disabled) | keyword |
 | cisco.site_tag | Load balancer site tag name | keyword |
 | cisco.ssid | Cisco SSID | keyword |
 | cisco.wps.channel | Cisco WPS channel | short |

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.21.0"
+version: "1.21.1"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:


### PR DESCRIPTION
## Executive summary

Adds support for parsing Cisco Aironet LOG-6-Q_IND RADIUS override messages in the grok processor. The fix introduces a new grok pattern to extract RADIUS status and optional source identifier, adds two new fields (cisco.radius.status and cisco.radius.source) with appropriate types (keyword and short), updates documentation, and includes test fixtures validating the parsing works correctly.

## Proposed commit message

```
[cisco_aironet] Add grok pattern for LOG-6-Q_IND Radius override messag…
```

## Root cause

The grok processor 'grok_message_c41fbfd3' that handles LOG-6-Q_IND messages has only two patterns (SISF-style and Username entry). When encountering a Radius override configuration message, it fails to match because the message format is different and ignore_failure is set to false. The processor needs an additional pattern to handle this LOG-6-Q_IND subtype.

## Approach

Add a third grok pattern to the grok_message_c41fbfd3 processor to match and parse LOG-6-Q_IND Radius override messages. The pattern will capture the Radius status (enabled/disabled) and optional source number. Add a test fixture and expected output to validate the fix handles the previously failing message.

## Implementation

1. Add a third grok pattern to packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml line 139-141 to match Radius override messages: 'Radius overrides %{WORD:cisco.radius.status}(?:, ignoring source %{INT:cisco.radius.source:int})?'
2. Update the processor description on line 132 to include 'LOG-6-Q_IND (Radius)' or similar to document the new pattern
3. Add the sanitized test event to packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log: '<46>host-1.example.local: *SISF BT Process: Jun 28 01:14:15.327: %LOG-6-Q_IND: [PA]apf_ms_radius_override.c:213 Radius overrides disabled, ignoring source 4'
4. Generate the expected JSON output entry in test-aironet-messages.log-expected.json with event fields: ecs.version, event (original, action=Q_IND, provider=LOG, severity=6), host.name, log.level=informational, message='Radius overrides disabled, ignoring source 4', cisco.radius.status='disabled', cisco.radius.source=4
5. Add field definitions for cisco.radius.status (keyword) and cisco.radius.source (short) to packages/cisco_aironet/data_stream/log/fields/aironet-fields.yml if extracting these fields
6. Update packages/cisco_aironet/changelog.yml to add a bugfix entry describing the fix for LOG-6-Q_IND Radius override messages
7. Update packages/cisco_aironet/manifest.yml version from 1.20.0 to 1.20.1

## Pipeline changes

- Add grok pattern to grok_message_c41fbfd3 processor (line 139-141) to match Radius override messages with optional source number extraction

## Field / mapping changes

- Add cisco.radius.status (keyword) field to aironet-fields.yml
- Add cisco.radius.source (short) field to aironet-fields.yml

## Sanitized error message

`Processor 'grok' with tag 'grok_message_c41fbfd3' in pipeline 'logs-cisco_aironet.log-default' failed with message '[on_failure_message]'`

## Sanitized log (`event_sanitized` excerpt)

```json
<46>host-1.example.local: *SISF BT Process: Jun 28 01:14:15.327: %LOG-6-Q_IND: [PA]apf_ms_radius_override.c:213 Radius overrides disabled, ignoring source 4
```

## Reviewer concerns

- The [clean] test step failed (exit code 1), though all validation tests (format, build, lint, install, check, test-pipeline, test-static, test-system) passed successfully. This may be environmental.

## Self-review findings

—

## Risk and classification

- **Plan risk level**: low
- **Tags**: pipeline, processors, test-fixture, ingest, field-mapping, docs
- **Impact**: low

## Links

- **Issue**: (no issue number)
- **Issue title**: cisco_aironet.log [MISSING_CASE]: Processor 'grok' with tag 'grok_message_c41fbfd3' in pipeline 'logs-cisc…
- **Pipeline case**: `5a243ddd06caf754`
