### PR TITLE
[crowdstrike] Expose Event Streams retry settings

### DIFF
--- a/packages/crowdstrike/_dev/build/docs/README.md
+++ b/packages/crowdstrike/_dev/build/docs/README.md
@@ -288,6 +288,20 @@ Elastic Agent is required to stream data from the AWS SQS, Event Streams API, RE
 
 ## Troubleshooting
 
+### Event Streams input stops collecting after repeated connection failures
+
+The **Falcon events** data stream's **Event Streams API** input (`streaming`) reconnects to the CrowdStrike stream with a bounded number of retries. Failures such as a non-200 response or an authentication error from bad credentials count towards **Retry - Maximum Attempts**; once that limit is reached the input terminates and the Elastic Agent must be restarted to resume collection.
+
+On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (an empty response, a network error, or a timeout) are instead retried indefinitely with back-off and do not count towards the limit, so the input self-heals once the upstream recovers. On earlier agents these transient failures count towards the limit and can terminate the input.
+
+If the Falcon Event Streams input goes **Degraded** and then stops, and the agent logs show repeated discover or connection errors, tune the retry settings on the integration policy:
+
+- Increase **Retry - Maximum Attempts** to tolerate longer upstream outages.
+- Enable **Retry - Infinite Retries** to never terminate on repeated failures. The input keeps retrying with capped back-off until the upstream recovers.
+- Adjust **Retry - Minimum Wait** and **Retry - Maximum Wait** to control the back-off window between attempts.
+
+Values above 10 for **Retry - Maximum Attempts**, and **Retry - Infinite Retries**, also require Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later; on earlier agents they are silently capped at 10 attempts.
+
 ### Vulnerability API returns 404 Not found
 
 This error can occur for the following reasons:

--- a/packages/crowdstrike/_dev/build/docs/README.md
+++ b/packages/crowdstrike/_dev/build/docs/README.md
@@ -290,15 +290,15 @@ Elastic Agent is required to stream data from the AWS SQS, Event Streams API, RE
 
 ### Event Streams input stops collecting after repeated connection failures
 
-The **Falcon events** data stream's **Event Streams API** input (`streaming`) reconnects to the CrowdStrike stream with a bounded number of retries. Failures such as a non-200 response or an authentication error from bad credentials count towards **Retry - Maximum Attempts**; once that limit is reached the input terminates and the Elastic Agent must be restarted to resume collection.
+The **Falcon events** data stream's **Event Streams API** input (`streaming`) reconnects to the CrowdStrike stream with a bounded number of retries. Failures such as a non-200 response or an authentication error from bad credentials count toward **Retry - Maximum Attempts**; once that limit is reached the input terminates and the Elastic Agent must be restarted to resume collection.
 
-On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (an empty response, a network error, or a timeout) are instead retried indefinitely with back-off and do not count towards the limit, so the input self-heals once the upstream recovers. On earlier agents these transient failures count towards the limit and can terminate the input.
+On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (an empty response, a network error, or a timeout) are instead retried indefinitely with back-off and do not count toward the limit, so the input self-heals once the upstream recovers. On earlier agents these transient failures count toward the limit and can terminate the input.
 
 If the Falcon Event Streams input goes **Degraded** and then stops, and the agent logs show repeated discover or connection errors, tune the retry settings on the integration policy:
 
 - Increase **Retry - Maximum Attempts** to tolerate longer upstream outages.
 - Enable **Retry - Infinite Retries** to never terminate on repeated failures. The input keeps retrying with capped back-off until the upstream recovers.
