### PR TITLE
[Backport] Add backport-aws-6.x entry for aws package

### DIFF
--- a/.backports.yml
+++ b/.backports.yml
@@ -21,6 +21,13 @@ backports:
     archived: true
     remove_other_packages: true
   - package: aws
+    branch: backport-aws-6.x
+    base_version: "6.21.0"
+    base_commit: "913b779a20"
+    maintained_until: null
+    archived: false
+    remove_other_packages: true
+  - package: aws
     branch: backport-aws-3.17
     base_version: "3.17.0"
     base_commit: "5b593f6681"

--- a/.backports.yml
+++ b/.backports.yml
@@ -24,7 +24,7 @@ backports:
     branch: backport-aws-6.x
     base_version: "6.21.0"
     base_commit: "913b779a20"
-    maintained_until: null
+    maintained_until: "2027-01-16"
     archived: false
     remove_other_packages: true
   - package: aws


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## Proposed commit message

```
[Backport] Add backport-aws-6.x entry for aws package

Add a new entry in `.backports.yml` for the `aws` package backport branch
`backport-aws-6.x`, based on version 6.21.0 (commit 913b779a20).

This branch is active (`archived: false`) and configured to strip all
other packages (`remove_other_packages: true`), consistent with other
aws backport entries.
```

## Author's Checklist

- [ ] `base_version` matches the package version at the point the branch diverged from main.
- [ ] `base_commit` is the exact commit SHA (or short SHA) on main that the branch is based on.
- [ ] `maintained_until` is set to the date until which this branch will receive backports, or `null` if indefinite.
- [ ] `archived: false` — branch is active and should receive backports.
- [ ] `remove_other_packages: true` — only the `aws` package is kept on the branch.

## How to test this PR locally

No local testing required. CI will validate the `.backports.yml` entry (inventory check) and dry-run the backport branch creation. After merge, the `backport-aws-6.x` branch will be created automatically by CI.

## Related issues

- 

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).