### PR TITLE
[lumos] Fix activity logs cursor so incremental collection filters requests by the stored timestamp

### DIFF
--- a/packages/lumos/_dev/deploy/docker/files/config.yml
+++ b/packages/lumos/_dev/deploy/docker/files/config.yml
@@ -1,22 +1,34 @@
 rules:
+  # Page 1: the initial request carries the cursor-derived `since` filter and the
+  # hardcoded `limit=100`, and has no `offset` yet (matched via the empty `offset`
+  # value, which requires the parameter to be absent). The `links.next` URL echoes
+  # the `since` and `limit` filters forward so the collection window stays bounded
+  # across pages, exactly as the real API returns fully-qualified pagination links.
   - path: /activity_logs
     methods: ["GET"]
+    query_params:
+      since: "{since:.*}"
+      limit: "100"
+      offset: ~
     request_headers:
       authorization: Bearer xoxp-1234567890
     responses:
       - status_code: 200
+        headers:
+          Content-Type:
+            - application/json
         body: |-
           {
               "items": [
                   {
                       "actor": {
                           "actor_type": "Lumos user",
-                          "email": "wile.e.coyote@lumos.com",
-                          "family_name": "Wile",
-                          "given_name": "Coyote"
+                          "email": "wile.e.coyote@example.com",
+                          "family_name": "Coyote",
+                          "given_name": "Wile"
                       },
                       "event_began_at": "2024-03-12T16:09:14",
-                      "event_hash": "630b90cedc35a8a5f43361534099bee51e032f42dd442085fc76ef094d228f543c78fbe59c132df992cf71a6b8496504e8ebbc6020fbae1f34206676985412e7",
+                      "event_hash": "1111111111111111111111111111111111111111111111111111111111111111",
                       "event_metadata": {},
                       "event_type": "SOD_POLICY_DELETED",
                       "event_type_user_friendly": "A user deleted a SOD Policy",
@@ -27,16 +39,155 @@ rules:
                               "target_type": "SOD Policy"
                           }
                       ]
+                  },
+                  {
+                      "actor": {
+                          "actor_type": "Lumos user",
+                          "email": "road.runner@example.com",
+                          "family_name": "Runner",
+                          "given_name": "Road"
+                      },
+                      "event_began_at": "2024-03-12T16:12:41",
+                      "event_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+                      "event_metadata": {},
+                      "event_type": "APP_ACCESS_GRANTED",
+                      "event_type_user_friendly": "A user was granted access to an app",
+                      "outcome": "Succeeded",
+                      "targets": [
+                          {
+                              "name": "Salesforce",
+                              "target_type": "Application"
+                          }
+                      ]
                   }
               ],
-              "limit": 50,
+              "limit": 100,
               "links": {
-                  "first": "/activity_logs?offset=0",
-                  "last": "/activity_logs?offset=1",
-                  "next": null,
+                  "first": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=0",
+                  "last": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=4",
+                  "next": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=2",
                   "prev": null,
-                  "self": "/activity_logs"
+                  "self": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=0"
               },
               "offset": 0,