-- Adjust **Retry - Minimum Wait** and **Retry - Maximum Wait** to control the back-off window between attempts.
+- Under **Advanced options**, adjust **Retry - Minimum Wait** and **Retry - Maximum Wait** to control the back-off window between attempts.
 
 Values above 10 for **Retry - Maximum Attempts**, and **Retry - Infinite Retries**, also require Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later; on earlier agents they are silently capped at 10 attempts.
 

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "4.1.0"
+  changes:
+    - description: >-
+        Expose the CrowdStrike Falcon Event Streams retry settings (maximum attempts, infinite retries, minimum and maximum wait) as configurable options so the streaming input can be tuned to recover from repeated connection failures without requiring an agent restart.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/19928
 - version: "4.0.0"
   changes:
     - description: >-

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -4,7 +4,7 @@
     - description: >-
         Expose the CrowdStrike Falcon Event Streams retry settings (maximum attempts, infinite retries, minimum and maximum wait) as configurable options so the streaming input can be tuned to recover from repeated connection failures without requiring an agent restart.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/19928
+      link: https://github.com/elastic/integrations/pull/20025
 - version: "4.0.0"
   changes:
     - description: >-

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/policy/test-streaming.expected
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/policy/test-streaming.expected
@@ -35,6 +35,9 @@ inputs:
           publisher_pipeline.disable_host: true
           redact:
             fields: null
+          retry.max_attempts: 5
+          retry.wait_max: 30s
+          retry.wait_min: 1s
           stream_type: crowdstrike
           tags:
             - preserve_original_event

--- a/packages/crowdstrike/data_stream/falcon/agent/stream/streaming.yml.hbs
+++ b/packages/crowdstrike/data_stream/falcon/agent/stream/streaming.yml.hbs
@@ -5,6 +5,18 @@ auth:
   client_secret: {{client_secret}}
   token_url: {{token_url}}
 crowdstrike_app_id: {{app_id}}
