### PR TITLE
[Cato Networks] Replace try/has with is_error

### DIFF
--- a/packages/cato_networks/changelog.yml
+++ b/packages/cato_networks/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: '0.1.1'
+  changes:
+    - description: Simplify the audit `last_timestamp` parse guard to use `is_error` instead of `try`/`has`.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: '0.1.0'
   changes:
     - description: Initial release of package.

--- a/packages/cato_networks/changelog.yml
+++ b/packages/cato_networks/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Simplify the audit `last_timestamp` parse guard to use `is_error` instead of `try`/`has`.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20051
 - version: '0.1.0'
   changes:
     - description: Initial release of package.

--- a/packages/cato_networks/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/cato_networks/data_stream/audit/agent/stream/cel.yml.hbs
@@ -100,7 +100,7 @@ program: |
                     // auditFeed.to may echo back the non-RFC3339 request layout, so guard the
                     // parse and fall back to window_to instead of aborting the final page.
                     "last_timestamp": body.data.auditFeed.?to.optMap(v,
-                      try(timestamp(v), "error").as(t, !has(t.error) ?
+                      timestamp(v).as(t, !is_error(t) ?
                         t.format("2006-01-02/15:04:05")
                       :
                         window_to

--- a/packages/cato_networks/manifest.yml
+++ b/packages/cato_networks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.2
 name: cato_networks
 title: Cato Networks
-version: 0.1.0
+version: 0.1.1
 description: Collect logs from Cato Networks with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Enhancement

## Proposed commit message
Use is_error inplace of try/has for last_timestamp

## Checklist

- [X] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## How to test this PR locally

### To test the cato networks package:

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/cato_networks directory.
- Run the following command to run tests.

> elastic-package test
```
Run asset tests for the package
2026/07/09 10:33:45  INFO elastic-package v0.125.1 version-hash 111636ab (build time: 2026-07-03T17:56:06+05:30)
2026/07/09 10:33:45  INFO elastic-stack: 8.19.0
--- Test results for package: cato_networks - START ---
╭───────────────┬─────────────┬───────────┬────────────────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME                                                              │ RESULT │ TIME ELAPSED │
├───────────────┼─────────────┼───────────┼────────────────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ cato_networks │             │ asset     │ dashboard cato_networks-95cbb672-baae-4508-b188-24a51b4d36da is loaded │ PASS   │      1.046µs │
│ cato_networks │             │ asset     │ dashboard cato_networks-9d363f59-caa0-4b84-af82-dd85d789a7dd is loaded │ PASS   │        260ns │
│ cato_networks │             │ asset     │ dashboard cato_networks-b4c8e2f1-3d5a-4f7b-9c2e-1a6d8e3f5b7c is loaded │ PASS   │        172ns │
│ cato_networks │             │ asset     │ dashboard cato_networks-f7a3c9d2-6e1b-4a8f-bc4d-9e2f5a8c1d6b is loaded │ PASS   │        196ns │
│ cato_networks │ audit       │ asset     │ index_template logs-cato_networks.audit is loaded                      │ PASS   │        201ns │
│ cato_networks │ audit       │ asset     │ ingest_pipeline logs-cato_networks.audit-0.1.1 is loaded               │ PASS   │        179ns │
│ cato_networks │ event       │ asset     │ index_template logs-cato_networks.event is loaded                      │ PASS   │        148ns │
│ cato_networks │ event       │ asset     │ ingest_pipeline logs-cato_networks.event-0.1.1 is loaded               │ PASS   │        155ns │
╰───────────────┴─────────────┴───────────┴────────────────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: cato_networks - END   ---
Done
Run pipeline tests for the package
2026/07/09 10:33:49  INFO elastic-package v0.125.1 version-hash 111636ab (build time: 2026-07-03T17:56:06+05:30)
2026/07/09 10:33:49  INFO elastic-stack: 8.19.0
--- Test results for package: cato_networks - START ---
╭───────────────┬─────────────┬───────────┬───────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME                                 │ RESULT │ TIME ELAPSED │
├───────────────┼─────────────┼───────────┼───────────────────────────────────────────┼────────┼──────────────┤
│ cato_networks │ audit       │ pipeline  │ (ingest pipeline warnings test-audit.log) │ PASS   │ 240.991776ms │
│ cato_networks │ audit       │ pipeline  │ test-audit.log                            │ PASS   │ 281.315433ms │
│ cato_networks │ event       │ pipeline  │ (ingest pipeline warnings test-event.log) │ PASS   │ 249.288462ms │
│ cato_networks │ event       │ pipeline  │ test-event.log                            │ PASS   │  235.38954ms │
╰───────────────┴─────────────┴───────────┴───────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: cato_networks - END   ---
Done
Run policy tests for the package
2026/07/09 10:33:50  INFO elastic-package v0.125.1 version-hash 111636ab (build time: 2026-07-03T17:56:06+05:30)
2026/07/09 10:33:50  INFO elastic-stack: 8.19.0
--- Test results for package: cato_networks - START ---
No test results
--- Test results for package: cato_networks - END   ---
Done
Run script tests for the package
PKG cato_networks
[no test files]
--- Test results for package: cato_networks - START ---
No test results
--- Test results for package: cato_networks - END   ---
Done
Run static tests for the package
2026/07/09 10:33:50  INFO elastic-package v0.125.1 version-hash 111636ab (build time: 2026-07-03T17:56:06+05:30)
--- Test results for package: cato_networks - START ---
╭───────────────┬─────────────┬───────────┬──────────────────────────┬────────┬──────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME                │ RESULT │ TIME ELAPSED │
├───────────────┼─────────────┼───────────┼──────────────────────────┼────────┼──────────────┤
│ cato_networks │ audit       │ static    │ Verify sample_event.json │ PASS   │  111.25522ms │
│ cato_networks │ event       │ static    │ Verify sample_event.json │ PASS   │ 121.272605ms │
╰───────────────┴─────────────┴───────────┴──────────────────────────┴────────┴──────────────╯
--- Test results for package: cato_networks - END   ---
Done
Run system tests for the package
2026/07/09 10:33:51  INFO elastic-package v0.125.1 version-hash 111636ab (build time: 2026-07-03T17:56:06+05:30)
2026/07/09 10:33:51  INFO elastic-stack: 8.19.0
2026/07/09 10:33:51  INFO Installing package...
2026/07/09 10:34:03  INFO Running test for data_stream "audit" with configuration 'default'
2026/07/09 10:34:12  INFO Setting up independent Elastic Agent...
2026/07/09 10:34:22  INFO Setting up service...
2026/07/09 10:35:03  INFO Validating test case...
2026/07/09 10:35:04  INFO Tearing down service...
2026/07/09 10:35:05  INFO Write container logs to file: /root/integrations/build/container-logs/cato_networks-1783573505220468833.log
2026/07/09 10:35:07  INFO Tearing down agent...
2026/07/09 10:35:07  INFO Write container logs to file: /root/integrations/build/container-logs/elastic-agent-1783573507644954595.log
2026/07/09 10:35:15  INFO Running test for data_stream "event" with configuration 'default'
2026/07/09 10:35:24  INFO Setting up independent Elastic Agent...
2026/07/09 10:37:02  INFO Setting up service...
2026/07/09 10:37:50  INFO Validating test case...
2026/07/09 10:37:51  INFO Tearing down service...
2026/07/09 10:37:52  INFO Write container logs to file: /root/integrations/build/container-logs/cato_networks-1783573672223416863.log
2026/07/09 10:37:54  INFO Tearing down agent...
2026/07/09 10:37:54  INFO Write container logs to file: /root/integrations/build/container-logs/elastic-agent-1783573674678950024.log
2026/07/09 10:38:02  INFO Uninstalling package...
--- Test results for package: cato_networks - START ---
╭───────────────┬─────────────┬───────────┬───────────┬────────┬─────────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │    TIME ELAPSED │
├───────────────┼─────────────┼───────────┼───────────┼────────┼─────────────────┤
│ cato_networks │ audit       │ system    │ default   │ PASS   │  1m1.214973462s │
│ cato_networks │ event       │ system    │ default   │ PASS   │ 2m36.067814202s │
╰───────────────┴─────────────┴───────────┴───────────┴────────┴─────────────────╯
--- Test results for package: cato_networks - END   ---
Done
```
### Resolves https://github.com/elastic/integrations/pull/19307#discussion_r3539864425
