### PR TITLE
[Atlassian Confluence][Atlassian Jira][Cisco Secure Endpoint][Okta] Fix CI for snapshot

### DIFF
--- a/packages/atlassian_confluence/_dev/deploy/docker/docker-compose.yml
+++ b/packages/atlassian_confluence/_dev/deploy/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   confluence-api:
     image: docker.elastic.co/observability/stream:v0.18.0
+    hostname: svc-confluence-api
     ports:
       - 8080
     volumes:

--- a/packages/atlassian_jira/_dev/deploy/docker/docker-compose.yml
+++ b/packages/atlassian_jira/_dev/deploy/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   jira-api:
     image: docker.elastic.co/observability/stream:v0.18.0
+    hostname: svc-jira-api
     ports:
       - 8080
     volumes:

--- a/packages/cisco_secure_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_secure_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.3'
 services:
   cisco_secure_endpoint:
     image: docker.elastic.co/observability/stream:v0.18.0
+    hostname: svc-cisco_secure_endpoint
     ports:
       - 8080
     volumes:

--- a/packages/okta/_dev/deploy/docker/docker-compose.yml
+++ b/packages/okta/_dev/deploy/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.3'
 services:
   okta:
     image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: svc-okta
     ports:
       - 8080
     volumes:
@@ -14,6 +15,7 @@ services:
       - --config=/files/config.yml
   okta-oauth2:
     image: docker.elastic.co/observability/stream:v0.20.0
+    hostname: svc-okta-oauth2
     ports:
       - 8080
     volumes:


### PR DESCRIPTION
## Proposed commit message

```
Set the mock service hostname to svc-<service> for atlassian_confluence,
atlassian_jira, cisco_secure_endpoint, and okta so stream-generated
absolute Link/next URLs match the origin injected into system test
configs, fixing flaky pagination in system tests.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Related issues

- Closes #19833, #19834, #19854, #19858, #19841, #19842, #19843, #19844