### PR TITLE
[Cloud Asset Inventory] Add extra resource fields #2 (EKS & Route 53)

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -17,7 +17,7 @@
         publicly-accessible flag) and a normalized resource creation timestamp across all
         asset types emitted by cloudbeat.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0
+      link: https://github.com/elastic/integrations/pull/19795
 - version: "1.6.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,5 +1,6 @@
 # newer versions go on top
 # version map:
+# 1.7.x - 9.6.x
 # 1.6.x - 9.5.x
 # 1.5.x - 9.4.x
 # 1.4.x - 9.3.x
@@ -8,6 +9,15 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.7.0"
+  changes:
+    - description: >
+        Add entity.attributes (flattened) and entity.lifecycle.CreatedAt (date) field
+        mappings to support missing AWS fields (RDS engine/version, ELB DNS name,
+        publicly-accessible flag) and a normalized resource creation timestamp across all
+        asset types emitted by cloudbeat.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0
 - version: "1.6.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -18,7 +18,7 @@
         existing entity.attributes (flattened) and entity.lifecycle.CreatedAt mappings, so
         no new field mappings are required.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/0
+      link: https://github.com/elastic/integrations/pull/19963
 - version: "1.7.0"
   changes:
     - description: >

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,5 +1,6 @@
 # newer versions go on top
 # version map:
+# 1.8.x - 9.6.x
 # 1.7.x - 9.6.x
 # 1.6.x - 9.5.x
 # 1.5.x - 9.4.x
@@ -9,6 +10,15 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.8.0"
+  changes:
+    - description: >
+        Support the new AWS Route53 DNS record and EKS cluster asset types emitted by
+        cloudbeat, plus the additional EC2 and ELB attributes. These flow through the
+        existing entity.attributes (flattened) and entity.lifecycle.CreatedAt mappings, so
+        no new field mappings are required.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/0
 - version: "1.7.0"
   changes:
     - description: >

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -27,7 +27,7 @@
         publicly-accessible flag) and a normalized resource creation timestamp across all
         asset types emitted by cloudbeat.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/19795
+      link: https://github.com/elastic/integrations/pull/19963
 - version: "1.6.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
@@ -1,5 +1,5 @@
 - name: entity
-  type: group  
+  type: group
   fields:
   - name: id
     type: keyword
@@ -12,11 +12,21 @@
 
   - name: sub_type
     type: keyword
-  
+
   - name: source
     type: keyword
-  
+
   - name: raw
     type: flattened
 
-  
+  - name: attributes
+    type: flattened
+    description: >
+      Non-ECS resource-specific attributes (e.g. Engine, EngineVersion, DNSName,
+      PubliclyAccessible). Keys use UpperCamelCase per the non-ECS naming convention.
+
+  - name: lifecycle.CreatedAt
+    type: date
+    description: >
+      The timestamp at which the cloud resource was created, as reported by the
+      cloud provider. Non-ECS field; uses UpperCamelCase naming.

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
@@ -22,8 +22,13 @@
   - name: attributes
     type: flattened
     description: >
-      Non-ECS resource-specific attributes (e.g. Engine, EngineVersion, DNSName,
-      PubliclyAccessible). Keys use UpperCamelCase per the non-ECS naming convention.
+      Non-ECS resource-specific attributes. Examples: RDS Engine/EngineVersion; ELB
+      DNSName/PubliclyAccessible/LoadBalancerType/State/IPAddresses/OwnerTag; EC2
+      ImageId/Platform/VpcId/SubnetId/State; Route53 record Type/ResourceRecords/ZoneID/
+      ZoneName/AliasTargetDNS/HealthCheckId; EKS Status/Version/Endpoint/RoleArn/
+      PlatformVersion/EndpointPublicAccess/EndpointPrivateAccess. As a flattened field this
+      accepts new keys without a mapping change. Keys use UpperCamelCase per the non-ECS
+      naming convention.
 
   - name: lifecycle.CreatedAt
     type: date

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.6.0"
+version: "1.7.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.7.0"
+version: "1.8.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"


### PR DESCRIPTION
## Summary

Follow-up to #19795, supporting the two new AWS asset types cloudbeat now emits: **Route53 DNS records** and **EKS clusters** (plus additional EC2 and ELB attributes).

No new mappings are required — these flow through fields already added in 1.7.0:
- `entity.attributes` (`type: flattened`) absorbs all new resource-specific keys (Route53 `Type`/`ResourceRecords`/`ZoneID`/…, EKS `Status`/`Version`/`Endpoint`/…, EC2/ELB extras) without a mapping change.
- `entity.lifecycle.CreatedAt` (`type: date`) carries the EKS cluster creation time.
- `entity.type` / `entity.sub_type` (`keyword`) hold the new asset-type values.

Changes:
- Enriched the `entity.attributes` description with the new example keys
- Version bumped `1.7.0` → `1.8.0`

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)


## Related issues

- Closes https://github.com/elastic/security-team/issues/17750
- Related cloudbeat PR: https://github.com/elastic/cloudbeat/pull/7183
