### PR TITLE
aws: derive OTel-compatible trace.id from X-Ray trace ID in elb_logs

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "6.21.1"
+  changes:
+    - description: Derive the OpenTelemetry-compatible 32-character hex `trace.id` from the X-Ray format trace ID in ELB access logs, enabling correlation with APM traces.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/20000
 - version: "6.21.0"
   changes:
     - description: Poll Amazon Inspector findings on `updatedAt` instead of `lastObservedAt` so that findings AWS marks CLOSED or SUPPRESSED are collected and no longer remain stale in Elastic.

--- a/packages/aws/data_stream/elb_logs/_dev/test/pipeline/test-alb.log-expected.json
+++ b/packages/aws/data_stream/elb_logs/_dev/test/pipeline/test-alb.log-expected.json
@@ -82,7 +82,7 @@
                 "preserve_original_event"
             ],
             "trace": {
-                "id": "Root=1-58337262-36d228ad5d99923122bbe354"
+                "id": "5833726236d228ad5d99923122bbe354"
             },
             "url": {
                 "domain": "www.example.com",
@@ -172,7 +172,7 @@
                 "preserve_original_event"
             ],
             "trace": {
-                "id": "Root=1-627cac19-4c6df30820daa80e3fd72ced"
+                "id": "627cac194c6df30820daa80e3fd72ced"
             },
             "url": {
                 "domain": "127.0.0.1",

--- a/packages/aws/data_stream/elb_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/elb_logs/elasticsearch/ingest_pipeline/default.yml
@@ -173,11 +173,24 @@ processors:
       field: event.outcome
       value: failure
       if: 'ctx?.http?.response?.status_code != null && ctx.http.response.status_code >= 400'
-  - set:
-      tag: set_trace_id_53565e4a
-      field: trace.id
-      value: '{{aws.elb.trace_id}}'
+  - script:
+      tag: script_derive_trace_id_from_xray
+      lang: painless
+      description: Derive the OpenTelemetry-compatible trace ID from the X-Ray format trace ID (Root=1-{8 hex}-{24 hex}) so ELB access logs and APM spans share the same trace.id. Falls back to the raw value for unrecognized formats.
       if: ctx?.aws?.elb?.trace_id != null
+      source: |-
+        String traceId = ctx.aws.elb.trace_id;
+        String root = traceId.splitOnToken(';')[0];
+        if (root.startsWith('Root=1-')) {
+          String[] parts = root.substring(7).splitOnToken('-');
+          if (parts.length == 2 && parts[0].length() == 8 && parts[1].length() == 24) {
+            traceId = parts[0] + parts[1];
+          }
+        }
+        if (ctx.trace == null) {
+          ctx.trace = new HashMap();
+        }
+        ctx.trace.id = traceId;
   - split:
       tag: split__tmp_actions_executed_to_aws_elb_action_executed_2b54cfea
       field: _tmp.actions_executed

--- a/packages/aws/data_stream/elb_logs/sample_event.json
+++ b/packages/aws/data_stream/elb_logs/sample_event.json
@@ -121,7 +121,7 @@
         "aws-elb-logs"
     ],
     "trace": {
-        "id": "Root=1-58337262-36d228ad5d99923122bbe354"
+        "id": "5833726236d228ad5d99923122bbe354"
     },
     "url": {
         "domain": "www.example.com",

--- a/packages/aws/docs/elb.md
+++ b/packages/aws/docs/elb.md
@@ -275,7 +275,7 @@ An example event for `elb` looks as following:
         "aws-elb-logs"
     ],
     "trace": {
-        "id": "Root=1-58337262-36d228ad5d99923122bbe354"
+        "id": "5833726236d228ad5d99923122bbe354"
     },
     "url": {
         "domain": "www.example.com",

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: aws
 title: AWS
-version: 6.21.0
+version: 6.21.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

aws: derive OTel-compatible trace.id from X-Ray trace ID in elb_logs

WHAT: The `elb_logs` ingest pipeline copied the raw ALB access log trace field (`Root=1-{8 hex}-{24 hex}[;Self=...]`) into ECS `trace.id` verbatim. This change replaces the verbatim `set` processor with a Painless script that strips the `Root=1-` prefix, drops any `;Self=`/`;Parent=` segments, and concatenates the two hex segments into the OpenTelemetry/ECS 32-character hex form. Values that don't match the X-Ray v1 format fall back to the previous raw-copy behavior. The raw value remains available unchanged in `aws.elb.trace_id`.

WHY: APM agents using the X-Ray propagator (OTel `xray`, AWS X-Ray SDKs) derive a 32-character hex `trace_id` from the same `X-Amzn-Trace-Id` header the ALB writes to its access log. Because the pipeline stored the raw `Root=1-...` string, the two values never matched, so ELB access logs could not be correlated with application traces on `trace.id` in Kibana. With this change, a request that traverses an ALB lands on the same `trace.id` in both the access log and the application spans.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] Pipeline test expectations (`test-alb.log-expected.json`), `sample_event.json`, and generated docs were updated by hand with the deterministic transform (`Root=1-58337262-36d2...` → `5833726236d2...`); please confirm CI pipeline tests regenerate identically.
- [ ] Confirm behavior change to `trace.id` is acceptable as a minor version bump (raw value still preserved in `aws.elb.trace_id`).

## How to test this PR locally

```
cd packages/aws
elastic-package stack up -d
elastic-package test pipeline --data-streams elb_logs -v
```

An ALB log line containing `"Root=1-58337262-36d228ad5d99923122bbe354"` should produce `trace.id: 5833726236d228ad5d99923122bbe354` while `aws.elb.trace_id` retains the raw value. This matches the trace ID derivation performed by the OTel `xray` propagator, e.g. following https://opentelemetry.io/docs/languages/java/configuration/ with `OTEL_PROPAGATORS=xray`.

## Related issues

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)