### PR TITLE
[Cloud Asset Inventory] Fix entity.attribute mapping bug by renaming it to entity.Details

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -17,7 +17,7 @@
         entity.Details. The entity.attributes (flattened) mapping added in 1.7.0 collided with the
         Entity Store's reserved entity.attributes.* typed leaves, aborting generic entity extraction.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/XXXXX
+      link: https://github.com/elastic/integrations/pull/20334
 - version: "1.7.0"
   changes:
     - description: >

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -9,6 +9,15 @@
 # 1.1.x - 9.2.x
 # 1.0.x - 9.1.x
 # 0.1.x - 8.15.x
+- version: "1.7.1"
+  changes:
+    - description: >
+        Fix generic entity extraction in the Entity Store: rename the flattened entity.attributes
+        bag to entity.Details, and add an ingest pipeline that moves legacy entity.attributes to
+        entity.Details. The entity.attributes (flattened) mapping added in 1.7.0 collided with the
+        Entity Store's reserved entity.attributes.* typed leaves, aborting generic entity extraction.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/XXXXX
 - version: "1.7.0"
   changes:
     - description: >

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,23 @@
+---
+description: |
+  Default pipeline for cloud_asset_inventory.asset_inventory.
+  Moves the legacy `entity.attributes` bag (emitted by pre-rename cloudbeat) to `entity.Details`.
+  `entity.attributes.*` collides with the Entity Store's reserved typed leaves and breaks generic
+  entity extraction; `entity.Details` is a safe flattened home. Once cloudbeat emits `entity.Details`
+  directly, this rename is a no-op (`ignore_missing`).
+processors:
+  - rename:
+      field: entity.attributes
+      target_field: entity.Details
+      ignore_missing: true
+      tag: rename_entity_attributes_to_details
+on_failure:
+  - append:
+      field: error.message
+      value: >-
+        Processor '{{{ _ingest.on_failure_processor_type }}}'
+        {{{#_ingest.on_failure_processor_tag}}}with tag '{{{ _ingest.on_failure_processor_tag }}}'
+        {{{/_ingest.on_failure_processor_tag}}}failed with message '{{{ _ingest.on_failure_message }}}'
+  - set:
+      field: event.kind
+      value: pipeline_error

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/entity.yml
@@ -19,7 +19,7 @@
   - name: raw
     type: flattened
 
-  - name: attributes
+  - name: Details
     type: flattened
     description: >
       Non-ECS resource-specific attributes. Examples: RDS Engine/EngineVersion; ELB
@@ -29,4 +29,6 @@
       Status/Version/Endpoint/RoleArn/PlatformVersion/EndpointPublicAccess/EndpointPrivateAccess;
       and a normalized resource creation timestamp CreatedAt across all asset types. As a
       flattened field this accepts new keys without a mapping change. Keys use UpperCamelCase
-      per the non-ECS naming convention.
+      per the non-ECS naming convention. Renamed from entity.attributes (1.7.0), which collided
+      with the Entity Store's reserved entity.attributes.* typed leaves and broke generic entity
+      extraction.

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.3.2
 name: cloud_asset_inventory
 title: "Cloud Asset Discovery"
-version: "1.7.0"
+version: "1.7.1"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Discovery"


### PR DESCRIPTION
For: #incident-3395-failing-quality-gate-for-entity-store-synthetics
Incident Slack: https://elastic.slack.com/archives/C0BJQCSBT47

Fixes issue outlined by https://github.com/elastic/security-team/issues/18408 by changing the conflicting `entity.attributes` mapping to `entity.Details` and providing an Ingest Pipeline so that Cloudbeat can continue using either.

## Checklist

- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] The fix has been tested and confirmed

## Related issues

Towards https://github.com/elastic/security-team/issues/18408
