### PR TITLE
[akamai] Add Support for Identity Fields from SIEM Events

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for identity fields from Akamai SIEM events.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20029
 - version: "3.1.1"
   changes:
     - description: Fix the issue of populating HTTP message headers.

--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.2.0"
+  changes:
+    - description: Add support for identity fields from Akamai SIEM events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.1.1"
   changes:
     - description: Fix the issue of populating HTTP message headers.

--- a/packages/akamai/data_stream/siem/_dev/test/pipeline/test-placeholder-json.log-expected.json
+++ b/packages/akamai/data_stream/siem/_dev/test/pipeline/test-placeholder-json.log-expected.json
@@ -5,6 +5,11 @@
             "akamai": {
                 "siem": {
                     "config_id": "67217",
+                    "identity": {
+                        "ja4": "t13d131000_f57a46bbacb6_e7c285222651",
+                        "tls_fingerprint_v2": "c6a4ce37a8dc4153",
+                        "tls_fingerprint_v3": "3~de293936a8dc4153"
+                    },
                     "policy_id": "PNWD_110088",
                     "request": {
                         "headers": {
@@ -164,6 +169,10 @@
             "akamai": {
                 "siem": {
                     "config_id": "12345",
+                    "identity": {
+                        "tls_fingerprint_v2": "1234567890",
+                        "tls_fingerprint_v3": "3~1234567"
+                    },
                     "policy_id": "qik1_3333",
                     "request": {
                         "headers": {

--- a/packages/akamai/data_stream/siem/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/akamai/data_stream/siem/elasticsearch/ingest_pipeline/default.yml
@@ -487,6 +487,22 @@ processors:
       field: json.clientData.sdkVersion
       target_field: akamai.siem.client_data.sdk_version
       ignore_missing: true
+  ## Identity
+  - rename:
+      field: json.identity.ja4
+      tag: rename_identity_ja4_to_identity_ja4
+      target_field: akamai.siem.identity.ja4
+      ignore_missing: true
+  - rename:
+      field: json.identity.tlsFingerprintV2
+      tag: rename_identity_tlsFingerprintV2_to_identity_tls_fingerprint_v2
+      target_field: akamai.siem.identity.tls_fingerprint_v2
+      ignore_missing: true
+  - rename:
+      field: json.identity.tlsFingerprintV3
+      tag: rename_identity_tlsFingerprintV3_to_identity_tls_fingerprint_v3
+      target_field: akamai.siem.identity.tls_fingerprint_v3
+      ignore_missing: true
   ## User Risk Data
   - rename:
       field: json.userRiskData.uuid

--- a/packages/akamai/data_stream/siem/fields/fields.yml
+++ b/packages/akamai/data_stream/siem/fields/fields.yml
@@ -105,6 +105,21 @@
       description: >
         SDK version
 
+    - name: identity
+      type: group
+      fields:
+        - name: ja4
+          type: keyword
+          description: A JA4 TLS client fingerprint value.
+    
+        - name: tls_fingerprint_v2
+          type: keyword
+          description: A client TLS fingerprint V2 value.
+    
+        - name: tls_fingerprint_v3
+          type: keyword
+          description: A client TLS fingerprint V3 value.
+
     - name: user_risk.uuid
       type: keyword
       description: >

--- a/packages/akamai/docs/README.md
+++ b/packages/akamai/docs/README.md
@@ -35,6 +35,9 @@ See [Akamai API get started](https://techdocs.akamai.com/siem-integration/refere
 | akamai.siem.client_data.telemetry_type | Specifies the telemetry type in use. | long |
 | akamai.siem.client_reputation | Client IP scores for Client Reputation. | keyword |
 | akamai.siem.config_id | ID of the Security Configuration applied to the request. | keyword |
+| akamai.siem.identity.ja4 | A JA4 TLS client fingerprint value. | keyword |
+| akamai.siem.identity.tls_fingerprint_v2 | A client TLS fingerprint V2 value. | keyword |
+| akamai.siem.identity.tls_fingerprint_v3 | A client TLS fingerprint V3 value. | keyword |
 | akamai.siem.policy_id | ID of the Firewall policy applied to the request. | keyword |
 | akamai.siem.request.headers | HTTP Request headers | flattened |
 | akamai.siem.response.headers | HTTP response headers | flattened |

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "3.1.1"
+version: "3.2.0"
 description: Collect logs from Akamai with Elastic Agent.
 type: integration
 format_version: "3.3.2"


### PR DESCRIPTION
## Proposed commit message

```
akamai: add support for identity fields in SIEM events

This change adds support for ingesting identity fields from Akamai SIEM events.
The new fields are parsed and mapped to the appropriate schema to provide additional
identity context for the events.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

- Clone integrations repo.
- Install the elastic package locally.
- Start the elastic stack using the elastic package.
- Move to integrations/packages/akamai directory.
- Run the following command to run tests.

> elastic-package test -v

## Related Issues

- Closes https://github.com/elastic/integrations/issues/17728