### PR TITLE
Tenable IO: add max_executions to asset, audit, plugin, and scan data streams

### DIFF
--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Allow user configuration of maximum number of CEL executions for the asset, audit, plugin, and scan data streams.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20192
 - version: "4.11.2"
   changes:
     - description: Preserve the `severity_level` filter across CEL export cycles in the vulnerability data stream so subsequent exports keep filtering by the configured severities.

--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.12.0"
+  changes:
+    - description: Allow user configuration of maximum number of CEL executions for the asset, audit, plugin, and scan data streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "4.11.2"
   changes:
     - description: Preserve the `severity_level` filter across CEL export cycles in the vulnerability data stream so subsequent exports keep filtering by the configured severities.

--- a/packages/tenable_io/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/tenable_io/data_stream/asset/agent/stream/cel.yml.hbs
@@ -25,6 +25,9 @@ redact:
   fields:
     - access_key
     - secret_key
+{{#if max_executions}}
+max_executions: {{max_executions}}
+{{/if}}
 program: |
   state.with(state.?chunk_status.orValue("") != "PROCESSING" && !state.?want_more.orValue(false) ?
     post_request(

--- a/packages/tenable_io/data_stream/asset/manifest.yml
+++ b/packages/tenable_io/data_stream/asset/manifest.yml
@@ -46,6 +46,14 @@ streams:
         required: true
         show_user: false
         default: 30s
+      - name: max_executions
+        type: integer
+        title: Maximum Pages Per Interval
+        description: Maximum Pages Per Interval is the maximum number of pages that can be collected at each interval.
+        multi: false
+        required: false
+        show_user: false
+        default: 2000
       - name: tags
         type: text
         title: Tags

--- a/packages/tenable_io/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/tenable_io/data_stream/audit/agent/stream/cel.yml.hbs
@@ -23,6 +23,9 @@ redact:
   fields:
     - access_key
     - secret_key
+{{#if max_executions}}
+max_executions: {{max_executions}}
+{{/if}}
 program: |
   (
     state.?want_more.orValue(false) ?

--- a/packages/tenable_io/data_stream/audit/manifest.yml
+++ b/packages/tenable_io/data_stream/audit/manifest.yml
@@ -39,6 +39,14 @@ streams:
         required: true
         show_user: false
         default: 30s
+      - name: max_executions
+        type: integer
+        title: Maximum Pages Per Interval
+        description: Maximum Pages Per Interval is the maximum number of pages that can be collected at each interval.
+        multi: false
+        required: false
+        show_user: false
+        default: 2000
       - name: tags
         type: text
         title: Tags

--- a/packages/tenable_io/data_stream/plugin/agent/stream/cel.yml.hbs
+++ b/packages/tenable_io/data_stream/plugin/agent/stream/cel.yml.hbs
@@ -24,6 +24,9 @@ redact:
   fields:
     - access_key
     - secret_key
+{{#if max_executions}}
+max_executions: {{max_executions}}
+{{/if}}
 program: |
   request("GET",
     state.url.trim_right("/") + "/plugins/plugin?last_updated=" + (

--- a/packages/tenable_io/data_stream/plugin/manifest.yml
+++ b/packages/tenable_io/data_stream/plugin/manifest.yml
@@ -30,6 +30,14 @@ streams:
         required: true
         show_user: false
         default: 30s
+      - name: max_executions
+        type: integer
+        title: Maximum Pages Per Interval
+        description: Maximum Pages Per Interval is the maximum number of pages that can be collected at each interval.
+        multi: false
+        required: false
+        show_user: false
+        default: 2000
       - name: tags
         type: text
         title: Tags

--- a/packages/tenable_io/data_stream/scan/agent/stream/cel.yml.hbs
+++ b/packages/tenable_io/data_stream/scan/agent/stream/cel.yml.hbs
@@ -21,6 +21,9 @@ redact:
   fields:
     - access_key
     - secret_key
+{{#if max_executions}}
+max_executions: {{max_executions}}
+{{/if}}
 program: |
   // Using worklist pattern: fetch scans, then process one at a time fetching details for each
   state.with(

--- a/packages/tenable_io/data_stream/scan/manifest.yml
+++ b/packages/tenable_io/data_stream/scan/manifest.yml
@@ -34,6 +34,14 @@ streams:
         required: true
         show_user: false
         default: 30s
+      - name: max_executions
+        type: integer
+        title: Maximum Pages Per Interval
+        description: Maximum Pages Per Interval is the maximum number of pages that can be collected at each interval.
+        multi: false
+        required: false
+        show_user: false
+        default: 2000
       - name: tags
         type: text
         title: Tags

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "4.11.2"
+version: "4.12.0"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[tenable_io] Add configurable max_executions to asset, audit, plugin, and scan data streams

The max_executions parameter was only exposed in the Fleet UI for the
vulnerability data stream. The asset, audit, plugin, and scan streams
all use CEL inputs with paginated API calls that can exceed the default
limit of executions under sufficient data volume, causing them to go
DEGRADED.

This change brings those streams to parity with vulnerability
by exposing the same optional parameter (default: 2000) in both the
manifest and the CEL template for each affected data stream.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 