-              "total": 1
+              "total": 5
+          }
+  # Page 2: reached via `links.next` from page 1. The request now carries the same
+  # `since` and `limit` filters plus `offset=2`, proving the window is preserved.
+  - path: /activity_logs
+    methods: ["GET"]
+    query_params:
+      since: "{since:.*}"
+      limit: "100"
+      offset: "2"
+    request_headers:
+      authorization: Bearer xoxp-1234567890
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - application/json
+        body: |-
+          {
+              "items": [
+                  {
+                      "actor": {
+                          "actor_type": "Lumos user",
+                          "email": "bugs.bunny@example.com",
+                          "family_name": "Bunny",
+                          "given_name": "Bugs"
+                      },
+                      "event_began_at": "2024-03-12T16:20:03",
+                      "event_hash": "3333333333333333333333333333333333333333333333333333333333333333",
+                      "event_metadata": {},
+                      "event_type": "APP_ACCESS_REVOKED",
+                      "event_type_user_friendly": "A user's access to an app was revoked",
+                      "outcome": "Succeeded",
+                      "targets": [
+                          {
+                              "name": "GitHub",
+                              "target_type": "Application"
+                          }
+                      ]
+                  },
+                  {
+                      "actor": {
+                          "actor_type": "Lumos user",
+                          "email": "daffy.duck@example.com",
+                          "family_name": "Duck",
+                          "given_name": "Daffy"
+                      },
+                      "event_began_at": "2024-03-12T16:25:57",
+                      "event_hash": "4444444444444444444444444444444444444444444444444444444444444444",
+                      "event_metadata": {},
+                      "event_type": "SOD_POLICY_CREATED",
+                      "event_type_user_friendly": "A user created a SOD Policy",
+                      "outcome": "Failed",
+                      "targets": [
+                          {
+                              "name": "Finance SOD",
+                              "target_type": "SOD Policy"
+                          }
+                      ]
+                  }
+              ],
+              "limit": 100,
+              "links": {
+                  "first": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=0",
+                  "last": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=4",
+                  "next": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=4",
+                  "prev": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=0",
+                  "self": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=2"
+              },
+              "offset": 2,
+              "total": 5
+          }
+  # Page 3: final page. `links.next` is null so pagination terminates here.
+  - path: /activity_logs
+    methods: ["GET"]
+    query_params:
+      since: "{since:.*}"
+      limit: "100"
+      offset: "4"
+    request_headers:
+      authorization: Bearer xoxp-1234567890
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - application/json
+        body: |-
+          {
+              "items": [
+                  {
+                      "actor": {
+                          "actor_type": "Lumos user",
+                          "email": "porky.pig@example.com",
+                          "family_name": "Pig",
+                          "given_name": "Porky"
+                      },
+                      "event_began_at": "2024-03-12T16:31:12",
+                      "event_hash": "5555555555555555555555555555555555555555555555555555555555555555",
+                      "event_metadata": {},
+                      "event_type": "USER_LOGIN",
+                      "event_type_user_friendly": "A user logged in",
+                      "outcome": "Succeeded",
+                      "targets": [
+                          {
+                              "name": "Lumos",
+                              "target_type": "Application"
+                          }
+                      ]
+                  }
+              ],
+              "limit": 100,
+              "links": {
+                  "first": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=0",
+                  "last": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=4",
+                  "next": null,
+                  "prev": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=2",
+                  "self": "/activity_logs?since=2024-03-12T00:00:00&limit=100&offset=4"
+              },
+              "offset": 4,
+              "total": 5
           }

--- a/packages/lumos/_dev/deploy/docker/files/config.yml
+++ b/packages/lumos/_dev/deploy/docker/files/config.yml
@@ -25,7 +25,7 @@ rules:
                           "actor_type": "Lumos user",
                           "email": "wile.e.coyote@example.com",
                           "family_name": "Coyote",
-                          "given_name": "Wile"
+                          "given_name": "Wile E."
                       },
                       "event_began_at": "2024-03-12T16:09:14",
                       "event_hash": "1111111111111111111111111111111111111111111111111111111111111111",

--- a/packages/lumos/changelog.yml
+++ b/packages/lumos/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix activity logs cursor so incremental collection filters requests by the stored timestamp instead of replaying the full history each interval.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/20279
 - version: "1.8.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/lumos/changelog.yml
+++ b/packages/lumos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Fix activity logs cursor so incremental collection filters requests by the stored timestamp instead of replaying the full history each interval.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.8.0"
   changes:
     - description: Use new `release` field for agentless deployment mode to establish as beta.

--- a/packages/lumos/data_stream/activity_logs/_dev/test/system/test-default-config.yml
+++ b/packages/lumos/data_stream/activity_logs/_dev/test/system/test-default-config.yml
@@ -5,5 +5,7 @@ vars:
 data_stream:
   vars:
     api_token: xoxp-1234567890
+    interval: 1h
+    initial_interval: 24h
 assert:
