### PR TITLE
sentinel_one: fix duplicate event ingestion in threat_event and application_risk

### DIFF
--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "2.11.1"
+  changes:
+    - description: Add time watermark and fingerprint deduplication to the threat event data stream to prevent duplicate ingestion.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20211
+    - description: Add fingerprint deduplication to the application risk data stream to prevent duplicate ingestion.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20211
 - version: "2.11.0"
   changes:
     - description: |

--- a/packages/sentinel_one/data_stream/application_risk/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/application_risk/elasticsearch/ingest_pipeline/default.yml
@@ -26,6 +26,13 @@ processors:
       field: event.original
       tag: json_event_original
       target_field: json
+  - fingerprint:
+      tag: fingerprint_application_risk_dedup
+      fields:
+        - json.id
+        - json.status
+      target_field: _id
+      ignore_missing: true
   - set:
       field: event.kind
       tag: set_event_kind

--- a/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-all.expected
+++ b/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-all.expected
@@ -33,8 +33,17 @@ inputs:
                     state.url.trim_right("/") + "/web/api/v2.1/threats?" + {
                       "skipCount": ["true"],
                       "limit": [string(state.batch_size)],
+                      "sortBy": ["updatedAt"],
+                      "sortOrder": ["asc"],
+                      "updatedAt__gte": [
+                        state.?cursor.?list_updated_at_gte.orValue(
+                          state.?cursor.?last_timestamp.orValue(
+                            (now - duration(state.initial_interval)).format(time_layout.RFC3339)
+                          )
+                        )
+                      ],
                       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-                      ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.?next_page.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -51,6 +60,12 @@ inputs:
                             ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
                           },
                           "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
+                          "list_updated_at_gte": state.?cursor.?list_updated_at_gte.orValue(
+                            state.?cursor.?last_timestamp.orValue(
+                              (now - duration(state.initial_interval)).format(time_layout.RFC3339)
+                            )
+                          ),
+                          ?"last_timestamp": state.?cursor.last_timestamp,
                         },
                       }
                     )
@@ -69,7 +84,6 @@ inputs:
                         },
                       },
                       "want_more": false,
-                      "cursor": {},
                     }
                   )
                 )
@@ -119,6 +133,11 @@ inputs:
                                 ?"token": has_more_events ? optional.of(body.pagination.nextCursor) : optional.none(),
                               },
                               "fetch_more": state.?cursor.fetch_more.orValue(false),
+                              "list_updated_at_gte": state.cursor.list_updated_at_gte,
+                              ?"last_timestamp": has_more_events ?
+                                state.?cursor.last_timestamp
+                              :
+                                state.cursor.worklist.data[0].?threatInfo.updatedAt.or(state.?cursor.last_timestamp),
                             },
                           }
                         )
@@ -145,7 +164,6 @@ inputs:
                   {
                     "events": [],
                     "want_more": false,
-                    "cursor": {},
                   }
               )
             )
@@ -242,6 +260,7 @@ inputs:
           state:
             api_token: ${SECRET_0}
             batch_size: 100
+            initial_interval: 1h
             site_ids: "123"
           tags:
             - preserve_original_event

--- a/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-all.yml
+++ b/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-all.yml
@@ -83,6 +83,7 @@ vars:
       -----END PRIVATE KEY-----
 data_stream:
   vars:
+    initial_interval: 1h
     interval: 30s
     batch_size: 100
     max_executions: 1000

--- a/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-default.expected
+++ b/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-default.expected
@@ -9,7 +9,7 @@ inputs:
         - config_version: 2
           data_stream:
             dataset: sentinel_one.threat_event
-          interval: 24h
+          interval: 5m
           max_executions: 1000
           program: |-
             (
@@ -22,8 +22,17 @@ inputs:
                     state.url.trim_right("/") + "/web/api/v2.1/threats?" + {
                       "skipCount": ["true"],
                       "limit": [string(state.batch_size)],
+                      "sortBy": ["updatedAt"],
+                      "sortOrder": ["asc"],
+                      "updatedAt__gte": [
+                        state.?cursor.?list_updated_at_gte.orValue(
+                          state.?cursor.?last_timestamp.orValue(
+                            (now - duration(state.initial_interval)).format(time_layout.RFC3339)
+                          )
+                        )
+                      ],
                       ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-                      ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
+                      ?"cursor": state.?cursor.?next_page.token.optMap(v, [v]),
                     }.format_query()
                   ).with(
                     {
@@ -40,6 +49,12 @@ inputs:
                             ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
                           },
                           "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
+                          "list_updated_at_gte": state.?cursor.?list_updated_at_gte.orValue(
+                            state.?cursor.?last_timestamp.orValue(
+                              (now - duration(state.initial_interval)).format(time_layout.RFC3339)
+                            )
+                          ),
+                          ?"last_timestamp": state.?cursor.last_timestamp,
                         },
                       }
                     )
@@ -58,7 +73,6 @@ inputs:
                         },
                       },
                       "want_more": false,
-                      "cursor": {},
                     }
                   )
                 )
@@ -108,6 +122,11 @@ inputs:
                                 ?"token": has_more_events ? optional.of(body.pagination.nextCursor) : optional.none(),
                               },
                               "fetch_more": state.?cursor.fetch_more.orValue(false),
+                              "list_updated_at_gte": state.cursor.list_updated_at_gte,
+                              ?"last_timestamp": has_more_events ?
+                                state.?cursor.last_timestamp
+                              :
+                                state.cursor.worklist.data[0].?threatInfo.updatedAt.or(state.?cursor.last_timestamp),
                             },
                           }
                         )
