### PR TITLE
[beyondinsight_password_safe] - Send auth header on all data requests

### DIFF
--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.1"
+  changes:
+    - description: Send the PS-Auth Authorization header on all data collection requests instead of only on sign-in, so collection works against API registrations that validate authentication on every call.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.3.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/beyondinsight_password_safe/changelog.yml
+++ b/packages/beyondinsight_password_safe/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Send the PS-Auth Authorization header on all data collection requests instead of only on sign-in, so collection works against API registrations that validate authentication on every call.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/20325
 - version: "1.3.0"
   changes:
     - description: Publish Agentless to Elastic Managed integrations name change.

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/deploy/docker/files/config.yml
@@ -49,6 +49,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/Workgroups"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     responses:
@@ -78,6 +79,7 @@ rules:
       limit: '1'
       offset: '0'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     responses:
@@ -113,6 +115,7 @@ rules:
       limit: '1'
       offset: '1'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     responses:
@@ -129,6 +132,7 @@ rules:
       limit: '1'
       offset: '1'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     responses:
@@ -165,6 +169,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/Workgroups/2/Assets"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     query_params:
@@ -186,6 +191,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/Workgroups"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     responses:
@@ -207,6 +213,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/Workgroups/3/Assets"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     query_params:

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-all.expected
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-all.expected
@@ -52,6 +52,11 @@ inputs:
                       ).with(
                         {
                           "Header": {
+                            // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                            "Authorization": [
+                              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                            ],
                             "Content-Type": ["application/json"],
                             "Cookie": state.cursor.cookies,
                           },
@@ -137,6 +142,11 @@ inputs:
                     request("GET", state.url.trim_suffix("/") + "/Workgroups").with(
                       {
                         "Header": {
+                          // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                          "Authorization": [
+                            sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                            (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                          ],
                           "Content-Type": ["application/json"],
                           "Cookie": state.cursor.cookies,
                         },

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-empty-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-empty-password.expected
@@ -52,6 +52,11 @@ inputs:
                       ).with(
                         {
                           "Header": {
+                            // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                            "Authorization": [
+                              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                            ],
                             "Content-Type": ["application/json"],
                             "Cookie": state.cursor.cookies,
                           },
@@ -137,6 +142,11 @@ inputs:
                     request("GET", state.url.trim_suffix("/") + "/Workgroups").with(
                       {
                         "Header": {
+                          // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                          "Authorization": [
+                            sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                            (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                          ],
                           "Content-Type": ["application/json"],
                           "Cookie": state.cursor.cookies,
                         },

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-missing-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-missing-password.expected
@@ -52,6 +52,11 @@ inputs:
                       ).with(
                         {
                           "Header": {
+                            // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                            "Authorization": [
+                              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                            ],
                             "Content-Type": ["application/json"],
                             "Cookie": state.cursor.cookies,
                           },
@@ -137,6 +142,11 @@ inputs:
                     request("GET", state.url.trim_suffix("/") + "/Workgroups").with(
                       {
                         "Header": {
+                          // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                          "Authorization": [
+                            sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                            (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                          ],
                           "Content-Type": ["application/json"],
                           "Cookie": state.cursor.cookies,
                         },

--- a/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-null-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/asset/_dev/test/policy/test-null-password.expected
@@ -52,6 +52,11 @@ inputs:
                       ).with(
                         {
                           "Header": {
+                            // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                            "Authorization": [
+                              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                            ],
                             "Content-Type": ["application/json"],
                             "Cookie": state.cursor.cookies,
                           },
@@ -137,6 +142,11 @@ inputs:
                     request("GET", state.url.trim_suffix("/") + "/Workgroups").with(
                       {
                         "Header": {
+                          // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                          "Authorization": [
+                            sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                            (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                          ],
                           "Content-Type": ["application/json"],
                           "Cookie": state.cursor.cookies,
                         },

--- a/packages/beyondinsight_password_safe/data_stream/asset/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/asset/agent/stream/cel.yml.hbs
@@ -74,6 +74,11 @@ program: |-
             ).with(
               {
                 "Header": {
+                  // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                  "Authorization": [
+                    sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                    (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                  ],
                   "Content-Type": ["application/json"],
                   "Cookie": state.cursor.cookies,
                 },
@@ -159,6 +164,11 @@ program: |-
           request("GET", state.url.trim_suffix("/") + "/Workgroups").with(
             {
               "Header": {
+                // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                "Authorization": [
+                  sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                  (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                ],
                 "Content-Type": ["application/json"],
                 "Cookie": state.cursor.cookies,
               },

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/deploy/docker/files/config.yml
@@ -63,6 +63,7 @@ rules:
     query_params:
       offset: '0'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     responses:
@@ -101,6 +102,7 @@ rules:
     query_params:
       offset: '1'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     responses:
@@ -116,6 +118,7 @@ rules:
       offset: '1'
       limit: '1'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     responses:
@@ -152,6 +155,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/ManagedAccounts"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     responses:

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-all.expected
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-all.expected
@@ -28,6 +28,11 @@ inputs:
                 ).with(
                   {
                     "Header": {
+                      // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                      "Authorization": [
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                      ],
                       "Content-Type": ["application/json"],
                       "Cookie": state.cursor.cookies,
                     },

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-empty-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-empty-password.expected
@@ -28,6 +28,11 @@ inputs:
                 ).with(
                   {
                     "Header": {
+                      // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                      "Authorization": [
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                      ],
                       "Content-Type": ["application/json"],
                       "Cookie": state.cursor.cookies,
                     },

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-null-password.expected
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/_dev/test/policy/test-null-password.expected
@@ -28,6 +28,11 @@ inputs:
                 ).with(
                   {
                     "Header": {
+                      // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                      "Authorization": [
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                      ],
                       "Content-Type": ["application/json"],
                       "Cookie": state.cursor.cookies,
                     },

--- a/packages/beyondinsight_password_safe/data_stream/managedaccount/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/managedaccount/agent/stream/cel.yml.hbs
@@ -44,6 +44,11 @@ program: |-
       ).with(
         {
           "Header": {
+            // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+            "Authorization": [
+              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+            ],
             "Content-Type": ["application/json"],
             "Cookie": state.cursor.cookies,
           },

--- a/packages/beyondinsight_password_safe/data_stream/managedsystem/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/managedsystem/_dev/deploy/docker/files/config.yml
@@ -64,6 +64,7 @@ rules:
     query_params:
       offset: '0'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     responses:
@@ -131,6 +132,7 @@ rules:
     query_params:
       offset: '1'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     responses:
@@ -146,6 +148,7 @@ rules:
       offset: '1'
       limit: '1'
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     responses:
@@ -211,6 +214,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/ManagedSystems"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     responses:

--- a/packages/beyondinsight_password_safe/data_stream/managedsystem/_dev/test/policy/test-all.expected
+++ b/packages/beyondinsight_password_safe/data_stream/managedsystem/_dev/test/policy/test-all.expected
@@ -28,6 +28,11 @@ inputs:
                 ).with(
                   {
                     "Header": {
+                      // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+                      "Authorization": [
+                        sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+                        (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+                      ],
                       "Content-Type": ["application/json"],
                       "Cookie": state.cursor.cookies,
                     },

--- a/packages/beyondinsight_password_safe/data_stream/managedsystem/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/managedsystem/agent/stream/cel.yml.hbs
@@ -44,6 +44,11 @@ program: |-
       ).with(
         {
           "Header": {
+            // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+            "Authorization": [
+              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+            ],
             "Content-Type": ["application/json"],
             "Cookie": state.cursor.cookies,
           },

--- a/packages/beyondinsight_password_safe/data_stream/session/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/session/_dev/deploy/docker/files/config.yml
@@ -59,6 +59,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/Sessions"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=session_cookie1']
     as_sequence: true
@@ -144,6 +145,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/Sessions"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=session_cookie2']
     as_sequence: true

--- a/packages/beyondinsight_password_safe/data_stream/session/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/session/agent/stream/cel.yml.hbs
@@ -40,6 +40,11 @@ program: |-
       ).with(
         {
           "Header": {
+            // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+            "Authorization": [
+              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+            ],
             "Content-Type": ["application/json"],
             "Cookie": state.cursor.cookies,
           },

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/_dev/deploy/docker/files/config.yml
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/_dev/deploy/docker/files/config.yml
@@ -68,6 +68,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/UserAudits"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     query_params:
@@ -101,6 +102,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/UserAudits"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value2']
     query_params:
@@ -143,6 +145,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/UserAudits"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     query_params:
@@ -161,6 +164,7 @@ rules:
   - path: "/BeyondTrust/api/public/v3/UserAudits"
     methods: ["GET"]
     request_headers:
+      Authorization: ['PS-Auth key=test_api_key;.*']
       Content-Type: ['application/json']
       Cookie: ['ASP.NET_SessionId=cookie_value1']
     query_params:

--- a/packages/beyondinsight_password_safe/data_stream/useraudit/agent/stream/cel.yml.hbs
+++ b/packages/beyondinsight_password_safe/data_stream/useraudit/agent/stream/cel.yml.hbs
@@ -60,6 +60,11 @@ program: |-
       ).with(
         {
           "Header": {
+            // Include credentials on every request; some API registrations validate them on all calls, not just sign-in.
+            "Authorization": [
+              sprintf("PS-Auth key=%s; runas=%s;", [state.apikey, state.username]) +
+              (has(state.password) ? (sprintf(" pwd=[%s];", [state.password])) : ""),
+            ],
             "Content-Type": ["application/json"],
             "Cookie": state.cursor.cookies,
           },

--- a/packages/beyondinsight_password_safe/manifest.yml
+++ b/packages/beyondinsight_password_safe/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: beyondinsight_password_safe
 title: BeyondInsight and Password Safe
-version: "1.3.0"
+version: "1.3.1"
 source:
   license: "Elastic-2.0"
 description: Ingest privileged access management (PAM) data from BeyondTrust's BeyondInsight PAM Reporting Platform and Password Safe, using Elastic Agent.


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
beyondinsight_password_safe: send auth header on all data requests

The CEL data streams sent the PS-Auth Authorization header only on the
POST /Auth/SignAppin request. API registrations that validate
authentication on every call rejected all subsequent data GETs with
401, and the 401 retry re-authenticated but re-issued the same
header-incomplete request, so it could never recover.

Add the Authorization header to every data request across the asset,
managedaccount, managedsystem, session, and useraudit streams, and
require it in the system test mock rules so the header cannot be
dropped again without failing the tests.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
