### PR TITLE
sentinel_one: persist cursor state across restarts in threat_event and application_risk data streams

### DIFF
--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "2.10.0"
+  changes:
+    - description: Persist threat event worklist in cursor across restarts and expose max_executions.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20022
+    - description: Persist application risk pagination cursor across restarts.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20022
 - version: "2.9.0"
   changes:
     - description: Migrate the threat data stream to CEL (`run_as_cel`).

--- a/packages/sentinel_one/data_stream/application/manifest.yml
+++ b/packages/sentinel_one/data_stream/application/manifest.yml
@@ -27,7 +27,7 @@ streams:
         type: integer
         title: Maximum Executions
         description: >-
-          Maximum number of CEL program re-evaluations per collection interval. The application stream makes two API calls per worklist entry (inventory + endpoints), so large estates may need a higher budget than the input default of 1000. Set to 0 for unlimited.
+          Maximum number of CEL program re-evaluations per collection interval. The application stream makes two API calls per worklist entry (inventory + endpoints), so large estates may need a higher budget than the input default of 1000.
         default: 1000
         multi: false
         required: true

--- a/packages/sentinel_one/data_stream/application_risk/_dev/test/policy/test-all.expected
+++ b/packages/sentinel_one/data_stream/application_risk/_dev/test/policy/test-all.expected
@@ -24,7 +24,7 @@ inputs:
           program: |
             request("GET",
               state.url.trim_right("/") + "/web/api/v2.1/application-management/risks?" + {
-                ?"cursor": state.?next.page.optMap(v, [v]),
+                ?"cursor": state.?cursor.next.page.optMap(v, [v]),
                 ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
                 "limit": [string(state.batch_size)],
               }.format_query()
@@ -40,8 +40,10 @@ inputs:
                 "api_token": state.api_token,
                 "batch_size": state.batch_size,
                 ?"site_ids": state.?site_ids,
-                "next": {
-                  ?"page": body.?pagination.?nextCursor.orValue(null) != null ? optional.of(body.pagination.nextCursor) : optional.none(),
+                "cursor": {
+                  "next": {
+                    ?"page": body.?pagination.?nextCursor.orValue(null) != null ? optional.of(body.pagination.nextCursor) : optional.none(),
+                  },
                 },
                 "want_more": body.?pagination.?nextCursor.orValue(null) != null,
               })
@@ -60,6 +62,7 @@ inputs:
                   },
                 },
                 "want_more": false,
+                "cursor": {},
                 "api_token": state.api_token,
                 "batch_size": state.batch_size,
                 ?"site_ids": state.?site_ids,

--- a/packages/sentinel_one/data_stream/application_risk/_dev/test/policy/test-default.expected
+++ b/packages/sentinel_one/data_stream/application_risk/_dev/test/policy/test-default.expected
@@ -13,7 +13,7 @@ inputs:
           program: |
             request("GET",
               state.url.trim_right("/") + "/web/api/v2.1/application-management/risks?" + {
-                ?"cursor": state.?next.page.optMap(v, [v]),
+                ?"cursor": state.?cursor.next.page.optMap(v, [v]),
                 ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
                 "limit": [string(state.batch_size)],
               }.format_query()
@@ -29,8 +29,10 @@ inputs:
                 "api_token": state.api_token,
                 "batch_size": state.batch_size,
                 ?"site_ids": state.?site_ids,
-                "next": {
-                  ?"page": body.?pagination.?nextCursor.orValue(null) != null ? optional.of(body.pagination.nextCursor) : optional.none(),
+                "cursor": {
+                  "next": {
+                    ?"page": body.?pagination.?nextCursor.orValue(null) != null ? optional.of(body.pagination.nextCursor) : optional.none(),
+                  },
                 },
                 "want_more": body.?pagination.?nextCursor.orValue(null) != null,
               })
@@ -49,6 +51,7 @@ inputs:
                   },
                 },
                 "want_more": false,
+                "cursor": {},
                 "api_token": state.api_token,
                 "batch_size": state.batch_size,
                 ?"site_ids": state.?site_ids,

