### PR TITLE
[system] Fix @timestamp overwritten by ClientCreationTime on CNG key events (5058, 5059, 5061)

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix `@timestamp` being overwritten by `ClientCreationTime` (process start time) on Windows Security events 5058, 5059, and 5061. The `date_clientcreationtime` processor was missing `target_field`, causing it to default to `@timestamp` instead of writing back to `winlog.event_data.ClientCreationTime`.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TODO
+      link: https://github.com/elastic/integrations/pull/20354
 - version: "2.22.0"
   changes:
     - description: >-

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # later versions go on top
+- version: "2.22.1"
+  changes:
+    - description: Fix `@timestamp` being overwritten by `ClientCreationTime` (process start time) on Windows Security events 5058, 5059, and 5061. The `date_clientcreationtime` processor was missing `target_field`, causing it to default to `@timestamp` instead of writing back to `winlog.event_data.ClientCreationTime`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TODO
 - version: "2.22.0"
   changes:
     - description: >-

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-5058.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-5058.json-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2025-08-01T08:04:06.770Z",
+            "@timestamp": "2025-04-10T08:14:21.278Z",
             "agent": {
                 "ephemeral_id": "62cd02b1-8419-4aae-a9f4-768f99cbb47b",
                 "id": "c84484dc-583d-4e71-9ccc-008c4837800b",
@@ -51,7 +51,7 @@
                 "computer_name": "Host-ID",
                 "event_data": {
                     "AlgorithmName": "UNKNOWN",
-                    "ClientCreationTime": "2025-08-01T08:04:06.7702905Z",
+                    "ClientCreationTime": "2025-08-01T08:04:06.770Z",
                     "ClientProcessId": "9916",
                     "KeyFilePath": "C:\\Users\\John.doe\\AppData\\Roaming\\Microsoft\\Crypto\\Keys\\de7cf8a7901d2ad13e5c67c29e5d1662_8e1277be-8070-4f41-91ee-c3c1fcca618a",
                     "KeyName": "Microsoft Connected Devices Platform device certificate",

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-5059.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-5059.json-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2025-03-19T05:33:45.009Z",
+            "@timestamp": "2025-03-19T05:33:46.294Z",
             "agent": {
                 "ephemeral_id": "1bae547c-b439-45c2-b87d-ea1964d048b7",
                 "id": "d7cc18f4-29b8-4c77-a07d-ea273d2890d6",
@@ -52,7 +52,7 @@
                 "computer_name": "WIN-E9MOU404H15",
                 "event_data": {
                     "AlgorithmName": "ECDSA_P256",
-                    "ClientCreationTime": "2025-03-19 05:33:45.9196243 +0000 UTC",
+                    "ClientCreationTime": "2025-03-19T05:33:45.009Z",
                     "ClientProcessId": "688",
                     "KeyName": "Microsoft Connected Devices Platform device certificate",
                     "KeyType": "User key.",

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -1384,6 +1384,7 @@ processors:
         ctx.winlog.event_data.put("StatusDescription", params[ctx.winlog.event_data.Status]);
   - date:
       field: winlog.event_data.ClientCreationTime
+      target_field: winlog.event_data.ClientCreationTime
       tag: date_clientcreationtime
       formats:
         - ISO8601

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: system
 title: System
-version: "2.22.0"
+version: "2.22.1"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
The `date_clientcreationtime` processor in `packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml` is missing `target_field`, so it defaults to writing `@timestamp`. For event IDs 5058, 5059, and 5061 (Windows CNG key operations), this overwrites the real event time (`TimeCreated SystemTime`) with `ClientCreationTime` — the process start time, which can be hours earlier.

Fix: add `target_field: winlog.event_data.ClientCreationTime` so the parsed date writes back to the source field.

Bug has been present since v2.5.0 (introduced in https://github.com/elastic/integrations/pull/13828).

**Verification:**
- [ ] `test-5058.json-expected.json` — `@timestamp` now reflects event time, not process start time
- [ ] `test-5059.json-expected.json` — same
- [ ] `test-5061.json-expected.json` — no `ClientCreationTime` present, unaffected