-  hit_count: 1
+  hit_count: 5

--- a/packages/lumos/data_stream/activity_logs/agent/stream/httpjson.yml.hbs
+++ b/packages/lumos/data_stream/activity_logs/agent/stream/httpjson.yml.hbs
@@ -11,6 +11,13 @@ request.transforms:
   - set:
       target: header.Authorization
       value: "Bearer {{api_token}}"
+  - set:
+      target: url.params.since
+      value: '[[.cursor.since]]'
+      default: '[[formatDate (now (parseDuration "-{{initial_interval}}")) "2006-01-02T15:04:05"]]'
+  - set:
+      target: url.params.limit
+      value: "100"
 
 response.pagination:
   - set:
@@ -25,7 +32,7 @@ response.split:
 
 cursor:
   since:
-    value: '[[if index .last_event "created"]][[.last_event.created]][[end]]'
+    value: '[[if index .last_event "event_began_at"]][[.last_event.event_began_at]][[end]]'
     ignore_empty_value: true
 
 {{#if processors}}

--- a/packages/lumos/data_stream/activity_logs/sample_event.json
+++ b/packages/lumos/data_stream/activity_logs/sample_event.json
@@ -1,32 +1,32 @@
 {
-    "@timestamp": "2026-07-22T09:40:48.477Z",
+    "@timestamp": "2026-07-23T05:57:08.315Z",
     "agent": {
-        "ephemeral_id": "9e24ed1c-c73a-41e6-a63f-dd1026e4884f",
-        "id": "4912077b-b7ff-4757-a721-3ad4ab97fead",
-        "name": "elastic-agent-48882",
+        "ephemeral_id": "d5dfc28b-0d8d-4107-9a36-b03df5679780",
+        "id": "635c6f7a-c6c2-427e-8b55-c817325bad18",
+        "name": "elastic-agent-14892",
         "type": "filebeat",
         "version": "8.19.4"
     },
     "data_stream": {
         "dataset": "lumos.activity_logs",
-        "namespace": "91086",
+        "namespace": "62571",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "4912077b-b7ff-4757-a721-3ad4ab97fead",
+        "id": "635c6f7a-c6c2-427e-8b55-c817325bad18",
         "snapshot": false,
         "version": "8.19.4"
     },
     "event": {
         "action": "SOD_POLICY_DELETED",
         "agent_id_status": "verified",
-        "created": "2026-07-22T09:40:48.477Z",
+        "created": "2026-07-23T05:57:08.315Z",
         "dataset": "lumos.activity_logs",
         "id": "1111111111111111111111111111111111111111111111111111111111111111",
-        "ingested": "2026-07-22T09:40:51Z",
+        "ingested": "2026-07-23T05:57:11Z",
         "kind": "event",
         "outcome": "success",
         "type": [
@@ -36,16 +36,16 @@
     "host": {
         "architecture": "aarch64",
         "containerized": false,
-        "hostname": "elastic-agent-48882",
+        "hostname": "elastic-agent-14892",
         "ip": [
             "172.19.0.2",
             "172.18.0.4"
         ],
         "mac": [
-            "26-E9-8B-78-AF-7F",
-            "E6-AD-7E-E1-1B-0B"
+            "2A-8B-8B-F3-CB-00",
+            "36-8B-CE-62-2E-F4"
         ],
-        "name": "elastic-agent-48882",
+        "name": "elastic-agent-14892",
         "os": {
             "kernel": "6.12.76-linuxkit",
             "name": "Wolfi",
@@ -63,7 +63,7 @@
                 "actor_type": "Lumos user",
                 "email": "wile.e.coyote@example.com",
                 "family_name": "Coyote",
-                "given_name": "Wile"
+                "given_name": "Wile E."
             },
             "event_began_at": "2024-03-12T16:09:14",
             "event_type_user_friendly": "A user deleted a SOD Policy",
@@ -75,5 +75,5 @@
             ]
         }
     },
-    "message": "{\"actor\":{\"actor_type\":\"Lumos user\",\"email\":\"wile.e.coyote@example.com\",\"family_name\":\"Coyote\",\"given_name\":\"Wile\"},\"event_began_at\":\"2024-03-12T16:09:14\",\"event_hash\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"event_metadata\":{},\"event_type\":\"SOD_POLICY_DELETED\",\"event_type_user_friendly\":\"A user deleted a SOD Policy\",\"outcome\":\"Succeeded\",\"targets\":[{\"name\":\"Untitled Rule\",\"target_type\":\"SOD Policy\"}]}"
+    "message": "{\"actor\":{\"actor_type\":\"Lumos user\",\"email\":\"wile.e.coyote@example.com\",\"family_name\":\"Coyote\",\"given_name\":\"Wile E.\"},\"event_began_at\":\"2024-03-12T16:09:14\",\"event_hash\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"event_metadata\":{},\"event_type\":\"SOD_POLICY_DELETED\",\"event_type_user_friendly\":\"A user deleted a SOD Policy\",\"outcome\":\"Succeeded\",\"targets\":[{\"name\":\"Untitled Rule\",\"target_type\":\"SOD Policy\"}]}"
 }

--- a/packages/lumos/data_stream/activity_logs/sample_event.json
+++ b/packages/lumos/data_stream/activity_logs/sample_event.json
@@ -1,32 +1,32 @@
 {
-    "@timestamp": "2025-10-07T10:29:39.283Z",
+    "@timestamp": "2026-07-22T09:40:48.477Z",
     "agent": {
-        "ephemeral_id": "2899cf43-154c-43bf-8e38-6dd8fcdddeb8",
-        "id": "ec7a2ba3-4ffe-4b9d-98cf-dce8eccd9455",
-        "name": "elastic-agent-76548",
+        "ephemeral_id": "9e24ed1c-c73a-41e6-a63f-dd1026e4884f",
+        "id": "4912077b-b7ff-4757-a721-3ad4ab97fead",
+        "name": "elastic-agent-48882",
         "type": "filebeat",
         "version": "8.19.4"
     },
     "data_stream": {
         "dataset": "lumos.activity_logs",
-        "namespace": "18028",
+        "namespace": "91086",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "ec7a2ba3-4ffe-4b9d-98cf-dce8eccd9455",
+        "id": "4912077b-b7ff-4757-a721-3ad4ab97fead",
         "snapshot": false,
         "version": "8.19.4"
     },
     "event": {
         "action": "SOD_POLICY_DELETED",
         "agent_id_status": "verified",
-        "created": "2025-10-07T10:29:39.283Z",
+        "created": "2026-07-22T09:40:48.477Z",
         "dataset": "lumos.activity_logs",
-        "id": "630b90cedc35a8a5f43361534099bee51e032f42dd442085fc76ef094d228f543c78fbe59c132df992cf71a6b8496504e8ebbc6020fbae1f34206676985412e7",
-        "ingested": "2025-10-07T10:29:42Z",
+        "id": "1111111111111111111111111111111111111111111111111111111111111111",
+        "ingested": "2026-07-22T09:40:51Z",
         "kind": "event",
         "outcome": "success",
         "type": [
@@ -34,20 +34,20 @@
         ]
     },
     "host": {
-        "architecture": "x86_64",
+        "architecture": "aarch64",
         "containerized": false,
-        "hostname": "elastic-agent-76548",
+        "hostname": "elastic-agent-48882",
         "ip": [
-            "192.168.241.2",
-            "192.168.240.4"
+            "172.19.0.2",
+            "172.18.0.4"
         ],
         "mac": [
-            "12-2A-F7-F2-2C-D7",
-            "DE-BF-74-CA-85-68"
+            "26-E9-8B-78-AF-7F",
+            "E6-AD-7E-E1-1B-0B"
         ],
-        "name": "elastic-agent-76548",
+        "name": "elastic-agent-48882",
         "os": {
-            "kernel": "5.15.0-156-generic",
+            "kernel": "6.12.76-linuxkit",
             "name": "Wolfi",
             "platform": "wolfi",
             "type": "linux",
@@ -61,9 +61,9 @@
         "activity_logs": {
             "actor": {
                 "actor_type": "Lumos user",
-                "email": "wile.e.coyote@lumos.com",
-                "family_name": "Wile",
-                "given_name": "Coyote"
+                "email": "wile.e.coyote@example.com",
+                "family_name": "Coyote",
+                "given_name": "Wile"
             },
             "event_began_at": "2024-03-12T16:09:14",
             "event_type_user_friendly": "A user deleted a SOD Policy",
@@ -75,5 +75,5 @@
             ]
         }
     },
-    "message": "{\"actor\":{\"actor_type\":\"Lumos user\",\"email\":\"wile.e.coyote@lumos.com\",\"family_name\":\"Wile\",\"given_name\":\"Coyote\"},\"event_began_at\":\"2024-03-12T16:09:14\",\"event_hash\":\"630b90cedc35a8a5f43361534099bee51e032f42dd442085fc76ef094d228f543c78fbe59c132df992cf71a6b8496504e8ebbc6020fbae1f34206676985412e7\",\"event_metadata\":{},\"event_type\":\"SOD_POLICY_DELETED\",\"event_type_user_friendly\":\"A user deleted a SOD Policy\",\"outcome\":\"Succeeded\",\"targets\":[{\"name\":\"Untitled Rule\",\"target_type\":\"SOD Policy\"}]}"
+    "message": "{\"actor\":{\"actor_type\":\"Lumos user\",\"email\":\"wile.e.coyote@example.com\",\"family_name\":\"Coyote\",\"given_name\":\"Wile\"},\"event_began_at\":\"2024-03-12T16:09:14\",\"event_hash\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"event_metadata\":{},\"event_type\":\"SOD_POLICY_DELETED\",\"event_type_user_friendly\":\"A user deleted a SOD Policy\",\"outcome\":\"Succeeded\",\"targets\":[{\"name\":\"Untitled Rule\",\"target_type\":\"SOD Policy\"}]}"
 }

--- a/packages/lumos/docs/README.md
+++ b/packages/lumos/docs/README.md
@@ -55,34 +55,34 @@ An example event for `activity` looks as following:
 
 ```json
 {
-    "@timestamp": "2026-07-22T09:40:48.477Z",
+    "@timestamp": "2026-07-23T05:57:08.315Z",
     "agent": {
-        "ephemeral_id": "9e24ed1c-c73a-41e6-a63f-dd1026e4884f",
-        "id": "4912077b-b7ff-4757-a721-3ad4ab97fead",
-        "name": "elastic-agent-48882",
+        "ephemeral_id": "d5dfc28b-0d8d-4107-9a36-b03df5679780",
+        "id": "635c6f7a-c6c2-427e-8b55-c817325bad18",
+        "name": "elastic-agent-14892",
         "type": "filebeat",
         "version": "8.19.4"
     },
     "data_stream": {
         "dataset": "lumos.activity_logs",
-        "namespace": "91086",
+        "namespace": "62571",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "4912077b-b7ff-4757-a721-3ad4ab97fead",
+        "id": "635c6f7a-c6c2-427e-8b55-c817325bad18",
         "snapshot": false,
         "version": "8.19.4"
     },
     "event": {
         "action": "SOD_POLICY_DELETED",
         "agent_id_status": "verified",
-        "created": "2026-07-22T09:40:48.477Z",
+        "created": "2026-07-23T05:57:08.315Z",
         "dataset": "lumos.activity_logs",
         "id": "1111111111111111111111111111111111111111111111111111111111111111",
-        "ingested": "2026-07-22T09:40:51Z",
+        "ingested": "2026-07-23T05:57:11Z",
         "kind": "event",
         "outcome": "success",
         "type": [
@@ -92,16 +92,16 @@ An example event for `activity` looks as following:
     "host": {
         "architecture": "aarch64",
         "containerized": false,
-        "hostname": "elastic-agent-48882",
+        "hostname": "elastic-agent-14892",
         "ip": [
             "172.19.0.2",
             "172.18.0.4"
         ],
         "mac": [
-            "26-E9-8B-78-AF-7F",
-            "E6-AD-7E-E1-1B-0B"
+            "2A-8B-8B-F3-CB-00",
+            "36-8B-CE-62-2E-F4"
         ],
-        "name": "elastic-agent-48882",
+        "name": "elastic-agent-14892",
         "os": {
             "kernel": "6.12.76-linuxkit",
             "name": "Wolfi",
@@ -119,7 +119,7 @@ An example event for `activity` looks as following:
                 "actor_type": "Lumos user",
                 "email": "wile.e.coyote@example.com",
                 "family_name": "Coyote",
-                "given_name": "Wile"
+                "given_name": "Wile E."
             },
             "event_began_at": "2024-03-12T16:09:14",
             "event_type_user_friendly": "A user deleted a SOD Policy",
@@ -131,6 +131,6 @@ An example event for `activity` looks as following:
             ]
         }
     },
-    "message": "{\"actor\":{\"actor_type\":\"Lumos user\",\"email\":\"wile.e.coyote@example.com\",\"family_name\":\"Coyote\",\"given_name\":\"Wile\"},\"event_began_at\":\"2024-03-12T16:09:14\",\"event_hash\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"event_metadata\":{},\"event_type\":\"SOD_POLICY_DELETED\",\"event_type_user_friendly\":\"A user deleted a SOD Policy\",\"outcome\":\"Succeeded\",\"targets\":[{\"name\":\"Untitled Rule\",\"target_type\":\"SOD Policy\"}]}"
+    "message": "{\"actor\":{\"actor_type\":\"Lumos user\",\"email\":\"wile.e.coyote@example.com\",\"family_name\":\"Coyote\",\"given_name\":\"Wile E.\"},\"event_began_at\":\"2024-03-12T16:09:14\",\"event_hash\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"event_metadata\":{},\"event_type\":\"SOD_POLICY_DELETED\",\"event_type_user_friendly\":\"A user deleted a SOD Policy\",\"outcome\":\"Succeeded\",\"targets\":[{\"name\":\"Untitled Rule\",\"target_type\":\"SOD Policy\"}]}"
 }
 ```

--- a/packages/lumos/docs/README.md
+++ b/packages/lumos/docs/README.md
@@ -55,34 +55,34 @@ An example event for `activity` looks as following:
 
 ```json
 {
-    "@timestamp": "2025-10-07T10:29:39.283Z",
+    "@timestamp": "2026-07-22T09:40:48.477Z",
     "agent": {
-        "ephemeral_id": "2899cf43-154c-43bf-8e38-6dd8fcdddeb8",
-        "id": "ec7a2ba3-4ffe-4b9d-98cf-dce8eccd9455",
-        "name": "elastic-agent-76548",
+        "ephemeral_id": "9e24ed1c-c73a-41e6-a63f-dd1026e4884f",
+        "id": "4912077b-b7ff-4757-a721-3ad4ab97fead",
+        "name": "elastic-agent-48882",
         "type": "filebeat",
         "version": "8.19.4"
     },
     "data_stream": {
         "dataset": "lumos.activity_logs",
-        "namespace": "18028",
+        "namespace": "91086",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "ec7a2ba3-4ffe-4b9d-98cf-dce8eccd9455",
+        "id": "4912077b-b7ff-4757-a721-3ad4ab97fead",
         "snapshot": false,
         "version": "8.19.4"
     },
     "event": {
         "action": "SOD_POLICY_DELETED",
         "agent_id_status": "verified",
-        "created": "2025-10-07T10:29:39.283Z",
+        "created": "2026-07-22T09:40:48.477Z",
         "dataset": "lumos.activity_logs",
-        "id": "630b90cedc35a8a5f43361534099bee51e032f42dd442085fc76ef094d228f543c78fbe59c132df992cf71a6b8496504e8ebbc6020fbae1f34206676985412e7",
-        "ingested": "2025-10-07T10:29:42Z",
+        "id": "1111111111111111111111111111111111111111111111111111111111111111",
+        "ingested": "2026-07-22T09:40:51Z",
         "kind": "event",
         "outcome": "success",
         "type": [
@@ -90,20 +90,20 @@ An example event for `activity` looks as following:
         ]
     },
     "host": {
-        "architecture": "x86_64",
+        "architecture": "aarch64",
         "containerized": false,
-        "hostname": "elastic-agent-76548",
+        "hostname": "elastic-agent-48882",
         "ip": [
-            "192.168.241.2",
-            "192.168.240.4"
+            "172.19.0.2",
+            "172.18.0.4"
         ],
         "mac": [
-            "12-2A-F7-F2-2C-D7",
-            "DE-BF-74-CA-85-68"
+            "26-E9-8B-78-AF-7F",
+            "E6-AD-7E-E1-1B-0B"
         ],
-        "name": "elastic-agent-76548",
+        "name": "elastic-agent-48882",
         "os": {
-            "kernel": "5.15.0-156-generic",
+            "kernel": "6.12.76-linuxkit",
             "name": "Wolfi",
             "platform": "wolfi",
             "type": "linux",
@@ -117,9 +117,9 @@ An example event for `activity` looks as following:
         "activity_logs": {
             "actor": {
                 "actor_type": "Lumos user",
-                "email": "wile.e.coyote@lumos.com",
-                "family_name": "Wile",
-                "given_name": "Coyote"
+                "email": "wile.e.coyote@example.com",
+                "family_name": "Coyote",
+                "given_name": "Wile"
             },
             "event_began_at": "2024-03-12T16:09:14",
             "event_type_user_friendly": "A user deleted a SOD Policy",
@@ -131,6 +131,6 @@ An example event for `activity` looks as following:
             ]
         }
     },
-    "message": "{\"actor\":{\"actor_type\":\"Lumos user\",\"email\":\"wile.e.coyote@lumos.com\",\"family_name\":\"Wile\",\"given_name\":\"Coyote\"},\"event_began_at\":\"2024-03-12T16:09:14\",\"event_hash\":\"630b90cedc35a8a5f43361534099bee51e032f42dd442085fc76ef094d228f543c78fbe59c132df992cf71a6b8496504e8ebbc6020fbae1f34206676985412e7\",\"event_metadata\":{},\"event_type\":\"SOD_POLICY_DELETED\",\"event_type_user_friendly\":\"A user deleted a SOD Policy\",\"outcome\":\"Succeeded\",\"targets\":[{\"name\":\"Untitled Rule\",\"target_type\":\"SOD Policy\"}]}"
+    "message": "{\"actor\":{\"actor_type\":\"Lumos user\",\"email\":\"wile.e.coyote@example.com\",\"family_name\":\"Coyote\",\"given_name\":\"Wile\"},\"event_began_at\":\"2024-03-12T16:09:14\",\"event_hash\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"event_metadata\":{},\"event_type\":\"SOD_POLICY_DELETED\",\"event_type_user_friendly\":\"A user deleted a SOD Policy\",\"outcome\":\"Succeeded\",\"targets\":[{\"name\":\"Untitled Rule\",\"target_type\":\"SOD Policy\"}]}"
 }
 ```

--- a/packages/lumos/manifest.yml
+++ b/packages/lumos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: lumos
 title: "Lumos"
-version: "1.8.0"
+version: "1.8.1"
 description: "An integration with Lumos to ship your Activity logs to your Elastic instance."
 type: integration
 categories:


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

```
lumos: Fix activity logs cursor so incremental collection filters requests by the stored timestamp
instead of replaying the full history each interval

Lumos Activity API details are (here)[1].

[1] https://developers.lumos.com/reference/getactivitylogs-1
```

> [!NOTE]  
> To Reviewers:
>  - This changes has not been tested with a live instance.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 


## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/lumos directory.
- Run the following command to run tests.

> elastic-package test -v

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #18494 
