### PR TITLE
[CI][Backports] add integrations-backport-dispatch private pipeline for triggering backport creation

### DIFF
--- a/.buildkite/pipeline.backport-dispatch.yml
+++ b/.buildkite/pipeline.backport-dispatch.yml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+env:
+  SETUP_GVM_VERSION: "v0.6.0"
+  LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
+  YQ_VERSION: 'v4.35.2'
+  GH_CLI_VERSION: "2.29.0"
+  NOTIFY_TO: "ecosystem-team@elastic.co"
+
+steps:
+  - label: ":ballot_box_with_check: Backports inventory validation"
+    key: "check-backports-inventory"
+    command: ".buildkite/scripts/check_backports_inventory.sh"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+    if_changed:
+      - ".backports.yml"
+      - ".buildkite/scripts/run_dev_scripts_tests.sh"
+      - "dev/scripts/**.sh"
+      - "dev/backports/**"
+    if: |
+      build.env('BUILDKITE_PULL_REQUEST') == "false" && build.branch == "main"
+
+  - label: ":git: Create backport branches for new entries"
+    key: "trigger-backport-create"
+    command: ".buildkite/scripts/trigger_backport.sh"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+    plugins:
+      - elastic/vault-github-token#v0.1.0:
+    depends_on:
+      - step: "check-backports-inventory"
+        allow_failure: false
+    if_changed:
+      - ".backports.yml"
+    if: |
+      build.env('BUILDKITE_PULL_REQUEST') == "false" &&
+      build.branch == "main" &&
+      build.env('BUILDKITE_PIPELINE_SLUG') == "integrations-backport-dispatch"
+
+notify:
+  - email: "$NOTIFY_TO"
+    if: "build.state == 'failed' && build.env('BUILDKITE_PULL_REQUEST') == 'false'"

--- a/.buildkite/pipeline.backport.yml
+++ b/.buildkite/pipeline.backport.yml
@@ -8,18 +8,20 @@ env:
   GH_CLI_VERSION: "2.29.0"
   # Agent images used in pipeline steps
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
+  NOTIFY_TO: "ecosystem-team@elastic.co"
 
 steps:
 
   - label: "Check that it runs from UI"
     key: "check-ui"
     command:
-      - "buildkite-agent annotate \"The $${BUILDKITE_PIPELINE_SLUG} pipeline can only be triggered from the UI by members of the 'ecosystem' team, or via a trigger step from the 'integrations' pipeline. For the recommended workflow see the [documentation](https://www.elastic.co/guide/en/integrations-developer/current/developer-workflow-support-old-package.html).\" --style 'warning'"
+      - "buildkite-agent annotate \"The $${BUILDKITE_PIPELINE_SLUG} pipeline can only be triggered from the UI by members of the 'ecosystem' team, or via a trigger step from the 'integrations' or 'integrations-backport-dispatch' pipeline. For the recommended workflow see the [documentation](https://www.elastic.co/guide/en/integrations-developer/current/developer-workflow-support-old-package.html).\" --style 'warning'"
       - "exit 1"
     if: |
       !(
         (build.source == 'ui' && build.creator.teams includes "ecosystem") ||
-        (build.source == 'trigger_job' && build.env('BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG') == 'integrations')
+        (build.source == 'trigger_job' && build.env('BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG') == 'integrations') ||
+        (build.source == 'trigger_job' && build.env('BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG') == 'integrations-backport-dispatch')
       )
 
   # Ensure that the check-ui step runs before any other step
@@ -99,3 +101,10 @@ steps:
     depends_on:
       - step: "create-backport-branch"
         allow_failure: true
+
+notify:
+  # Only notify for automated backport creation failures (triggered by integrations-backport-dispatch).
+  # Dry-run failures from PR builds (triggered by integrations) are already surfaced as a failing
+  # CI status on the PR itself and do not warrant a team email.
+  - email: "$NOTIFY_TO"
+    if: "build.state == 'failed' && build.source == 'trigger_job' && build.env('BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG') == 'integrations-backport-dispatch'"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -170,8 +170,6 @@ steps:
         allow_failure: false
       - step: "check-buildkite-scripts"
         allow_failure: false
