### PR TITLE
mimecast: apply grace period to threat intel feed end timestamp

### DIFF
--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.4"
+  changes:
+    - description: Apply grace period to threat intel feed end timestamp to avoid Mimecast API rejecting requests due to clock skew.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20001
 - version: "3.4.3"
   changes:
     - description: Use the ECS definition for email.attachments.

--- a/packages/mimecast/data_stream/threat_intel_malware_customer/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/threat_intel_malware_customer/agent/stream/cel.yml.hbs
@@ -12,6 +12,7 @@ state:
   client_secret: {{client_secret}}
   page_size: {{batch_size}}
   look_back: {{initial_interval}}
+  end_grace: 1m
   path: /api/ttp/threat-intel/get-feed
   feed_type: malware_customer
 redact:
@@ -67,7 +68,7 @@ program: |
           ?"start": has(state.?cursor.token) ? optional.none() :
             optional.of(state.?cursor.last.orValue((now - duration(state.look_back)).format(time_layout.RFC3339))),
           ?"end": has(state.?cursor.token) ? optional.none() :
-            optional.of(now.format(time_layout.RFC3339)),
+            optional.of((now - duration(state.end_grace)).format(time_layout.RFC3339)),
           "feedType": state.feed_type,
           ?"token": state.?cursor.token,
           "fileType": "stix",
@@ -102,7 +103,7 @@ program: |
                     (size(times) > 0) ?
                       times.max()
                     :
-                      now
+                      now - duration(state.end_grace)
                   ).format(time_layout.RFC3339)
                 ),
                 ?"token": resp.?Header["X-Mc-Threat-Feed-Next-Token"][0],

--- a/packages/mimecast/data_stream/threat_intel_malware_customer/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/threat_intel_malware_customer/agent/stream/httpjson.yml.hbs
@@ -9,8 +9,8 @@ request.tracer:
 request.transforms:
 - set:
     target: body.data
-    value: '[{"feedType": "malware_customer","fileType": "stix","compress": false,"token": "[[.last_response.header.Get "x-mc-threat-feed-next-token"]]", "end": "[[formatDate (now) "2006-01-02T15:04:05-0700"]]", "start":"[[formatDate (.cursor.next_date)  "2006-01-02T15:04:05-0700"]]"}]'
-    default: '[{"feedType": "malware_customer","fileType": "stix","compress": false,"end": "[[formatDate (now) "2006-01-02T15:04:05-0700"]]", "start":"[[formatDate (now (parseDuration "-{{interval}}")) "2006-01-02T15:04:05-0700"]]"}]'          
+    value: '[{"feedType": "malware_customer","fileType": "stix","compress": false,"token": "[[.last_response.header.Get "x-mc-threat-feed-next-token"]]", "end": "[[formatDate (now (parseDuration "-1m")) "2006-01-02T15:04:05-0700"]]", "start":"[[formatDate (.cursor.next_date)  "2006-01-02T15:04:05-0700"]]"}]'
+    default: '[{"feedType": "malware_customer","fileType": "stix","compress": false,"end": "[[formatDate (now (parseDuration "-1m")) "2006-01-02T15:04:05-0700"]]", "start":"[[formatDate (now (parseDuration "-{{interval}}")) "2006-01-02T15:04:05-0700"]]"}]'          
     value_type: json
 - set:
     target: header.x-mc-app-id

--- a/packages/mimecast/data_stream/threat_intel_malware_customer/manifest.yml
+++ b/packages/mimecast/data_stream/threat_intel_malware_customer/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s. Minimum is 2m.
         multi: false
         required: true
         show_user: false
@@ -62,7 +62,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s. Minimum is 2m.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/data_stream/threat_intel_malware_grid/agent/stream/cel.yml.hbs
+++ b/packages/mimecast/data_stream/threat_intel_malware_grid/agent/stream/cel.yml.hbs
@@ -12,6 +12,7 @@ state:
   client_secret: {{client_secret}}
   page_size: {{batch_size}}
   look_back: {{initial_interval}}
