### PR TITLE
fix(ti_custom): preserve added_after when paginating TAXII requests

### DIFF
--- a/packages/ti_custom/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_custom/_dev/deploy/docker/files/config.yml
@@ -38,6 +38,8 @@ rules:
       Authorization:
         - 'Bearer abcd1234'
     query_params:
+      # TAXII 2.1: paginated requests must retain the original added_after filter with next.
+      added_after: '{added_after:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z}'
       next: 'empty_page'
     responses:
       - status_code: 200

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.2"
+  changes:
+    - description: Preserve `added_after` with `next` when paginating TAXII 2.1 requests.
+      type: bugfix
+      link: TBD
 - version: "1.8.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_custom/changelog.yml
+++ b/packages/ti_custom/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Preserve `added_after` with `next` when paginating TAXII 2.1 requests.
       type: bugfix
-      link: TBD
+      link: https://github.com/elastic/integrations/pull/20184
 - version: "1.8.1"
   changes:
     - description: Fix transform destination to use keyword for data_stream.namespace, allowing multi-namespace deployments.

--- a/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -133,7 +133,7 @@ program: |
                             (
                                 state.url.trim_right("/") + "/?" + {
                                     "next": [string(body.next)],
-                                    ?"added_after": added_after.optMap(a, [string(a)]),
+                                    ?"added_after": added_after.optMap(a, [a]),
                                     ?"limit": state.?limit.optMap(l, [string(int(l))]),
                                 }.format_query()
                             )

--- a/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -79,7 +79,7 @@ program: |
             state.?added_after
         : (has(state.initial_interval) && state.initial_interval != "") ?
             state.?cursor.last_timestamp.or(
-                state.?initial_interval.optMap(i, (now() - duration(i)).format("2006-01-02T15:04:05.000000Z07:00"))
+                optional.of((now() - duration(state.initial_interval)).format("2006-01-02T15:04:05.000000Z07:00"))
             )
         :
             optional.none()

--- a/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -92,7 +92,7 @@ program: |
                 : added_after.hasValue() ?
                     (
                         state.url.trim_right("/") + "/?" + {
-                            "added_after": [string(added_after.value())],
+                            "added_after": [added_after.value()],
                             ?"limit": state.?limit.optMap(l, [string(int(l))]),
                         }.format_query()
                     )

--- a/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_custom/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -72,87 +72,97 @@ redact:
     - password
 
 # CEL program to follow TAXII 2.1 protocol. See https://docs.oasis-open.org/cti/taxii/v2.1/os/taxii-v2.1-os.html
+# Clients must paginate with next along with the same original query filters (e.g. added_after).
 program: |