+{{#if retry_max_attempts}}
+retry.max_attempts: {{retry_max_attempts}}
+{{/if}}
+{{#if retry_infinite_retries}}
+retry.infinite_retries: {{retry_infinite_retries}}
+{{/if}}
+{{#if retry_wait_min}}
+retry.wait_min: {{retry_wait_min}}
+{{/if}}
+{{#if retry_wait_max}}
+retry.wait_max: {{retry_wait_max}}
+{{/if}}
 {{#if proxy_url}}
 proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/crowdstrike/data_stream/falcon/manifest.yml
+++ b/packages/crowdstrike/data_stream/falcon/manifest.yml
@@ -84,6 +84,42 @@ streams:
         multi: false
         required: true
         show_user: true
+      - name: retry_max_attempts
+        type: integer
+        title: Retry - Maximum Attempts
+        description: >-
+          The maximum number of times a failed connection to the Event Streams API is retried before the input terminates and needs to be restarted. Failures such as a non-200 response or bad credentials count towards this limit. Enable `Retry - Infinite Retries` to never terminate on repeated failures. On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (empty responses, network errors, timeouts) are retried indefinitely and do not count towards this limit; values above 10 (and `Retry - Infinite Retries`) also require those agent versions and are silently capped at 10 on earlier agents.
+        multi: false
+        required: false
+        show_user: true
+        default: 5
+      - name: retry_infinite_retries
+        type: bool
+        title: Retry - Infinite Retries
+        description: >-
+          Retry failed connections indefinitely instead of terminating after the maximum number of attempts is reached. When enabled, `Retry - Maximum Attempts` is ignored. Requires Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later; on earlier agents retries are silently capped at 10.
+        multi: false
+        required: false
+        show_user: true
+        default: false
+      - name: retry_wait_min
+        type: text
+        title: Retry - Minimum Wait
+        description: >-
+          The minimum time to wait before retrying a failed connection, as a duration string (for example `1s` or `500ms`). Must be less than or equal to `Retry - Maximum Wait`.
+        multi: false
+        required: false
+        show_user: false
+        default: 1s
+      - name: retry_wait_max
+        type: text
+        title: Retry - Maximum Wait
+        description: >-
+          The maximum time to wait before retrying a failed connection, as a duration string (for example `30s`). Back-off grows exponentially between the minimum and maximum wait.
+        multi: false
+        required: false
+        show_user: false
+        default: 30s
       - name: tags
         type: text
         title: Tags

--- a/packages/crowdstrike/data_stream/falcon/manifest.yml
+++ b/packages/crowdstrike/data_stream/falcon/manifest.yml
@@ -88,7 +88,7 @@ streams:
         type: integer
         title: Retry - Maximum Attempts
         description: >-
-          The maximum number of times a failed connection to the Event Streams API is retried before the input terminates and needs to be restarted. Failures such as a non-200 response or bad credentials count towards this limit. Enable `Retry - Infinite Retries` to never terminate on repeated failures. On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (empty responses, network errors, timeouts) are retried indefinitely and do not count towards this limit; values above 10 (and `Retry - Infinite Retries`) also require those agent versions and are silently capped at 10 on earlier agents.
+          The maximum number of times a failed connection to the Event Streams API is retried before the input terminates and needs to be restarted. Failures such as a non-200 response or bad credentials count toward this limit. Enable `Retry - Infinite Retries` to never terminate on repeated failures. On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (empty responses, network errors, timeouts) are retried indefinitely and do not count toward this limit; values above 10 (and `Retry - Infinite Retries`) also require those agent versions and are silently capped at 10 on earlier agents.
         multi: false
         required: false
         show_user: true

--- a/packages/crowdstrike/docs/README.md
+++ b/packages/crowdstrike/docs/README.md
@@ -288,6 +288,20 @@ Elastic Agent is required to stream data from the AWS SQS, Event Streams API, RE
 
 ## Troubleshooting
 
+### Event Streams input stops collecting after repeated connection failures
+
+The **Falcon events** data stream's **Event Streams API** input (`streaming`) reconnects to the CrowdStrike stream with a bounded number of retries. Failures such as a non-200 response or an authentication error from bad credentials count towards **Retry - Maximum Attempts**; once that limit is reached the input terminates and the Elastic Agent must be restarted to resume collection.
+
+On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (an empty response, a network error, or a timeout) are instead retried indefinitely with back-off and do not count towards the limit, so the input self-heals once the upstream recovers. On earlier agents these transient failures count towards the limit and can terminate the input.
+
+If the Falcon Event Streams input goes **Degraded** and then stops, and the agent logs show repeated discover or connection errors, tune the retry settings on the integration policy:
+
+- Increase **Retry - Maximum Attempts** to tolerate longer upstream outages.
+- Enable **Retry - Infinite Retries** to never terminate on repeated failures. The input keeps retrying with capped back-off until the upstream recovers.
+- Adjust **Retry - Minimum Wait** and **Retry - Maximum Wait** to control the back-off window between attempts.
+
+Values above 10 for **Retry - Maximum Attempts**, and **Retry - Infinite Retries**, also require Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later; on earlier agents they are silently capped at 10 attempts.
+
 ### Vulnerability API returns 404 Not found
 
 This error can occur for the following reasons:

--- a/packages/crowdstrike/docs/README.md
+++ b/packages/crowdstrike/docs/README.md
@@ -290,15 +290,15 @@ Elastic Agent is required to stream data from the AWS SQS, Event Streams API, RE
 
 ### Event Streams input stops collecting after repeated connection failures
 
-The **Falcon events** data stream's **Event Streams API** input (`streaming`) reconnects to the CrowdStrike stream with a bounded number of retries. Failures such as a non-200 response or an authentication error from bad credentials count towards **Retry - Maximum Attempts**; once that limit is reached the input terminates and the Elastic Agent must be restarted to resume collection.
+The **Falcon events** data stream's **Event Streams API** input (`streaming`) reconnects to the CrowdStrike stream with a bounded number of retries. Failures such as a non-200 response or an authentication error from bad credentials count toward **Retry - Maximum Attempts**; once that limit is reached the input terminates and the Elastic Agent must be restarted to resume collection.
 
-On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (an empty response, a network error, or a timeout) are instead retried indefinitely with back-off and do not count towards the limit, so the input self-heals once the upstream recovers. On earlier agents these transient failures count towards the limit and can terminate the input.
+On Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later, transient connection-level failures (an empty response, a network error, or a timeout) are instead retried indefinitely with back-off and do not count toward the limit, so the input self-heals once the upstream recovers. On earlier agents these transient failures count toward the limit and can terminate the input.
 
 If the Falcon Event Streams input goes **Degraded** and then stops, and the agent logs show repeated discover or connection errors, tune the retry settings on the integration policy:
 
 - Increase **Retry - Maximum Attempts** to tolerate longer upstream outages.
 - Enable **Retry - Infinite Retries** to never terminate on repeated failures. The input keeps retrying with capped back-off until the upstream recovers.
-- Adjust **Retry - Minimum Wait** and **Retry - Maximum Wait** to control the back-off window between attempts.
+- Under **Advanced options**, adjust **Retry - Minimum Wait** and **Retry - Maximum Wait** to control the back-off window between attempts.
 
 Values above 10 for **Retry - Maximum Attempts**, and **Retry - Infinite Retries**, also require Elastic Agent 8.19.19, 9.3.8, 9.4.4, or later; on earlier agents they are silently capped at 10 attempts.
 

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "4.0.0"
+version: "4.1.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
[crowdstrike] Expose Event Streams retry settings

Add configurable retry options to the CrowdStrike Falcon "streaming" input
(the Event Streams API collector): maximum attempts, infinite retries, and
minimum/maximum back-off wait. Previously these were fixed at the beats
defaults (5 attempts, 1s-30s back-off) with no way to tune them, so an input
that hit repeated connection failures terminated and needed an agent restart
to recover.

The variables are wired into the stream template as dotted retry keys, which
merge onto the input's existing retry defaults, so an unset field keeps its
default rather than becoming a zero value. Defaults match the beats-side
values, so existing behaviour is unchanged; users can now raise max_attempts
or enable infinite_retries to keep the input running through outages.

Document the behaviour in the troubleshooting section and variable
descriptions, including that transient self-heal (retrying connection-level
failures indefinitely) and values above 10 / infinite retries require Elastic
Agent 8.19.19, 9.3.8, 9.4.4, or later. blanket_retries is intentionally not
exposed: it is only honoured by the websocket stream type, not the crowdstrike
one, so it would be a no-op here.

Regenerate the streaming policy test.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Policy tests regenerated successfully.
```
--- Test results for package: crowdstrike - START ---
╭─────────────┬────────────────────────────────┬───────────┬───────────────────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM                    │ TEST TYPE │ TEST NAME             │ RESULT │  TIME ELAPSED │
├─────────────┼────────────────────────────────┼───────────┼───────────────────────┼────────┼───────────────┤
│ crowdstrike │ alert                          │ policy    │ test-default.yml      │ PASS   │  13.99723975s │
│ crowdstrike │ alert                          │ policy    │ test-traced.yml       │ PASS   │ 12.038457667s │
│ crowdstrike │ falcon                         │ policy    │ test-default.yml      │ PASS   │ 12.028112083s │
│ crowdstrike │ falcon                         │ policy    │ test-streaming.yml    │ PASS   │  13.02373225s │
│ crowdstrike │ fdr                            │ policy    │ test-default.yml      │ PASS   │ 12.025779583s │
│ crowdstrike │ host                           │ policy    │ test-default.yml      │ PASS   │ 12.018557625s │
│ crowdstrike │ identity_protection_assessment │ policy    │ test-data-sources.yml │ PASS   │ 12.022898167s │
│ crowdstrike │ identity_protection_assessment │ policy    │ test-default.yml      │ PASS   │ 12.032462375s │
│ crowdstrike │ identity_protection_timeline   │ policy    │ test-default.yml      │ PASS   │ 12.013214417s │
│ crowdstrike │ vulnerability                  │ policy    │ test-default.yml      │ PASS   │  12.02549325s │
│ crowdstrike │ vulnerability                  │ policy    │ test-traced.yml       │ PASS   │ 12.039657167s │
╰─────────────┴────────────────────────────────┴───────────┴───────────────────────┴────────┴───────────────╯
--- Test results for package: crowdstrike - END   ---
Done
```