--- a/packages/sentinel_one/data_stream/application_risk/agent/stream/cel.yml.hbs
+++ b/packages/sentinel_one/data_stream/application_risk/agent/stream/cel.yml.hbs
@@ -26,7 +26,7 @@ redact:
 program: |
   request("GET",
     state.url.trim_right("/") + "/web/api/v2.1/application-management/risks?" + {
-      ?"cursor": state.?next.page.optMap(v, [v]),
+      ?"cursor": state.?cursor.next.page.optMap(v, [v]),
       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
       "limit": [string(state.batch_size)],
     }.format_query()
@@ -42,8 +42,10 @@ program: |
       "api_token": state.api_token,
       "batch_size": state.batch_size,
       ?"site_ids": state.?site_ids,
-      "next": {
-        ?"page": body.?pagination.?nextCursor.orValue(null) != null ? optional.of(body.pagination.nextCursor) : optional.none(),
+      "cursor": {
+        "next": {
+          ?"page": body.?pagination.?nextCursor.orValue(null) != null ? optional.of(body.pagination.nextCursor) : optional.none(),
+        },
       },
       "want_more": body.?pagination.?nextCursor.orValue(null) != null,
     })
@@ -62,6 +64,7 @@ program: |
         },
       },
       "want_more": false,
+      "cursor": {},
       "api_token": state.api_token,
       "batch_size": state.batch_size,
       ?"site_ids": state.?site_ids,

--- a/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-all.expected
+++ b/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-all.expected
@@ -10,6 +10,7 @@ inputs:
           data_stream:
             dataset: sentinel_one.threat_event
           interval: 30s
+          max_executions: 1000
           processors:
             - add_fields:
                 fields:
