### PR TITLE
[system] Use user.target.* in New users and groups dashboard

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,10 @@
 # later versions go on top
+- version: "2.23.0"
+  changes:
+    - description: >-
+        Update the New users and groups dashboard to read the created account from `user.target.name`/`user.target.id` instead of the deprecated duplication in `user.name`/`user.id`. The New users panels only show events ingested with system 2.22.0 or later, where these fields were introduced.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/20105
 - version: "2.22.2"
   changes:
     - description: Replace the hardcoded host link in the "[Metrics System] Overview" dashboard with a dashboard-to-dashboard drilldown, so navigation to "[Metrics System] Host Overview" works across Kibana Spaces (including after "Copy to Space").

--- a/packages/system/kibana/dashboard/system-0d3f2380-fa78-11e6-ae9b-81e5311e8cab.json
+++ b/packages/system/kibana/dashboard/system-0d3f2380-fa78-11e6-ae9b-81e5311e8cab.json
@@ -236,7 +236,7 @@
                                                         "size": 5
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "user.id"
+                                                    "sourceField": "user.target.id"
                                                 },
                                                 "7b9368fd-c087-4f71-b9ca-454774a85c72": {
                                                     "customLabel": true,
@@ -262,7 +262,7 @@
                                                         "size": 5
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "user.name"
+                                                    "sourceField": "user.target.name"
                                                 },
                                                 "db31a995-74d5-49ed-be8b-4e70cbf80ce4": {
                                                     "customLabel": true,
@@ -448,7 +448,7 @@
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "user.name: Descending",
+                                                    "label": "user.target.name: Descending",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -468,7 +468,7 @@
                                                         "size": 5
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "user.name"
+                                                    "sourceField": "user.target.name"
                                                 }
                                             },
                                             "ignoreGlobalFilters": false,
@@ -641,7 +641,7 @@
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "user.name: Descending",
+                                                    "label": "user.target.name: Descending",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -661,7 +661,7 @@
                                                         "size": 5
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "user.name"
+                                                    "sourceField": "user.target.name"
                                                 }
                                             },
                                             "ignoreGlobalFilters": false,
@@ -773,7 +773,7 @@
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "user.name: Descending",
+                                                    "label": "user.target.name: Descending",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -793,7 +793,7 @@
                                                         "size": 5
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "user.name"
+                                                    "sourceField": "user.target.name"
                                                 },
                                                 "87629456-e54e-47dc-854b-6eabac7052ec": {
                                                     "customLabel": true,

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.22.2"
+version: "2.23.0"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Updates the "[Logs System] New users and groups" dashboard to read the
created account from `user.target.name`/`user.target.id` instead of
`user.name`/`user.id` in the four New users panels (table, over time, by
shell, by home directory). The New groups panels are unchanged, as groupadd
events still map `group.name`/`group.id`.

Since system 2.22.0 (elastic/integrations#20339) useradd events populate
`user.target.*` with the created account; `user.name`/`user.id` only carry a
deprecated duplication that a future major version will remove (contract
phase of the expand-and-contract migration, elastic/integrations#20105).
Moving the dashboard to the new fields now means it keeps working after that
removal.

Note the New users panels only show events ingested with system 2.22.0 or
later, where `user.target.*` was introduced for useradd events.

## Checklist

- [x] I have reviewed [tips for building integrations](https://www.elastic.co/docs/extend/integrations/tips-for-building) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~ N/A, dashboard-only change
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] ~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~ N/A, no new field types or features used
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices)

## Author's Checklist

- [ ] The New users panels intentionally switch to fields that only exist on
  events ingested with system 2.22.0+; older useradd events will no longer
  appear in them. This is disclosed in the changelog entry.

## How to test this PR locally

```
cd packages/system
elastic-package stack up -d
elastic-package build && elastic-package install
```

Then in Kibana:

1. Ingest a useradd auth event, e.g. append to a file collected by the
   system auth logfile stream (or POST a doc through the
   `logs-system.auth-2.24.0` pipeline into `logs-system.auth-default`):
   `Jul 24 12:00:00 testhost useradd[1234]: new user: name=alice, UID=1001, GID=1001, home=/home/alice, shell=/bin/bash`
2. Open the "[Logs System] New users and groups" dashboard and verify the
   New users table shows the account with User=alice and UID=1001, and the
   over time / by shell / by home directory panels populate.
3. Verify the New groups panels still work for a groupadd event.

## Related issues

- Relates https://github.com/elastic/integrations/issues/20105
- Relates https://github.com/elastic/integrations/pull/20339

