### PR TITLE
Crowdstrike: use inclusive >= cursor boundary in vulnerability and alert CEL programs

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use an inclusive lower bound (>=) on the updated_timestamp cursor filter in the vulnerability and alert data streams to prevent records sharing a boundary timestamp from being permanently skipped at page or error boundaries.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999
+      link: https://github.com/elastic/integrations/pull/20190
 - version: "4.3.0"
   changes:
     - description: Add ECS categorization and field mappings for new FDR event types including IDP telemetry, Active Directory account changes, DBus/systemd events, network containment, host firewall, sensor diagnostics, and container activity.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.3.1"
+  changes:
+    - description: Use an inclusive lower bound (>=) on the updated_timestamp cursor filter in the vulnerability and alert data streams to prevent records sharing a boundary timestamp from being permanently skipped at page or error boundaries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999
 - version: "4.3.0"
   changes:
     - description: Add ECS categorization and field mappings for new FDR event types including IDP telemetry, Active Directory account changes, DBus/systemd events, network containment, host firewall, sensor diagnostics, and container activity.

--- a/packages/crowdstrike/data_stream/alert/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/alert/_dev/test/policy/test-default.expected
@@ -33,7 +33,10 @@ inputs:
                     "limit": int(state.batch_size),
                     "sort": "updated_timestamp|asc",
                     "filter": [
-                      "updated_timestamp:>'" + start_time + "'",
+                      // Inclusive lower bound: records sharing the boundary timestamp can span a page
+                      // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+                      // Re-fetched records are de-duplicated downstream by the fingerprint _id
+                      "updated_timestamp:>='" + start_time + "'",
                       ?state.?query.optMap(q, "(" + q + ")"),
                     ].join("+"),
                   }.encode_json()

--- a/packages/crowdstrike/data_stream/alert/_dev/test/policy/test-traced.expected
+++ b/packages/crowdstrike/data_stream/alert/_dev/test/policy/test-traced.expected
@@ -33,7 +33,10 @@ inputs:
                     "limit": int(state.batch_size),
                     "sort": "updated_timestamp|asc",
                     "filter": [
-                      "updated_timestamp:>'" + start_time + "'",
+                      // Inclusive lower bound: records sharing the boundary timestamp can span a page
+                      // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+                      // Re-fetched records are de-duplicated downstream by the fingerprint _id
+                      "updated_timestamp:>='" + start_time + "'",
                       ?state.?query.optMap(q, "(" + q + ")"),
                     ].join("+"),
                   }.encode_json()

--- a/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
@@ -51,7 +51,6 @@ program: |-
             // Inclusive lower bound: records sharing the boundary timestamp can span a page
             // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
             // Re-fetched records are de-duplicated downstream by the fingerprint _id
-            // (see elasticsearch/ingest_pipeline/default.yml).
             "updated_timestamp:>='" + start_time + "'",
             ?state.?query.optMap(q, "(" + q + ")"),
           ].join("+"),

--- a/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
@@ -48,7 +48,11 @@ program: |-
           "limit": int(state.batch_size),
           "sort": "updated_timestamp|asc",
           "filter": [
-            "updated_timestamp:>'" + start_time + "'",
+            // Inclusive lower bound: records sharing the boundary timestamp can span a page
+            // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+            // Re-fetched records are de-duplicated downstream by the fingerprint _id
+            // (see elasticsearch/ingest_pipeline/default.yml).
+            "updated_timestamp:>='" + start_time + "'",
             ?state.?query.optMap(q, "(" + q + ")"),
           ].join("+"),
         }.encode_json()

--- a/packages/crowdstrike/data_stream/vulnerability/_dev/test/policy/test-default.expected
+++ b/packages/crowdstrike/data_stream/vulnerability/_dev/test/policy/test-default.expected
@@ -36,7 +36,10 @@ inputs:
                     "limit": [string(state.batch_size)],
                     "filter": [
                       [
-                        "updated_timestamp:>'" + state.start_time + "'",
+                        // Inclusive lower bound: records sharing the boundary timestamp can span a page
+                        // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+                        // Re-fetched records are de-duplicated downstream by the fingerprint _id
+                        "updated_timestamp:>='" + state.start_time + "'",
                         ?state.?query.optMap(q, "(" + q + ")"),
                       ].join("+"),
                     ],

--- a/packages/crowdstrike/data_stream/vulnerability/_dev/test/policy/test-traced.expected
+++ b/packages/crowdstrike/data_stream/vulnerability/_dev/test/policy/test-traced.expected
@@ -36,7 +36,10 @@ inputs:
                     "limit": [string(state.batch_size)],
                     "filter": [
                       [
-                        "updated_timestamp:>'" + state.start_time + "'",
+                        // Inclusive lower bound: records sharing the boundary timestamp can span a page
+                        // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+                        // Re-fetched records are de-duplicated downstream by the fingerprint _id
+                        "updated_timestamp:>='" + state.start_time + "'",
                         ?state.?query.optMap(q, "(" + q + ")"),
                       ].join("+"),
                     ],

--- a/packages/crowdstrike/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -55,7 +55,6 @@ program: |-
               // Inclusive lower bound: records sharing the boundary timestamp can span a page
               // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
               // Re-fetched records are de-duplicated downstream by the fingerprint _id
-              // (see elasticsearch/ingest_pipeline/default.yml).
               "updated_timestamp:>='" + state.start_time + "'",
               ?state.?query.optMap(q, "(" + q + ")"),
             ].join("+"),

--- a/packages/crowdstrike/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -52,7 +52,11 @@ program: |-
           "limit": [string(state.batch_size)],
           "filter": [
             [
-              "updated_timestamp:>'" + state.start_time + "'",
+              // Inclusive lower bound: records sharing the boundary timestamp can span a page
+              // or error boundary, so ">=" avoids permanently skipping same-timestamp records.
+              // Re-fetched records are de-duplicated downstream by the fingerprint _id
+              // (see elasticsearch/ingest_pipeline/default.yml).
+              "updated_timestamp:>='" + state.start_time + "'",
               ?state.?query.optMap(q, "(" + q + ")"),
             ].join("+"),
           ],

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "4.3.0"
+version: "4.3.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.4.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
[crowdstrike]: use inclusive >= cursor boundary in vulnerability and alert CEL programs

Strict > on updated_timestamp permanently skips records that share a
boundary timestamp when a page or error boundary falls mid-group. Switch
to >= so same-timestamp records are always re-queried.

Re-fetched boundary records are absorbed without creating duplicates:
both pipelines run fingerprint processors that include updated_timestamp
so events that were already ingested are dropped.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