-    if: |
-      build.branch == "nonexisting"
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,8 +84,7 @@ steps:
       - "dev/scripts/**.sh"
       - "dev/backports/**"
     if: |
-      (build.env('BUILDKITE_PULL_REQUEST') != "false" && build.env('BUILDKITE_PULL_REQUEST_BASE_BRANCH') == "main") ||
-      (build.env('BUILDKITE_PULL_REQUEST') == "false" && build.branch == "main")
+      build.env('BUILDKITE_PULL_REQUEST') != "false" && build.env('BUILDKITE_PULL_REQUEST_BASE_BRANCH') == "main"
 
   - label: ":git: Trigger backport dry-runs"
     key: "trigger-backport-dryrun"
@@ -101,23 +100,6 @@ steps:
       build.env('BUILDKITE_PULL_REQUEST') != "false" &&
       build.env('BUILDKITE_PIPELINE_SLUG') == "integrations" &&
       build.env('BUILDKITE_PULL_REQUEST_BASE_BRANCH') == "main"
-
-  - label: ":git: Create backport branches for new entries"
-    key: "trigger-backport-create"
-    command: ".buildkite/scripts/trigger_backport.sh"
-    agents:
-      image: "${LINUX_AGENT_IMAGE}"
-    plugins:
-      - elastic/vault-github-token#v0.1.0:
-    depends_on:
-      - step: "check-backports-inventory"
-        allow_failure: false
-    if_changed:
-      - ".backports.yml"
-    if: |
-      build.env('BUILDKITE_PULL_REQUEST') == "false" &&
-      build.branch == "main" &&
-      build.env('BUILDKITE_PIPELINE_SLUG') == "integrations"
 
   - label: ":junit: Sources Junit annotate"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -169,6 +169,8 @@ steps:
         allow_failure: false
       - step: "check-buildkite-scripts"
         allow_failure: false
+    if: |
+      build.branch == "nonexisting"
 
   - wait: ~
     continue_on_failure: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,7 +84,8 @@ steps:
       - "dev/scripts/**.sh"
       - "dev/backports/**"
     if: |