@@ -23,7 +24,7 @@ inputs:
                 target: environment
           program: |-
             (
-              (has(state.?worklist.data) && size(state.worklist.data) > 0) ?
+              (has(state.?cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
                 state
               :
                 state.with(
@@ -33,7 +34,7 @@ inputs:
                       "skipCount": ["true"],
                       "limit": [string(state.batch_size)],
                       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-                      ?"cursor": state.?next_page.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -44,11 +45,13 @@ inputs:
                   ).do_request().as(resp, (resp.StatusCode == 200) ?
                     resp.Body.decode_json().as(body,
                       {
-                        "worklist": body,
-                        "next_page": {
-                          ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                        "cursor": {
+                          "worklist": body,
+                          "next_page": {
+                            ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                          },
+                          "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
                         },
-                        "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
                       }
                     )
                   :
@@ -66,21 +69,21 @@ inputs:
                         },
                       },
                       "want_more": false,
-                      "offset": 0,
+                      "cursor": {},
                     }
                   )
                 )
             ).as(state,
               state.with(
-                !has(state.worklist) ? // Exit early due to GET failure.
+                !has(state.?cursor.worklist) ?
                   state
-                : (has(state.worklist.data) && size(state.worklist.data) > 0) ?
+                : (has(state.cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
                   request(
                     "GET",
-                    state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.worklist.data[0].id) + "/explore/events?" + {
+                    state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.cursor.worklist.data[0].id) + "/explore/events?" + {
                       "skipCount": ["true"],
                       "limit": [string(state.batch_size)],
-                      ?"cursor": state.?next_chain.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.next_chain.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -90,26 +93,36 @@ inputs:
                     }
                   ).do_request().as(resp, (resp.StatusCode == 200) ?
                     resp.Body.decode_json().as(body,
-                      {
-                        "events": (has(body.data) && body.data.size() > 0) ?
-                          body.data.map(e,
-                            {
-                              "message": e.encode_json(),
-                            }
-                          )
-                        :
-                          [{"message": "retry"}],
-                        "next_chain": {
-                          ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
-                        },
-                        "worklist": {
-                          "data": (body.?pagination.nextCursor.orValue(null) != null) ? state.worklist.data : tail(state.worklist.data),
-                        },
-                        "want_more": state.?fetch_more.orValue(false) ?
-                          state.fetch_more
-                        :
-                          size(state.worklist.data) > 1 || (body.?pagination.nextCursor.orValue(null) != null),
-                      }
+                      (body.?pagination.nextCursor.orValue(null) != null).as(has_more_events,
+                        {
+                          "data": has_more_events ? state.cursor.worklist.data : tail(state.cursor.worklist.data),
+                        }.as(new_worklist,
+                          {
+                            "events": (has(body.data) && body.data.size() > 0) ?
+                              body.data.map(e,
+                                {
+                                  "message": e.encode_json(),
+                                }
+                              )
+                            :
+                              [{"message": "retry"}],
+                            "want_more": state.?cursor.fetch_more.orValue(false) ?
+                              state.cursor.fetch_more
+                            :
+                              size(state.cursor.worklist.data) > 1 || has_more_events,
+                            "cursor": {
+                              "worklist": new_worklist,
+                              "next_page": {
+                                ?"token": state.?cursor.next_page.token,
+                              },
+                              "next_chain": {
+                                ?"token": has_more_events ? optional.of(body.pagination.nextCursor) : optional.none(),
+                              },
+                              "fetch_more": state.?cursor.fetch_more.orValue(false),
+                            },
+                          }
+                        )
+                      )
                     )
                   :
                     {
@@ -117,7 +130,7 @@ inputs:
                         "error": {
                           "code": string(resp.StatusCode),
                           "id": string(resp.Status),
-                          "message": "GET " + state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.worklist.data[0].id) + "/explore/events: " + (
+                          "message": "GET " + state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.cursor.worklist.data[0].id) + "/explore/events: " + (
                             (size(resp.Body) != 0) ?
                               string(resp.Body)
                             :
@@ -132,6 +145,7 @@ inputs:
                   {
                     "events": [],
                     "want_more": false,
+                    "cursor": {},
                   }
               )
             )

--- a/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-all.yml
+++ b/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-all.yml
@@ -85,6 +85,7 @@ data_stream:
   vars:
     interval: 30s
     batch_size: 100
+    max_executions: 1000
     site_ids: 123
     tags:
       - forwarded

--- a/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-default.expected
+++ b/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-default.expected
@@ -10,9 +10,10 @@ inputs:
           data_stream:
             dataset: sentinel_one.threat_event
           interval: 24h
+          max_executions: 1000
           program: |-
             (
-              (has(state.?worklist.data) && size(state.worklist.data) > 0) ?
+              (has(state.?cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
                 state
               :
                 state.with(
@@ -22,7 +23,7 @@ inputs:
                       "skipCount": ["true"],
                       "limit": [string(state.batch_size)],
                       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-                      ?"cursor": state.?next_page.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -33,11 +34,13 @@ inputs:
                   ).do_request().as(resp, (resp.StatusCode == 200) ?
                     resp.Body.decode_json().as(body,
                       {
-                        "worklist": body,
-                        "next_page": {
-                          ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                        "cursor": {
+                          "worklist": body,
+                          "next_page": {
+                            ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                          },
+                          "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
                         },
-                        "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
                       }
                     )
                   :
@@ -55,21 +58,21 @@ inputs:
                         },
                       },
                       "want_more": false,
-                      "offset": 0,
+                      "cursor": {},
                     }
                   )
                 )
             ).as(state,
               state.with(
-                !has(state.worklist) ? // Exit early due to GET failure.
+                !has(state.?cursor.worklist) ?
                   state
-                : (has(state.worklist.data) && size(state.worklist.data) > 0) ?
+                : (has(state.cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
                   request(
                     "GET",
-                    state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.worklist.data[0].id) + "/explore/events?" + {
+                    state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.cursor.worklist.data[0].id) + "/explore/events?" + {
                       "skipCount": ["true"],
                       "limit": [string(state.batch_size)],
-                      ?"cursor": state.?next_chain.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.next_chain.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -79,26 +82,36 @@ inputs:
                     }
                   ).do_request().as(resp, (resp.StatusCode == 200) ?
                     resp.Body.decode_json().as(body,
-                      {
-                        "events": (has(body.data) && body.data.size() > 0) ?
-                          body.data.map(e,
-                            {
-                              "message": e.encode_json(),
-                            }
-                          )
-                        :
-                          [{"message": "retry"}],
-                        "next_chain": {
-                          ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
-                        },
-                        "worklist": {
-                          "data": (body.?pagination.nextCursor.orValue(null) != null) ? state.worklist.data : tail(state.worklist.data),
-                        },
-                        "want_more": state.?fetch_more.orValue(false) ?
-                          state.fetch_more
-                        :
-                          size(state.worklist.data) > 1 || (body.?pagination.nextCursor.orValue(null) != null),
-                      }
+                      (body.?pagination.nextCursor.orValue(null) != null).as(has_more_events,
+                        {
+                          "data": has_more_events ? state.cursor.worklist.data : tail(state.cursor.worklist.data),
+                        }.as(new_worklist,
+                          {
+                            "events": (has(body.data) && body.data.size() > 0) ?
+                              body.data.map(e,
+                                {
+                                  "message": e.encode_json(),
+                                }
+                              )
+                            :
+                              [{"message": "retry"}],
+                            "want_more": state.?cursor.fetch_more.orValue(false) ?
+                              state.cursor.fetch_more
+                            :
+                              size(state.cursor.worklist.data) > 1 || has_more_events,
+                            "cursor": {
+                              "worklist": new_worklist,
+                              "next_page": {
+                                ?"token": state.?cursor.next_page.token,
+                              },
+                              "next_chain": {
+                                ?"token": has_more_events ? optional.of(body.pagination.nextCursor) : optional.none(),
+                              },
+                              "fetch_more": state.?cursor.fetch_more.orValue(false),
+                            },
+                          }
+                        )
+                      )
                     )
                   :
                     {
@@ -106,7 +119,7 @@ inputs:
                         "error": {
                           "code": string(resp.StatusCode),
                           "id": string(resp.Status),
-                          "message": "GET " + state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.worklist.data[0].id) + "/explore/events: " + (
+                          "message": "GET " + state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.cursor.worklist.data[0].id) + "/explore/events: " + (
                             (size(resp.Body) != 0) ?
                               string(resp.Body)
                             :
@@ -121,6 +134,7 @@ inputs:
                   {
                     "events": [],
                     "want_more": false,
+                    "cursor": {},
                   }
               )
             )

--- a/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-default.yml
+++ b/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-default.yml
@@ -5,6 +5,7 @@ data_stream:
   vars:
     interval: 24h
     batch_size: 1000
+    max_executions: 1000
     enable_request_tracer: false
     preserve_original_event: false
     http_client_timeout: 30s

--- a/packages/sentinel_one/data_stream/threat_event/agent/stream/cel.yml.hbs
+++ b/packages/sentinel_one/data_stream/threat_event/agent/stream/cel.yml.hbs
@@ -1,5 +1,6 @@
 config_version: 2
 interval: {{interval}}
+max_executions: {{max_executions}}
 resource.tracer:
   enabled: {{enable_request_tracer}}
   filename: "../../logs/cel/http-request-trace-*.ndjson"
@@ -25,7 +26,7 @@ redact:
     - api_token
 program: |-
   (
-    (has(state.?worklist.data) && size(state.worklist.data) > 0) ?
+    (has(state.?cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
       state
     :
       state.with(
@@ -35,7 +36,7 @@ program: |-
             "skipCount": ["true"],
             "limit": [string(state.batch_size)],
             ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-            ?"cursor": state.?next_page.token.optMap(v, [v]),
+            ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
           }.format_query()
         ).with(
           {
@@ -46,11 +47,13 @@ program: |-
         ).do_request().as(resp, (resp.StatusCode == 200) ?
           resp.Body.decode_json().as(body,
             {
-              "worklist": body,
-              "next_page": {
-                ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+              "cursor": {
+                "worklist": body,
+                "next_page": {
+                  ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
+                },
+                "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
               },
-              "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
             }
           )
         :
@@ -68,21 +71,21 @@ program: |-
               },
             },
             "want_more": false,
-            "offset": 0,
+            "cursor": {},
           }
         )
       )
   ).as(state,
     state.with(
-      !has(state.worklist) ? // Exit early due to GET failure.
+      !has(state.?cursor.worklist) ?
         state
-      : (has(state.worklist.data) && size(state.worklist.data) > 0) ?
+      : (has(state.cursor.worklist.data) && size(state.cursor.worklist.data) > 0) ?
         request(
           "GET",
-          state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.worklist.data[0].id) + "/explore/events?" + {
+          state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.cursor.worklist.data[0].id) + "/explore/events?" + {
             "skipCount": ["true"],
             "limit": [string(state.batch_size)],
-            ?"cursor": state.?next_chain.token.optMap(v, [v]),
+            ?"cursor": state.?cursor.next_chain.token.optMap(v, [v]),
           }.format_query()
         ).with(
           {
@@ -92,26 +95,36 @@ program: |-
           }
         ).do_request().as(resp, (resp.StatusCode == 200) ?
           resp.Body.decode_json().as(body,
-            {
-              "events": (has(body.data) && body.data.size() > 0) ?
-                body.data.map(e,
-                  {
-                    "message": e.encode_json(),
-                  }
-                )
-              :
-                [{"message": "retry"}],
-              "next_chain": {
-                ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
-              },
-              "worklist": {
-                "data": (body.?pagination.nextCursor.orValue(null) != null) ? state.worklist.data : tail(state.worklist.data),
-              },
-              "want_more": state.?fetch_more.orValue(false) ?
-                state.fetch_more
-              :
-                size(state.worklist.data) > 1 || (body.?pagination.nextCursor.orValue(null) != null),
-            }
+            (body.?pagination.nextCursor.orValue(null) != null).as(has_more_events,
+              {
+                "data": has_more_events ? state.cursor.worklist.data : tail(state.cursor.worklist.data),
+              }.as(new_worklist,
+                {
+                  "events": (has(body.data) && body.data.size() > 0) ?
+                    body.data.map(e,
+                      {
+                        "message": e.encode_json(),
+                      }
+                    )
+                  :
+                    [{"message": "retry"}],
+                  "want_more": state.?cursor.fetch_more.orValue(false) ?
+                    state.cursor.fetch_more
+                  :
+                    size(state.cursor.worklist.data) > 1 || has_more_events,
+                  "cursor": {
+                    "worklist": new_worklist,
+                    "next_page": {
+                      ?"token": state.?cursor.next_page.token,
+                    },
+                    "next_chain": {
+                      ?"token": has_more_events ? optional.of(body.pagination.nextCursor) : optional.none(),
+                    },
+                    "fetch_more": state.?cursor.fetch_more.orValue(false),
+                  },
+                }
+              )
+            )
           )
         :
           {
@@ -119,7 +132,7 @@ program: |-
               "error": {
                 "code": string(resp.StatusCode),
                 "id": string(resp.Status),
-                "message": "GET " + state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.worklist.data[0].id) + "/explore/events: " + (
+                "message": "GET " + state.url.trim_right("/") + "/web/api/v2.1/threats/" + string(state.cursor.worklist.data[0].id) + "/explore/events: " + (
                   (size(resp.Body) != 0) ?
                     string(resp.Body)
                   :
@@ -134,6 +147,7 @@ program: |-
         {
           "events": [],
           "want_more": false,
+          "cursor": {},
         }
     )
   )

--- a/packages/sentinel_one/data_stream/threat_event/manifest.yml
+++ b/packages/sentinel_one/data_stream/threat_event/manifest.yml
@@ -24,6 +24,15 @@ streams:
         multi: false
         required: true
         show_user: false
+      - name: max_executions
+        type: integer
+        title: Maximum Executions
+        description: >-
+          Maximum number of CEL program re-evaluations per collection interval. The threat event stream makes two API calls per worklist entry (threats + events), so large estates may need a higher budget than the input default of 1000.
+        default: 1000
+        multi: false
+        required: true
+        show_user: false
       - name: site_ids
         type: text
         title: Site IDs

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: sentinel_one
 title: SentinelOne
-version: "2.9.0"
+version: "2.10.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
sentinel_one: persist cursor state across restarts in threat_event and application_risk data streams

The threat_event CEL program stores its two-level worklist
(threats list, page cursors, fetch_more flag) in plain state
keys that are discarded on agent restart. This causes the
program to re-walk the entire SentinelOne threats catalog from
scratch.

Move worklist state under state.cursor.* so the CEL input
persists it to the registry. Also expose max_executions in the
threat_event manifest so large estates can raise the execution
budget beyond the default 1000.

Apply the same cursor persistence fix to application_risk,
which stores its pagination cursor in state.next.page instead
of state.cursor.*.

This mirrors the fix applied to the application data stream in
v2.7.0 (PR #18976).
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
