### PR TITLE
workday: fix infinite 401 retry loop in activity CEL program

### DIFF
--- a/packages/workday/_dev/deploy/docker/files/config.yml
+++ b/packages/workday/_dev/deploy/docker/files/config.yml
@@ -15,6 +15,7 @@ rules:
           {
             "access_token": "xxxx",
             "token_type": "Bearer",
+            "expires_in": 3600,
             "refresh_token": "refresh_token"
           }
           `}}

--- a/packages/workday/changelog.yml
+++ b/packages/workday/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: '0.2.0'
+  changes:
+    - description: Fix token refresh after 401 by adding TTL-based expiry tracking.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20072
 - version: '0.1.0'
   changes:
     - description: Add support for activity data stream.

--- a/packages/workday/data_stream/activity/agent/stream/cel.yml.hbs
+++ b/packages/workday/data_stream/activity/agent/stream/cel.yml.hbs
@@ -42,7 +42,9 @@ program: |-
     state.url.trim_right("/").as(base_url,
       state.with(
         (
-          (state.?cursor.access_token.orValue("") == "") ?
+          (!has(state.?cursor.access_token) ||
+           !has(state.?cursor.token_expiry) ||
+           timestamp(state.cursor.token_expiry) < now - duration("30s")) ?
             post_request(
               state.token_url,
               "application/x-www-form-urlencoded",
@@ -58,6 +60,17 @@ program: |-
                   {
                     "ok": true,
                     "access_token": ao.access_token,
+                    // Workday's "Enforce 60 Minute Access Token Expiry"
+                    // is a server-side admin setting. When disabled, the
+                    // token endpoint returns expires_in:-1 and tokens are
+                    // "valid for several hours". Default to 60m in that
+                    // case. This is conservative but well within the actual
+                    // lifetime.
+                    "token_expiry":
+                      (!has(ao.expires_in) || int(ao.expires_in) < 0) ?
+                        (now + duration("3540s")).format(time_layout.RFC3339)
+                      :
+                        (now + duration(string(int(ao.expires_in) - 60) + "s")).format(time_layout.RFC3339),
                   }
                 )
               :
@@ -72,6 +85,7 @@ program: |-
             {
               "ok": true,
               "access_token": state.cursor.access_token,
+              "token_expiry": state.cursor.token_expiry,
             }
         ).as(tok,
           !tok.ok ?
@@ -116,6 +130,7 @@ program: |-
                         "want_more": has_more,
                         "cursor": {
                           "access_token": tok.access_token,
+                          "token_expiry": tok.token_expiry,
                           ?"max_ingested_time": has_more ?
                             (
                               has(state.?cursor.max_ingested_time) ?
@@ -152,11 +167,11 @@ program: |-
                     "error": {
                       "code": string(resp.StatusCode),
                       "id": resp.Status,
-                      "message": "GET " + base_url + "/activityLogging: token expired, retrying",
+                      "message": "GET " + base_url + "/activityLogging: token expired",
                     },
                   },
-                  "want_more": true,
-                  "offset": state.offset,
+                  "want_more": false,
+                  "offset": 0,
                 }
               :
                 {

--- a/packages/workday/manifest.yml
+++ b/packages/workday/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: workday
 title: 'Workday'
-version: 0.1.0
+version: 0.2.0
 description: 'Collect logs from Workday with Elastic Agent.'
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
workday: fix infinite 401 retry loop in activity CEL program

The token validity check only tested presence, not expiry. When
the Workday API returned 401, the handler set want_more:true
without clearing the cached access_token, causing an infinite
retry loop against the stale token with no backoff.

Add TTL-based token expiry tracking using the expires_in value
from the token endpoint response. When expires_in is absent or
negative (Workday's non-enforced expiry mode), default to 60
minutes, this is conservative but within the documented "several
hours" actual lifetime. The 401 handler now sets want_more:false
so the next poll interval triggers a fresh token exchange.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