-      build.env('BUILDKITE_PULL_REQUEST') != "false" && build.env('BUILDKITE_PULL_REQUEST_BASE_BRANCH') == "main"
+      build.env('BUILDKITE_PULL_REQUEST') != "false" &&
+      build.env('BUILDKITE_PULL_REQUEST_BASE_BRANCH') == "main"
 
   - label: ":git: Trigger backport dry-runs"
     key: "trigger-backport-dryrun"

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -16,6 +16,7 @@
       "skip_ci_on_only_changed": [
         "^.agents/skills/",
         "^.buildkite/pipeline.backport.yml$",
+        "^.buildkite/pipeline.backport-dispatch.yml$",
         "^.buildkite/pipeline.publish.yml$",
         "^.buildkite/pipeline.serverless.yml$",
         "^.buildkite/pipeline.schedule-daily.yml$",
@@ -74,6 +75,22 @@
     {
       "enabled": false,
       "pipelineSlug": "integrations-serverless",
+      "allow_org_users": true,
+      "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": [],
+      "set_commit_status": false,
+      "build_on_commit": false,
+      "build_on_comment": false,
+      "trigger_comment_regex": "",
+      "always_trigger_comment_regex": "",
+      "skip_ci_labels": [],
+      "skip_target_branches": [],
+      "skip_ci_on_only_changed": [],
+      "always_require_ci_on_changed": []
+    },
+    {
+      "enabled": false,
+      "pipelineSlug": "integrations-backport-dispatch",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
       "allowed_list": [],

--- a/.buildkite/scripts/non_package_patterns.txt
+++ b/.buildkite/scripts/non_package_patterns.txt
@@ -5,6 +5,7 @@
 ^\.agents/skills/
 ^\.backports\.yml
 ^\.buildkite/pipeline\.backport\.yml
+^\.buildkite/pipeline\.backport-dispatch\.yml
 ^\.buildkite/pipeline\.publish\.yml
 ^\.buildkite/pipeline\.schedule-daily\.yml
 ^\.buildkite/pipeline\.schedule-weekly\.yml

--- a/.buildkite/scripts/trigger_backport.sh
+++ b/.buildkite/scripts/trigger_backport.sh
@@ -36,6 +36,10 @@ main() {
             echo "Not on main branch (branch: ${BUILDKITE_BRANCH}), skipping"
             exit 0
         fi
+        if [[ "${BUILDKITE_PIPELINE_SLUG}" != "integrations-backport-dispatch" ]]; then
+            echo "Backport branch creation can only run from the 'integrations-backport-dispatch' pipeline (got: ${BUILDKITE_PIPELINE_SLUG})"
+            exit 1
+        fi
         dry_run="false"
         label="create"
         diff_from="HEAD^"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -373,6 +373,50 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
+  name: pipeline-integrations-backport-dispatch
+  description: 'Pipeline to dispatch backport branch creation on merges to main'
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/integrations-backport-dispatch
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: platform-ingest
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: integrations-backport-dispatch
+      description: 'Pipeline to dispatch backport branch creation on merges to main'
+    spec:
+      branch_configuration: "main"
+      pipeline_file: ".buildkite/pipeline.backport-dispatch.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: false
+        build_tags: false
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null && build.source == 'api')
+      repository: elastic/integrations
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        ecosystem:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
   name: buildkite-pipeline-integrations-publish
   description: 'Pipeline for the Integrations project to publish packages'
   links:


### PR DESCRIPTION
<!-- Type of change: Enhancement -->

## Proposed commit message

```
[CI][Backports] add integrations-backport-dispatch private pipeline

Move backport branch creation trigger from the public integrations pipeline
to a new private integrations-backport-dispatch pipeline, preventing failures
caused by public-to-private pipeline trigger restrictions in Buildkite.
```

The public `integrations` pipeline can fail to trigger the private
`integrations-backport` pipeline in some scenarios due to public→private
pipeline restrictions in Buildkite. This PR introduces a new dedicated
private pipeline (`integrations-backport-dispatch`) that reliably triggers
`integrations-backport` on merges to main.

**WHAT:**
- New `.buildkite/pipeline.backport-dispatch.yml`: private pipeline that
  runs `check-backports-inventory` and `trigger-backport-create` on pushes
  to `main` when `.backports.yml` changes.
- `pipeline.yml`: removed the `trigger-backport-create` step (moved to
  dispatch pipeline); narrowed `check-backports-inventory` to PR-only since
  the main-push case is now owned by the dispatch pipeline.
- `pipeline.backport.yml`: added `integrations-backport-dispatch` as a
  valid trigger source in the `check-ui` guard; added failure email
  notifications scoped to automated runs from the dispatch pipeline.
- `trigger_backport.sh`: added a safeguard that exits 1 if backport branch
  creation is attempted from any pipeline other than
  `integrations-backport-dispatch`.
- `catalog-info.yaml`: registered the new pipeline as a Backstage resource.
- `pull-requests.json`: added the new pipeline entry and
  `pipeline.backport-dispatch.yml` to `skip_ci_on_only_changed`.
- `non_package_patterns.txt`: added `pipeline.backport-dispatch.yml` so
  changes to it alone do not trigger package integration tests.

**WHY:**
Buildkite restricts public pipelines from triggering private pipelines in
certain scenarios (e.g. fork builds, specific webhook configurations). By
moving the backport branch creation trigger to a private pipeline, we
eliminate that failure mode while keeping the dry-run validation in the
public `integrations` pipeline for PR builds.

An example of the failure this addresses can be seen in:
https://buildkite.com/elastic/integrations/builds/46280

## Author's Checklist

- [x] Revert commit `0c3d9a6f47` ("Skip integrations tests - to be removed") before merging — it was added for testing purposes only.


## Related issues

- Closes https://github.com/elastic/integrations/issues/19211
- Follow-up from https://github.com/elastic/integrations/pull/19273

---

> This PR was generated with the assistance of [Claude](https://claude.ai) (claude-sonnet-4-6).