### PR TITLE
feat(azure_metrics): add resource_manager_audience for sovereign cloud (GovCloud) support

### DIFF
--- a/packages/azure_metrics/_dev/build/docs/README.md
+++ b/packages/azure_metrics/_dev/build/docs/README.md
@@ -241,6 +241,16 @@ Examples:
 * `https://login.microsoftonline.com` for Azure PublicCloud
 * `https://login.microsoftonline.us` for Azure USGovernmentCloud
 
+`Resource Manager Audience` _string_
+: Optional. By default, the integration uses the associated Resource Manager Audience. To override, users can provide a specific resource manager audience to use a different Azure environment. This is required for sovereign clouds such as Azure GovCloud, where the public-cloud audience value is rejected by ARM even when the other endpoints are correctly configured.
+
+Examples:
+
+* `https://management.core.chinacloudapi.cn` for Azure ChinaCloud
+* `https://management.core.cloudapi.de` for Azure GermanCloud
+* `https://management.core.windows.net` for Azure PublicCloud
+* `https://management.core.usgovcloudapi.net` for Azure USGovernmentCloud
+
 `Enable Batch Api` _boolean_
 : Optional, by default is set to False. Set this to True when facing scalability issues. When configured, the azure batch api will be used
  to fetch metrics of multiple resources in one api call. 

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.15.0"
+  changes:
+    - description: Add `resource_manager_audience` configuration option to all data streams, enabling full sovereign cloud (GovCloud) support.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/TODO
 - version: "1.14.0"
   changes:
     - description: Add Available Memory Percentage metric to compute VM data streams.

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add `resource_manager_audience` configuration option to all data streams, enabling full sovereign cloud (GovCloud) support.
       type: enhancement
-      link: https://github.com/elastic/integrations/issues/TODO
+      link: https://github.com/elastic/integrations/pull/20266
 - version: "1.14.0"
   changes:
     - description: Add Available Memory Percentage metric to compute VM data streams.

