### PR TITLE
[Osquery_manager] Add pack_name and query_name fields for scheduled queries

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.1"
+  changes:
+    - description: Add `pack_name` and `query_name` fields to the result and action_responses data streams for scheduled pack queries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/51782
 - version: "1.30.0"
   changes:
     - description: Add Process_open_handles query and pack

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -4,6 +4,9 @@
     - description: Add `pack_name` and `query_name` fields to the result and action_responses data streams for scheduled pack queries.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/20017
+    - description: Update legacy pack dashboards and saved searches to also match scheduled queries by `pack_name` and `query_name` instead of `action_id` only.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20017
 - version: "1.30.0"
   changes:
     - description: Add Process_open_handles query and pack

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `pack_name` and `query_name` fields to the result and action_responses data streams for scheduled pack queries.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/51782
+      link: https://github.com/elastic/integrations/pull/20017
 - version: "1.30.0"
   changes:
     - description: Add Process_open_handles query and pack

--- a/packages/osquery_manager/data_stream/action_responses/fields/action-responses.yml
+++ b/packages/osquery_manager/data_stream/action_responses/fields/action-responses.yml
@@ -32,6 +32,14 @@
   type: keyword
   ignore_above: 1024
   description: Pack identifier for scheduled queries that belong to a pack.
+- name: pack_name
+  type: keyword
+  ignore_above: 1024
+  description: Human-readable pack name for scheduled queries that belong to a pack.
+- name: query_name
+  type: keyword
+  ignore_above: 1024
+  description: Query name (the pack's queries config map key) for scheduled queries that belong to a pack.
 - name: response_id
   type: keyword
   ignore_above: 1024

--- a/packages/osquery_manager/data_stream/action_responses/fields/action-responses.yml
+++ b/packages/osquery_manager/data_stream/action_responses/fields/action-responses.yml
@@ -39,7 +39,7 @@
 - name: query_name
   type: keyword
   ignore_above: 1024
-  description: Query name (the pack's queries config map key) for scheduled queries that belong to a pack.
+  description: Query name for scheduled queries. For pack queries this is the pack's queries config map key; for top-level scheduled queries it is the schedule config map key. Absent for live queries.
 - name: response_id
   type: keyword
   ignore_above: 1024

--- a/packages/osquery_manager/data_stream/result/fields/primary-fields.yml
+++ b/packages/osquery_manager/data_stream/result/fields/primary-fields.yml
@@ -9,9 +9,11 @@
   description: Pack identifier for scheduled queries that belong to a pack.
 - name: pack_name
   type: keyword
+  ignore_above: 1024
   description: Human-readable pack name for scheduled queries that belong to a pack.
 - name: query_name
   type: keyword
+  ignore_above: 1024
   description: Query name for scheduled queries. For pack queries this is the pack's queries config map key; for top-level scheduled queries it is the schedule config map key. Absent for live queries.
 - name: response_id
   type: keyword

--- a/packages/osquery_manager/data_stream/result/fields/primary-fields.yml
+++ b/packages/osquery_manager/data_stream/result/fields/primary-fields.yml
@@ -12,7 +12,7 @@
   description: Human-readable pack name for scheduled queries that belong to a pack.
 - name: query_name
   type: keyword
-  description: Query name (the pack's queries config map key) for scheduled queries that belong to a pack.
+  description: Query name for scheduled queries. For pack queries this is the pack's queries config map key; for top-level scheduled queries it is the schedule config map key. Absent for live queries.
 - name: response_id
   type: keyword
   description: Query response id. Present only for scheduled queries.

--- a/packages/osquery_manager/data_stream/result/fields/primary-fields.yml
+++ b/packages/osquery_manager/data_stream/result/fields/primary-fields.yml
@@ -7,6 +7,12 @@
 - name: pack_id
   type: keyword
   description: Pack identifier for scheduled queries that belong to a pack.
+- name: pack_name
+  type: keyword
+  description: Human-readable pack name for scheduled queries that belong to a pack.
+- name: query_name
+  type: keyword
+  description: Query name (the pack's queries config map key) for scheduled queries that belong to a pack.
 - name: response_id
   type: keyword
   description: Query response id. Present only for scheduled queries.

--- a/packages/osquery_manager/kibana/dashboard/osquery_manager-69f5ae20-eb02-11e7-8f04-51231daa5b05.json
+++ b/packages/osquery_manager/kibana/dashboard/osquery_manager-69f5ae20-eb02-11e7-8f04-51231daa5b05.json
@@ -428,20 +428,40 @@
                                             },
                                             {
                                                 "meta": {
-                                                    "alias": null,
+                                                    "alias": "it-compliance / mounts",
                                                     "disabled": false,
-                                                    "field": "action_id",
                                                     "index": "logs-*",
-                                                    "key": "action_id",
+                                                    "key": "query",
                                                     "negate": false,
-                                                    "params": {
-                                                        "query": "pack_it-compliance_mounts"
-                                                    },
-                                                    "type": "phrase"
+                                                    "type": "custom",
+                                                    "value": "{\"bool\":{\"minimum_should_match\":1,\"should\":[{\"match_phrase\":{\"action_id\":\"pack_it-compliance_mounts\"}},{\"bool\":{\"filter\":[{\"match_phrase\":{\"pack_name\":\"it-compliance\"}},{\"match_phrase\":{\"query_name\":\"mounts\"}}]}}]}}"
                                                 },
                                                 "query": {
-                                                    "match_phrase": {
-                                                        "action_id": "pack_it-compliance_mounts"
+                                                    "bool": {
+                                                        "minimum_should_match": 1,
+                                                        "should": [
+                                                            {
+                                                                "match_phrase": {
+                                                                    "action_id": "pack_it-compliance_mounts"
+                                                                }
+                                                            },
+                                                            {
+                                                                "bool": {
+                                                                    "filter": [
+                                                                        {
+                                                                            "match_phrase": {
+                                                                                "pack_name": "it-compliance"
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "match_phrase": {
+                                                                                "query_name": "mounts"
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             }
@@ -656,20 +676,40 @@
                                             },
                                             {
                                                 "meta": {
-                                                    "alias": null,
+                                                    "alias": "it-compliance / kernel_integrations",
                                                     "disabled": false,
-                                                    "field": "action_id",
                                                     "index": "logs-*",
-                                                    "key": "action_id",
+                                                    "key": "query",
                                                     "negate": false,
-                                                    "params": {
-                                                        "query": "pack_it-compliance_kernel_integrations"
-                                                    },
-                                                    "type": "phrase"
+                                                    "type": "custom",
+                                                    "value": "{\"bool\":{\"minimum_should_match\":1,\"should\":[{\"match_phrase\":{\"action_id\":\"pack_it-compliance_kernel_integrations\"}},{\"bool\":{\"filter\":[{\"match_phrase\":{\"pack_name\":\"it-compliance\"}},{\"match_phrase\":{\"query_name\":\"kernel_integrations\"}}]}}]}}"
                                                 },
                                                 "query": {
-                                                    "match_phrase": {
-                                                        "action_id": "pack_it-compliance_kernel_integrations"
+                                                    "bool": {
+                                                        "minimum_should_match": 1,
+                                                        "should": [
+                                                            {
+                                                                "match_phrase": {
+                                                                    "action_id": "pack_it-compliance_kernel_integrations"
+                                                                }
+                                                            },
+                                                            {
+                                                                "bool": {
+                                                                    "filter": [
+                                                                        {
+                                                                            "match_phrase": {
+                                                                                "pack_name": "it-compliance"
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "match_phrase": {
+                                                                                "query_name": "kernel_integrations"
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             }

--- a/packages/osquery_manager/kibana/dashboard/osquery_manager-c0a7ce90-f4aa-11e7-8647-534bb4c21040.json
+++ b/packages/osquery_manager/kibana/dashboard/osquery_manager-c0a7ce90-f4aa-11e7-8647-534bb4c21040.json
@@ -229,20 +229,29 @@
                                             },
                                             {
                                                 "meta": {
-                                                    "alias": null,
+                                                    "alias": "ossec-rootkit",
                                                     "disabled": false,
-                                                    "field": "action_id",
                                                     "index": "logs-*",
-                                                    "key": "action_id",
+                                                    "key": "query",
                                                     "negate": false,
-                                                    "params": {
-                                                        "query": "pack_ossec-rootkit"
-                                                    },
-                                                    "type": "phrase"
+                                                    "type": "custom",
+                                                    "value": "{\"bool\":{\"minimum_should_match\":1,\"should\":[{\"match_phrase\":{\"action_id\":\"pack_ossec-rootkit\"}},{\"match_phrase\":{\"pack_name\":\"ossec-rootkit\"}}]}}"
                                                 },
                                                 "query": {
-                                                    "match_phrase": {
-                                                        "action_id": "pack_ossec-rootkit"
+                                                    "bool": {
+                                                        "minimum_should_match": 1,
+                                                        "should": [
+                                                            {
+                                                                "match_phrase": {
+                                                                    "action_id": "pack_ossec-rootkit"
+                                                                }
+                                                            },
+                                                            {
+                                                                "match_phrase": {
+                                                                    "pack_name": "ossec-rootkit"
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             }
@@ -405,20 +414,29 @@
                                             },
                                             {
                                                 "meta": {
-                                                    "alias": null,
+                                                    "alias": "ossec-rootkit",
                                                     "disabled": false,
-                                                    "field": "action_id",
                                                     "index": "logs-*",
-                                                    "key": "action_id",
+                                                    "key": "query",
                                                     "negate": false,
-                                                    "params": {
-                                                        "query": "pack_ossec-rootkit"
-                                                    },
-                                                    "type": "phrase"
+                                                    "type": "custom",
+                                                    "value": "{\"bool\":{\"minimum_should_match\":1,\"should\":[{\"match_phrase\":{\"action_id\":\"pack_ossec-rootkit\"}},{\"match_phrase\":{\"pack_name\":\"ossec-rootkit\"}}]}}"
                                                 },
                                                 "query": {
-                                                    "match_phrase": {
-                                                        "action_id": "pack_ossec-rootkit"
+                                                    "bool": {
+                                                        "minimum_should_match": 1,
+                                                        "should": [
+                                                            {
+                                                                "match_phrase": {
+                                                                    "action_id": "pack_ossec-rootkit"
+                                                                }
+                                                            },
+                                                            {
+                                                                "match_phrase": {
+                                                                    "pack_name": "ossec-rootkit"
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             }

--- a/packages/osquery_manager/kibana/search/osquery_manager-0fe5dc00-f49b-11e7-8647-534bb4c21040.json
+++ b/packages/osquery_manager/kibana/search/osquery_manager-0fe5dc00-f49b-11e7-8647-534bb4c21040.json
@@ -44,20 +44,29 @@
                                 },
                                 {
                                     "meta": {
-                                        "alias": null,
+                                        "alias": "ossec-rootkit",
                                         "disabled": false,
-                                        "field": "action_id",
                                         "index": "logs-*",
-                                        "key": "action_id",
+                                        "key": "query",
                                         "negate": false,
-                                        "params": {
-                                            "query": "pack_ossec-rootkit"
-                                        },
-                                        "type": "phrase"
+                                        "type": "custom",
+                                        "value": "{\"bool\":{\"minimum_should_match\":1,\"should\":[{\"match_phrase\":{\"action_id\":\"pack_ossec-rootkit\"}},{\"match_phrase\":{\"pack_name\":\"ossec-rootkit\"}}]}}"
                                     },
                                     "query": {
-                                        "match_phrase": {
-                                            "action_id": "pack_ossec-rootkit"
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "action_id": "pack_ossec-rootkit"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "pack_name": "ossec-rootkit"
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 }

--- a/packages/osquery_manager/kibana/search/osquery_manager-3824b080-eb02-11e7-8f04-51231daa5b05.json
+++ b/packages/osquery_manager/kibana/search/osquery_manager-3824b080-eb02-11e7-8f04-51231daa5b05.json
@@ -44,20 +44,40 @@
                                 },
                                 {
                                     "meta": {
-                                        "alias": null,
+                                        "alias": "it-compliance / deb_packages",
                                         "disabled": false,
-                                        "field": "action_id",
                                         "index": "logs-*",
-                                        "key": "action_id",
+                                        "key": "query",
                                         "negate": false,
-                                        "params": {
-                                            "query": "pack_it-compliance_deb_packages"
-                                        },
-                                        "type": "phrase"
+                                        "type": "custom",
+                                        "value": "{\"bool\":{\"minimum_should_match\":1,\"should\":[{\"match_phrase\":{\"action_id\":\"pack_it-compliance_deb_packages\"}},{\"bool\":{\"filter\":[{\"match_phrase\":{\"pack_name\":\"it-compliance\"}},{\"match_phrase\":{\"query_name\":\"deb_packages\"}}]}}]}}"
                                     },
                                     "query": {
-                                        "match_phrase": {
-                                            "action_id": "pack_it-compliance_deb_packages"
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "action_id": "pack_it-compliance_deb_packages"
+                                                    }
+                                                },
+                                                {
+                                                    "bool": {
+                                                        "filter": [
+                                                            {
+                                                                "match_phrase": {
+                                                                    "pack_name": "it-compliance"
+                                                                }
+                                                            },
+                                                            {
+                                                                "match_phrase": {
+                                                                    "query_name": "deb_packages"
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 }

--- a/packages/osquery_manager/kibana/search/osquery_manager-7a9482d0-eb00-11e7-8f04-51231daa5b05.json
+++ b/packages/osquery_manager/kibana/search/osquery_manager-7a9482d0-eb00-11e7-8f04-51231daa5b05.json
@@ -44,20 +44,40 @@
                                 },
                                 {
                                     "meta": {
-                                        "alias": null,
+                                        "alias": "it-compliance / mounts",
                                         "disabled": false,
-                                        "field": "action_id",
                                         "index": "logs-*",
-                                        "key": "action_id",
+                                        "key": "query",
                                         "negate": false,
-                                        "params": {
-                                            "query": "pack_it-compliance_mounts"
-                                        },
-                                        "type": "phrase"
+                                        "type": "custom",
+                                        "value": "{\"bool\":{\"minimum_should_match\":1,\"should\":[{\"match_phrase\":{\"action_id\":\"pack_it-compliance_mounts\"}},{\"bool\":{\"filter\":[{\"match_phrase\":{\"pack_name\":\"it-compliance\"}},{\"match_phrase\":{\"query_name\":\"mounts\"}}]}}]}}"
                                     },
                                     "query": {
-                                        "match_phrase": {
-                                            "action_id": "pack_it-compliance_mounts"
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "action_id": "pack_it-compliance_mounts"
+                                                    }
+                                                },
+                                                {
+                                                    "bool": {
+                                                        "filter": [
+                                                            {
+                                                                "match_phrase": {
+                                                                    "pack_name": "it-compliance"
+                                                                }
+                                                            },
+                                                            {
+                                                                "match_phrase": {
+                                                                    "query_name": "mounts"
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 }

--- a/packages/osquery_manager/kibana/search/osquery_manager-b5d6baa0-eb02-11e7-8f04-51231daa5b05.json
+++ b/packages/osquery_manager/kibana/search/osquery_manager-b5d6baa0-eb02-11e7-8f04-51231daa5b05.json
@@ -6,7 +6,7 @@
         "description": "",
         "hits": 0,
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"action_id:pack_it-compliance_os_version\"},\"version\":true}"
+            "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"action_id:\\\"pack_it-compliance_os_version\\\" or (pack_name:\\\"it-compliance\\\" and query_name:\\\"os_version\\\")\"},\"version\":true}"
         },
         "sort": [
             [

--- a/packages/osquery_manager/kibana/search/osquery_manager-f59e21e0-eb03-11e7-8f04-51231daa5b05.json
+++ b/packages/osquery_manager/kibana/search/osquery_manager-f59e21e0-eb03-11e7-8f04-51231daa5b05.json
@@ -8,7 +8,7 @@
         "description": "",
         "hits": 0,
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"action_id:pack_it-compliance_kernel_integrations\"},\"version\":true}"
+            "searchSourceJSON": "{\"filter\":[],\"highlightAll\":true,\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"action_id:\\\"pack_it-compliance_kernel_integrations\\\" or (pack_name:\\\"it-compliance\\\" and query_name:\\\"kernel_integrations\\\")\"},\"version\":true}"
         },
         "sort": [
             [

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.8
 name: osquery_manager
 title: Osquery Manager
-version: 1.30.0
+version: 1.30.1
 description: Deploy Osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
 categories:


### PR DESCRIPTION
<!--
Type of change: bugfix
-->

## What does this PR do?

Adds two keyword fields to the `osquery_manager` package data streams:

- `pack_name` — human-readable pack name for scheduled queries that belong to a pack.
- `query_name` — the query name (the pack's `queries` config map key) for scheduled queries that belong to a pack.

Both fields are added to:
- `data_stream/result` (`primary-fields.yml`) — osquery result documents.
- `data_stream/action_responses` (`action-responses.yml`) — synthetic scheduled response documents.

The legacy pack dashboards and saved searches (Compliance pack, OSSEC rootkit pack) previously matched scheduled queries by `action_id` only. They are updated to match `action_id` **OR** (`pack_name` **AND** `query_name`) so they keep working for both legacy documents and documents produced after the beats change.

Package version bumped `1.30.0` → `1.30.1` with `bugfix` changelog entries.

## Why is it important?

Osquerybeat now emits `pack_name` and `query_name` on scheduled pack query result and response documents (companion change on the beats side), and no longer sets `action_id` for scheduled queries. The Osquery Manager dashboards group and label scheduled query results by pack and query name; without mappings for these fields and updated filters, the dashboards cannot render those results correctly.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to the [Kibana version support policy](https://github.com/elastic/integrations/blob/main/docs/kibana_version_support_policy.md).

## How to test this PR locally

1. Build the package (`elastic-package build`) and boot the stack (`elastic-package stack up -d`).
2. Install the package (`elastic-package install`).
3. Ingest scheduled pack query documents in both shapes into `logs-osquery_manager.result-default`:
   - legacy: `action_id: "pack_<pack>_<query>"`
   - new: `pack_name`, `query_name`, `schedule_id` (no `action_id`), with realistic `osquery.*` fields per query.
4. Open the two dashboards and the five saved searches and confirm both legacy and new documents are matched.

## Verification performed

Verified against a local `elastic-package` stack (Elasticsearch/Kibana `9.5.0-SNAPSHOT`) with package `1.30.1` installed. Realistic per-query documents were ingested in both shapes (legacy `action_id` and new `pack_name`+`query_name` with `action_id` absent), then the dashboards and saved searches were driven headlessly with Playwright.

Saved searches (Discover) — each returns both shapes with the expected columns populated:

| Saved search | Docs (legacy + new) | Filter type |
| --- | --- | --- |
| Mounts | 6 (3 + 3) | custom `bool.should` |
| DEB packages installed | 6 (3 + 3) | custom `bool.should` |
| OSSEC Rootkits | 6 (3 + 3) | custom `bool.should` |
| OS versions | 4 (2 + 2) | KQL OR |
| Kernel integrations | 4 (2 + 2) | KQL OR |

Dashboards — **0 "No results" panels and 0 panel errors** on both:
- **OSSEC rootkit pack** — the "hosts infected" metric counts both legacy and new hosts; the embedded search shows legacy rows (`action_id = pack_ossec-rootkit`) and new rows (`action_id = (null)`, matched via `pack_name`).
- **Compliance pack** — the Mounts-by-type donut, OS-versions donut, "Live Kernel integrations" gauge, and the DEB packages / Mounts tables all populate from both document shapes.

New documents show `action_id = (null)` in Discover yet still appear, confirming they match on `pack_name` + `query_name`, while legacy documents continue to match on `action_id`.

## Related issues

-
