### PR TITLE
[ti_otx] Align mock pagination links with service origin

### DIFF
--- a/packages/ti_otx/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_otx/_dev/deploy/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: "2.3"
 services:
   otx:
     image: docker.elastic.co/observability/stream:v0.18.0
+    hostname: svc-otx
     ports:
       - 8080
     environment:


### PR DESCRIPTION
## Proposed commit message

```
Set the OTX mock service hostname to svc-otx so stream-generated
absolute pagination URLs match the origin injected into system test
configs.

Closes #19869
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Relates https://github.com/elastic/beats/pull/51551
- Relates https://github.com/elastic/stream/issues/206
- Closes #19869