### PR TITLE
Enable scheduled required package updates

### DIFF
--- a/.github/workflows/requires-update.yml
+++ b/.github/workflows/requires-update.yml
@@ -12,11 +12,9 @@ on:
         description: 'Print what would be published without touching git or GitHub'
         type: boolean
         default: false
-  # Manual-only for now: adoption of `requires:` blocks is just starting (first
-  # package is landing). Re-enable the schedule once a manual run has been
-  # verified end-to-end against a real package (PR/issue creation included).
-  # schedule:
-  #   - cron: '0 9 * * 1'
+  schedule:
+    # Every weekday at 02:30 UTC.
+    - cron: '30 2 * * 1-5'
 
 permissions:
   contents: read
@@ -59,8 +57,8 @@ jobs:
       - name: Run RequiresUpdate
         # Scans packages, applies proposals, and opens one PR (or issue) per
         # package — see dev/requiresupdate.
-        # Scheduled runs (when cron is enabled) always use dryRun=false and
-        # preview=false; workflow_dispatch inputs are only read for manual runs.
+        # Scheduled runs always use dryRun=false and preview=false;
+        # workflow_dispatch inputs are only read for manual runs.
         id: requires_update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Type of change: Enhancement -->

## Proposed commit message

Enable the required-package update workflow to run automatically every weekday at 02:30 UTC.

Running on weekdays keeps required input and content package dependencies current while avoiding unattended update PRs being opened over the weekend.

The 02:30 UTC start provides a 90-minute separation from the existing Elastic Stack dependency update workflow, which is scheduled for 01:00 UTC on weekdays. It also avoids the repository's main cluster of scheduled workflows between 09:00 and 15:00 UTC, reducing the likelihood of concurrent automation workloads.

Manual execution through `workflow_dispatch` remains available, including the existing dry-run and preview options. Scheduled executions run with both options disabled so updates are applied and published automatically.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs. _(N/A — workflow-only change)_
- [ ] I have added an entry to my package's `changelog.yml` file. _(N/A — no package changed)_
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition). _(N/A — no package changed)_
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices). _(N/A — no dashboard changed)_

## Author's Checklist

- [x] The workflow runs every weekday at 02:30 UTC.
- [x] The schedule does not share a start time with another scheduled workflow.
- [x] Manual dry-run and preview execution remains available.
- [x] Scheduled runs apply and publish dependency updates automatically.
- [x] The workflow YAML parses successfully.
- [x] `git diff --check` passes.

## How to test this PR locally

Confirm that the cron expression is:

```yaml
# Every weekday at 02:30 UTC.
- cron: '30 2 * * 1-5'
```

The existing `workflow_dispatch` trigger can still be used for an end-to-end dry run or preview.

## Related issues

- Closes #20127
- Follow-up to #19217

## Screenshots

N/A — workflow-only change.