+  end_grace: 1m
   path: /api/ttp/threat-intel/get-feed
   feed_type: malware_grid
 redact:
@@ -67,7 +68,7 @@ program: |
           ?"start": has(state.?cursor.token) ? optional.none() :
             optional.of(state.?cursor.last.orValue((now - duration(state.look_back)).format(time_layout.RFC3339))),
           ?"end": has(state.?cursor.token) ? optional.none() :
-            optional.of(now.format(time_layout.RFC3339)),
+            optional.of((now - duration(state.end_grace)).format(time_layout.RFC3339)),
           "feedType": state.feed_type,
           ?"token": state.?cursor.token,
           "fileType": "stix",
@@ -102,7 +103,7 @@ program: |
                     (size(times) > 0) ?
                       times.max()
                     :
-                      now
+                      now - duration(state.end_grace)
                   ).format(time_layout.RFC3339)
                 ),
                 ?"token": resp.?Header["X-Mc-Threat-Feed-Next-Token"][0],

--- a/packages/mimecast/data_stream/threat_intel_malware_grid/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/threat_intel_malware_grid/agent/stream/httpjson.yml.hbs
@@ -9,8 +9,8 @@ request.tracer:
 request.transforms:
 - set:
     target: body.data
-    value: '[{"feedType": "malware_grid","fileType": "stix","compress": false,"token": "[[.last_response.header.Get "x-mc-threat-feed-next-token"]]", "end": "[[formatDate (now) "2006-01-02T15:04:05-0700"]]", "start":"[[formatDate (.cursor.next_date)  "2006-01-02T15:04:05-0700"]]"}]'
-    default: '[{"feedType": "malware_grid","fileType": "stix","compress": false,"end": "[[formatDate (now) "2006-01-02T15:04:05-0700"]]", "start":"[[formatDate (now (parseDuration "-{{interval}}")) "2006-01-02T15:04:05-0700"]]"}]'          
+    value: '[{"feedType": "malware_grid","fileType": "stix","compress": false,"token": "[[.last_response.header.Get "x-mc-threat-feed-next-token"]]", "end": "[[formatDate (now (parseDuration "-1m")) "2006-01-02T15:04:05-0700"]]", "start":"[[formatDate (.cursor.next_date)  "2006-01-02T15:04:05-0700"]]"}]'
+    default: '[{"feedType": "malware_grid","fileType": "stix","compress": false,"end": "[[formatDate (now (parseDuration "-1m")) "2006-01-02T15:04:05-0700"]]", "start":"[[formatDate (now (parseDuration "-{{interval}}")) "2006-01-02T15:04:05-0700"]]"}]'          
     value_type: json
 - set:
     target: header.x-mc-app-id

--- a/packages/mimecast/data_stream/threat_intel_malware_grid/manifest.yml
+++ b/packages/mimecast/data_stream/threat_intel_malware_grid/manifest.yml
@@ -9,7 +9,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s. Minimum is 2m.
         multi: false
         required: true
         show_user: false
@@ -62,7 +62,7 @@ streams:
       - name: interval
         type: text
         title: Interval
-        description: Duration between requests to the API. Supported units for this parameter are h/m/s.
+        description: Duration between requests to the API. Supported units for this parameter are h/m/s. Minimum is 2m.
         multi: false
         required: true
         show_user: false

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.3.2"
 name: mimecast
 title: "Mimecast"
-version: "3.4.3"
+version: "3.4.4"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
mimecast: apply grace period to threat intel feed end timestamp

The Mimecast /api/ttp/threat-intel/get-feed endpoint rejects requests
where the end timestamp is at or beyond its server's current time,
returning err_validation_enddate_in_the_future. Because the integration
was sending end=now(), any clock skew between the agent host and
Mimecast's servers could trigger persistent failures.

Subtract a 1-minute grace period from now when computing the end
timestamp for both the CEL and httpjson input types. The CEL programs
hold the grace value in a state field (end_grace) so it can be made
user-configurable later if needed. The cursor fallback is also
adjusted to match the collection window so events in the grace period
are not skipped on the next cycle.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
