### PR TITLE
.github: Add sit-crest-contractors as co-owner of new security packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,7 +113,7 @@
 /packages/awsfargate @elastic/obs-infraobs-integrations
 /packages/awsfirehose @elastic/obs-ds-hosted-services
 /packages/aws_cloudwatch_input_otel @elastic/obs-infraobs-integrations
-/packages/axonius @elastic/security-service-integrations
+/packages/axonius @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/azure @elastic/obs-infraobs-integrations @elastic/obs-ds-hosted-services @elastic/security-service-integrations
 /packages/azure/data_stream/aadgraphactivitylogs @elastic/security-service-integrations
 /packages/azure/data_stream/activitylogs @elastic/obs-infraobs-integrations
@@ -163,7 +163,7 @@
 /packages/beat @elastic/stack-monitoring
 /packages/beelzebub @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/beyondinsight_password_safe @elastic/security-service-integrations @elastic/sit-crest-contractors
-/packages/beyondtrust_epm @elastic/security-service-integrations
+/packages/beyondtrust_epm @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/beyondtrust_isi @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/beyondtrust_pra @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/bitdefender @elastic/security-service-integrations @elastic/sit-crest-contractors
@@ -239,8 +239,8 @@
 /packages/docker @elastic/obs-ds-hosted-services
 /packages/docker_input_otel @elastic/ecosystem
 /packages/docker_otel @elastic/obs-ds-hosted-services
-/packages/doppel @elastic/security-service-integrations
-/packages/doppler @elastic/security-service-integrations
+/packages/doppel @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/doppler @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/elastic_agent @elastic/elastic-agent-data-plane @elastic/elastic-agent-control-plane
 /packages/elastic_connectors @elastic/search-extract-and-transform
 /packages/elastic_package_registry @elastic/ecosystem
@@ -622,8 +622,8 @@
 /packages/withsecure_elements @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/wiz @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/wmi @elastic/obs-infraobs-integrations
-/packages/workday @elastic/security-service-integrations
-/packages/xm_cyber @elastic/security-service-integrations
+/packages/workday @elastic/security-service-integrations @elastic/sit-crest-contractors
+/packages/xm_cyber @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/zeek @elastic/integration-experience
 /packages/zerofox @elastic/security-service-integrations @elastic/sit-crest-contractors
 /packages/zeronetworks @elastic/security-service-integrations @elastic/sit-crest-contractors


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
.github: add sit-crest-contractors as co-owner of security packages

Add @elastic/sit-crest-contractors alongside
@elastic/security-service-integrations for axonius, beyondtrust_epm,
doppel, doppler, workday, and xm_cyber.

Relates: https://github.com/elastic/integrations/pull/19089
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates: https://github.com/elastic/integrations/pull/19089
