### PR TITLE
fix: restrict backport inventory validation to main-targeting builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,6 +83,9 @@ steps:
       - ".buildkite/scripts/run_dev_scripts_tests.sh"
       - "dev/scripts/**.sh"
       - "dev/backports/**"
+    if: |
+      (build.env('BUILDKITE_PULL_REQUEST') != "false" && build.env('BUILDKITE_PULL_REQUEST_BASE_BRANCH') == "main") ||
+      (build.env('BUILDKITE_PULL_REQUEST') == "false" && build.branch == "main")
 
   - label: ":git: Trigger backport dry-runs"
     key: "trigger-backport-dryrun"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## Proposed commit message

```
fix: restrict backport inventory validation to main-targeting builds

The `check-backports-inventory` step had no `if:` condition, causing it
to run on backport branches that only carry a subset of packages, which
made the validation fail unnecessarily.

Add an `if:` guard so the step only runs on PRs targeting `main` or
direct pushes/merges to `main`, mirroring the guards already on the
dependent `trigger-backport-dryrun` and `trigger-backport-create` steps.
```

## Author's Checklist

- [ ] Verified the `if:` condition matches the guards on the dependent steps.

## How to test this PR locally

Trigger a Buildkite build on a backport branch (e.g. `backport-aws-6.x`) and confirm the `check-backports-inventory` step is skipped. Trigger a build on a PR targeting `main` and confirm the step runs.

Example of a failing build: https://buildkite.com/elastic/integrations/builds/46243

## Related issues

- Relates https://github.com/elastic/integrations/pull/20114
- Relates https://github.com/elastic/integrations/pull/20235

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).