### PR TITLE
fix(backports): replace strings.SplitSeq with strings.Split for go1.22 compatibility

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -68,9 +68,9 @@ FULL_ZIP_PACKAGE_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.zip"
 TRIMMED_PACKAGE_VERSION="$(echo "$PACKAGE_VERSION" | cut -d '.' -f -2)"
 SOURCE_BRANCH="main"
 ## In order to test other branches probably it is required to copy the dev files or magefile from the PR branch, and for that it would require these changes
-# git checkout -b test_main
-# SOURCE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-# echo "--- SOURCE_BRANCH: ${SOURCE_BRANCH}"
+git checkout -b test_main
+SOURCE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+echo "--- SOURCE_BRANCH: ${SOURCE_BRANCH}"
 
 # If the backport branch name is not set, use the expected one.
 EXPECTED_BACKPORT_BRANCH_NAME="backport-${PACKAGE_NAME}-${TRIMMED_PACKAGE_VERSION}"

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -68,9 +68,9 @@ FULL_ZIP_PACKAGE_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.zip"
 TRIMMED_PACKAGE_VERSION="$(echo "$PACKAGE_VERSION" | cut -d '.' -f -2)"
 SOURCE_BRANCH="main"
 ## In order to test other branches probably it is required to copy the dev files or magefile from the PR branch, and for that it would require these changes
-git checkout -b test_main
-SOURCE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-echo "--- SOURCE_BRANCH: ${SOURCE_BRANCH}"
+# git checkout -b test_main
+# SOURCE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+# echo "--- SOURCE_BRANCH: ${SOURCE_BRANCH}"
 
 # If the backport branch name is not set, use the expected one.
 EXPECTED_BACKPORT_BRANCH_NAME="backport-${PACKAGE_NAME}-${TRIMMED_PACKAGE_VERSION}"

--- a/dev/backports/apply/apply.go
+++ b/dev/backports/apply/apply.go
@@ -557,7 +557,8 @@ func (a applier) conflictingFiles() ([]string, error) {
 		return nil, err
 	}
 	var files []string
-	for line := range strings.SplitSeq(string(out), "\n") {
+	// strings.SplitSeq requires go1.23; go.mod pins go1.22 for backport compatibility with older base commits.
+	for _, line := range strings.Split(string(out), "\n") {
 		if len(line) < 3 {
 			continue
 		}

--- a/dev/backports/checklist/checklist.go
+++ b/dev/backports/checklist/checklist.go
@@ -39,7 +39,8 @@ func ParseCheckedBranches(body string) map[string]bool {
 	if !strings.Contains(body, marker) {
 		return checked
 	}
-	for line := range strings.SplitSeq(body, "\n") {
+	// strings.SplitSeq requires go1.23; go.mod pins go1.22 for backport compatibility with older base commits.
+	for _, line := range strings.Split(body, "\n") {
 		if m := checkedLineRe.FindStringSubmatch(strings.TrimRight(line, "\r")); m != nil {
 			checked[m[1]] = true
 		}


### PR DESCRIPTION
## Proposed commit message

fix(backports): replace strings.SplitSeq with strings.Split for go1.22 compatibility

strings.SplitSeq requires go1.23, but backport branches are created from
older base commits whose go.mod pins go1.22, causing build failures.

## Author's Checklist

- [x] Verified `go build ./dev/backports/...` passes
- [x] Verified `backport_branch.sh` runs successfully against an old base commit pinned to go1.22 - https://buildkite.com/elastic/integrations-backport/builds/307/list

## How to test this PR locally

1. Check out a backport branch whose base commit has `go 1.22` in `go.mod` (e.g. via the `dev/backports` scripts).
2. Run `go build ./dev/backports/...` — it should no longer fail with `cannot range over strings.SplitSeq(...): requires go1.23 or later`.
3. Run the existing tests for `dev/backports/apply` and `dev/backports/checklist` to confirm behavior is unchanged.

## Related issues

- Relates elastic/integrations#19213
- Relates elastic/integrations#19217

---

> This PR was generated with the assistance of [Claude Code](https://claude.com/claude-code) (claude-sonnet-5).