### PR TITLE
[github] Align mock pagination links with service origin

### DIFF
--- a/packages/github/_dev/deploy/docker/docker-compose.yml
+++ b/packages/github/_dev/deploy/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.3'
 services:
   github:
     image: docker.elastic.co/observability/stream:v0.18.0
+    hostname: svc-github
     ports:
       - 8080
     volumes:

--- a/packages/github/_dev/deploy/docker/files/config.yml
+++ b/packages/github/_dev/deploy/docker/files/config.yml
@@ -95,7 +95,7 @@ rules:
           Content-Type:
             - application/json
           Link:
-            - '<http://{{ hostname }}:{{ env "PORT" }}/orgs/test/audit-log?after=abcd>; rel="next"'
+            - '<http://{{ hostname }}:{{ env "PORT" }}/enterprises/test/audit-log?after=abcd>; rel="next"'
           X-RateLimit-Remaining:
             - 59
         body: |
@@ -172,8 +172,6 @@ rules:
         headers:
           Content-Type:
             - application/json
-          Link:
-            - '<http://{{ hostname }}:{{ env "PORT" }}/repos/sample_owner/sample_repo/code-scanning/alerts>; rel="next"'
           X-RateLimit-Remaining:
             - 59
         body: |-
@@ -283,8 +281,6 @@ rules:
         headers:
           Content-Type:
             - application/json
-          Link:
-            - '<http://{{ hostname }}:{{ env "PORT" }}/repos/sample_owner/sample_repo/secret-scanning/alerts>; rel="next"'
           X-RateLimit-Remaining:
             - 59
         body: |-


### PR DESCRIPTION
## Proposed commit message

```
Set the GitHub mock service hostname to svc-github so stream-generated
absolute Link headers match the origin injected into system test
configs, and clean up fixture pagination by fixing the enterprise audit
next URL and removing bogus next links from one-page responses.

Closes #19838
Closes #19945
Closes #20003
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates https://github.com/elastic/beats/pull/51551
- https://github.com/elastic/stream/issues/206
- Closes #19838
- Closes #19945
- Closes #20003
