### PR TITLE
[o365] - Recover from transport-level fetch failures instead of stalling

### DIFF
--- a/packages/o365/_dev/deploy/docker/docker-compose.yml
+++ b/packages/o365/_dev/deploy/docker/docker-compose.yml
@@ -12,3 +12,22 @@ services:
       - http-server
       - --addr=:8080
       - --config=/config.yml
+  # Custom Go mock used only by the transport-error system test. The stream
+  # http-server cannot truncate a response body mid-stream, which is what is
+  # needed to reproduce the io.ErrUnexpectedEOF ("unexpected EOF") transport
+  # failure, so this dedicated service does it instead.
+  o365-transport-error:
+    image: golang:1.24.7-alpine
+    working_dir: /app
+    volumes:
+      - ./transport-error-mock:/app
+    environment:
+      PORT: "8080"
+    ports:
+      - 8080
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    command: ["go", "run", "main.go"]

--- a/packages/o365/_dev/deploy/docker/transport-error-mock/go.mod
+++ b/packages/o365/_dev/deploy/docker/transport-error-mock/go.mod
@@ -1,0 +1,3 @@
+module transport-error-mock
+
+go 1.24.7

--- a/packages/o365/_dev/deploy/docker/transport-error-mock/main.go
+++ b/packages/o365/_dev/deploy/docker/transport-error-mock/main.go
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Command transport-error-mock is a synthetic Office 365 Management Activity
+// API used by the audit data stream's transport-error system test. It walks the
+// CEL program through the normal token -> subscribe -> list -> fetch flow, but
+// the first fetch of one content blob is answered with a truncated body so the
+// HTTP client fails the read with io.ErrUnexpectedEOF ("unexpected EOF"). The
+// same blob succeeds on retry, which lets the test confirm that a transient
+// transport failure no longer stalls collection: the other blob is still
+// fetched and the failed blob is picked up on a later evaluation.
+//
+// All data served here is synthetic and contains no real tenant information.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	tenant = "test-cel-tenant-id"
+
+	goodContentID      = "blob-good"
+	transientContentID = "blob-transient"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	addr := ":" + port
+
+	m := &mock{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/", m.route)
+	log.Printf("transport-error mock listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+// mock holds the small amount of state needed to make the scenario
+// deterministic: the content listing is served once, and the transient blob
+// fails exactly once before succeeding.
+type mock struct {
+	mu              sync.Mutex
+	listingServed   bool
+	transientFailed bool
+}
+
+func (m *mock) route(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path
+	switch {
+	case strings.HasSuffix(p, "/oauth2/v2.0/token"):
+		writeJSON(w, `{"access_token":"synthetic-token","token_type":"Bearer","expires_in":3600,"ext_expires_in":3600}`)
+	case strings.HasSuffix(p, "/activity/feed/subscriptions/start"):
+		writeJSON(w, `{"contentType":"Audit.Exchange","status":"enabled","webhook":null}`)
+	case strings.HasSuffix(p, "/activity/feed/subscriptions/content"):
+		m.serveListing(w, r)
+	case strings.HasSuffix(p, "/activity/feed/audit/"+transientContentID):
+		m.serveTransientContent(w)
+	case strings.HasSuffix(p, "/activity/feed/audit/"+goodContentID):
+		writeJSON(w, auditEvent("synthetic-good-0001"))
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// serveListing returns the two content blobs on the first call and an empty
+// list afterwards, so the scenario cannot grow unbounded across polls.
+func (m *mock) serveListing(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	served := m.listingServed
+	m.listingServed = true
+	m.mu.Unlock()
+
+	if served {
+		writeJSON(w, `[]`)
+		return
+	}
+	base := "http://" + r.Host + "/api/v1.0/" + tenant + "/activity/feed/audit/"
+	writeJSON(w, `[`+
+		contentRef(transientContentID, base)+`,`+
+		contentRef(goodContentID, base)+
+		`]`)
+}
+
+// serveTransientContent truncates the body on the first request to simulate a
+// dropped connection, then serves a valid event on every later request.
+func (m *mock) serveTransientContent(w http.ResponseWriter) {
+	m.mu.Lock()
+	failed := m.transientFailed
+	m.transientFailed = true
+	m.mu.Unlock()
+
+	if failed {
+		writeJSON(w, auditEvent("synthetic-transient-0001"))
+		return
+	}
+	truncate(w)
+}
+
+// truncate advertises a large Content-Length, writes a few bytes, and then
+// closes the connection so the client's body read ends with io.ErrUnexpectedEOF.
+func truncate(w http.ResponseWriter) {
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	conn, bufrw, err := hj.Hijack()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 100000\r\n\r\n")
+	bufrw.WriteString(`[{"Id":"synthetic-truncated"`)
+	bufrw.Flush()
+}
+
+func contentRef(id, base string) string {
+	return `{"contentType":"Audit.Exchange","contentId":"` + id + `","contentUri":"` + base + id + `","contentCreated":"2020-01-01T00:00:00.000Z","contentExpiration":"2199-12-31T23:59:59.000Z"}`
+}
+
+func auditEvent(id string) string {
+	return `[{"Id":"` + id + `","CreationTime":"2020-01-01T00:00:00","Operation":"MailItemsAccessed","Workload":"Exchange","RecordType":2,"OrganizationId":"00000000-0000-0000-0000-000000000000","UserId":"analyst@example.com","ClientIP":"192.0.2.10"}]`
+}
+
+func writeJSON(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(body))
+}

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,9 +1,11 @@
 # newer versions go on top
 - version: "3.10.6"
   changes:
-    - description: Prevent the audit data stream from stalling when a content or listing request fails at the transport level (for example a dropped connection or a truncated response body). Such failures are now caught and advance the cursor instead of freezing it, so a single unfetchable item no longer blocks all further collection until the agent is restarted.
+    - description: >- 
+        Prevent the audit data stream from stalling when a content or listing request fails at the transport level (for example a dropped connection or a truncated response body). 
+        Such failures are now caught and advance the cursor instead of freezing it, so a single unfetchable item no longer blocks all further collection until the agent is restarted.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/20200
+      link: https://github.com/elastic/integrations/pull/20333
 - version: "3.10.5"
   changes:
     - description: Expand the README troubleshooting section with common scenarios (authentication failures, missing permissions, no data collected, outage recovery, rate limiting, and unhealthy transforms) and add a security note that request trace files are not redacted.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.10.6"
+  changes:
+    - description: Prevent the audit data stream from stalling when a content or listing request fails at the transport level (for example a dropped connection or a truncated response body). Such failures are now caught and advance the cursor instead of freezing it, so a single unfetchable item no longer blocks all further collection until the agent is restarted.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/20200
 - version: "3.10.5"
   changes:
     - description: Expand the README troubleshooting section with common scenarios (authentication failures, missing permissions, no data collected, outage recovery, rate limiting, and unhealthy transforms) and add a security note that request trace files are not redacted.

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
@@ -167,19 +167,15 @@ inputs:
                 ).as(sub_resp, sub_resp.?_transport_error.hasValue() ?
                   // A transport-level failure such as a dropped connection or a truncated
                   // response body makes do_request return an error rather than a response
-                  // with a status code. Emit an array error to surface it and stop this
-                  // cycle so the subscription is retried on the next polling interval
-                  // instead of crashing the evaluation.
+                  // with a status code, which would otherwise crash the evaluation. Emit
+                  // a dropped retry event and stop this cycle so the subscription is
+                  // retried on the next polling interval. The failure is not indexed as
+                  // an event; it remains visible through the input's HTTP metrics and
+                  // request tracer.
                   state.with(
                     {
-                      "events": [
-                        {
-                          "error": {
-                            "message": "POST /activity/feed/subscriptions/start?contentType=" + state.todo_types[0] + ": " + sub_resp._transport_error,
-                          },
-                        },
-                      ],
                       "want_more": false,
+                      "events": [{"retry": true}],
                     }
                   )
                 : (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
@@ -241,24 +237,21 @@ inputs:
                       // than a response with a status code. Returning a single error
                       // object here would make the runtime discard the cursor update, so
                       // the failing item would be retried on every evaluation and stall
-                      // all further collection. Emit an array error to advance, move the
-                      // item to the back of the queue so the remaining items can still be
-                      // fetched, and stop this cycle to back off until the next interval.
+                      // all further collection. Instead, move the item to the back of the
+                      // queue so the remaining items can still be fetched, emit a dropped
+                      // retry event so the cursor change persists, and stop this cycle to
+                      // back off until the next interval. The failure is not indexed as an
+                      // event; it remains visible through the input's HTTP metrics and
+                      // request tracer.
                       state.with(
                         {
-                          "events": [
-                            {
-                              "error": {
-                                "message": "GET " + state.cursor.todo_content[0].contentUri + ": " + content_resp._transport_error,
-                              },
-                            },
-                          ],
                           "cursor": state.cursor.with(
                             {
                               "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
                             }
                           ),
                           "want_more": false,
+                          "events": [{"retry": true}],
                         }
                       )
                     : (content_resp.StatusCode == 200) ?
@@ -313,24 +306,20 @@ inputs:
                   // a response with a status code. Returning a single error object here
                   // would make the runtime discard the cursor update, so the failing link
                   // would be retried on every evaluation and stall all further
-                  // collection. Emit an array error to advance, move the link to the back
-                  // of the queue so the remaining links can still be requested, and stop
-                  // this cycle to back off until the next interval.
+                  // collection. Instead, move the link to the back of the queue so the
+                  // remaining links can still be requested, emit a dropped retry event so
+                  // the cursor change persists, and stop this cycle to back off until the
+                  // next interval. The failure is not indexed as an event; it remains
+                  // visible through the input's HTTP metrics and request tracer.
                   state.with(
                     {
-                      "events": [
-                        {
-                          "error": {
-                            "message": "GET " + state.cursor.todo_links[0] + ": " + list_resp._transport_error,
-                          },
-                        },
-                      ],
                       "cursor": state.cursor.with(
                         {
                           "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
                         }
                       ),
                       "want_more": false,
+                      "events": [{"retry": true}],
                     }
                   )
                 : (list_resp.StatusCode == 200) ?

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-all.expected
@@ -148,20 +148,41 @@ inputs:
                 // Not subscribed to the current type - Subscribe
                 // ------------------------------------------------------------------------
 
-                request(
-                  "POST",
-                  sprintf(
-                    "%s/api/v1.0/%s/activity/feed/subscriptions/start?%s",
-                    [
-                      state.url.trim_right("/"),
-                      state.base.tenant_id,
-                      {
-                        "contentType": [state.todo_types[0]],
-                        "PublisherIdentifier": [state.base.tenant_id],
-                      }.format_query(),
-                    ]
+                try(
+                  request(
+                    "POST",
+                    sprintf(
+                      "%s/api/v1.0/%s/activity/feed/subscriptions/start?%s",
+                      [
+                        state.url.trim_right("/"),
+                        state.base.tenant_id,
+                        {
+                          "contentType": [state.todo_types[0]],
+                          "PublisherIdentifier": [state.base.tenant_id],
+                        }.format_query(),
+                      ]
+                    )
+                  ).do_request(),
+                  "_transport_error"
+                ).as(sub_resp, sub_resp.?_transport_error.hasValue() ?
+                  // A transport-level failure such as a dropped connection or a truncated
+                  // response body makes do_request return an error rather than a response
+                  // with a status code. Emit an array error to surface it and stop this
+                  // cycle so the subscription is retried on the next polling interval
+                  // instead of crashing the evaluation.
+                  state.with(
+                    {
+                      "events": [
+                        {
+                          "error": {
+                            "message": "POST /activity/feed/subscriptions/start?contentType=" + state.todo_types[0] + ": " + sub_resp._transport_error,
+                          },
+                        },
+                      ],
+                      "want_more": false,
+                    }
                   )
-                ).do_request().as(sub_resp, (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
+                : (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
                   // Subscription successful - Record subscription, requeue type and continue
                   state.with(
                     {
@@ -208,10 +229,39 @@ inputs:
                       }
                     )
                   :
-                    request(
-                      "GET",
-                      state.cursor.todo_content[0].contentUri
-                    ).do_request().as(content_resp, (content_resp.StatusCode == 200) ?
+                    try(
+                      request(
+                        "GET",
+                        state.cursor.todo_content[0].contentUri
+                      ).do_request(),
+                      "_transport_error"
+                    ).as(content_resp, content_resp.?_transport_error.hasValue() ?
+                      // A transport-level failure such as a dropped connection or a
+                      // truncated response body makes do_request return an error rather
+                      // than a response with a status code. Returning a single error
+                      // object here would make the runtime discard the cursor update, so
+                      // the failing item would be retried on every evaluation and stall
+                      // all further collection. Emit an array error to advance, move the
+                      // item to the back of the queue so the remaining items can still be
+                      // fetched, and stop this cycle to back off until the next interval.
+                      state.with(
+                        {
+                          "events": [
+                            {
+                              "error": {
+                                "message": "GET " + state.cursor.todo_content[0].contentUri + ": " + content_resp._transport_error,
+                              },
+                            },
+                          ],
+                          "cursor": state.cursor.with(
+                            {
+                              "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                            }
+                          ),
+                          "want_more": false,
+                        }
+                      )
+                    : (content_resp.StatusCode == 200) ?
                       // Fetch successful - Return events, continue with remaining content
                       state.with(
                         {
@@ -251,10 +301,39 @@ inputs:
                 // Listing link generated or received - Request it
                 // ------------------------------------------------------------------------
 
-                request(
-                  "GET",
-                  state.cursor.todo_links[0]
-                ).do_request().as(list_resp, (list_resp.StatusCode == 200) ?
+                try(
+                  request(
+                    "GET",
+                    state.cursor.todo_links[0]
+                  ).do_request(),
+                  "_transport_error"
+                ).as(list_resp, list_resp.?_transport_error.hasValue() ?
+                  // A transport-level failure such as a dropped connection or a
+                  // truncated response body makes do_request return an error rather than
+                  // a response with a status code. Returning a single error object here
+                  // would make the runtime discard the cursor update, so the failing link
+                  // would be retried on every evaluation and stall all further
+                  // collection. Emit an array error to advance, move the link to the back
+                  // of the queue so the remaining links can still be requested, and stop
+                  // this cycle to back off until the next interval.
+                  state.with(
+                    {
+                      "events": [
+                        {
+                          "error": {
+                            "message": "GET " + state.cursor.todo_links[0] + ": " + list_resp._transport_error,
+                          },
+                        },
+                      ],
+                      "cursor": state.cursor.with(
+                        {
+                          "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+                        }
+                      ),
+                      "want_more": false,
+                    }
+                  )
+                : (list_resp.StatusCode == 200) ?
                   // Listing successful - Enqueue any additional link, enqueue content to fetch
                   list_resp.Body.decode_json().as(content_list,
                     state.with(

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
@@ -157,19 +157,15 @@ inputs:
                 ).as(sub_resp, sub_resp.?_transport_error.hasValue() ?
                   // A transport-level failure such as a dropped connection or a truncated
                   // response body makes do_request return an error rather than a response
-                  // with a status code. Emit an array error to surface it and stop this
-                  // cycle so the subscription is retried on the next polling interval
-                  // instead of crashing the evaluation.
+                  // with a status code, which would otherwise crash the evaluation. Emit
+                  // a dropped retry event and stop this cycle so the subscription is
+                  // retried on the next polling interval. The failure is not indexed as
+                  // an event; it remains visible through the input's HTTP metrics and
+                  // request tracer.
                   state.with(
                     {
-                      "events": [
-                        {
-                          "error": {
-                            "message": "POST /activity/feed/subscriptions/start?contentType=" + state.todo_types[0] + ": " + sub_resp._transport_error,
-                          },
-                        },
-                      ],
                       "want_more": false,
+                      "events": [{"retry": true}],
                     }
                   )
                 : (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
@@ -231,24 +227,21 @@ inputs:
                       // than a response with a status code. Returning a single error
                       // object here would make the runtime discard the cursor update, so
                       // the failing item would be retried on every evaluation and stall
-                      // all further collection. Emit an array error to advance, move the
-                      // item to the back of the queue so the remaining items can still be
-                      // fetched, and stop this cycle to back off until the next interval.
+                      // all further collection. Instead, move the item to the back of the
+                      // queue so the remaining items can still be fetched, emit a dropped
+                      // retry event so the cursor change persists, and stop this cycle to
+                      // back off until the next interval. The failure is not indexed as an
+                      // event; it remains visible through the input's HTTP metrics and
+                      // request tracer.
                       state.with(
                         {
-                          "events": [
-                            {
-                              "error": {
-                                "message": "GET " + state.cursor.todo_content[0].contentUri + ": " + content_resp._transport_error,
-                              },
-                            },
-                          ],
                           "cursor": state.cursor.with(
                             {
                               "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
                             }
                           ),
                           "want_more": false,
+                          "events": [{"retry": true}],
                         }
                       )
                     : (content_resp.StatusCode == 200) ?
@@ -303,24 +296,20 @@ inputs:
                   // a response with a status code. Returning a single error object here
                   // would make the runtime discard the cursor update, so the failing link
                   // would be retried on every evaluation and stall all further
-                  // collection. Emit an array error to advance, move the link to the back
-                  // of the queue so the remaining links can still be requested, and stop
-                  // this cycle to back off until the next interval.
+                  // collection. Instead, move the link to the back of the queue so the
+                  // remaining links can still be requested, emit a dropped retry event so
+                  // the cursor change persists, and stop this cycle to back off until the
+                  // next interval. The failure is not indexed as an event; it remains
+                  // visible through the input's HTTP metrics and request tracer.
                   state.with(
                     {
-                      "events": [
-                        {
-                          "error": {
-                            "message": "GET " + state.cursor.todo_links[0] + ": " + list_resp._transport_error,
-                          },
-                        },
-                      ],
                       "cursor": state.cursor.with(
                         {
                           "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
                         }
                       ),
                       "want_more": false,
+                      "events": [{"retry": true}],
                     }
                   )
                 : (list_resp.StatusCode == 200) ?

--- a/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
+++ b/packages/o365/data_stream/audit/_dev/test/policy/test-cel-default.expected
@@ -138,20 +138,41 @@ inputs:
                 // Not subscribed to the current type - Subscribe
                 // ------------------------------------------------------------------------
 
-                request(
-                  "POST",
-                  sprintf(
-                    "%s/api/v1.0/%s/activity/feed/subscriptions/start?%s",
-                    [
-                      state.url.trim_right("/"),
-                      state.base.tenant_id,
-                      {
-                        "contentType": [state.todo_types[0]],
-                        "PublisherIdentifier": [state.base.tenant_id],
-                      }.format_query(),
-                    ]
+                try(
+                  request(
+                    "POST",
+                    sprintf(
+                      "%s/api/v1.0/%s/activity/feed/subscriptions/start?%s",
+                      [
+                        state.url.trim_right("/"),
+                        state.base.tenant_id,
+                        {
+                          "contentType": [state.todo_types[0]],
+                          "PublisherIdentifier": [state.base.tenant_id],
+                        }.format_query(),
+                      ]
+                    )
+                  ).do_request(),
+                  "_transport_error"
+                ).as(sub_resp, sub_resp.?_transport_error.hasValue() ?
+                  // A transport-level failure such as a dropped connection or a truncated
+                  // response body makes do_request return an error rather than a response
+                  // with a status code. Emit an array error to surface it and stop this
+                  // cycle so the subscription is retried on the next polling interval
+                  // instead of crashing the evaluation.
+                  state.with(
+                    {
+                      "events": [
+                        {
+                          "error": {
+                            "message": "POST /activity/feed/subscriptions/start?contentType=" + state.todo_types[0] + ": " + sub_resp._transport_error,
+                          },
+                        },
+                      ],
+                      "want_more": false,
+                    }
                   )
-                ).do_request().as(sub_resp, (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
+                : (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
                   // Subscription successful - Record subscription, requeue type and continue
                   state.with(
                     {
@@ -198,10 +219,39 @@ inputs:
                       }
                     )
                   :
-                    request(
-                      "GET",
-                      state.cursor.todo_content[0].contentUri
-                    ).do_request().as(content_resp, (content_resp.StatusCode == 200) ?
+                    try(
+                      request(
+                        "GET",
+                        state.cursor.todo_content[0].contentUri
+                      ).do_request(),
+                      "_transport_error"
+                    ).as(content_resp, content_resp.?_transport_error.hasValue() ?
+                      // A transport-level failure such as a dropped connection or a
+                      // truncated response body makes do_request return an error rather
+                      // than a response with a status code. Returning a single error
+                      // object here would make the runtime discard the cursor update, so
+                      // the failing item would be retried on every evaluation and stall
+                      // all further collection. Emit an array error to advance, move the
+                      // item to the back of the queue so the remaining items can still be
+                      // fetched, and stop this cycle to back off until the next interval.
+                      state.with(
+                        {
+                          "events": [
+                            {
+                              "error": {
+                                "message": "GET " + state.cursor.todo_content[0].contentUri + ": " + content_resp._transport_error,
+                              },
+                            },
+                          ],
+                          "cursor": state.cursor.with(
+                            {
+                              "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                            }
+                          ),
+                          "want_more": false,
+                        }
+                      )
+                    : (content_resp.StatusCode == 200) ?
                       // Fetch successful - Return events, continue with remaining content
                       state.with(
                         {
@@ -241,10 +291,39 @@ inputs:
                 // Listing link generated or received - Request it
                 // ------------------------------------------------------------------------
 
-                request(
-                  "GET",
-                  state.cursor.todo_links[0]
-                ).do_request().as(list_resp, (list_resp.StatusCode == 200) ?
+                try(
+                  request(
+                    "GET",
+                    state.cursor.todo_links[0]
+                  ).do_request(),
+                  "_transport_error"
+                ).as(list_resp, list_resp.?_transport_error.hasValue() ?
+                  // A transport-level failure such as a dropped connection or a
+                  // truncated response body makes do_request return an error rather than
+                  // a response with a status code. Returning a single error object here
+                  // would make the runtime discard the cursor update, so the failing link
+                  // would be retried on every evaluation and stall all further
+                  // collection. Emit an array error to advance, move the link to the back
+                  // of the queue so the remaining links can still be requested, and stop
+                  // this cycle to back off until the next interval.
+                  state.with(
+                    {
+                      "events": [
+                        {
+                          "error": {
+                            "message": "GET " + state.cursor.todo_links[0] + ": " + list_resp._transport_error,
+                          },
+                        },
+                      ],
+                      "cursor": state.cursor.with(
+                        {
+                          "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+                        }
+                      ),
+                      "want_more": false,
+                    }
+                  )
+                : (list_resp.StatusCode == 200) ?
                   // Listing successful - Enqueue any additional link, enqueue content to fetch
                   list_resp.Body.decode_json().as(content_list,
                     state.with(

--- a/packages/o365/data_stream/audit/_dev/test/system/test-cel-transport-error-config.yml
+++ b/packages/o365/data_stream/audit/_dev/test/system/test-cel-transport-error-config.yml
@@ -1,0 +1,40 @@
+input: cel
+service: o365-transport-error
+vars: ~
+policy_template: o365
+data_stream:
+  vars:
+    url: http://{{Hostname}}:{{Port}}
+    token_url: http://{{Hostname}}:{{Port}}
+    preserve_original_event: true
+    client_id: test-cel-client-id
+    client_secret: test-cel-client-secret
+    azure_tenant_id: test-cel-tenant-id
+    content_types: "Audit.Exchange"
+    interval: 30s
+    initial_interval: 1h
+    enable_request_tracer: true
+    # Disable the HTTP client's retries (they are only wrapped when
+    # max_attempts > 1). With retries on, the client would transparently
+    # re-fetch the truncated response and the transport error would never reach
+    # the CEL program, masking the behaviour under test. Disabling them makes a
+    # single truncated response surface to the program as it would once retries
+    # are exhausted in the field.
+    resource_retry_max_attempts: 1
+# Exercises transport-level resilience. The mock lists two content blobs; the
+# first fetch of blob-transient is answered with a truncated body, which makes
+# do_request fail with "unexpected EOF". Before the 3.10.6 fix that error
+# crashed the evaluation and froze the cursor, so nothing more was collected
+# until the agent restarted. Now the failure is caught, the blob is moved to the
+# back of the queue, and the cursor advances (via a dropped retry event) instead
+# of freezing. The failure itself is not indexed.
+#
+# Expected documents (hit_count 2), both audit events and no pipeline_error:
+#   - 1 audit event from blob-good (proves the failing blob did not block it)
+#   - 1 audit event from blob-transient when a later poll re-fetches it
+#     successfully (proves recovery)
+#
+# The mock serves the content listing once and truncates blob-transient exactly
+# once, so the count is stable and does not grow across polling intervals.
+assert:
+  hit_count: 2

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -221,20 +221,37 @@ program: |-
       // Not subscribed to the current type - Subscribe
       // ------------------------------------------------------------------------
   
-      request(
-        "POST",
-        sprintf(
-          "%s/api/v1.0/%s/activity/feed/subscriptions/start?%s",
-          [
-            state.url.trim_right("/"),
-            state.base.tenant_id,
-            {
-              "contentType": [state.todo_types[0]],
-              "PublisherIdentifier": [state.base.tenant_id],
-            }.format_query(),
-          ]
+      try(
+        request(
+          "POST",
+          sprintf(
+            "%s/api/v1.0/%s/activity/feed/subscriptions/start?%s",
+            [
+              state.url.trim_right("/"),
+              state.base.tenant_id,
+              {
+                "contentType": [state.todo_types[0]],
+                "PublisherIdentifier": [state.base.tenant_id],
+              }.format_query(),
+            ]
+          )
+        ).do_request(),
+        "_transport_error"
+      ).as(sub_resp, sub_resp.?_transport_error.hasValue() ?
+        // A transport-level failure such as a dropped connection or a truncated
+        // response body makes do_request return an error rather than a response
+        // with a status code, which would otherwise crash the evaluation. Emit
+        // a dropped retry event and stop this cycle so the subscription is
+        // retried on the next polling interval. The failure is not indexed as
+        // an event; it remains visible through the input's HTTP metrics and
+        // request tracer.
+        state.with(
+          {
+            "want_more": false,
+            "events": [{"retry": true}],
+          }
         )
-      ).do_request().as(sub_resp, (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
+      : (sub_resp.StatusCode == 200 || sub_resp.StatusCode == 400) ?
         // Subscription successful - Record subscription, requeue type and continue
         state.with(
           {
@@ -281,10 +298,36 @@ program: |-
             }
           )
         :
-          request(
-            "GET",
-            state.cursor.todo_content[0].contentUri
-          ).do_request().as(content_resp, (content_resp.StatusCode == 200) ?
+          try(
+            request(
+              "GET",
+              state.cursor.todo_content[0].contentUri
+            ).do_request(),
+            "_transport_error"
+          ).as(content_resp, content_resp.?_transport_error.hasValue() ?
+            // A transport-level failure such as a dropped connection or a
+            // truncated response body makes do_request return an error rather
+            // than a response with a status code. Returning a single error
+            // object here would make the runtime discard the cursor update, so
+            // the failing item would be retried on every evaluation and stall
+            // all further collection. Instead, move the item to the back of the
+            // queue so the remaining items can still be fetched, emit a dropped
+            // retry event so the cursor change persists, and stop this cycle to
+            // back off until the next interval. The failure is not indexed as an
+            // event; it remains visible through the input's HTTP metrics and
+            // request tracer.
+            state.with(
+              {
+                "cursor": state.cursor.with(
+                  {
+                    "todo_content": tail(state.cursor.todo_content) + [state.cursor.todo_content[0]],
+                  }
+                ),
+                "want_more": false,
+                "events": [{"retry": true}],
+              }
+            )
+          : (content_resp.StatusCode == 200) ?
             // Fetch successful - Return events, continue with remaining content
             state.with(
               {
@@ -324,10 +367,35 @@ program: |-
       // Listing link generated or received - Request it
       // ------------------------------------------------------------------------
   
-      request(
-        "GET",
-        state.cursor.todo_links[0]
-      ).do_request().as(list_resp, (list_resp.StatusCode == 200) ?
+      try(
+        request(
+          "GET",
+          state.cursor.todo_links[0]
+        ).do_request(),
+        "_transport_error"
+      ).as(list_resp, list_resp.?_transport_error.hasValue() ?
+        // A transport-level failure such as a dropped connection or a
+        // truncated response body makes do_request return an error rather than
+        // a response with a status code. Returning a single error object here
+        // would make the runtime discard the cursor update, so the failing link
+        // would be retried on every evaluation and stall all further
+        // collection. Instead, move the link to the back of the queue so the
+        // remaining links can still be requested, emit a dropped retry event so
+        // the cursor change persists, and stop this cycle to back off until the
+        // next interval. The failure is not indexed as an event; it remains
+        // visible through the input's HTTP metrics and request tracer.
+        state.with(
+          {
+            "cursor": state.cursor.with(
+              {
+                "todo_links": tail(state.cursor.todo_links) + [state.cursor.todo_links[0]],
+              }
+            ),
+            "want_more": false,
+            "events": [{"retry": true}],
+          }
+        )
+      : (list_resp.StatusCode == 200) ?
         // Listing successful - Enqueue any additional link, enqueue content to fetch
         list_resp.Body.decode_json().as(content_list,
           state.with(

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft Office 365
-version: "3.10.5"
+version: "3.10.6"
 description: Collect logs from Microsoft Office 365 with Elastic Agent.
 type: integration
 format_version: "3.2.3"


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
o365: recover from transport-level fetch failures instead of stalling

The audit data stream's CEL program froze when a content or listing
request to the Office 365 Management Activity API failed at the
transport level, for example a dropped connection or a truncated
response body surfacing as "unexpected EOF". do_request returned an
error that crashed the evaluation, and the runtime then discarded the
cursor update, so the failing request stayed at the head of the queue
and blocked all further collection until the agent was restarted.

Catch these transport errors, move the failing item to the back of its
queue so the remaining items still progress, advance the cursor via a
dropped retry event, and stop the cycle to back off until the next
interval. The item is retained and retried later rather than dropped,
and last_for is left untouched so no time window is skipped. HTTP
status errors keep their existing behaviour.

Add a system test that reproduces the failure with a custom mock that
truncates one content fetch. Retries are disabled in that test so the
single truncation reaches the program deterministically.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [ ] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
