### PR TITLE
Android OTel dashboards 0.1.3

### DIFF
--- a/packages/otel_android_dashboards/changelog.yml
+++ b/packages/otel_android_dashboards/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.3"
+  changes:
+    - description: Fix Top values aggregation on exception.message by adding a keyword runtime field after the field type changed to match_only_text in Elasticsearch OTel mappings
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/TODO
 - version: "0.1.2"
   changes:
     - description: Also match app.crash event name alongside device.crash in crash queries

--- a/packages/otel_android_dashboards/changelog.yml
+++ b/packages/otel_android_dashboards/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix Top values aggregation on exception.message by adding a keyword runtime field after the field type changed to match_only_text in Elasticsearch OTel mappings
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/TODO
+      link: https://github.com/elastic/integrations/pull/20368
 - version: "0.1.2"
   changes:
     - description: Also match app.crash event name alongside device.crash in crash queries

--- a/packages/otel_android_dashboards/kibana/dashboard/otel_android_dashboards-4cff90ff-0bd6-48eb-9ea6-57f91391ebce.json
+++ b/packages/otel_android_dashboards/kibana/dashboard/otel_android_dashboards-4cff90ff-0bd6-48eb-9ea6-57f91391ebce.json
@@ -1662,6 +1662,12 @@
                                     "id": "9fffeed5-13fb-4ca8-ace7-7c7d6e1f5d77",
                                     "name": "android-observability",
                                     "runtimeFieldMap": {
+                                        "_exception.message": {
+                                            "script": {
+                                                "source": "String msg = $(\"exception.message\", null);\nif (msg != null) {\n    emit(msg);\n}"
+                                            },
+                                            "type": "keyword"
+                                        },
                                         "_stacktrace.group_id": {
                                             "script": {
                                                 "source": "if(!doc.containsKey(\"exception.stacktrace\") || doc[\"exception.stacktrace\"].isEmpty()){\n    return;\n}\ndef stacktrace = doc[\"exception.stacktrace\"].value;\ndef exceptionType = doc[\"exception.type\"].value;\n\ndef stacktraceLinesPattern = /^[^\\s].+((\\n\\sat.+)+)[\\S\\s]*/;\ndef lineNumberPattern = /:\\d+\\)/;\ndef unwantedLinePattern = /\\nCaused by.+|\\n\\s+\\..+/;\ndef stackTraceLinesMatcher = stacktraceLinesPattern.matcher(stacktrace.replaceAll(unwantedLinePattern, (s)-\u003e\"\"));\n\nif(stackTraceLinesMatcher.matches()) {\n    def curatedLines = stackTraceLinesMatcher.group(1).replaceAll(lineNumberPattern, (s)-\u003e\")\");\n    def stacktracePattern = exceptionType + curatedLines;\n    emit(String.valueOf(stacktracePattern.hashCode()).encodeBase64());\n}"
@@ -1695,7 +1701,7 @@
                                                     "dataType": "string",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "exception.message: *"
+                                                        "query": "_exception.message: *"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Message sample",
@@ -1704,7 +1710,7 @@
                                                         "showArrayValues": true,
                                                         "sortField": "@timestamp"
                                                     },
-                                                    "sourceField": "exception.message"
+                                                    "sourceField": "_exception.message"
                                                 },
                                                 "6b8ad834-8eea-4c9a-9091-3f6a0de935ec": {
                                                     "customLabel": true,
@@ -2347,8 +2353,7 @@
         "version": 3
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-07-09T08:43:39.912Z",
-    "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+    "created_at": "2026-07-27T12:31:56.119Z",
     "id": "otel_android_dashboards-4cff90ff-0bd6-48eb-9ea6-57f91391ebce",
     "references": [
         {
@@ -2358,6 +2363,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "10.3.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "typeMigrationVersion": "10.3.0"
 }

--- a/packages/otel_android_dashboards/kibana/dashboard/otel_android_dashboards-66c53e5e-9a86-43f3-a85d-a1d90d974bff.json
+++ b/packages/otel_android_dashboards/kibana/dashboard/otel_android_dashboards-66c53e5e-9a86-43f3-a85d-a1d90d974bff.json
@@ -627,6 +627,12 @@
                                     "id": "9fffeed5-13fb-4ca8-ace7-7c7d6e1f5d77",
                                     "name": "android-observability",
                                     "runtimeFieldMap": {
+                                        "_exception.message": {
+                                            "script": {
+                                                "source": "String msg = $(\"exception.message\", null);\nif (msg != null) {\n    emit(msg);\n}"
+                                            },
+                                            "type": "keyword"
+                                        },
                                         "_stacktrace.group_id": {
                                             "script": {
                                                 "source": "if(!doc.containsKey(\"exception.stacktrace\") || doc[\"exception.stacktrace\"].isEmpty()){\n    return;\n}\ndef stacktrace = doc[\"exception.stacktrace\"].value;\ndef exceptionType = doc[\"exception.type\"].value;\n\ndef stacktraceLinesPattern = /^[^\\s].+((\\n\\sat.+)+)[\\S\\s]*/;\ndef lineNumberPattern = /:\\d+\\)/;\ndef unwantedLinePattern = /\\nCaused by.+|\\n\\s+\\..+/;\ndef stackTraceLinesMatcher = stacktraceLinesPattern.matcher(stacktrace.replaceAll(unwantedLinePattern, (s)-\u003e\"\"));\n\nif(stackTraceLinesMatcher.matches()) {\n    def curatedLines = stackTraceLinesMatcher.group(1).replaceAll(lineNumberPattern, (s)-\u003e\")\");\n    def stacktracePattern = exceptionType + curatedLines;\n    emit(String.valueOf(stacktracePattern.hashCode()).encodeBase64());\n}"
@@ -687,7 +693,7 @@
                                                         },
                                                         "size": 10
                                                     },
-                                                    "sourceField": "exception.message"
+                                                    "sourceField": "_exception.message"
                                                 }
                                             },
                                             "ignoreGlobalFilters": false,
@@ -1296,8 +1302,7 @@
         "version": 3
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2026-07-09T08:43:39.912Z",
-    "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+    "created_at": "2026-07-27T12:31:56.119Z",
     "id": "otel_android_dashboards-66c53e5e-9a86-43f3-a85d-a1d90d974bff",
     "references": [
         {
@@ -1307,6 +1312,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "10.3.0",
-    "updated_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+    "typeMigrationVersion": "10.3.0"
 }

--- a/packages/otel_android_dashboards/manifest.yml
+++ b/packages/otel_android_dashboards/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.4.0
 name: otel_android_dashboards
 title: "Android OpenTelemetry Assets"
-version: 0.1.2
+version: 0.1.3
 description: "Dashboards for visualizing Android application's telemetry"
 type: content
 categories:


### PR DESCRIPTION
Fixes https://github.com/elastic/integrations/issues/20364

## Summary

- Bumps `otel_android_dashboards` to version 0.1.3
- Fixes Top values aggregation on `exception.message` by adding a `_exception.message` keyword runtime field after the field type was changed to `match_only_text` in Elasticsearch OTel mappings

## Changelog

See `packages/otel_android_dashboards/changelog.yml`.