-    state.with(
-        request(
-            "GET",
-            state.?want_more.orValue(false) ?
-                state.next_url
-            : (has(state.initial_interval) && state.initial_interval != "") ?
-                (
-                    state.url.trim_right("/") + "/?" + {
-                        ?"added_after": state.?cursor.last_timestamp.optMap(ts,
-                            [ts]
-                        ).or(
-                            state.?initial_interval.optMap(i, [(now() - duration(i)).format("2006-01-02T15:04:05.000000Z07:00")])
-                        ),
-                        ?"limit": state.?limit.optMap(l, [string(int(l))]),
-                    }.format_query()
-                )
-                :
-                    state.url
-        ).with(
-            {
-                "Header": {
-                    "Accept": [string(state.accept_header)],
-                    ?"Content-Type": state.?content_header.orValue("") != "" ? optional.of([state.content_header]) : optional.none(),
-                    "Authorization": (has(state.api_key) && state.api_key != "") ?
-                        [state.?key_type.orValue("Bearer") + " " + string(state.api_key)]
-                    : (state.?username.orValue("") != "" && state.?password.orValue("") != "") ?
-                        ["Basic " + (state.username + ":" + state.password).base64()]
-                    :
-                        []
-                },
-            }
-        ).do_request().as(resp, (resp.StatusCode == 200 || resp.StatusCode == 206) ?
-            bytes(resp.Body).decode_json().as(body,
-                {
-                    "events": has(body.objects) && type(body.objects) == list ?
-                        body.objects.map(e,
-                            {
-                                "message": e.encode_json(),
-                            }
-                        )
-                    :
-                        [],
-                    "accept_header": state.accept_header,
-                    "content_header": state.?content_header.orValue(""),
-                    "url": state.url,
-                    "api_key": state.?api_key.orValue(""),
-                    "username": state.?username.orValue(""),
-                    "password": state.?password.orValue(""),
-                    "want_more": has(body.next) && body.next != null && body.next != "",
-                    "next_url": (has(body.next) && body.next != null && body.next != "") ?
-                        (
-                            state.url.trim_right("/") + "/?" + {
-                                "next": [string(body.next)],
-                                ?"limit": state.?limit.optMap(l, [string(int(l))]),
-                            }.format_query()
-                        )
-                    :
-                        state.url,
-                    "cursor": {
-                        ?"last_timestamp": resp.Header[?"X-Taxii-Date-Added-Last"][0],
-                    },
-                }
+    (
+        state.?want_more.orValue(false) ?
+            state.?added_after
+        : (has(state.initial_interval) && state.initial_interval != "") ?
+            state.?cursor.last_timestamp.or(
+                state.?initial_interval.optMap(i, (now() - duration(i)).format("2006-01-02T15:04:05.000000Z07:00"))
             )
         :
-            {
-                "events": {
-                    "error": {
-                        "code": string(resp.StatusCode),
-                        "id": string(resp.Status),
-                        "message": "GET:" +
-                        (
-                            (size(resp.Body) != 0) ?
-                                string(resp.Body)
-                            :
-                                string(resp.Status) + " (" + string(resp.StatusCode) + ")"
-                        ),
+            optional.none()
+    ).as(added_after,
+        state.with(
+            request(
+                "GET",
+                state.?want_more.orValue(false) ?
+                    state.next_url
+                : added_after.hasValue() ?
+                    (
+                        state.url.trim_right("/") + "/?" + {
+                            "added_after": [string(added_after.value())],
+                            ?"limit": state.?limit.optMap(l, [string(int(l))]),
+                        }.format_query()
+                    )
+                :
+                    state.url
+            ).with(
+                {
+                    "Header": {
+                        "Accept": [string(state.accept_header)],
+                        ?"Content-Type": state.?content_header.orValue("") != "" ? optional.of([state.content_header]) : optional.none(),
+                        "Authorization": (has(state.api_key) && state.api_key != "") ?
+                            [state.?key_type.orValue("Bearer") + " " + string(state.api_key)]
+                        : (state.?username.orValue("") != "" && state.?password.orValue("") != "") ?
+                            ["Basic " + (state.username + ":" + state.password).base64()]
+                        :
+                            []
                     },
-                },
-                "want_more": false,
-            }
+                }
+            ).do_request().as(resp, (resp.StatusCode == 200 || resp.StatusCode == 206) ?
+                bytes(resp.Body).decode_json().as(body,
+                    {
+                        "events": has(body.objects) && type(body.objects) == list ?
+                            body.objects.map(e,
+                                {
+                                    "message": e.encode_json(),
+                                }
+                            )
+                        :
+                            [],
+                        "accept_header": state.accept_header,
+                        "content_header": state.?content_header.orValue(""),
+                        "url": state.url,
+                        "api_key": state.?api_key.orValue(""),
+                        "username": state.?username.orValue(""),
+                        "password": state.?password.orValue(""),
+                        "want_more": has(body.next) && body.next != null && body.next != "",
+                        "next_url": (has(body.next) && body.next != null && body.next != "") ?
+                            (
+                                state.url.trim_right("/") + "/?" + {
+                                    "next": [string(body.next)],
+                                    ?"added_after": added_after.optMap(a, [string(a)]),
+                                    ?"limit": state.?limit.optMap(l, [string(int(l))]),
+                                }.format_query()
+                            )
+                        :
+                            state.url,
+                        ?"added_after": added_after,
+                        "cursor": {
+                            ?"last_timestamp": resp.Header[?"X-Taxii-Date-Added-Last"][0],
+                        },
+                    }
+                )
+            :
+                {
+                    "events": {
+                        "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "GET:" +
+                            (
+                                (size(resp.Body) != 0) ?
+                                    string(resp.Body)
+                                :
+                                    string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+                            ),
+                        },
+                    },
+                    "want_more": false,
+                }
+            )
         )
     )
 

--- a/packages/ti_custom/data_stream/indicator/manifest.yml
+++ b/packages/ti_custom/data_stream/indicator/manifest.yml
@@ -56,7 +56,6 @@ streams:
         secret: true
         description: >
           API key that the API server may require for token authorization.
-
       - name: key_type
         type: text
         title: API Key Type
@@ -133,7 +132,6 @@ streams:
         title: Accept header value
         description: >
           The Accept header is used by HTTP Requests to specify which Content-Types are acceptable in response. All TAXII requests must include a media range in the Accept header. More information can be found in the [TAXII specification](https://docs.oasis-open.org/cti/taxii/v2.1/csprd02/taxii-v2.1-csprd02.html#_Toc16526016). This option only applies when `Enable TAXII 2.1` is enabled.
-
         multi: false
         required: true
         show_user: false
@@ -143,7 +141,6 @@ streams:
         title: Content-Type header value
         description: >
           The Content-Type header is used by HTTP to identify the format of HTTP Requests and HTTP Responses. More information can be found in the [TAXII specification](https://docs.oasis-open.org/cti/taxii/v2.1/csprd02/taxii-v2.1-csprd02.html#_Toc16526016). This option only applies when `Enable TAXII 2.1` is enabled.
-
         multi: false
         required: false
         show_user: false
@@ -213,7 +210,10 @@ streams:
         type: integer
         title: Maximum Pages Per Interval
         description: >-
-          The maximum number of pages that can be collected during each polling interval. Increase this if the integration goes into a degraded state with the message "exceeding maximum number of CEL executions". It must be a positive integer.
+          The maximum number of pages that can be collected during each polling
+          interval. Increase this if the integration goes into a degraded state
+          with the message "exceeding maximum number of CEL executions". It must
+          be a positive integer.
         multi: false
         required: false
         show_user: false

--- a/packages/ti_custom/data_stream/indicator/manifest.yml
+++ b/packages/ti_custom/data_stream/indicator/manifest.yml
@@ -56,6 +56,7 @@ streams:
         secret: true
         description: >
           API key that the API server may require for token authorization.
+
       - name: key_type
         type: text
         title: API Key Type
@@ -132,6 +133,7 @@ streams:
         title: Accept header value
         description: >
           The Accept header is used by HTTP Requests to specify which Content-Types are acceptable in response. All TAXII requests must include a media range in the Accept header. More information can be found in the [TAXII specification](https://docs.oasis-open.org/cti/taxii/v2.1/csprd02/taxii-v2.1-csprd02.html#_Toc16526016). This option only applies when `Enable TAXII 2.1` is enabled.
+
         multi: false
         required: true
         show_user: false
@@ -141,6 +143,7 @@ streams:
         title: Content-Type header value
         description: >
           The Content-Type header is used by HTTP to identify the format of HTTP Requests and HTTP Responses. More information can be found in the [TAXII specification](https://docs.oasis-open.org/cti/taxii/v2.1/csprd02/taxii-v2.1-csprd02.html#_Toc16526016). This option only applies when `Enable TAXII 2.1` is enabled.
+
         multi: false
         required: false
         show_user: false
@@ -210,10 +213,7 @@ streams:
         type: integer
         title: Maximum Pages Per Interval
         description: >-
-          The maximum number of pages that can be collected during each polling
-          interval. Increase this if the integration goes into a degraded state
-          with the message "exceeding maximum number of CEL executions". It must
-          be a positive integer.
+          The maximum number of pages that can be collected during each polling interval. Increase this if the integration goes into a degraded state with the message "exceeding maximum number of CEL executions". It must be a positive integer.
         multi: false
         required: false
         show_user: false

--- a/packages/ti_custom/manifest.yml
+++ b/packages/ti_custom/manifest.yml
@@ -3,7 +3,7 @@ name: ti_custom
 title: Custom Threat Intelligence
 description: Ingest threat intelligence data in STIX 2.1 format with Elastic Agent
 type: integration
-version: "1.8.1"
+version: "1.8.2"
 categories:
   - custom
   - security


### PR DESCRIPTION
TAXII 2.1 requires clients to paginate with `next` using the same original query filters. `next_url` previously omitted `added_after`, so servers that use page-number cursors returned unfiltered historical pages after page 1.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Preserve `added_after` across TAXII 2.1 pagination in `ti_custom`.

WHAT:
- Compute the poll-window `added_after` once (cursor `last_timestamp`, else `now() - initial_interval`).
- Persist it in CEL state and include it on `next_url` with `next` and optional `limit`.
- Keep interval-to-interval cursor updates via `X-Taxii-Date-Added-Last`.
- Update the TAXII system-test mock so follow-up pages require `added_after`.
- Bump package to `1.8.2`.

WHY:
TAXII 2.1 requires `next` to be used with the same original query options. Dropping `added_after` on page 2+ breaks servers where `next` is a page index rather than an opaque cursor that embeds filters, causing unbounded historical IOC crawls each interval.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] CEL `next_url` includes the same window `added_after` used on page 1
- [ ] `cursor.last_timestamp` still drives the next interval's first request
- [ ] Auth / headers / `events` mapping unchanged
- [ ] Changelog `link:` updated to this PR after open

## How to test this PR locally

```bash
cd packages/ti_custom
elastic-package format
elastic-package check
elastic-package stack up -d
elastic-package test system
elastic-package stack down

With request tracing enabled against a page-number next TAXII server, confirm:

Page 1: `?added_after=<T0>&limit=...`
Page 2+: `?next=...&added_after=<T0>&limit=...` (same T0)
Next interval page 1: `added_after` from `X-Taxii-Date-Added-Last`

## Related issues

- Relates [#12084](https://github.com/elastic/integrations/pull/12084)
- Relates [#19107](https://github.com/elastic/integrations/pull/19107)

## Screenshots

n/a