--- a/packages/azure_metrics/data_stream/compute_vm/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/compute_vm/agent/stream/stream.yml.hbs
@@ -26,6 +26,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if resource_manager_audience}}
+resource_manager_audience: {{resource_manager_audience}}
+{{/if}}
 {{#if enable_batch_api}}
 enable_batch_api: {{enable_batch_api}}
 {{/if}}

--- a/packages/azure_metrics/data_stream/compute_vm_scaleset/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/compute_vm_scaleset/agent/stream/stream.yml.hbs
@@ -26,6 +26,9 @@ refresh_list_interval: {{refresh_list_interval}}
 {{#if active_directory_endpoint}}
     active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if resource_manager_audience}}
+    resource_manager_audience: {{resource_manager_audience}}
+{{/if}}
 {{#if enable_batch_api}}
 enable_batch_api: {{enable_batch_api}}
 {{/if}}

--- a/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_instance/agent/stream/stream.yml.hbs
@@ -24,6 +24,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if resource_manager_audience}}
+resource_manager_audience: {{resource_manager_audience}}
+{{/if}}
 {{#if enable_batch_api}}
 enable_batch_api: {{enable_batch_api}}
 {{/if}}

--- a/packages/azure_metrics/data_stream/container_registry/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_registry/agent/stream/stream.yml.hbs
@@ -24,6 +24,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if resource_manager_audience}}
+resource_manager_audience: {{resource_manager_audience}}
+{{/if}}
 {{#if enable_batch_api}}
 enable_batch_api: {{enable_batch_api}}
 {{/if}}

--- a/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
@@ -24,6 +24,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if resource_manager_audience}}
+resource_manager_audience: {{resource_manager_audience}}
+{{/if}}
 {{#if enable_batch_api}}
 enable_batch_api: {{enable_batch_api}}
 {{/if}}

--- a/packages/azure_metrics/data_stream/database_account/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/database_account/agent/stream/stream.yml.hbs
@@ -24,6 +24,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if resource_manager_audience}}
+resource_manager_audience: {{resource_manager_audience}}
+{{/if}}
 {{#if enable_batch_api}}
 enable_batch_api: {{enable_batch_api}}
 {{/if}}

--- a/packages/azure_metrics/data_stream/monitor/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/monitor/agent/stream/stream.yml.hbs
@@ -24,6 +24,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if resource_manager_audience}}
+resource_manager_audience: {{resource_manager_audience}}
+{{/if}}
 {{#if enable_batch_api}}
 enable_batch_api: {{enable_batch_api}}
 {{/if}}

--- a/packages/azure_metrics/data_stream/storage_account/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/storage_account/agent/stream/stream.yml.hbs
@@ -24,6 +24,9 @@ resource_manager_endpoint: {{resource_manager_endpoint}}
 {{#if active_directory_endpoint}}
 active_directory_endpoint: {{active_directory_endpoint}}
 {{/if}}
+{{#if resource_manager_audience}}
+resource_manager_audience: {{resource_manager_audience}}
+{{/if}}
 {{#if enable_batch_api}}
 enable_batch_api: {{enable_batch_api}}
 {{/if}}

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -241,6 +241,16 @@ Examples:
 * `https://login.microsoftonline.com` for Azure PublicCloud
 * `https://login.microsoftonline.us` for Azure USGovernmentCloud
 
+`Resource Manager Audience` _string_
+: Optional. By default, the integration uses the associated Resource Manager Audience. To override, users can provide a specific resource manager audience to use a different Azure environment. This is required for sovereign clouds such as Azure GovCloud, where the public-cloud audience value is rejected by ARM even when the other endpoints are correctly configured.
+
+Examples:
+
+* `https://management.core.chinacloudapi.cn` for Azure ChinaCloud
+* `https://management.core.cloudapi.de` for Azure GermanCloud
+* `https://management.core.windows.net` for Azure PublicCloud
+* `https://management.core.usgovcloudapi.net` for Azure USGovernmentCloud
+
 `Enable Batch Api` _boolean_
 : Optional, by default is set to False. Set this to True when facing scalability issues. When configured, the azure batch api will be used
  to fetch metrics of multiple resources in one api call. 

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: "1.14.0"
+version: "1.15.0"
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:
@@ -72,6 +72,13 @@ vars:
     multi: false
     required: false
     show_user: true
+  - name: resource_manager_audience
+    type: text
+    title: Resource Manager Audience
+    description: By default, the integration uses the associated Resource Manager Audience. To override, users can provide a specific resource manager audience to use a different Azure environment.
+    multi: false
+    required: false
+    show_user: false
   - name: enable_batch_api
     type: bool
     title: Enable Batch Api


### PR DESCRIPTION
## Summary

- Adds the missing `resource_manager_audience` configuration field to all eight `azure_metrics` data streams (`monitor`, `compute_vm`, `compute_vm_scaleset`, `container_instance`, `container_registry`, `container_service`, `database_account`, `storage_account`)
- Updates `docs/README.md` with field description and sovereign-cloud audience values
- Bumps package version to `1.15.0`

## Problem

Azure sovereign clouds (e.g. GovCloud) require three settings to be redirected correctly:

| Setting | GovCloud value |
|---|---|
| `resource_manager_endpoint` | `https://management.usgovcloudapi.net/` |
| `active_directory_endpoint` | `https://login.microsoftonline.us` |
| `resource_manager_audience` | `https://management.core.usgovcloudapi.net` |

`azure_metrics` exposed only the first two. Without `resource_manager_audience`, the Beats Azure Monitor client requests an OAuth2 token scoped for the **public cloud** audience (`https://management.core.windows.net/`) even when the other endpoints are set to GovCloud values. ARM then rejects the token with:

```
RESPONSE 404: 404 Not Found
ERROR CODE: SubscriptionNotFound
```

`azure_billing` already exposes all three settings correctly. This PR brings `azure_metrics` to parity.

## Test plan

- [ ] Deploy `azure_metrics` integration with GovCloud endpoints and `resource_manager_audience: https://management.core.usgovcloudapi.net` — verify metrics are collected without `SubscriptionNotFound` errors
- [ ] Deploy without `resource_manager_audience` set — verify existing public-cloud behaviour is unchanged
- [ ] Confirm the field appears (hidden by default, `show_user: false`) in the Kibana integration UI advanced settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)