### PR TITLE
fix: restrict backport inventory validation to main-targeting builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,6 +83,9 @@ steps:
       - ".buildkite/scripts/run_dev_scripts_tests.sh"
       - "dev/scripts/**.sh"
       - "dev/backports/**"
+    if: |
+      (build.env('BUILDKITE_PULL_REQUEST') != "false" && build.env('BUILDKITE_PULL_REQUEST_BASE_BRANCH') == "main") ||
+      (build.env('BUILDKITE_PULL_REQUEST') == "false" && build.branch == "main")
 
   - label: ":git: Trigger backport dry-runs"
     key: "trigger-backport-dryrun"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## Proposed commit message

```
Restrict backport inventory validation to main-targeting runs

The `check-backports-inventory` step in `.buildkite/pipeline.yml` had
no `if:` condition, so it ran on every branch including backport
branches that only carry a subset of packages (e.g. `backport-aws-6.x`
which contains only the `aws` package). This caused the validation to
fail because the full package inventory is not present on those branches.

Example of a failing build: https://buildkite.com/elastic/integrations/builds/46243

Add an `if:` condition that restricts the step to two scenarios:
- Pull requests whose base branch is `main`
- Direct pushes/merges to `main`

This mirrors the same guards already used by the two downstream steps
(`trigger-backport-dryrun` and `trigger-backport-create`) that depend
on this step.
```

## Author's Checklist

- [ ] Verified the `if:` condition matches the guards on the dependent steps.

## How to test this PR locally

Trigger a Buildkite build on a backport branch (e.g. `backport-aws-6.x`) and confirm the `check-backports-inventory` step is skipped. Trigger a build on a PR targeting `main` and confirm the step runs.

## Related issues

- Relates https://github.com/elastic/integrations/pull/20114

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).