### PR TITLE
[OTel] [AWS] Extend AWS ELB support to cover Classic LB, Network LB, GatewayLB

### DIFF
--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Add policy templates for Classic Load Balancer, Network Load Balancer and Gateway Load Balancer. The existing `aws.elb` template now covers Application Load Balancers only.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.4.0"
   changes:
     - description: Add `recently_active` option to restrict metric discovery to metrics active in the last three hours.

--- a/packages/aws_cloudwatch_input_otel/changelog.yml
+++ b/packages/aws_cloudwatch_input_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add policy templates for Classic Load Balancer, Network Load Balancer and Gateway Load Balancer. The existing `aws.elb` template now covers Application Load Balancers only.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/19988
 - version: "0.4.0"
   changes:
     - description: Add `recently_active` option to restrict metric discovery to metrics active in the last three hours.

--- a/packages/aws_cloudwatch_input_otel/manifest.yml
+++ b/packages/aws_cloudwatch_input_otel/manifest.yml
@@ -1,10 +1,10 @@
 format_version: 3.5.0
 name: aws_cloudwatch_input_otel
 title: "AWS CloudWatch (OpenTelemetry)"
-version: 0.4.0
+version: 0.5.0
 source:
   license: "Elastic-2.0"
-description: "Collect AWS CloudWatch metrics for selected AWS services (EC2, RDS, SQS, ELB, Lambda, Fargate) using the OpenTelemetry Collector awscloudwatch receiver."
+description: "Collect AWS CloudWatch metrics for selected AWS services (EC2, RDS, SQS, ELB — Application, Classic, Network, Gateway — Lambda, Fargate) using the OpenTelemetry Collector awscloudwatch receiver."
 type: input
 categories:
   - aws
@@ -319,8 +319,8 @@ policy_templates:
 
   - name: aws.elb
     type: metrics
-    title: AWS Application ELB OpenTelemetry Metrics
-    description: Collect AWS/ApplicationELB CloudWatch metrics.
+    title: AWS Application Load Balancer (ALB) OpenTelemetry Metrics
+    description: Collect AWS/ApplicationELB CloudWatch metrics for Application Load Balancers.
     input: otelcol
     template_path: input.yml.hbs
     icons:
@@ -341,7 +341,189 @@ policy_templates:
         type: integer
         title: Autodiscover Limit
         description: Maximum number of metrics to enumerate for this namespace. Higher values pick up more metrics but cost more API calls.
