### PR TITLE
[backport/sync-changelog] Skip changelog link check on sync PRs

### DIFF
--- a/dev/backports/changelog/sync.go
+++ b/dev/backports/changelog/sync.go
@@ -95,6 +95,7 @@ func CreateSyncPR(workDir, entriesTSV, workingBranch, backportPRNumber, backport
 		"--head", workingBranch,
 		"--title", prTitle,
 		"--label", "backport:sync-changelog",
+		"--label", "changelog-link-check:skip",
 		"--reviewer", "elastic/ecosystem",
 		"--body", body,
 	)


### PR DESCRIPTION
## Summary

Add the `changelog-link-check:skip` label to the PRs automatically created by the `sync-backport-changelog` workflow.

## Context

When a backport branch is pushed and its `changelog.yml` is updated, the `sync-backport-changelog` workflow creates a PR to sync those changelog entries to `main`. Buildkite then runs the "Check changelog PR links" step, which validates that each changelog entry's linked PR number matches the PR being merged.

These sync PRs will **always** fail that check: the changelog entries reference the original backport PR number, not the sync PR number. The check is therefore both irrelevant and noisy for this class of PRs.

## Change

- `dev/backports/changelog/sync.go`: pass `--label changelog-link-check:skip` alongside the existing `--label backport:sync-changelog` when calling `gh pr create`.

## Related issues

- https://github.com/elastic/integrations/issues/19215

## Proposed commit

```
[backport/sync-changelog] Skip changelog link check on sync PRs

Add the `changelog-link-check:skip` label when creating sync-changelog
PRs so Buildkite does not validate changelog PR links — those links
always point to the original backport PR, not the sync PR number.
```

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).