@@ -134,7 +153,6 @@ inputs:
                   {
                     "events": [],
                     "want_more": false,
-                    "cursor": {},
                   }
               )
             )
@@ -152,6 +170,7 @@ inputs:
           state:
             api_token: ${SECRET_0}
             batch_size: 1000
+            initial_interval: 24h
           tags:
             - forwarded
             - sentinel_one-threat_event

--- a/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-default.yml
+++ b/packages/sentinel_one/data_stream/threat_event/_dev/test/policy/test-default.yml
@@ -3,7 +3,8 @@ vars:
   api_token: test_api_token
 data_stream:
   vars:
-    interval: 24h
+    initial_interval: 24h
+    interval: 5m
     batch_size: 1000
     max_executions: 1000
     enable_request_tracer: false

--- a/packages/sentinel_one/data_stream/threat_event/agent/stream/cel.yml.hbs
+++ b/packages/sentinel_one/data_stream/threat_event/agent/stream/cel.yml.hbs
@@ -18,6 +18,7 @@ resource.url: {{url}}
 state:
   api_token: {{api_token}}
   batch_size: {{batch_size}}
+  initial_interval: {{initial_interval}}
 {{#if site_ids }}
   site_ids: !!str {{site_ids}}
 {{/if}}
@@ -35,8 +36,17 @@ program: |-
           state.url.trim_right("/") + "/web/api/v2.1/threats?" + {
             "skipCount": ["true"],
             "limit": [string(state.batch_size)],
+            "sortBy": ["updatedAt"],
+            "sortOrder": ["asc"],
+            "updatedAt__gte": [
+              state.?cursor.?list_updated_at_gte.orValue(
+                state.?cursor.?last_timestamp.orValue(
+                  (now - duration(state.initial_interval)).format(time_layout.RFC3339)
+                )
+              )
+            ],
             ?"siteIds": state.?site_ids.optMap(v, [string(v)]),
-            ?"cursor": state.?cursor.next_page.token.optMap(v, [v]),
+            ?"cursor": state.?cursor.?next_page.token.optMap(v, [v]),
           }.format_query()
         ).with(
           {
@@ -53,6 +63,12 @@ program: |-
                   ?"token": (body.?pagination.nextCursor.orValue(null) != null) ? optional.of(body.pagination.nextCursor) : optional.none(),
                 },
                 "fetch_more": body.?pagination.nextCursor.orValue(null) != null,
+                "list_updated_at_gte": state.?cursor.?list_updated_at_gte.orValue(
+                  state.?cursor.?last_timestamp.orValue(
+                    (now - duration(state.initial_interval)).format(time_layout.RFC3339)
+                  )
+                ),
+                ?"last_timestamp": state.?cursor.last_timestamp,
               },
             }
           )
@@ -71,7 +87,6 @@ program: |-
               },
             },
             "want_more": false,
-            "cursor": {},
           }
         )
       )
@@ -121,6 +136,11 @@ program: |-
                       ?"token": has_more_events ? optional.of(body.pagination.nextCursor) : optional.none(),
                     },
                     "fetch_more": state.?cursor.fetch_more.orValue(false),
+                    "list_updated_at_gte": state.cursor.list_updated_at_gte,
+                    ?"last_timestamp": has_more_events ?
+                      state.?cursor.last_timestamp
+                    :
+                      state.cursor.worklist.data[0].?threatInfo.updatedAt.or(state.?cursor.last_timestamp),
                   },
                 }
               )
@@ -147,7 +167,6 @@ program: |-
         {
           "events": [],
           "want_more": false,
-          "cursor": {},
         }
     )
   )

--- a/packages/sentinel_one/data_stream/threat_event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/threat_event/elasticsearch/ingest_pipeline/default.yml
@@ -45,6 +45,13 @@ processors:
       field: event.original
       tag: json_event_original
       target_field: json
+  - fingerprint:
+      tag: fingerprint_threat_event_dedup
+      fields:
+        - json.id
+        - json.createdAt
+      target_field: _id
+      ignore_missing: true
   - rename:
       field: json.id
       tag: rename_id

--- a/packages/sentinel_one/data_stream/threat_event/manifest.yml
+++ b/packages/sentinel_one/data_stream/threat_event/manifest.yml
@@ -8,11 +8,19 @@ streams:
     enabled: false
     template_path: cel.yml.hbs
     vars:
+      - name: initial_interval
+        type: text
+        title: Initial Interval
+        description: How far back to look for threats on the first run. Supported units for this parameter are h/m/s.
+        default: 24h
+        multi: false
+        required: true
+        show_user: true
       - name: interval
         type: text
         title: Interval
         description: Duration between requests to the SentinelOne API. Supported units for this parameter are h/m/s.
-        default: 24h
+        default: 5m
         multi: false
         required: true
         show_user: true

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.4.0"
 name: sentinel_one
 title: SentinelOne
-version: "2.11.0"
+version: "2.11.1"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
sentinel_one: fix duplicate event ingestion in threat_event and application_risk

Add a time watermark (updatedAt__gte) to the threat_event CEL program
so each interval only fetches threats updated since the last completed
walk, rather than re-walking the entire catalog. The high-water mark
is tracked in cursor.last_timestamp and seeded from a new
initial_interval manifest variable on the first run. The default poll
interval drops from 24h to 5m since the watermark eliminates full
re-walks.

Add fingerprint processors to both the threat_event and
application_risk ingest pipelines so that re-emitted documents with
the same id are rejected within a backing index rather than
accumulating as duplicates.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