-        default: 100
+        default: 250
+        required: false
+        show_user: false
+      - name: collection_interval
+        type: duration
+        title: Collection Interval
+        description: How often the receiver polls CloudWatch.
+        default: 1m
+        required: false
+        show_user: false
+      - name: period
+        type: duration
+        title: Period
+        description: CloudWatch aggregation window. Must match the metric resolution.
+        default: 1m
+        required: false
+        show_user: true
+      - name: delay
+        type: duration
+        title: Delay
+        description: How far back from now each scrape's query window ends. Increase if metrics arrive late from CloudWatch.
+        default: 5m
+        required: false
+        show_user: false
+      - name: autodiscover_aggregation
+        type: text
+        multi: true
+        title: Aggregation Statistics
+        description: CloudWatch statistics applied to every discovered metric for this namespace.
+        default:
+          - Maximum
+          - Average
+          - Sum
+        required: true
+        show_user: false
+
+  - name: aws.elb_classic
+    type: metrics
+    title: AWS Classic Load Balancer (CLB) OpenTelemetry Metrics
+    description: Collect AWS/ELB CloudWatch metrics for Classic Load Balancers (legacy HTTP/TCP layer 4+7).
+    input: otelcol
+    template_path: input.yml.hbs
+    icons:
+      - src: /img/logo_elb.svg
+        title: AWS ELB logo
+        size: 32x32
+        type: image/svg+xml
+    deployment_modes: *deployment_modes
+    vars:
+      - name: namespace
+        type: text
+        title: CloudWatch Namespace
+        description: CloudWatch namespace this template scrapes. Fixed per service.
+        default: "AWS/ELB"
+        required: true
+        show_user: false
+      - name: autodiscover_limit
+        type: integer
+        title: Autodiscover Limit
+        description: Maximum number of metrics to enumerate for this namespace. Higher values pick up more metrics but cost more API calls.
+        default: 250
+        required: false
+        show_user: false
+      - name: collection_interval
+        type: duration
+        title: Collection Interval
+        description: How often the receiver polls CloudWatch.
+        default: 1m
+        required: false
+        show_user: false
+      - name: period
+        type: duration
+        title: Period
+        description: CloudWatch aggregation window. Must match the metric resolution.
+        default: 1m
+        required: false
+        show_user: true
+      - name: delay
+        type: duration
+        title: Delay
+        description: How far back from now each scrape's query window ends. Increase if metrics arrive late from CloudWatch.
+        default: 5m
+        required: false
+        show_user: false
+      - name: autodiscover_aggregation
+        type: text
+        multi: true
+        title: Aggregation Statistics
+        description: CloudWatch statistics applied to every discovered metric for this namespace.
+        default:
+          - Maximum
+          - Average
+          - Sum
+        required: true
+        show_user: false
+
+  - name: aws.elb_network
+    type: metrics
+    title: AWS Network Load Balancer (NLB) OpenTelemetry Metrics
+    description: Collect AWS/NetworkELB CloudWatch metrics for Network Load Balancers.
+    input: otelcol
+    template_path: input.yml.hbs
+    icons:
+      - src: /img/logo_elb.svg
+        title: AWS ELB logo
+        size: 32x32
+        type: image/svg+xml
+    deployment_modes: *deployment_modes
+    vars:
+      - name: namespace
+        type: text
+        title: CloudWatch Namespace
+        description: CloudWatch namespace this template scrapes. Fixed per service.
+        default: "AWS/NetworkELB"
+        required: true
+        show_user: false
+      - name: autodiscover_limit
+        type: integer
+        title: Autodiscover Limit
+        description: >-
+          Maximum number of metrics to enumerate for this namespace.
+          NLB can have 200+ metric/dimension combinations — set this higher than the default if metrics are missing.
+        default: 250
+        required: false
+        show_user: false
+      - name: collection_interval
+        type: duration
+        title: Collection Interval
+        description: How often the receiver polls CloudWatch.
+        default: 1m
+        required: false
+        show_user: false
+      - name: period
+        type: duration
+        title: Period
+        description: CloudWatch aggregation window. Must match the metric resolution.
+        default: 1m
+        required: false
+        show_user: true
+      - name: delay
+        type: duration
+        title: Delay
+        description: How far back from now each scrape's query window ends. Increase if metrics arrive late from CloudWatch.
+        default: 5m
+        required: false
+        show_user: false
+      - name: autodiscover_aggregation
+        type: text
+        multi: true
+        title: Aggregation Statistics
+        description: CloudWatch statistics applied to every discovered metric for this namespace.
+        default:
+          - Maximum
+          - Average
+          - Sum
+        required: true
+        show_user: false
+
+  - name: aws.elb_gateway
+    type: metrics
+    title: AWS Gateway Load Balancer (GWLB) OpenTelemetry Metrics
+    description: Collect AWS/GatewayELB CloudWatch metrics for Gateway Load Balancers.
+    input: otelcol
+    template_path: input.yml.hbs
+    icons:
+      - src: /img/logo_elb.svg
+        title: AWS ELB logo
+        size: 32x32
+        type: image/svg+xml
+    deployment_modes: *deployment_modes
+    vars:
+      - name: namespace
+        type: text
+        title: CloudWatch Namespace
+        description: CloudWatch namespace this template scrapes. Fixed per service.
+        default: "AWS/GatewayELB"
+        required: true
+        show_user: false
+      - name: autodiscover_limit
+        type: integer
+        title: Autodiscover Limit
+        description: Maximum number of metrics to enumerate for this namespace. Higher values pick up more metrics but cost more API calls.
+        default: 250
         required: false
         show_user: false
       - name: collection_interval


### PR DESCRIPTION

- Enhancement

## Proposed commit message

Add Classic, Network, and Gateway Load Balancer support to AWS CloudWatch OTel input

Extend the aws_cloudwatch_input_otel package with three new policy
templates — aws.elb_classic (AWS/ELB), aws.elb_network (AWS/NetworkELB),
and aws.elb_gateway (AWS/GatewayELB) — so all four ELB types can be
collected from a single integration.

Set autodiscover_limit to 250 for every ELB template to prevent the
silent metric truncation we observed when the default of 100 was exceeded
(NLB alone produced 189 metric/dimension combinations with just 5 load
balancers).


## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

- [x] Package upgrading testing
- [x] Integration testing  

## How to test this PR locally

- `elastic-package build && elastic-package stack up -v -d --services package-registry`

## Screenshots


### Discover view 

<img width="2315" height="1234" alt="image" src="https://github.com/user-attachments/assets/b33616b9-abfe-411b-bb6c-cb0208f3f2b8" />


### Configuration interface

<img width="857" height="860" alt="image" src="https://github.com/user-attachments/assets/108af368-faf7-4695-b3bc-ed9a81cf60bd" />

