### PR TITLE
[CI][Backports] Restructure backport checklist comment intro

### DIFF
--- a/.github/workflows/backport-packages-detect.yml
+++ b/.github/workflows/backport-packages-detect.yml
@@ -6,7 +6,6 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
-      - backport-checklist-automation-message
 
 jobs:
   detect-packages:

--- a/.github/workflows/backport-packages-detect.yml
+++ b/.github/workflows/backport-packages-detect.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
+      - backport-checklist-automation-message
 
 jobs:
   detect-packages:

--- a/dev/backports/checklist/checklist.go
+++ b/dev/backports/checklist/checklist.go
@@ -65,11 +65,11 @@ func BuildComment(pkgs []PackageBranches, checked map[string]bool) string {
 	fmt.Fprintln(&b, marker)
 	fmt.Fprintln(&b, "## Backport branches")
 	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, "Only branches for packages touched by this PR's current diff are shown.")
+	fmt.Fprintln(&b, "> [!IMPORTANT]")
+	fmt.Fprintln(&b, "> Only branches for packages touched by this PR's current diff are shown.")
+	fmt.Fprintln(&b, "> This comment is updated automatically on each push — manual edits will be overwritten.")
 	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, "Consider backporting this change to the branches listed below.")
-	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, "This comment is updated automatically on each push — manual edits will be overwritten.")
+	fmt.Fprintln(&b, "Active backport branches for the packages touched by this PR:")
 
 	for _, p := range pkgs {
 		if len(p.Branches) == 0 {


### PR DESCRIPTION
<!-- Type of change: Enhancement -->

## Proposed commit message

```
restructure checklist comment intro with [!IMPORTANT] callout

Move the scope and auto-update notices into a GitHub [!IMPORTANT] alert
block at the top, and replace the call-to-action with a plain intro line
describing the listed branches.
```

## Author's Checklist

- [x] Test new message

<img width="907" height="871" alt="new checklist message" src="https://github.com/user-attachments/assets/c053e10b-559c-45a0-be50-e2788b490175" />



## How to test this PR locally

Open or update a PR that triggers the backport checklist comment and verify
the rendered comment shows the `[!IMPORTANT]` alert block at the top, followed
by the "Active backport branches for the packages touched by this PR:" intro line.

## Related issues

- Fixes #19213
- Follow-up of #19997

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).