### PR TITLE
[DO NOT MERGE] [kubernetes_otel] Add alerting v2 rule templates for recommended alerts

### DIFF
--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Add alerting v2 rule templates for Kubernetes OTel recommended alerts.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/22222
 - version: "2.4.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/kubernetes_otel/changelog.yml
+++ b/packages/kubernetes_otel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add alerting v2 rule templates for Kubernetes OTel recommended alerts.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/22222
+      link: https://github.com/elastic/integrations/pull/20371
 - version: "2.4.0"
   changes:
     - description: Add tags to Kibana assets

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-container-cpu-throttling-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-container-cpu-throttling-v2.json
@@ -3,45 +3,47 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Container CPU throttling",
-      "description": "Alerts when containers are using more than 90% of their CPU limit. Throttled containers experience increased latency without triggering crashes or OOMKills, making them hard to detect without explicit monitoring.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "5m",
-      "lookback": "15m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-container-cpu-throttling-v2-runbook",
-        "type": "runbook",
-        "value": "## Container CPU Throttling\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see CPU usage vs limits over time.\n3. Determine if CPU usage is sustained (undersized limit) or spiking (bursty workload).\n4. Check current CPU usage: `kubectl top pods -n <namespace> --containers`.\n5. Review the container's CPU limit — is it set appropriately for the workload?\n\n### Common Causes\n- CPU limit too low for actual workload requirements\n- Bursty workloads that periodically exceed their limit\n- Increased traffic or processing load\n- Inefficient code or unoptimised queries\n\n### Tuning\n- The default threshold is 90% of the CPU limit.\n- Lower to 80% for early warning; raise to 95% to reduce noise.\n- Exclude known CPU-intensive containers that run close to their limits by design.\n\n### Escalation\nThrottled containers cause latency degradation without visible errors. Increase CPU limits or optimise the workload."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.container.cpu_limit_utilization IS NOT NULL\n| STATS\n    avg_util = AVG(k8s.container.cpu_limit_utilization)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name, k8s.node.name",
-      "breach": {
-        "segment": "WHERE avg_util > 0.9\n| EVAL util_pct = ROUND(avg_util * 100, 1)\n| SORT util_pct DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, k8s.node.name, util_pct\n| LIMIT 50"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.pod.name",
-        "k8s.container.name",
-        "k8s.namespace.name",
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Container CPU throttling",
+        "description": "Alerts when containers are using more than 90% of their CPU limit. Throttled containers experience increased latency without triggering crashes or OOMKills, making them hard to detect without explicit monitoring.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "5m",
+        "lookback": "15m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-container-cpu-throttling-v2-runbook",
+          "type": "runbook",
+          "value": "## Container CPU Throttling\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see CPU usage vs limits over time.\n3. Determine if CPU usage is sustained (undersized limit) or spiking (bursty workload).\n4. Check current CPU usage: `kubectl top pods -n <namespace> --containers`.\n5. Review the container's CPU limit \u2014 is it set appropriately for the workload?\n\n### Common Causes\n- CPU limit too low for actual workload requirements\n- Bursty workloads that periodically exceed their limit\n- Increased traffic or processing load\n- Inefficient code or unoptimised queries\n\n### Tuning\n- The default threshold is 90% of the CPU limit.\n- Lower to 80% for early warning; raise to 95% to reduce noise.\n- Exclude known CPU-intensive containers that run close to their limits by design.\n\n### Escalation\nThrottled containers cause latency degradation without visible errors. Increase CPU limits or optimise the workload."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.container.cpu_limit_utilization IS NOT NULL\n| STATS\n    avg_util = AVG(k8s.container.cpu_limit_utilization)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name, k8s.node.name",
+        "breach": {
+          "segment": "WHERE avg_util > 0.9\n| EVAL util_pct = ROUND(avg_util * 100, 1)\n| SORT util_pct DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, k8s.node.name, util_pct\n| LIMIT 50"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.pod.name",
+          "k8s.container.name",
+          "k8s.namespace.name",
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-container-cpu-throttling-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-container-cpu-throttling-v2.json
@@ -1,0 +1,47 @@
+{
+  "id": "kubernetes_otel-container-cpu-throttling-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Container CPU throttling",
+      "description": "Alerts when containers are using more than 90% of their CPU limit. Throttled containers experience increased latency without triggering crashes or OOMKills, making them hard to detect without explicit monitoring.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "5m",
+      "lookback": "15m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-container-cpu-throttling-v2-runbook",
+        "type": "runbook",
+        "value": "## Container CPU Throttling\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see CPU usage vs limits over time.\n3. Determine if CPU usage is sustained (undersized limit) or spiking (bursty workload).\n4. Check current CPU usage: `kubectl top pods -n <namespace> --containers`.\n5. Review the container's CPU limit — is it set appropriately for the workload?\n\n### Common Causes\n- CPU limit too low for actual workload requirements\n- Bursty workloads that periodically exceed their limit\n- Increased traffic or processing load\n- Inefficient code or unoptimised queries\n\n### Tuning\n- The default threshold is 90% of the CPU limit.\n- Lower to 80% for early warning; raise to 95% to reduce noise.\n- Exclude known CPU-intensive containers that run close to their limits by design.\n\n### Escalation\nThrottled containers cause latency degradation without visible errors. Increase CPU limits or optimise the workload."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.container.cpu_limit_utilization IS NOT NULL\n| STATS\n    avg_util = AVG(k8s.container.cpu_limit_utilization)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name, k8s.node.name",
+      "breach": {
+        "segment": "WHERE avg_util > 0.9\n| EVAL util_pct = ROUND(avg_util * 100, 1)\n| SORT util_pct DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, k8s.node.name, util_pct\n| LIMIT 50"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.pod.name",
+        "k8s.container.name",
+        "k8s.namespace.name",
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-container-memory-near-limit-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-container-memory-near-limit-v2.json
@@ -3,45 +3,47 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Container memory near limit",
-      "description": "Alerts when containers are using more than 90% of their memory limit. Containers approaching their memory limit will be OOMKilled, causing restarts and service disruption.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "5m",
-      "lookback": "15m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-container-memory-near-limit-v2-runbook",
-        "type": "runbook",
-        "value": "## Container Memory Near Limit\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see memory usage vs limits over time.\n3. Determine if memory is steadily climbing (leak) or spiking (load-related).\n4. Check current memory usage: `kubectl top pods -n <namespace> --containers`.\n5. Review the container's memory limit — is it set appropriately for the workload?\n\n### Common Causes\n- Memory limit too low for actual workload requirements\n- Memory leak in the application\n- Increased traffic causing higher memory consumption\n- In-memory caching growing without eviction\n- JVM heap sized too close to the container memory limit\n\n### Tuning\n- The default threshold is 90% of the memory limit.\n- Lower to 80% for early warning; raise to 95% to reduce noise.\n- Exclude known memory-intensive containers that run close to their limits by design.\n\n### Escalation\nContainers above 90% memory utilisation are at imminent risk of OOMKill. Increase memory limits as a short-term mitigation and investigate the root cause."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.container.memory_limit_utilization IS NOT NULL\n| STATS\n    avg_util = AVG(k8s.container.memory_limit_utilization)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name, k8s.node.name",
-      "breach": {
-        "segment": "WHERE avg_util > 0.9\n| EVAL util_pct = ROUND(avg_util * 100, 1)\n| SORT util_pct DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, k8s.node.name, util_pct\n| LIMIT 50"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.pod.name",
-        "k8s.container.name",
-        "k8s.namespace.name",
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Container memory near limit",
+        "description": "Alerts when containers are using more than 90% of their memory limit. Containers approaching their memory limit will be OOMKilled, causing restarts and service disruption.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "5m",
+        "lookback": "15m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-container-memory-near-limit-v2-runbook",
+          "type": "runbook",
+          "value": "## Container Memory Near Limit\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see memory usage vs limits over time.\n3. Determine if memory is steadily climbing (leak) or spiking (load-related).\n4. Check current memory usage: `kubectl top pods -n <namespace> --containers`.\n5. Review the container's memory limit \u2014 is it set appropriately for the workload?\n\n### Common Causes\n- Memory limit too low for actual workload requirements\n- Memory leak in the application\n- Increased traffic causing higher memory consumption\n- In-memory caching growing without eviction\n- JVM heap sized too close to the container memory limit\n\n### Tuning\n- The default threshold is 90% of the memory limit.\n- Lower to 80% for early warning; raise to 95% to reduce noise.\n- Exclude known memory-intensive containers that run close to their limits by design.\n\n### Escalation\nContainers above 90% memory utilisation are at imminent risk of OOMKill. Increase memory limits as a short-term mitigation and investigate the root cause."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.container.memory_limit_utilization IS NOT NULL\n| STATS\n    avg_util = AVG(k8s.container.memory_limit_utilization)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name, k8s.node.name",
+        "breach": {
+          "segment": "WHERE avg_util > 0.9\n| EVAL util_pct = ROUND(avg_util * 100, 1)\n| SORT util_pct DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, k8s.node.name, util_pct\n| LIMIT 50"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.pod.name",
+          "k8s.container.name",
+          "k8s.namespace.name",
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-container-memory-near-limit-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-container-memory-near-limit-v2.json
@@ -1,0 +1,47 @@
+{
+  "id": "kubernetes_otel-container-memory-near-limit-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Container memory near limit",
+      "description": "Alerts when containers are using more than 90% of their memory limit. Containers approaching their memory limit will be OOMKilled, causing restarts and service disruption.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "5m",
+      "lookback": "15m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-container-memory-near-limit-v2-runbook",
+        "type": "runbook",
+        "value": "## Container Memory Near Limit\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see memory usage vs limits over time.\n3. Determine if memory is steadily climbing (leak) or spiking (load-related).\n4. Check current memory usage: `kubectl top pods -n <namespace> --containers`.\n5. Review the container's memory limit — is it set appropriately for the workload?\n\n### Common Causes\n- Memory limit too low for actual workload requirements\n- Memory leak in the application\n- Increased traffic causing higher memory consumption\n- In-memory caching growing without eviction\n- JVM heap sized too close to the container memory limit\n\n### Tuning\n- The default threshold is 90% of the memory limit.\n- Lower to 80% for early warning; raise to 95% to reduce noise.\n- Exclude known memory-intensive containers that run close to their limits by design.\n\n### Escalation\nContainers above 90% memory utilisation are at imminent risk of OOMKill. Increase memory limits as a short-term mitigation and investigate the root cause."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.container.memory_limit_utilization IS NOT NULL\n| STATS\n    avg_util = AVG(k8s.container.memory_limit_utilization)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name, k8s.node.name",
+      "breach": {
+        "segment": "WHERE avg_util > 0.9\n| EVAL util_pct = ROUND(avg_util * 100, 1)\n| SORT util_pct DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, k8s.node.name, util_pct\n| LIMIT 50"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.pod.name",
+        "k8s.container.name",
+        "k8s.namespace.name",
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-daemonset-mis-scheduled-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-daemonset-mis-scheduled-v2.json
@@ -3,43 +3,45 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] DaemonSet mis-scheduled or not ready",
-      "description": "Alerts when a DaemonSet has misscheduled nodes (pods running where they shouldn't) or is not fully scheduled (current < desired). Indicates node selector, taint/toleration, or scheduling issues.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "1m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-daemonset-mis-scheduled-v2-runbook",
-        "type": "runbook",
-        "value": "## DaemonSet Mis-scheduled or Not Ready\n\n### Triage Steps\n1. Identify the affected DaemonSet(s) from the alert results.\n2. Check the Workload Health dashboard for DaemonSet status.\n3. Run `kubectl describe daemonset <name> -n <namespace>` for events and scheduling details.\n4. Check node taints and DaemonSet tolerations: `kubectl get nodes -o json | jq '.items[].spec.taints'`.\n5. For misscheduled pods, check if node selectors or affinity rules changed.\n\n### Common Causes\n- Node taints changed without updating DaemonSet tolerations\n- Node selectors no longer match available nodes\n- New nodes added without expected labels\n- Resource constraints preventing pod scheduling on some nodes\n\n### Tuning\n- This rule alerts on both misscheduled (pods on wrong nodes) and not-ready (fewer ready than desired).\n- If your DaemonSet intentionally runs on a subset of nodes, verify the desired count is correct.\n\n### Escalation\nDaemonSet issues affect cluster-wide services (logging, monitoring, networking). Investigate promptly."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n| STATS\n    desired = LAST(k8s.daemonset.desired_scheduled_nodes, @timestamp),\n    current = LAST(k8s.daemonset.current_scheduled_nodes, @timestamp),\n    ready = LAST(k8s.daemonset.ready_nodes, @timestamp),\n    misscheduled = LAST(k8s.daemonset.misscheduled_nodes, @timestamp)\n    BY k8s.daemonset.name, k8s.namespace.name",
-      "breach": {
-        "segment": "WHERE misscheduled > 0\n    OR ready < desired\n| EVAL not_ready = desired - ready\n| KEEP k8s.namespace.name, k8s.daemonset.name, desired, ready, not_ready, misscheduled"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.daemonset.name",
-        "k8s.namespace.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] DaemonSet mis-scheduled or not ready",
+        "description": "Alerts when a DaemonSet has misscheduled nodes (pods running where they shouldn't) or is not fully scheduled (current < desired). Indicates node selector, taint/toleration, or scheduling issues.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "1m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-daemonset-mis-scheduled-v2-runbook",
+          "type": "runbook",
+          "value": "## DaemonSet Mis-scheduled or Not Ready\n\n### Triage Steps\n1. Identify the affected DaemonSet(s) from the alert results.\n2. Check the Workload Health dashboard for DaemonSet status.\n3. Run `kubectl describe daemonset <name> -n <namespace>` for events and scheduling details.\n4. Check node taints and DaemonSet tolerations: `kubectl get nodes -o json | jq '.items[].spec.taints'`.\n5. For misscheduled pods, check if node selectors or affinity rules changed.\n\n### Common Causes\n- Node taints changed without updating DaemonSet tolerations\n- Node selectors no longer match available nodes\n- New nodes added without expected labels\n- Resource constraints preventing pod scheduling on some nodes\n\n### Tuning\n- This rule alerts on both misscheduled (pods on wrong nodes) and not-ready (fewer ready than desired).\n- If your DaemonSet intentionally runs on a subset of nodes, verify the desired count is correct.\n\n### Escalation\nDaemonSet issues affect cluster-wide services (logging, monitoring, networking). Investigate promptly."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n| STATS\n    desired = LAST(k8s.daemonset.desired_scheduled_nodes, @timestamp),\n    current = LAST(k8s.daemonset.current_scheduled_nodes, @timestamp),\n    ready = LAST(k8s.daemonset.ready_nodes, @timestamp),\n    misscheduled = LAST(k8s.daemonset.misscheduled_nodes, @timestamp)\n    BY k8s.daemonset.name, k8s.namespace.name",
+        "breach": {
+          "segment": "WHERE misscheduled > 0\n    OR ready < desired\n| EVAL not_ready = desired - ready\n| KEEP k8s.namespace.name, k8s.daemonset.name, desired, ready, not_ready, misscheduled"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.daemonset.name",
+          "k8s.namespace.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-daemonset-mis-scheduled-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-daemonset-mis-scheduled-v2.json
@@ -1,0 +1,45 @@
+{
+  "id": "kubernetes_otel-daemonset-mis-scheduled-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] DaemonSet mis-scheduled or not ready",
+      "description": "Alerts when a DaemonSet has misscheduled nodes (pods running where they shouldn't) or is not fully scheduled (current < desired). Indicates node selector, taint/toleration, or scheduling issues.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "1m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-daemonset-mis-scheduled-v2-runbook",
+        "type": "runbook",
+        "value": "## DaemonSet Mis-scheduled or Not Ready\n\n### Triage Steps\n1. Identify the affected DaemonSet(s) from the alert results.\n2. Check the Workload Health dashboard for DaemonSet status.\n3. Run `kubectl describe daemonset <name> -n <namespace>` for events and scheduling details.\n4. Check node taints and DaemonSet tolerations: `kubectl get nodes -o json | jq '.items[].spec.taints'`.\n5. For misscheduled pods, check if node selectors or affinity rules changed.\n\n### Common Causes\n- Node taints changed without updating DaemonSet tolerations\n- Node selectors no longer match available nodes\n- New nodes added without expected labels\n- Resource constraints preventing pod scheduling on some nodes\n\n### Tuning\n- This rule alerts on both misscheduled (pods on wrong nodes) and not-ready (fewer ready than desired).\n- If your DaemonSet intentionally runs on a subset of nodes, verify the desired count is correct.\n\n### Escalation\nDaemonSet issues affect cluster-wide services (logging, monitoring, networking). Investigate promptly."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.daemonset.desired_scheduled_nodes IS NOT NULL\n| STATS\n    desired = LAST(k8s.daemonset.desired_scheduled_nodes, @timestamp),\n    current = LAST(k8s.daemonset.current_scheduled_nodes, @timestamp),\n    ready = LAST(k8s.daemonset.ready_nodes, @timestamp),\n    misscheduled = LAST(k8s.daemonset.misscheduled_nodes, @timestamp)\n    BY k8s.daemonset.name, k8s.namespace.name",
+      "breach": {
+        "segment": "WHERE misscheduled > 0\n    OR ready < desired\n| EVAL not_ready = desired - ready\n| KEEP k8s.namespace.name, k8s.daemonset.name, desired, ready, not_ready, misscheduled"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.daemonset.name",
+        "k8s.namespace.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-deployment-unavailable-replicas-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-deployment-unavailable-replicas-v2.json
@@ -3,43 +3,45 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Deployment unavailable replicas",
-      "description": "Alerts when a Kubernetes deployment has fewer available replicas than desired, indicating the deployment cannot maintain its target replica count. Common causes: rolling update failures, resource starvation, image pull errors.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "1m"
-    },
-    "state_transition": {
-      "pending_count": 5
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-deployment-unavailable-replicas-v2-runbook",
-        "type": "runbook",
-        "value": "## Deployment Unavailable Replicas\n\n### Triage Steps\n1. Identify the affected deployment(s) from the alert results.\n2. Check the Workload Health dashboard for deployment status.\n3. Run `kubectl describe deployment <name> -n <namespace>` to check events and conditions.\n4. Look for pods in non-Running states: `kubectl get pods -l app=<deployment> -n <namespace>`.\n5. Navigate to Pod & Container Detail filtered by the namespace to inspect failing pods.\n\n### Common Causes\n- Image pull errors (wrong tag, private registry auth)\n- Insufficient cluster resources (CPU, memory) to schedule pods\n- Pod crash loops preventing readiness\n- Rolling update stuck due to new version failures\n- PVC binding failures for pods requiring persistent storage\n\n### Tuning\n- The `alertDelay` of 5 runs allows for brief transient gaps during rolling updates.\n- Increase `alertDelay` if your deployments have slow startup times.\n- The rule uses `desired > 0` to exclude scaled-to-zero deployments.\n\n### Escalation\nIf a deployment remains degraded for more than 10 minutes, investigate the underlying pod failures and consider rolling back."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.desired IS NOT NULL\n    AND k8s.deployment.available IS NOT NULL\n| STATS\n    desired = LAST(k8s.deployment.desired, @timestamp),\n    available = LAST(k8s.deployment.available, @timestamp)\n    BY k8s.deployment.name, k8s.namespace.name",
-      "breach": {
-        "segment": "WHERE desired > 0\n| WHERE available < desired\n| EVAL unavailable = desired - available\n| KEEP k8s.namespace.name, k8s.deployment.name, desired, available, unavailable\n| SORT unavailable DESC"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.deployment.name",
-        "k8s.namespace.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Deployment unavailable replicas",
+        "description": "Alerts when a Kubernetes deployment has fewer available replicas than desired, indicating the deployment cannot maintain its target replica count. Common causes: rolling update failures, resource starvation, image pull errors.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "1m"
+      },
+      "state_transition": {
+        "pending_count": 5
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-deployment-unavailable-replicas-v2-runbook",
+          "type": "runbook",
+          "value": "## Deployment Unavailable Replicas\n\n### Triage Steps\n1. Identify the affected deployment(s) from the alert results.\n2. Check the Workload Health dashboard for deployment status.\n3. Run `kubectl describe deployment <name> -n <namespace>` to check events and conditions.\n4. Look for pods in non-Running states: `kubectl get pods -l app=<deployment> -n <namespace>`.\n5. Navigate to Pod & Container Detail filtered by the namespace to inspect failing pods.\n\n### Common Causes\n- Image pull errors (wrong tag, private registry auth)\n- Insufficient cluster resources (CPU, memory) to schedule pods\n- Pod crash loops preventing readiness\n- Rolling update stuck due to new version failures\n- PVC binding failures for pods requiring persistent storage\n\n### Tuning\n- The `alertDelay` of 5 runs allows for brief transient gaps during rolling updates.\n- Increase `alertDelay` if your deployments have slow startup times.\n- The rule uses `desired > 0` to exclude scaled-to-zero deployments.\n\n### Escalation\nIf a deployment remains degraded for more than 10 minutes, investigate the underlying pod failures and consider rolling back."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.desired IS NOT NULL\n    AND k8s.deployment.available IS NOT NULL\n| STATS\n    desired = LAST(k8s.deployment.desired, @timestamp),\n    available = LAST(k8s.deployment.available, @timestamp)\n    BY k8s.deployment.name, k8s.namespace.name",
+        "breach": {
+          "segment": "WHERE desired > 0\n| WHERE available < desired\n| EVAL unavailable = desired - available\n| KEEP k8s.namespace.name, k8s.deployment.name, desired, available, unavailable\n| SORT unavailable DESC"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.deployment.name",
+          "k8s.namespace.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-deployment-unavailable-replicas-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-deployment-unavailable-replicas-v2.json
@@ -1,0 +1,45 @@
+{
+  "id": "kubernetes_otel-deployment-unavailable-replicas-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Deployment unavailable replicas",
+      "description": "Alerts when a Kubernetes deployment has fewer available replicas than desired, indicating the deployment cannot maintain its target replica count. Common causes: rolling update failures, resource starvation, image pull errors.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "1m"
+    },
+    "state_transition": {
+      "pending_count": 5
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-deployment-unavailable-replicas-v2-runbook",
+        "type": "runbook",
+        "value": "## Deployment Unavailable Replicas\n\n### Triage Steps\n1. Identify the affected deployment(s) from the alert results.\n2. Check the Workload Health dashboard for deployment status.\n3. Run `kubectl describe deployment <name> -n <namespace>` to check events and conditions.\n4. Look for pods in non-Running states: `kubectl get pods -l app=<deployment> -n <namespace>`.\n5. Navigate to Pod & Container Detail filtered by the namespace to inspect failing pods.\n\n### Common Causes\n- Image pull errors (wrong tag, private registry auth)\n- Insufficient cluster resources (CPU, memory) to schedule pods\n- Pod crash loops preventing readiness\n- Rolling update stuck due to new version failures\n- PVC binding failures for pods requiring persistent storage\n\n### Tuning\n- The `alertDelay` of 5 runs allows for brief transient gaps during rolling updates.\n- Increase `alertDelay` if your deployments have slow startup times.\n- The rule uses `desired > 0` to exclude scaled-to-zero deployments.\n\n### Escalation\nIf a deployment remains degraded for more than 10 minutes, investigate the underlying pod failures and consider rolling back."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.deployment.desired IS NOT NULL\n    AND k8s.deployment.available IS NOT NULL\n| STATS\n    desired = LAST(k8s.deployment.desired, @timestamp),\n    available = LAST(k8s.deployment.available, @timestamp)\n    BY k8s.deployment.name, k8s.namespace.name",
+      "breach": {
+        "segment": "WHERE desired > 0\n| WHERE available < desired\n| EVAL unavailable = desired - available\n| KEEP k8s.namespace.name, k8s.deployment.name, desired, available, unavailable\n| SORT unavailable DESC"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.deployment.name",
+        "k8s.namespace.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-hpa-at-max-replicas-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-hpa-at-max-replicas-v2.json
@@ -3,43 +3,45 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] HPA at max replicas",
-      "description": "Alerts when a HorizontalPodAutoscaler has scaled to its maximum replica count. This means demand is outpacing the autoscaler's ability to scale, and pods may start becoming resource-constrained or pending.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "1m"
-    },
-    "state_transition": {
-      "pending_count": 5
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-hpa-at-max-replicas-v2-runbook",
-        "type": "runbook",
-        "value": "## HPA at Max Replicas\n\n### Triage Steps\n1. Identify the affected HPA(s) from the alert results.\n2. Check current HPA status: `kubectl get hpa -n <namespace>`.\n3. Review the target metrics: `kubectl describe hpa <name> -n <namespace>` — are target metrics exceeded?\n4. Check if pods are pending or resource-constrained on the Workload Health dashboard.\n5. Verify cluster capacity — can additional pods be scheduled?\n\n### Common Causes\n- Traffic spike exceeding expected capacity\n- Gradual load increase that has reached the configured ceiling\n- Max replicas set too low for the workload's requirements\n- Upstream service issues causing increased per-request resource usage\n\n### Tuning\n- The alertDelay of 5 runs (5 minutes) avoids alerting on brief scaling spikes.\n- If your HPA frequently hits max during expected peak hours, consider raising maxReplicas or adding time-based exclusions.\n\n### Escalation\nHPA at max means the autoscaler cannot add more capacity. Consider raising maxReplicas, scaling the node pool, or investigating the load increase."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.hpa.desired_replicas IS NOT NULL\n    AND k8s.hpa.max_replicas IS NOT NULL\n| STATS\n    desired = LAST(k8s.hpa.desired_replicas, @timestamp),\n    max_replicas = LAST(k8s.hpa.max_replicas, @timestamp)\n    BY k8s.hpa.name, k8s.namespace.name",
-      "breach": {
-        "segment": "WHERE desired >= max_replicas\n    AND max_replicas > 0\n| KEEP k8s.namespace.name, k8s.hpa.name, desired, max_replicas"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.hpa.name",
-        "k8s.namespace.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] HPA at max replicas",
+        "description": "Alerts when a HorizontalPodAutoscaler has scaled to its maximum replica count. This means demand is outpacing the autoscaler's ability to scale, and pods may start becoming resource-constrained or pending.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "1m"
+      },
+      "state_transition": {
+        "pending_count": 5
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-hpa-at-max-replicas-v2-runbook",
+          "type": "runbook",
+          "value": "## HPA at Max Replicas\n\n### Triage Steps\n1. Identify the affected HPA(s) from the alert results.\n2. Check current HPA status: `kubectl get hpa -n <namespace>`.\n3. Review the target metrics: `kubectl describe hpa <name> -n <namespace>` \u2014 are target metrics exceeded?\n4. Check if pods are pending or resource-constrained on the Workload Health dashboard.\n5. Verify cluster capacity \u2014 can additional pods be scheduled?\n\n### Common Causes\n- Traffic spike exceeding expected capacity\n- Gradual load increase that has reached the configured ceiling\n- Max replicas set too low for the workload's requirements\n- Upstream service issues causing increased per-request resource usage\n\n### Tuning\n- The alertDelay of 5 runs (5 minutes) avoids alerting on brief scaling spikes.\n- If your HPA frequently hits max during expected peak hours, consider raising maxReplicas or adding time-based exclusions.\n\n### Escalation\nHPA at max means the autoscaler cannot add more capacity. Consider raising maxReplicas, scaling the node pool, or investigating the load increase."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.hpa.desired_replicas IS NOT NULL\n    AND k8s.hpa.max_replicas IS NOT NULL\n| STATS\n    desired = LAST(k8s.hpa.desired_replicas, @timestamp),\n    max_replicas = LAST(k8s.hpa.max_replicas, @timestamp)\n    BY k8s.hpa.name, k8s.namespace.name",
+        "breach": {
+          "segment": "WHERE desired >= max_replicas\n    AND max_replicas > 0\n| KEEP k8s.namespace.name, k8s.hpa.name, desired, max_replicas"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.hpa.name",
+          "k8s.namespace.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-hpa-at-max-replicas-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-hpa-at-max-replicas-v2.json
@@ -1,0 +1,45 @@
+{
+  "id": "kubernetes_otel-hpa-at-max-replicas-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] HPA at max replicas",
+      "description": "Alerts when a HorizontalPodAutoscaler has scaled to its maximum replica count. This means demand is outpacing the autoscaler's ability to scale, and pods may start becoming resource-constrained or pending.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "1m"
+    },
+    "state_transition": {
+      "pending_count": 5
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-hpa-at-max-replicas-v2-runbook",
+        "type": "runbook",
+        "value": "## HPA at Max Replicas\n\n### Triage Steps\n1. Identify the affected HPA(s) from the alert results.\n2. Check current HPA status: `kubectl get hpa -n <namespace>`.\n3. Review the target metrics: `kubectl describe hpa <name> -n <namespace>` — are target metrics exceeded?\n4. Check if pods are pending or resource-constrained on the Workload Health dashboard.\n5. Verify cluster capacity — can additional pods be scheduled?\n\n### Common Causes\n- Traffic spike exceeding expected capacity\n- Gradual load increase that has reached the configured ceiling\n- Max replicas set too low for the workload's requirements\n- Upstream service issues causing increased per-request resource usage\n\n### Tuning\n- The alertDelay of 5 runs (5 minutes) avoids alerting on brief scaling spikes.\n- If your HPA frequently hits max during expected peak hours, consider raising maxReplicas or adding time-based exclusions.\n\n### Escalation\nHPA at max means the autoscaler cannot add more capacity. Consider raising maxReplicas, scaling the node pool, or investigating the load increase."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.hpa.desired_replicas IS NOT NULL\n    AND k8s.hpa.max_replicas IS NOT NULL\n| STATS\n    desired = LAST(k8s.hpa.desired_replicas, @timestamp),\n    max_replicas = LAST(k8s.hpa.max_replicas, @timestamp)\n    BY k8s.hpa.name, k8s.namespace.name",
+      "breach": {
+        "segment": "WHERE desired >= max_replicas\n    AND max_replicas > 0\n| KEEP k8s.namespace.name, k8s.hpa.name, desired, max_replicas"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.hpa.name",
+        "k8s.namespace.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-job-failures-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-job-failures-v2.json
@@ -3,43 +3,45 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Job failures",
-      "description": "Alerts when Kubernetes Jobs have failed pods. Non-zero failed pod counts indicate processing failures in batch workloads. Repeated failures in CronJobs can cause a backlog of active jobs.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "5m"
-    },
-    "state_transition": {
-      "pending_count": 1
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-job-failures-v2-runbook",
-        "type": "runbook",
-        "value": "## Job Failures\n\n### Triage Steps\n1. Identify the failed Job(s) from the alert results.\n2. Check the Workload Health dashboard for Job status.\n3. Get job details: `kubectl describe job <job_name> -n <namespace>`.\n4. Check pod logs from the failed job: `kubectl logs job/<job_name> -n <namespace>`.\n5. If this is a CronJob child, check `kubectl get cronjobs -n <namespace>` for scheduling issues.\n\n### Common Causes\n- Application errors in the job's processing logic\n- Missing input data or dependencies\n- Resource limits too low for the job's requirements\n- Timeout exceeded (activeDeadlineSeconds)\n- Image pull errors\n\n### Tuning\n- Jobs with `backoffLimit` will retry before reporting failures. This alert catches jobs where retries are exhausted.\n- For CronJobs that occasionally fail and self-correct on the next run, increase `alertDelay`.\n- Add namespace filters to exclude test or development namespaces.\n\n### Escalation\nFailed jobs may indicate data processing issues. Check whether downstream systems are affected by missing job output."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.job.failed_pods IS NOT NULL\n| STATS\n    failed = MAX(k8s.job.failed_pods)\n    BY k8s.job.name, k8s.namespace.name",
-      "breach": {
-        "segment": "WHERE failed > 0\n| SORT failed DESC\n| KEEP k8s.namespace.name, k8s.job.name, failed\n| LIMIT 50"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.job.name",
-        "k8s.namespace.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Job failures",
+        "description": "Alerts when Kubernetes Jobs have failed pods. Non-zero failed pod counts indicate processing failures in batch workloads. Repeated failures in CronJobs can cause a backlog of active jobs.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "5m"
+      },
+      "state_transition": {
+        "pending_count": 1
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-job-failures-v2-runbook",
+          "type": "runbook",
+          "value": "## Job Failures\n\n### Triage Steps\n1. Identify the failed Job(s) from the alert results.\n2. Check the Workload Health dashboard for Job status.\n3. Get job details: `kubectl describe job <job_name> -n <namespace>`.\n4. Check pod logs from the failed job: `kubectl logs job/<job_name> -n <namespace>`.\n5. If this is a CronJob child, check `kubectl get cronjobs -n <namespace>` for scheduling issues.\n\n### Common Causes\n- Application errors in the job's processing logic\n- Missing input data or dependencies\n- Resource limits too low for the job's requirements\n- Timeout exceeded (activeDeadlineSeconds)\n- Image pull errors\n\n### Tuning\n- Jobs with `backoffLimit` will retry before reporting failures. This alert catches jobs where retries are exhausted.\n- For CronJobs that occasionally fail and self-correct on the next run, increase `alertDelay`.\n- Add namespace filters to exclude test or development namespaces.\n\n### Escalation\nFailed jobs may indicate data processing issues. Check whether downstream systems are affected by missing job output."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.job.failed_pods IS NOT NULL\n| STATS\n    failed = MAX(k8s.job.failed_pods)\n    BY k8s.job.name, k8s.namespace.name",
+        "breach": {
+          "segment": "WHERE failed > 0\n| SORT failed DESC\n| KEEP k8s.namespace.name, k8s.job.name, failed\n| LIMIT 50"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.job.name",
+          "k8s.namespace.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-job-failures-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-job-failures-v2.json
@@ -1,0 +1,45 @@
+{
+  "id": "kubernetes_otel-job-failures-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Job failures",
+      "description": "Alerts when Kubernetes Jobs have failed pods. Non-zero failed pod counts indicate processing failures in batch workloads. Repeated failures in CronJobs can cause a backlog of active jobs.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "5m"
+    },
+    "state_transition": {
+      "pending_count": 1
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-job-failures-v2-runbook",
+        "type": "runbook",
+        "value": "## Job Failures\n\n### Triage Steps\n1. Identify the failed Job(s) from the alert results.\n2. Check the Workload Health dashboard for Job status.\n3. Get job details: `kubectl describe job <job_name> -n <namespace>`.\n4. Check pod logs from the failed job: `kubectl logs job/<job_name> -n <namespace>`.\n5. If this is a CronJob child, check `kubectl get cronjobs -n <namespace>` for scheduling issues.\n\n### Common Causes\n- Application errors in the job's processing logic\n- Missing input data or dependencies\n- Resource limits too low for the job's requirements\n- Timeout exceeded (activeDeadlineSeconds)\n- Image pull errors\n\n### Tuning\n- Jobs with `backoffLimit` will retry before reporting failures. This alert catches jobs where retries are exhausted.\n- For CronJobs that occasionally fail and self-correct on the next run, increase `alertDelay`.\n- Add namespace filters to exclude test or development namespaces.\n\n### Escalation\nFailed jobs may indicate data processing issues. Check whether downstream systems are affected by missing job output."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.job.failed_pods IS NOT NULL\n| STATS\n    failed = MAX(k8s.job.failed_pods)\n    BY k8s.job.name, k8s.namespace.name",
+      "breach": {
+        "segment": "WHERE failed > 0\n| SORT failed DESC\n| KEEP k8s.namespace.name, k8s.job.name, failed\n| LIMIT 50"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.job.name",
+        "k8s.namespace.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-cpu-saturation-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-cpu-saturation-v2.json
@@ -3,42 +3,44 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Node CPU saturation",
-      "description": "Alerts when a node's average CPU usage exceeds a configurable threshold. High CPU usage causes scheduling failures, pod throttling, and degraded workload performance. Threshold should be calibrated to your node's allocatable CPU.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "5m",
-      "lookback": "15m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-node-cpu-saturation-v2-runbook",
-        "type": "runbook",
-        "value": "## Node CPU Saturation\n\n### Triage Steps\n1. Identify the saturated node(s) from the alert results.\n2. Open the Node Performance dashboard to view CPU usage trends.\n3. Navigate to Pod & Container Detail filtered by the affected node to find the top CPU consumers.\n4. Check whether any pods lack CPU limits or have excessively high limits.\n5. Run `kubectl top pods --sort-by=cpu -A` on the affected node.\n\n### Common Causes\n- CPU-intensive workloads without proper resource limits\n- Too many pods scheduled on a single node\n- Runaway processes or infinite loops in containers\n- Insufficient cluster capacity for the workload\n\n### Tuning\n- The default threshold is 90% of allocatable CPU. Adjust based on your tolerance.\n- For heterogeneous clusters, consider creating separate rules per node pool.\n\n### Escalation\nSustained CPU saturation will cause workload degradation and scheduling failures. Consider scaling the node pool or redistributing workloads."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.cpu.usage IS NOT NULL OR k8s.node.allocatable_cpu IS NOT NULL)\n| STATS avg_cpu = AVG(k8s.node.cpu.usage),\n    allocatable_cpu = MAX(k8s.node.allocatable_cpu)\n    BY k8s.node.name\n| EVAL cpu_utilization = avg_cpu / allocatable_cpu",
-      "breach": {
-        "segment": "WHERE cpu_utilization > 0.9\n| KEEP k8s.node.name, avg_cpu, allocatable_cpu, cpu_utilization"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Node CPU saturation",
+        "description": "Alerts when a node's average CPU usage exceeds a configurable threshold. High CPU usage causes scheduling failures, pod throttling, and degraded workload performance. Threshold should be calibrated to your node's allocatable CPU.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "5m",
+        "lookback": "15m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-node-cpu-saturation-v2-runbook",
+          "type": "runbook",
+          "value": "## Node CPU Saturation\n\n### Triage Steps\n1. Identify the saturated node(s) from the alert results.\n2. Open the Node Performance dashboard to view CPU usage trends.\n3. Navigate to Pod & Container Detail filtered by the affected node to find the top CPU consumers.\n4. Check whether any pods lack CPU limits or have excessively high limits.\n5. Run `kubectl top pods --sort-by=cpu -A` on the affected node.\n\n### Common Causes\n- CPU-intensive workloads without proper resource limits\n- Too many pods scheduled on a single node\n- Runaway processes or infinite loops in containers\n- Insufficient cluster capacity for the workload\n\n### Tuning\n- The default threshold is 90% of allocatable CPU. Adjust based on your tolerance.\n- For heterogeneous clusters, consider creating separate rules per node pool.\n\n### Escalation\nSustained CPU saturation will cause workload degradation and scheduling failures. Consider scaling the node pool or redistributing workloads."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.cpu.usage IS NOT NULL OR k8s.node.allocatable_cpu IS NOT NULL)\n| STATS avg_cpu = AVG(k8s.node.cpu.usage),\n    allocatable_cpu = MAX(k8s.node.allocatable_cpu)\n    BY k8s.node.name\n| EVAL cpu_utilization = avg_cpu / allocatable_cpu",
+        "breach": {
+          "segment": "WHERE cpu_utilization > 0.9\n| KEEP k8s.node.name, avg_cpu, allocatable_cpu, cpu_utilization"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-cpu-saturation-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-cpu-saturation-v2.json
@@ -1,0 +1,44 @@
+{
+  "id": "kubernetes_otel-node-cpu-saturation-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Node CPU saturation",
+      "description": "Alerts when a node's average CPU usage exceeds a configurable threshold. High CPU usage causes scheduling failures, pod throttling, and degraded workload performance. Threshold should be calibrated to your node's allocatable CPU.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "5m",
+      "lookback": "15m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-node-cpu-saturation-v2-runbook",
+        "type": "runbook",
+        "value": "## Node CPU Saturation\n\n### Triage Steps\n1. Identify the saturated node(s) from the alert results.\n2. Open the Node Performance dashboard to view CPU usage trends.\n3. Navigate to Pod & Container Detail filtered by the affected node to find the top CPU consumers.\n4. Check whether any pods lack CPU limits or have excessively high limits.\n5. Run `kubectl top pods --sort-by=cpu -A` on the affected node.\n\n### Common Causes\n- CPU-intensive workloads without proper resource limits\n- Too many pods scheduled on a single node\n- Runaway processes or infinite loops in containers\n- Insufficient cluster capacity for the workload\n\n### Tuning\n- The default threshold is 90% of allocatable CPU. Adjust based on your tolerance.\n- For heterogeneous clusters, consider creating separate rules per node pool.\n\n### Escalation\nSustained CPU saturation will cause workload degradation and scheduling failures. Consider scaling the node pool or redistributing workloads."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.cpu.usage IS NOT NULL OR k8s.node.allocatable_cpu IS NOT NULL)\n| STATS avg_cpu = AVG(k8s.node.cpu.usage),\n    allocatable_cpu = MAX(k8s.node.allocatable_cpu)\n    BY k8s.node.name\n| EVAL cpu_utilization = avg_cpu / allocatable_cpu",
+      "breach": {
+        "segment": "WHERE cpu_utilization > 0.9\n| KEEP k8s.node.name, avg_cpu, allocatable_cpu, cpu_utilization"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-disk-pressure-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-disk-pressure-v2.json
@@ -1,0 +1,44 @@
+{
+  "id": "kubernetes_otel-node-disk-pressure-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Node disk pressure",
+      "description": "Alerts when any Kubernetes node reports the DiskPressure condition. This is a warning signal that the node is running low on disk space and may begin evicting pods.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "1m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-node-disk-pressure-v2-runbook",
+        "type": "runbook",
+        "value": "## Node Disk Pressure\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard filtered to the affected node to see filesystem usage trends.\n3. Check what is consuming disk space: `df -h` on the affected node.\n4. Look for container log accumulation, unused images, or large ephemeral volumes.\n5. Check for pods using large ephemeral storage without limits.\n\n### Common Causes\n- Container log accumulation without rotation\n- Large container images or unused image layers\n- Ephemeral storage abuse by workloads\n- kubelet garbage collection unable to keep up\n\n### Escalation\nIf disk pressure persists, the node will begin evicting pods. Consider cleaning up unused images (`crictl rmi --prune`), rotating logs, or expanding disk capacity."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_disk_pressure IS NOT NULL\n| STATS any_pressure = MAX(k8s.node.condition_disk_pressure)\n    BY k8s.node.name",
+      "breach": {
+        "segment": "WHERE any_pressure == 1\n| EVAL status = \"DiskPressure\""
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-disk-pressure-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-disk-pressure-v2.json
@@ -3,42 +3,44 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Node disk pressure",
-      "description": "Alerts when any Kubernetes node reports the DiskPressure condition. This is a warning signal that the node is running low on disk space and may begin evicting pods.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "1m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-node-disk-pressure-v2-runbook",
-        "type": "runbook",
-        "value": "## Node Disk Pressure\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard filtered to the affected node to see filesystem usage trends.\n3. Check what is consuming disk space: `df -h` on the affected node.\n4. Look for container log accumulation, unused images, or large ephemeral volumes.\n5. Check for pods using large ephemeral storage without limits.\n\n### Common Causes\n- Container log accumulation without rotation\n- Large container images or unused image layers\n- Ephemeral storage abuse by workloads\n- kubelet garbage collection unable to keep up\n\n### Escalation\nIf disk pressure persists, the node will begin evicting pods. Consider cleaning up unused images (`crictl rmi --prune`), rotating logs, or expanding disk capacity."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_disk_pressure IS NOT NULL\n| STATS any_pressure = MAX(k8s.node.condition_disk_pressure)\n    BY k8s.node.name",
-      "breach": {
-        "segment": "WHERE any_pressure == 1\n| EVAL status = \"DiskPressure\""
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Node disk pressure",
+        "description": "Alerts when any Kubernetes node reports the DiskPressure condition. This is a warning signal that the node is running low on disk space and may begin evicting pods.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "1m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-node-disk-pressure-v2-runbook",
+          "type": "runbook",
+          "value": "## Node Disk Pressure\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard filtered to the affected node to see filesystem usage trends.\n3. Check what is consuming disk space: `df -h` on the affected node.\n4. Look for container log accumulation, unused images, or large ephemeral volumes.\n5. Check for pods using large ephemeral storage without limits.\n\n### Common Causes\n- Container log accumulation without rotation\n- Large container images or unused image layers\n- Ephemeral storage abuse by workloads\n- kubelet garbage collection unable to keep up\n\n### Escalation\nIf disk pressure persists, the node will begin evicting pods. Consider cleaning up unused images (`crictl rmi --prune`), rotating logs, or expanding disk capacity."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_disk_pressure IS NOT NULL\n| STATS any_pressure = MAX(k8s.node.condition_disk_pressure)\n    BY k8s.node.name",
+        "breach": {
+          "segment": "WHERE any_pressure == 1\n| EVAL status = \"DiskPressure\""
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-filesystem-saturation-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-filesystem-saturation-v2.json
@@ -1,0 +1,44 @@
+{
+  "id": "kubernetes_otel-node-filesystem-saturation-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Node filesystem saturation",
+      "description": "Alerts when a node's filesystem usage exceeds 85% of capacity. Disk pressure triggers pod evictions and can destabilise the node.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "5m",
+      "lookback": "15m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-node-filesystem-saturation-v2-runbook",
+        "type": "runbook",
+        "value": "## Node Filesystem Saturation\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Storage & Volumes dashboard to see filesystem and volume usage trends.\n3. Check what is consuming disk space: container images, logs, ephemeral storage, or emptyDir volumes.\n4. Run `df -h` on the affected node to confirm disk usage.\n5. Check for pods using large ephemeral storage without limits.\n\n### Common Causes\n- Container log accumulation without rotation\n- Large container images or unused image layers\n- Ephemeral storage abuse by workloads\n- Persistent volume data growth\n\n### Tuning\n- Adjust the 85% usage threshold based on your operational tolerance.\n- For nodes with smaller disks, consider a lower threshold (e.g. 80%).\n\n### Escalation\nDisk pressure causes pod evictions. Clean up unused images (`crictl rmi --prune`), rotate logs, or expand node disk capacity."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.node.filesystem.usage IS NOT NULL\n    AND k8s.node.filesystem.capacity IS NOT NULL\n    AND k8s.node.filesystem.capacity > 0\n| STATS\n    avg_usage = AVG(k8s.node.filesystem.usage),\n    avg_capacity = AVG(k8s.node.filesystem.capacity)\n    BY k8s.node.name\n| EVAL usage_pct = ROUND(avg_usage / avg_capacity * 100, 1)",
+      "breach": {
+        "segment": "WHERE usage_pct > 85\n| KEEP k8s.node.name, usage_pct"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-filesystem-saturation-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-filesystem-saturation-v2.json
@@ -3,42 +3,44 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Node filesystem saturation",
-      "description": "Alerts when a node's filesystem usage exceeds 85% of capacity. Disk pressure triggers pod evictions and can destabilise the node.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "5m",
-      "lookback": "15m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-node-filesystem-saturation-v2-runbook",
-        "type": "runbook",
-        "value": "## Node Filesystem Saturation\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Storage & Volumes dashboard to see filesystem and volume usage trends.\n3. Check what is consuming disk space: container images, logs, ephemeral storage, or emptyDir volumes.\n4. Run `df -h` on the affected node to confirm disk usage.\n5. Check for pods using large ephemeral storage without limits.\n\n### Common Causes\n- Container log accumulation without rotation\n- Large container images or unused image layers\n- Ephemeral storage abuse by workloads\n- Persistent volume data growth\n\n### Tuning\n- Adjust the 85% usage threshold based on your operational tolerance.\n- For nodes with smaller disks, consider a lower threshold (e.g. 80%).\n\n### Escalation\nDisk pressure causes pod evictions. Clean up unused images (`crictl rmi --prune`), rotate logs, or expand node disk capacity."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.node.filesystem.usage IS NOT NULL\n    AND k8s.node.filesystem.capacity IS NOT NULL\n    AND k8s.node.filesystem.capacity > 0\n| STATS\n    avg_usage = AVG(k8s.node.filesystem.usage),\n    avg_capacity = AVG(k8s.node.filesystem.capacity)\n    BY k8s.node.name\n| EVAL usage_pct = ROUND(avg_usage / avg_capacity * 100, 1)",
-      "breach": {
-        "segment": "WHERE usage_pct > 85\n| KEEP k8s.node.name, usage_pct"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Node filesystem saturation",
+        "description": "Alerts when a node's filesystem usage exceeds 85% of capacity. Disk pressure triggers pod evictions and can destabilise the node.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "5m",
+        "lookback": "15m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-node-filesystem-saturation-v2-runbook",
+          "type": "runbook",
+          "value": "## Node Filesystem Saturation\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Storage & Volumes dashboard to see filesystem and volume usage trends.\n3. Check what is consuming disk space: container images, logs, ephemeral storage, or emptyDir volumes.\n4. Run `df -h` on the affected node to confirm disk usage.\n5. Check for pods using large ephemeral storage without limits.\n\n### Common Causes\n- Container log accumulation without rotation\n- Large container images or unused image layers\n- Ephemeral storage abuse by workloads\n- Persistent volume data growth\n\n### Tuning\n- Adjust the 85% usage threshold based on your operational tolerance.\n- For nodes with smaller disks, consider a lower threshold (e.g. 80%).\n\n### Escalation\nDisk pressure causes pod evictions. Clean up unused images (`crictl rmi --prune`), rotate logs, or expand node disk capacity."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.node.filesystem.usage IS NOT NULL\n    AND k8s.node.filesystem.capacity IS NOT NULL\n    AND k8s.node.filesystem.capacity > 0\n| STATS\n    avg_usage = AVG(k8s.node.filesystem.usage),\n    avg_capacity = AVG(k8s.node.filesystem.capacity)\n    BY k8s.node.name\n| EVAL usage_pct = ROUND(avg_usage / avg_capacity * 100, 1)",
+        "breach": {
+          "segment": "WHERE usage_pct > 85\n| KEEP k8s.node.name, usage_pct"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-memory-pressure-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-memory-pressure-v2.json
@@ -3,42 +3,44 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Node memory pressure",
-      "description": "Alerts when any Kubernetes node reports the MemoryPressure condition. This is a warning signal that the node is running low on memory and may begin evicting pods.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "1m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-node-memory-pressure-v2-runbook",
-        "type": "runbook",
-        "value": "## Node Memory Pressure\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard filtered to the affected node to see memory usage trends.\n3. Navigate to Pod & Container Detail filtered by node name to find the top memory consumers.\n4. Check for pods without memory limits or with very high limits.\n5. Run `kubectl top pods --sort-by=memory -A` to see current memory consumption.\n\n### Common Causes\n- Memory-intensive workloads without proper limits\n- Memory leaks in application containers\n- Too many pods scheduled on the node\n- Insufficient node memory capacity for the workload mix\n\n### Escalation\nIf memory pressure persists, the node will begin evicting pods. Consider cordoning the node and migrating workloads."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_memory_pressure IS NOT NULL\n| STATS any_pressure = MAX(k8s.node.condition_memory_pressure)\n    BY k8s.node.name",
-      "breach": {
-        "segment": "WHERE any_pressure == 1\n| EVAL status = \"MemoryPressure\""
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Node memory pressure",
+        "description": "Alerts when any Kubernetes node reports the MemoryPressure condition. This is a warning signal that the node is running low on memory and may begin evicting pods.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "1m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-node-memory-pressure-v2-runbook",
+          "type": "runbook",
+          "value": "## Node Memory Pressure\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard filtered to the affected node to see memory usage trends.\n3. Navigate to Pod & Container Detail filtered by node name to find the top memory consumers.\n4. Check for pods without memory limits or with very high limits.\n5. Run `kubectl top pods --sort-by=memory -A` to see current memory consumption.\n\n### Common Causes\n- Memory-intensive workloads without proper limits\n- Memory leaks in application containers\n- Too many pods scheduled on the node\n- Insufficient node memory capacity for the workload mix\n\n### Escalation\nIf memory pressure persists, the node will begin evicting pods. Consider cordoning the node and migrating workloads."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_memory_pressure IS NOT NULL\n| STATS any_pressure = MAX(k8s.node.condition_memory_pressure)\n    BY k8s.node.name",
+        "breach": {
+          "segment": "WHERE any_pressure == 1\n| EVAL status = \"MemoryPressure\""
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-memory-pressure-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-memory-pressure-v2.json
@@ -1,0 +1,44 @@
+{
+  "id": "kubernetes_otel-node-memory-pressure-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Node memory pressure",
+      "description": "Alerts when any Kubernetes node reports the MemoryPressure condition. This is a warning signal that the node is running low on memory and may begin evicting pods.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "1m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-node-memory-pressure-v2-runbook",
+        "type": "runbook",
+        "value": "## Node Memory Pressure\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard filtered to the affected node to see memory usage trends.\n3. Navigate to Pod & Container Detail filtered by node name to find the top memory consumers.\n4. Check for pods without memory limits or with very high limits.\n5. Run `kubectl top pods --sort-by=memory -A` to see current memory consumption.\n\n### Common Causes\n- Memory-intensive workloads without proper limits\n- Memory leaks in application containers\n- Too many pods scheduled on the node\n- Insufficient node memory capacity for the workload mix\n\n### Escalation\nIf memory pressure persists, the node will begin evicting pods. Consider cordoning the node and migrating workloads."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_memory_pressure IS NOT NULL\n| STATS any_pressure = MAX(k8s.node.condition_memory_pressure)\n    BY k8s.node.name",
+      "breach": {
+        "segment": "WHERE any_pressure == 1\n| EVAL status = \"MemoryPressure\""
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-memory-saturation-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-memory-saturation-v2.json
@@ -1,0 +1,44 @@
+{
+  "id": "kubernetes_otel-node-memory-saturation-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Node memory saturation",
+      "description": "Alerts when a node's memory working set exceeds a configurable threshold. High memory usage triggers OOM kills and pod evictions. Threshold should be calibrated to your node's allocatable memory.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "5m",
+      "lookback": "15m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-node-memory-saturation-v2-runbook",
+        "type": "runbook",
+        "value": "## Node Memory Saturation\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard to view memory usage trends (working_set, rss, available).\n3. Navigate to Pod & Container Detail filtered by the affected node to find the top memory consumers.\n4. Check for pods without memory limits or with very generous limits.\n5. Run `kubectl top pods --sort-by=memory -A` on the affected node.\n\n### Common Causes\n- Memory leaks in application containers\n- Workloads without proper memory limits\n- Too many pods scheduled on the node\n- Large in-memory caches or datasets\n\n### Tuning\n- The default threshold is 85% of allocatable memory. Adjust based on your tolerance.\n- For heterogeneous clusters, consider creating separate rules per node pool.\n\n### Escalation\nSustained memory saturation will cause OOM kills and pod evictions. Consider scaling the node pool or optimising workload memory usage."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.memory.working_set IS NOT NULL OR k8s.node.allocatable_memory IS NOT NULL)\n| STATS avg_memory = AVG(k8s.node.memory.working_set),\n    allocatable_memory = MAX(k8s.node.allocatable_memory)\n    BY k8s.node.name\n| EVAL memory_utilization = avg_memory / allocatable_memory",
+      "breach": {
+        "segment": "WHERE memory_utilization > 0.85\n| EVAL avg_memory_gib = ROUND(avg_memory / 1073741824, 2)\n| KEEP k8s.node.name, avg_memory_gib, allocatable_memory, memory_utilization"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-memory-saturation-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-memory-saturation-v2.json
@@ -3,42 +3,44 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Node memory saturation",
-      "description": "Alerts when a node's memory working set exceeds a configurable threshold. High memory usage triggers OOM kills and pod evictions. Threshold should be calibrated to your node's allocatable memory.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "5m",
-      "lookback": "15m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-node-memory-saturation-v2-runbook",
-        "type": "runbook",
-        "value": "## Node Memory Saturation\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard to view memory usage trends (working_set, rss, available).\n3. Navigate to Pod & Container Detail filtered by the affected node to find the top memory consumers.\n4. Check for pods without memory limits or with very generous limits.\n5. Run `kubectl top pods --sort-by=memory -A` on the affected node.\n\n### Common Causes\n- Memory leaks in application containers\n- Workloads without proper memory limits\n- Too many pods scheduled on the node\n- Large in-memory caches or datasets\n\n### Tuning\n- The default threshold is 85% of allocatable memory. Adjust based on your tolerance.\n- For heterogeneous clusters, consider creating separate rules per node pool.\n\n### Escalation\nSustained memory saturation will cause OOM kills and pod evictions. Consider scaling the node pool or optimising workload memory usage."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.memory.working_set IS NOT NULL OR k8s.node.allocatable_memory IS NOT NULL)\n| STATS avg_memory = AVG(k8s.node.memory.working_set),\n    allocatable_memory = MAX(k8s.node.allocatable_memory)\n    BY k8s.node.name\n| EVAL memory_utilization = avg_memory / allocatable_memory",
-      "breach": {
-        "segment": "WHERE memory_utilization > 0.85\n| EVAL avg_memory_gib = ROUND(avg_memory / 1073741824, 2)\n| KEEP k8s.node.name, avg_memory_gib, allocatable_memory, memory_utilization"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Node memory saturation",
+        "description": "Alerts when a node's memory working set exceeds a configurable threshold. High memory usage triggers OOM kills and pod evictions. Threshold should be calibrated to your node's allocatable memory.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "5m",
+        "lookback": "15m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-node-memory-saturation-v2-runbook",
+          "type": "runbook",
+          "value": "## Node Memory Saturation\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Open the Node Performance dashboard to view memory usage trends (working_set, rss, available).\n3. Navigate to Pod & Container Detail filtered by the affected node to find the top memory consumers.\n4. Check for pods without memory limits or with very generous limits.\n5. Run `kubectl top pods --sort-by=memory -A` on the affected node.\n\n### Common Causes\n- Memory leaks in application containers\n- Workloads without proper memory limits\n- Too many pods scheduled on the node\n- Large in-memory caches or datasets\n\n### Tuning\n- The default threshold is 85% of allocatable memory. Adjust based on your tolerance.\n- For heterogeneous clusters, consider creating separate rules per node pool.\n\n### Escalation\nSustained memory saturation will cause OOM kills and pod evictions. Consider scaling the node pool or optimising workload memory usage."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-kubeletstatsreceiver.otel-*, metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.name IS NOT NULL\n    AND (k8s.node.memory.working_set IS NOT NULL OR k8s.node.allocatable_memory IS NOT NULL)\n| STATS avg_memory = AVG(k8s.node.memory.working_set),\n    allocatable_memory = MAX(k8s.node.allocatable_memory)\n    BY k8s.node.name\n| EVAL memory_utilization = avg_memory / allocatable_memory",
+        "breach": {
+          "segment": "WHERE memory_utilization > 0.85\n| EVAL avg_memory_gib = ROUND(avg_memory / 1073741824, 2)\n| KEEP k8s.node.name, avg_memory_gib, allocatable_memory, memory_utilization"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-not-ready-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-not-ready-v2.json
@@ -3,42 +3,44 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Node not ready",
-      "description": "Alerts when any Kubernetes node has condition_ready == 0, indicating the node is not ready to accept workloads. Pods on NotReady nodes are eventually evicted. Common causes: kubelet crashes, network partitions, resource exhaustion.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "1m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-node-not-ready-v2-runbook",
-        "type": "runbook",
-        "value": "## Node Not Ready\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Check the Node Performance dashboard filtered to the affected node for CPU, memory, disk pressure, or network issues.\n3. Verify kubelet status: `kubectl get nodes` and `kubectl describe node <node_name>`.\n4. Check for node conditions: memory pressure, disk pressure, PID pressure.\n5. Review kubelet logs on the affected node.\n\n### Common Causes\n- Kubelet process crashed or became unresponsive\n- Network partition between node and control plane\n- Node resource exhaustion (disk, memory, PIDs)\n- Underlying VM/hardware failure\n\n### Escalation\nIf a node remains NotReady for more than 5 minutes, workloads will be evicted. Page the on-call infrastructure engineer."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_ready IS NOT NULL\n| STATS all_ready = MIN(k8s.node.condition_ready)\n    BY k8s.node.name",
-      "breach": {
-        "segment": "WHERE all_ready == 0\n| EVAL status = \"NotReady\""
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Node not ready",
+        "description": "Alerts when any Kubernetes node has condition_ready == 0, indicating the node is not ready to accept workloads. Pods on NotReady nodes are eventually evicted. Common causes: kubelet crashes, network partitions, resource exhaustion.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "1m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-node-not-ready-v2-runbook",
+          "type": "runbook",
+          "value": "## Node Not Ready\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Check the Node Performance dashboard filtered to the affected node for CPU, memory, disk pressure, or network issues.\n3. Verify kubelet status: `kubectl get nodes` and `kubectl describe node <node_name>`.\n4. Check for node conditions: memory pressure, disk pressure, PID pressure.\n5. Review kubelet logs on the affected node.\n\n### Common Causes\n- Kubelet process crashed or became unresponsive\n- Network partition between node and control plane\n- Node resource exhaustion (disk, memory, PIDs)\n- Underlying VM/hardware failure\n\n### Escalation\nIf a node remains NotReady for more than 5 minutes, workloads will be evicted. Page the on-call infrastructure engineer."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_ready IS NOT NULL\n| STATS all_ready = MIN(k8s.node.condition_ready)\n    BY k8s.node.name",
+        "breach": {
+          "segment": "WHERE all_ready == 0\n| EVAL status = \"NotReady\""
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-not-ready-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-node-not-ready-v2.json
@@ -1,0 +1,44 @@
+{
+  "id": "kubernetes_otel-node-not-ready-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Node not ready",
+      "description": "Alerts when any Kubernetes node has condition_ready == 0, indicating the node is not ready to accept workloads. Pods on NotReady nodes are eventually evicted. Common causes: kubelet crashes, network partitions, resource exhaustion.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "1m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-node-not-ready-v2-runbook",
+        "type": "runbook",
+        "value": "## Node Not Ready\n\n### Triage Steps\n1. Identify the affected node(s) from the alert results.\n2. Check the Node Performance dashboard filtered to the affected node for CPU, memory, disk pressure, or network issues.\n3. Verify kubelet status: `kubectl get nodes` and `kubectl describe node <node_name>`.\n4. Check for node conditions: memory pressure, disk pressure, PID pressure.\n5. Review kubelet logs on the affected node.\n\n### Common Causes\n- Kubelet process crashed or became unresponsive\n- Network partition between node and control plane\n- Node resource exhaustion (disk, memory, PIDs)\n- Underlying VM/hardware failure\n\n### Escalation\nIf a node remains NotReady for more than 5 minutes, workloads will be evicted. Page the on-call infrastructure engineer."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.node.condition_ready IS NOT NULL\n| STATS all_ready = MIN(k8s.node.condition_ready)\n    BY k8s.node.name",
+      "breach": {
+        "segment": "WHERE all_ready == 0\n| EVAL status = \"NotReady\""
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-oomkilled-containers-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-oomkilled-containers-v2.json
@@ -1,0 +1,47 @@
+{
+  "id": "kubernetes_otel-oomkilled-containers-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] OOMKilled containers",
+      "description": "Alerts when containers have been OOMKilled — terminated by the kernel OOM killer for exceeding their memory limit. Indicates the container's memory limit is too low or it has a memory leak.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "15m"
+    },
+    "state_transition": {
+      "pending_count": 1
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-oomkilled-containers-v2-runbook",
+        "type": "runbook",
+        "value": "## OOMKilled Containers\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see memory usage vs limits for the container.\n3. Check the container's memory limit vs actual usage: is the limit too low, or is the application using too much?\n4. Review application memory profiling if available.\n5. Check if the OOMKill is a one-off (startup spike) or recurring (memory leak).\n\n### Common Causes\n- Memory limit set too low for the workload's actual requirements\n- Memory leak in the application\n- Sudden traffic spike causing increased memory usage\n- JVM heap not aligned with container memory limit\n- In-memory caching growing unbounded\n\n### Tuning\n- This rule triggers on any container with `last_terminated_reason == OOMKilled`.\n- If certain containers are expected to occasionally OOM (e.g. batch jobs), exclude them by adding a namespace or pod name filter.\n\n### Escalation\nRecurring OOMKills indicate either insufficient memory limits or an application memory leak. Increase limits as a short-term fix and investigate root cause."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.container.status.last_terminated_reason == \"OOMKilled\"\n| STATS\n    restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name,\n       container.image.name",
+      "breach": {
+        "segment": "SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, container.image.name, restarts\n| LIMIT 50"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.pod.name",
+        "k8s.container.name",
+        "k8s.namespace.name",
+        "container.image.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-oomkilled-containers-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-oomkilled-containers-v2.json
@@ -3,45 +3,47 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] OOMKilled containers",
-      "description": "Alerts when containers have been OOMKilled — terminated by the kernel OOM killer for exceeding their memory limit. Indicates the container's memory limit is too low or it has a memory leak.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "15m"
-    },
-    "state_transition": {
-      "pending_count": 1
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-oomkilled-containers-v2-runbook",
-        "type": "runbook",
-        "value": "## OOMKilled Containers\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see memory usage vs limits for the container.\n3. Check the container's memory limit vs actual usage: is the limit too low, or is the application using too much?\n4. Review application memory profiling if available.\n5. Check if the OOMKill is a one-off (startup spike) or recurring (memory leak).\n\n### Common Causes\n- Memory limit set too low for the workload's actual requirements\n- Memory leak in the application\n- Sudden traffic spike causing increased memory usage\n- JVM heap not aligned with container memory limit\n- In-memory caching growing unbounded\n\n### Tuning\n- This rule triggers on any container with `last_terminated_reason == OOMKilled`.\n- If certain containers are expected to occasionally OOM (e.g. batch jobs), exclude them by adding a namespace or pod name filter.\n\n### Escalation\nRecurring OOMKills indicate either insufficient memory limits or an application memory leak. Increase limits as a short-term fix and investigate root cause."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.container.status.last_terminated_reason == \"OOMKilled\"\n| STATS\n    restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name,\n       container.image.name",
-      "breach": {
-        "segment": "SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, container.image.name, restarts\n| LIMIT 50"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.pod.name",
-        "k8s.container.name",
-        "k8s.namespace.name",
-        "container.image.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] OOMKilled containers",
+        "description": "Alerts when containers have been OOMKilled \u2014 terminated by the kernel OOM killer for exceeding their memory limit. Indicates the container's memory limit is too low or it has a memory leak.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "15m"
+      },
+      "state_transition": {
+        "pending_count": 1
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-oomkilled-containers-v2-runbook",
+          "type": "runbook",
+          "value": "## OOMKilled Containers\n\n### Triage Steps\n1. Identify the affected container(s) from the alert results.\n2. Open the Pod & Container Detail dashboard to see memory usage vs limits for the container.\n3. Check the container's memory limit vs actual usage: is the limit too low, or is the application using too much?\n4. Review application memory profiling if available.\n5. Check if the OOMKill is a one-off (startup spike) or recurring (memory leak).\n\n### Common Causes\n- Memory limit set too low for the workload's actual requirements\n- Memory leak in the application\n- Sudden traffic spike causing increased memory usage\n- JVM heap not aligned with container memory limit\n- In-memory caching growing unbounded\n\n### Tuning\n- This rule triggers on any container with `last_terminated_reason == OOMKilled`.\n- If certain containers are expected to occasionally OOM (e.g. batch jobs), exclude them by adding a namespace or pod name filter.\n\n### Escalation\nRecurring OOMKills indicate either insufficient memory limits or an application memory leak. Increase limits as a short-term fix and investigate root cause."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.container.status.last_terminated_reason == \"OOMKilled\"\n| STATS\n    restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name,\n       container.image.name",
+        "breach": {
+          "segment": "SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, container.image.name, restarts\n| LIMIT 50"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.pod.name",
+          "k8s.container.name",
+          "k8s.namespace.name",
+          "container.image.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-persistent-volume-space-low-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-persistent-volume-space-low-v2.json
@@ -1,0 +1,46 @@
+{
+  "id": "kubernetes_otel-persistent-volume-space-low-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Persistent volume space low",
+      "description": "Alerts when PersistentVolumes have less than 20% space remaining. Running out of volume space causes application write failures and potential data loss.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "5m",
+      "lookback": "15m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-persistent-volume-space-low-v2-runbook",
+        "type": "runbook",
+        "value": "## Persistent Volume Space Low\n\n### Triage Steps\n1. Identify the affected volume(s) from the alert results.\n2. Open the Storage & Volumes dashboard to view volume usage trends.\n3. Check which pod is using the volume and what data it stores.\n4. Determine if the data growth rate requires immediate action or can be planned.\n5. Run `kubectl exec <pod> -- df -h` to confirm volume usage from inside the pod.\n\n### Common Causes\n- Application logs written to the persistent volume without rotation\n- Database data growth exceeding provisioned capacity\n- Temporary files or caches accumulating without cleanup\n- Backup data stored on the volume\n\n### Tuning\n- The default threshold is 20% remaining space (`available_pct < 20`).\n- Increase for critical databases; decrease for less important storage.\n\n### Remediation\n- Expand the PVC if the storage class supports volume expansion\n- Clean up unnecessary data from the volume\n- Add log rotation or data retention policies\n- Migrate to a larger volume\n\n### Escalation\nVolumes below 10% remaining space are at critical risk of write failures. Immediate action required."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n    AND k8s.volume.capacity > 0\n| STATS\n    avg_available = AVG(k8s.volume.available),\n    avg_capacity = AVG(k8s.volume.capacity)\n    BY k8s.volume.name, k8s.pod.name, k8s.namespace.name\n| EVAL available_pct = ROUND(avg_available / avg_capacity * 100, 1)",
+      "breach": {
+        "segment": "WHERE available_pct < 20\n| EVAL used_pct = ROUND(100 - available_pct, 1)\n| SORT available_pct ASC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.volume.name, used_pct, available_pct\n| LIMIT 50"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.volume.name",
+        "k8s.pod.name",
+        "k8s.namespace.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-persistent-volume-space-low-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-persistent-volume-space-low-v2.json
@@ -3,44 +3,46 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Persistent volume space low",
-      "description": "Alerts when PersistentVolumes have less than 20% space remaining. Running out of volume space causes application write failures and potential data loss.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "5m",
-      "lookback": "15m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-persistent-volume-space-low-v2-runbook",
-        "type": "runbook",
-        "value": "## Persistent Volume Space Low\n\n### Triage Steps\n1. Identify the affected volume(s) from the alert results.\n2. Open the Storage & Volumes dashboard to view volume usage trends.\n3. Check which pod is using the volume and what data it stores.\n4. Determine if the data growth rate requires immediate action or can be planned.\n5. Run `kubectl exec <pod> -- df -h` to confirm volume usage from inside the pod.\n\n### Common Causes\n- Application logs written to the persistent volume without rotation\n- Database data growth exceeding provisioned capacity\n- Temporary files or caches accumulating without cleanup\n- Backup data stored on the volume\n\n### Tuning\n- The default threshold is 20% remaining space (`available_pct < 20`).\n- Increase for critical databases; decrease for less important storage.\n\n### Remediation\n- Expand the PVC if the storage class supports volume expansion\n- Clean up unnecessary data from the volume\n- Add log rotation or data retention policies\n- Migrate to a larger volume\n\n### Escalation\nVolumes below 10% remaining space are at critical risk of write failures. Immediate action required."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n    AND k8s.volume.capacity > 0\n| STATS\n    avg_available = AVG(k8s.volume.available),\n    avg_capacity = AVG(k8s.volume.capacity)\n    BY k8s.volume.name, k8s.pod.name, k8s.namespace.name\n| EVAL available_pct = ROUND(avg_available / avg_capacity * 100, 1)",
-      "breach": {
-        "segment": "WHERE available_pct < 20\n| EVAL used_pct = ROUND(100 - available_pct, 1)\n| SORT available_pct ASC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.volume.name, used_pct, available_pct\n| LIMIT 50"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.volume.name",
-        "k8s.pod.name",
-        "k8s.namespace.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Persistent volume space low",
+        "description": "Alerts when PersistentVolumes have less than 20% space remaining. Running out of volume space causes application write failures and potential data loss.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "5m",
+        "lookback": "15m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-persistent-volume-space-low-v2-runbook",
+          "type": "runbook",
+          "value": "## Persistent Volume Space Low\n\n### Triage Steps\n1. Identify the affected volume(s) from the alert results.\n2. Open the Storage & Volumes dashboard to view volume usage trends.\n3. Check which pod is using the volume and what data it stores.\n4. Determine if the data growth rate requires immediate action or can be planned.\n5. Run `kubectl exec <pod> -- df -h` to confirm volume usage from inside the pod.\n\n### Common Causes\n- Application logs written to the persistent volume without rotation\n- Database data growth exceeding provisioned capacity\n- Temporary files or caches accumulating without cleanup\n- Backup data stored on the volume\n\n### Tuning\n- The default threshold is 20% remaining space (`available_pct < 20`).\n- Increase for critical databases; decrease for less important storage.\n\n### Remediation\n- Expand the PVC if the storage class supports volume expansion\n- Clean up unnecessary data from the volume\n- Add log rotation or data retention policies\n- Migrate to a larger volume\n\n### Escalation\nVolumes below 10% remaining space are at critical risk of write failures. Immediate action required."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-kubeletstatsreceiver.otel-*\n| WHERE k8s.volume.available IS NOT NULL\n    AND k8s.volume.capacity IS NOT NULL\n    AND k8s.volume.capacity > 0\n| STATS\n    avg_available = AVG(k8s.volume.available),\n    avg_capacity = AVG(k8s.volume.capacity)\n    BY k8s.volume.name, k8s.pod.name, k8s.namespace.name\n| EVAL available_pct = ROUND(avg_available / avg_capacity * 100, 1)",
+        "breach": {
+          "segment": "WHERE available_pct < 20\n| EVAL used_pct = ROUND(100 - available_pct, 1)\n| SORT available_pct ASC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.volume.name, used_pct, available_pct\n| LIMIT 50"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.volume.name",
+          "k8s.pod.name",
+          "k8s.namespace.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pod-crashloopbackoff-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pod-crashloopbackoff-v2.json
@@ -3,44 +3,46 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Pod CrashLoopBackOff",
-      "description": "Alerts when containers have a high restart count, indicating CrashLoopBackOff. Rapidly increasing restarts mean a container is repeatedly crashing and being restarted by the kubelet.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "15m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-pod-crashloopbackoff-v2-runbook",
-        "type": "runbook",
-        "value": "## Pod CrashLoopBackOff\n\n### Triage Steps\n1. Identify the affected pod(s) and container(s) from the alert results.\n2. Check container logs: `kubectl logs <pod> -c <container> -n <namespace> --previous` (use `--previous` to see logs from the crashed instance).\n3. Open the Pod & Container Detail dashboard filtered to the affected namespace/pod.\n4. Check the container's `last_terminated_reason` for clues (OOMKilled, Error, etc.).\n5. Verify the container image is correct and pullable.\n6. Check if ConfigMaps, Secrets, or environment variables are missing.\n\n### Common Causes\n- Application bugs causing immediate crashes\n- Missing or incorrect configuration (ConfigMaps, Secrets, env vars)\n- Missing dependencies (database not reachable, required service unavailable)\n- OOM kills (check for OOMKilled terminated reason)\n- Liveness probe misconfiguration causing healthy containers to be killed\n\n### Tuning\n- The rule alerts on any container with `restarts > 0` within the 15-minute window. The `k8s.container.restarts` gauge resets to 0 when kubelet prunes dead containers, so > 0 reliably means the container is restarting in the recent past.\n- Combined with `alertDelay` of 3 consecutive evaluations, this catches sustained crash loops while filtering out one-off restarts.\n- To reduce noise for workloads that legitimately restart, add a namespace or pod name filter.\n\n### Escalation\nCrashLooping pods consume cluster resources without providing service. If the root cause isn't immediately clear from logs, escalate to the application team."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| STATS restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name",
-      "breach": {
-        "segment": "WHERE restarts > 0\n| SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, restarts\n| LIMIT 50"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.pod.name",
-        "k8s.container.name",
-        "k8s.namespace.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Pod CrashLoopBackOff",
+        "description": "Alerts when containers have a high restart count, indicating CrashLoopBackOff. Rapidly increasing restarts mean a container is repeatedly crashing and being restarted by the kubelet.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "15m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-pod-crashloopbackoff-v2-runbook",
+          "type": "runbook",
+          "value": "## Pod CrashLoopBackOff\n\n### Triage Steps\n1. Identify the affected pod(s) and container(s) from the alert results.\n2. Check container logs: `kubectl logs <pod> -c <container> -n <namespace> --previous` (use `--previous` to see logs from the crashed instance).\n3. Open the Pod & Container Detail dashboard filtered to the affected namespace/pod.\n4. Check the container's `last_terminated_reason` for clues (OOMKilled, Error, etc.).\n5. Verify the container image is correct and pullable.\n6. Check if ConfigMaps, Secrets, or environment variables are missing.\n\n### Common Causes\n- Application bugs causing immediate crashes\n- Missing or incorrect configuration (ConfigMaps, Secrets, env vars)\n- Missing dependencies (database not reachable, required service unavailable)\n- OOM kills (check for OOMKilled terminated reason)\n- Liveness probe misconfiguration causing healthy containers to be killed\n\n### Tuning\n- The rule alerts on any container with `restarts > 0` within the 15-minute window. The `k8s.container.restarts` gauge resets to 0 when kubelet prunes dead containers, so > 0 reliably means the container is restarting in the recent past.\n- Combined with `alertDelay` of 3 consecutive evaluations, this catches sustained crash loops while filtering out one-off restarts.\n- To reduce noise for workloads that legitimately restart, add a namespace or pod name filter.\n\n### Escalation\nCrashLooping pods consume cluster resources without providing service. If the root cause isn't immediately clear from logs, escalate to the application team."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| STATS restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name",
+        "breach": {
+          "segment": "WHERE restarts > 0\n| SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, restarts\n| LIMIT 50"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.pod.name",
+          "k8s.container.name",
+          "k8s.namespace.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pod-crashloopbackoff-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pod-crashloopbackoff-v2.json
@@ -1,0 +1,46 @@
+{
+  "id": "kubernetes_otel-pod-crashloopbackoff-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Pod CrashLoopBackOff",
+      "description": "Alerts when containers have a high restart count, indicating CrashLoopBackOff. Rapidly increasing restarts mean a container is repeatedly crashing and being restarted by the kubelet.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "15m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-pod-crashloopbackoff-v2-runbook",
+        "type": "runbook",
+        "value": "## Pod CrashLoopBackOff\n\n### Triage Steps\n1. Identify the affected pod(s) and container(s) from the alert results.\n2. Check container logs: `kubectl logs <pod> -c <container> -n <namespace> --previous` (use `--previous` to see logs from the crashed instance).\n3. Open the Pod & Container Detail dashboard filtered to the affected namespace/pod.\n4. Check the container's `last_terminated_reason` for clues (OOMKilled, Error, etc.).\n5. Verify the container image is correct and pullable.\n6. Check if ConfigMaps, Secrets, or environment variables are missing.\n\n### Common Causes\n- Application bugs causing immediate crashes\n- Missing or incorrect configuration (ConfigMaps, Secrets, env vars)\n- Missing dependencies (database not reachable, required service unavailable)\n- OOM kills (check for OOMKilled terminated reason)\n- Liveness probe misconfiguration causing healthy containers to be killed\n\n### Tuning\n- The rule alerts on any container with `restarts > 0` within the 15-minute window. The `k8s.container.restarts` gauge resets to 0 when kubelet prunes dead containers, so > 0 reliably means the container is restarting in the recent past.\n- Combined with `alertDelay` of 3 consecutive evaluations, this catches sustained crash loops while filtering out one-off restarts.\n- To reduce noise for workloads that legitimately restart, add a namespace or pod name filter.\n\n### Escalation\nCrashLooping pods consume cluster resources without providing service. If the root cause isn't immediately clear from logs, escalate to the application team."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| STATS restarts = MAX(k8s.container.restarts)\n    BY k8s.pod.name, k8s.container.name, k8s.namespace.name",
+      "breach": {
+        "segment": "WHERE restarts > 0\n| SORT restarts DESC\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.container.name, restarts\n| LIMIT 50"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.pod.name",
+        "k8s.container.name",
+        "k8s.namespace.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pods-failed-phase-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pods-failed-phase-v2.json
@@ -3,44 +3,46 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Pods in Failed phase",
-      "description": "Alerts when pods are in Failed phase (phase == 4). Failed pods have terminated with an error and will not be restarted. May indicate persistent issues requiring operator intervention.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "5m"
-    },
-    "state_transition": {
-      "pending_count": 2
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-pods-failed-phase-v2-runbook",
-        "type": "runbook",
-        "value": "## Pods in Failed Phase\n\n### Triage Steps\n1. Identify the affected pod(s) from the alert results.\n2. Check the Cluster Overview dashboard for an increase in Failed phase pods.\n3. Get pod details: `kubectl describe pod <pod_name> -n <namespace>`.\n4. Check container logs: `kubectl logs <pod_name> -n <namespace> --all-containers --previous`.\n5. Review pod events for scheduling failures, image pull errors, or resource issues.\n\n### Common Causes\n- All containers in the pod exited with non-zero exit codes\n- Eviction due to node resource pressure\n- Preemption by higher-priority pods\n- Job pods that failed their task\n\n### Tuning\n- Pods in Failed phase from completed Jobs are expected; exclude Job namespaces if they cause noise.\n- Add namespace filters to focus on production workloads.\n\n### Escalation\nFailed pods that belong to Deployments or StatefulSets should trigger replica replacement. If they don't, the controller may be stuck — investigate the controller logs."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.phase IS NOT NULL\n| STATS observed_phases = VALUES(k8s.pod.phase)\n    BY k8s.pod.name, k8s.namespace.name, k8s.node.name",
-      "breach": {
-        "segment": "WHERE MV_CONTAINS(observed_phases, TO_LONG(4))\n| EVAL status = \"Failed\"\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.node.name, status, observed_phases\n| SORT k8s.namespace.name ASC, k8s.pod.name ASC\n| LIMIT 100"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.pod.name",
-        "k8s.namespace.name",
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Pods in Failed phase",
+        "description": "Alerts when pods are in Failed phase (phase == 4). Failed pods have terminated with an error and will not be restarted. May indicate persistent issues requiring operator intervention.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "5m"
+      },
+      "state_transition": {
+        "pending_count": 2
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-pods-failed-phase-v2-runbook",
+          "type": "runbook",
+          "value": "## Pods in Failed Phase\n\n### Triage Steps\n1. Identify the affected pod(s) from the alert results.\n2. Check the Cluster Overview dashboard for an increase in Failed phase pods.\n3. Get pod details: `kubectl describe pod <pod_name> -n <namespace>`.\n4. Check container logs: `kubectl logs <pod_name> -n <namespace> --all-containers --previous`.\n5. Review pod events for scheduling failures, image pull errors, or resource issues.\n\n### Common Causes\n- All containers in the pod exited with non-zero exit codes\n- Eviction due to node resource pressure\n- Preemption by higher-priority pods\n- Job pods that failed their task\n\n### Tuning\n- Pods in Failed phase from completed Jobs are expected; exclude Job namespaces if they cause noise.\n- Add namespace filters to focus on production workloads.\n\n### Escalation\nFailed pods that belong to Deployments or StatefulSets should trigger replica replacement. If they don't, the controller may be stuck \u2014 investigate the controller logs."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.phase IS NOT NULL\n| STATS observed_phases = VALUES(k8s.pod.phase)\n    BY k8s.pod.name, k8s.namespace.name, k8s.node.name",
+        "breach": {
+          "segment": "WHERE MV_CONTAINS(observed_phases, TO_LONG(4))\n| EVAL status = \"Failed\"\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.node.name, status, observed_phases\n| SORT k8s.namespace.name ASC, k8s.pod.name ASC\n| LIMIT 100"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.pod.name",
+          "k8s.namespace.name",
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pods-failed-phase-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pods-failed-phase-v2.json
@@ -1,0 +1,46 @@
+{
+  "id": "kubernetes_otel-pods-failed-phase-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Pods in Failed phase",
+      "description": "Alerts when pods are in Failed phase (phase == 4). Failed pods have terminated with an error and will not be restarted. May indicate persistent issues requiring operator intervention.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "5m"
+    },
+    "state_transition": {
+      "pending_count": 2
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-pods-failed-phase-v2-runbook",
+        "type": "runbook",
+        "value": "## Pods in Failed Phase\n\n### Triage Steps\n1. Identify the affected pod(s) from the alert results.\n2. Check the Cluster Overview dashboard for an increase in Failed phase pods.\n3. Get pod details: `kubectl describe pod <pod_name> -n <namespace>`.\n4. Check container logs: `kubectl logs <pod_name> -n <namespace> --all-containers --previous`.\n5. Review pod events for scheduling failures, image pull errors, or resource issues.\n\n### Common Causes\n- All containers in the pod exited with non-zero exit codes\n- Eviction due to node resource pressure\n- Preemption by higher-priority pods\n- Job pods that failed their task\n\n### Tuning\n- Pods in Failed phase from completed Jobs are expected; exclude Job namespaces if they cause noise.\n- Add namespace filters to focus on production workloads.\n\n### Escalation\nFailed pods that belong to Deployments or StatefulSets should trigger replica replacement. If they don't, the controller may be stuck — investigate the controller logs."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.phase IS NOT NULL\n| STATS observed_phases = VALUES(k8s.pod.phase)\n    BY k8s.pod.name, k8s.namespace.name, k8s.node.name",
+      "breach": {
+        "segment": "WHERE MV_CONTAINS(observed_phases, TO_LONG(4))\n| EVAL status = \"Failed\"\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.node.name, status, observed_phases\n| SORT k8s.namespace.name ASC, k8s.pod.name ASC\n| LIMIT 100"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.pod.name",
+        "k8s.namespace.name",
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pods-pending-phase-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pods-pending-phase-v2.json
@@ -1,0 +1,46 @@
+{
+  "id": "kubernetes_otel-pods-pending-phase-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] Pods stuck in Pending phase",
+      "description": "Alerts when pods are stuck in Pending phase (phase == 1). Pending pods cannot be scheduled — typically due to insufficient node resources, node affinity/taint mismatches, or missing PVCs. Sustained Pending pods are a proxy for scheduling latency.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "1m"
+    },
+    "state_transition": {
+      "pending_count": 5
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-pods-pending-phase-v2-runbook",
+        "type": "runbook",
+        "value": "## Pods Stuck in Pending Phase\n\n### Triage Steps\n1. Identify the affected pod(s) from the alert results.\n2. Run `kubectl describe pod <pod_name> -n <namespace>` — the Events section shows why scheduling failed.\n3. Check the Cluster Overview dashboard for node resource availability.\n4. Verify node resources: `kubectl describe nodes | grep -A 5 'Allocated resources'`.\n5. Check for PVC binding issues: `kubectl get pvc -n <namespace>`.\n\n### Common Causes\n- Insufficient CPU or memory on available nodes\n- Node affinity, anti-affinity, or taint/toleration mismatches\n- PersistentVolumeClaim not bound (no available PV)\n- Pod topology spread constraints cannot be satisfied\n- Resource quotas exceeded in the namespace\n\n### Tuning\n- The `alertDelay` of 5 runs (5 minutes at 1m interval) allows for normal scheduling delays.\n- Increase `alertDelay` for clusters with slow autoscaling (e.g. cloud node provisioning).\n- Add namespace filters to exclude namespaces where Pending pods are expected (e.g. batch workloads waiting for resources).\n\n### Escalation\nSustained Pending pods indicate the cluster cannot meet workload demand. Consider scaling up the node pool or reviewing resource requests."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.phase IS NOT NULL\n| STATS max_phase = MAX(k8s.pod.phase)\n    BY k8s.pod.name, k8s.namespace.name, k8s.node.name",
+      "breach": {
+        "segment": "WHERE max_phase == 1\n| EVAL status = \"Pending\"\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.node.name, status\n| SORT k8s.namespace.name ASC, k8s.pod.name ASC\n| LIMIT 100"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.pod.name",
+        "k8s.namespace.name",
+        "k8s.node.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pods-pending-phase-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-pods-pending-phase-v2.json
@@ -3,44 +3,46 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] Pods stuck in Pending phase",
-      "description": "Alerts when pods are stuck in Pending phase (phase == 1). Pending pods cannot be scheduled — typically due to insufficient node resources, node affinity/taint mismatches, or missing PVCs. Sustained Pending pods are a proxy for scheduling latency.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "1m"
-    },
-    "state_transition": {
-      "pending_count": 5
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-pods-pending-phase-v2-runbook",
-        "type": "runbook",
-        "value": "## Pods Stuck in Pending Phase\n\n### Triage Steps\n1. Identify the affected pod(s) from the alert results.\n2. Run `kubectl describe pod <pod_name> -n <namespace>` — the Events section shows why scheduling failed.\n3. Check the Cluster Overview dashboard for node resource availability.\n4. Verify node resources: `kubectl describe nodes | grep -A 5 'Allocated resources'`.\n5. Check for PVC binding issues: `kubectl get pvc -n <namespace>`.\n\n### Common Causes\n- Insufficient CPU or memory on available nodes\n- Node affinity, anti-affinity, or taint/toleration mismatches\n- PersistentVolumeClaim not bound (no available PV)\n- Pod topology spread constraints cannot be satisfied\n- Resource quotas exceeded in the namespace\n\n### Tuning\n- The `alertDelay` of 5 runs (5 minutes at 1m interval) allows for normal scheduling delays.\n- Increase `alertDelay` for clusters with slow autoscaling (e.g. cloud node provisioning).\n- Add namespace filters to exclude namespaces where Pending pods are expected (e.g. batch workloads waiting for resources).\n\n### Escalation\nSustained Pending pods indicate the cluster cannot meet workload demand. Consider scaling up the node pool or reviewing resource requests."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.phase IS NOT NULL\n| STATS max_phase = MAX(k8s.pod.phase)\n    BY k8s.pod.name, k8s.namespace.name, k8s.node.name",
-      "breach": {
-        "segment": "WHERE max_phase == 1\n| EVAL status = \"Pending\"\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.node.name, status\n| SORT k8s.namespace.name ASC, k8s.pod.name ASC\n| LIMIT 100"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.pod.name",
-        "k8s.namespace.name",
-        "k8s.node.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] Pods stuck in Pending phase",
+        "description": "Alerts when pods are stuck in Pending phase (phase == 1). Pending pods cannot be scheduled \u2014 typically due to insufficient node resources, node affinity/taint mismatches, or missing PVCs. Sustained Pending pods are a proxy for scheduling latency.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "1m"
+      },
+      "state_transition": {
+        "pending_count": 5
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-pods-pending-phase-v2-runbook",
+          "type": "runbook",
+          "value": "## Pods Stuck in Pending Phase\n\n### Triage Steps\n1. Identify the affected pod(s) from the alert results.\n2. Run `kubectl describe pod <pod_name> -n <namespace>` \u2014 the Events section shows why scheduling failed.\n3. Check the Cluster Overview dashboard for node resource availability.\n4. Verify node resources: `kubectl describe nodes | grep -A 5 'Allocated resources'`.\n5. Check for PVC binding issues: `kubectl get pvc -n <namespace>`.\n\n### Common Causes\n- Insufficient CPU or memory on available nodes\n- Node affinity, anti-affinity, or taint/toleration mismatches\n- PersistentVolumeClaim not bound (no available PV)\n- Pod topology spread constraints cannot be satisfied\n- Resource quotas exceeded in the namespace\n\n### Tuning\n- The `alertDelay` of 5 runs (5 minutes at 1m interval) allows for normal scheduling delays.\n- Increase `alertDelay` for clusters with slow autoscaling (e.g. cloud node provisioning).\n- Add namespace filters to exclude namespaces where Pending pods are expected (e.g. batch workloads waiting for resources).\n\n### Escalation\nSustained Pending pods indicate the cluster cannot meet workload demand. Consider scaling up the node pool or reviewing resource requests."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.pod.phase IS NOT NULL\n| STATS max_phase = MAX(k8s.pod.phase)\n    BY k8s.pod.name, k8s.namespace.name, k8s.node.name",
+        "breach": {
+          "segment": "WHERE max_phase == 1\n| EVAL status = \"Pending\"\n| KEEP k8s.namespace.name, k8s.pod.name, k8s.node.name, status\n| SORT k8s.namespace.name ASC, k8s.pod.name ASC\n| LIMIT 100"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.pod.name",
+          "k8s.namespace.name",
+          "k8s.node.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-statefulset-replicas-not-ready-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-statefulset-replicas-not-ready-v2.json
@@ -1,0 +1,45 @@
+{
+  "id": "kubernetes_otel-statefulset-replicas-not-ready-v2",
+  "type": "alerting_rule_template",
+  "managed": true,
+  "attributes": {
+    "kind": "alert",
+    "metadata": {
+      "name": "[Kubernetes OTel] StatefulSet replicas not ready",
+      "description": "Alerts when a StatefulSet has fewer ready pods than desired. StatefulSets manage stateful applications with stable identities, so missing replicas can cause data availability issues.",
+      "tags": [
+        "Kubernetes"
+      ]
+    },
+    "schedule": {
+      "every": "1m",
+      "lookback": "1m"
+    },
+    "state_transition": {
+      "pending_count": 3
+    },
+    "recovery_strategy": "no_breach",
+    "artifacts": [
+      {
+        "id": "kubernetes_otel-statefulset-replicas-not-ready-v2-runbook",
+        "type": "runbook",
+        "value": "## StatefulSet Replicas Not Ready\n\n### Triage Steps\n1. Identify the affected StatefulSet(s) from the alert results.\n2. Check the Workload Health dashboard for StatefulSet status.\n3. Run `kubectl describe statefulset <name> -n <namespace>` for events.\n4. Check individual pod status: `kubectl get pods -l app=<statefulset> -n <namespace>`.\n5. Verify PVC bindings — StatefulSet pods require their PVCs to be bound before starting.\n\n### Common Causes\n- PersistentVolumeClaim binding failures (no matching PV available)\n- Pod crash loops in stateful workloads\n- Ordered startup blocked by earlier pod failures (StatefulSets start sequentially)\n- Resource constraints preventing pod scheduling\n\n### Tuning\n- The rule filters out StatefulSets scaled to zero (`desired > 0`).\n- StatefulSets roll out pods sequentially, so transient gaps during updates are normal. The `alertDelay` of 3 runs helps avoid false positives.\n\n### Escalation\nStatefulSet failures often affect databases and message queues. Prioritise investigation to prevent data loss."
+      }
+    ],
+    "engine": "v2",
+    "query": {
+      "format": "composed",
+      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.statefulset.desired_pods IS NOT NULL\n    AND k8s.statefulset.ready_pods IS NOT NULL\n| STATS\n    desired = LAST(k8s.statefulset.desired_pods, @timestamp),\n    ready = LAST(k8s.statefulset.ready_pods, @timestamp)\n    BY k8s.statefulset.name, k8s.namespace.name",
+      "breach": {
+        "segment": "WHERE desired > 0\n| WHERE ready < desired\n| EVAL not_ready = desired - ready\n| KEEP k8s.namespace.name, k8s.statefulset.name, desired, ready, not_ready\n| SORT not_ready DESC"
+      }
+    },
+    "grouping": {
+      "fields": [
+        "k8s.statefulset.name",
+        "k8s.namespace.name"
+      ]
+    },
+    "time_field": "@timestamp"
+  }
+}

--- a/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-statefulset-replicas-not-ready-v2.json
+++ b/packages/kubernetes_otel/kibana/alerting_rule_template/kubernetes_otel-statefulset-replicas-not-ready-v2.json
@@ -3,43 +3,45 @@
   "type": "alerting_rule_template",
   "managed": true,
   "attributes": {
-    "kind": "alert",
-    "metadata": {
-      "name": "[Kubernetes OTel] StatefulSet replicas not ready",
-      "description": "Alerts when a StatefulSet has fewer ready pods than desired. StatefulSets manage stateful applications with stable identities, so missing replicas can cause data availability issues.",
-      "tags": [
-        "Kubernetes"
-      ]
-    },
-    "schedule": {
-      "every": "1m",
-      "lookback": "1m"
-    },
-    "state_transition": {
-      "pending_count": 3
-    },
-    "recovery_strategy": "no_breach",
-    "artifacts": [
-      {
-        "id": "kubernetes_otel-statefulset-replicas-not-ready-v2-runbook",
-        "type": "runbook",
-        "value": "## StatefulSet Replicas Not Ready\n\n### Triage Steps\n1. Identify the affected StatefulSet(s) from the alert results.\n2. Check the Workload Health dashboard for StatefulSet status.\n3. Run `kubectl describe statefulset <name> -n <namespace>` for events.\n4. Check individual pod status: `kubectl get pods -l app=<statefulset> -n <namespace>`.\n5. Verify PVC bindings — StatefulSet pods require their PVCs to be bound before starting.\n\n### Common Causes\n- PersistentVolumeClaim binding failures (no matching PV available)\n- Pod crash loops in stateful workloads\n- Ordered startup blocked by earlier pod failures (StatefulSets start sequentially)\n- Resource constraints preventing pod scheduling\n\n### Tuning\n- The rule filters out StatefulSets scaled to zero (`desired > 0`).\n- StatefulSets roll out pods sequentially, so transient gaps during updates are normal. The `alertDelay` of 3 runs helps avoid false positives.\n\n### Escalation\nStatefulSet failures often affect databases and message queues. Prioritise investigation to prevent data loss."
-      }
-    ],
     "engine": "v2",
-    "query": {
-      "format": "composed",
-      "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.statefulset.desired_pods IS NOT NULL\n    AND k8s.statefulset.ready_pods IS NOT NULL\n| STATS\n    desired = LAST(k8s.statefulset.desired_pods, @timestamp),\n    ready = LAST(k8s.statefulset.ready_pods, @timestamp)\n    BY k8s.statefulset.name, k8s.namespace.name",
-      "breach": {
-        "segment": "WHERE desired > 0\n| WHERE ready < desired\n| EVAL not_ready = desired - ready\n| KEEP k8s.namespace.name, k8s.statefulset.name, desired, ready, not_ready\n| SORT not_ready DESC"
-      }
-    },
-    "grouping": {
-      "fields": [
-        "k8s.statefulset.name",
-        "k8s.namespace.name"
-      ]
-    },
-    "time_field": "@timestamp"
+    "rule": {
+      "kind": "alert",
+      "metadata": {
+        "name": "[Kubernetes OTel] StatefulSet replicas not ready",
+        "description": "Alerts when a StatefulSet has fewer ready pods than desired. StatefulSets manage stateful applications with stable identities, so missing replicas can cause data availability issues.",
+        "tags": [
+          "Kubernetes"
+        ]
+      },
+      "schedule": {
+        "every": "1m",
+        "lookback": "1m"
+      },
+      "state_transition": {
+        "pending_count": 3
+      },
+      "recovery_strategy": "no_breach",
+      "artifacts": [
+        {
+          "id": "kubernetes_otel-statefulset-replicas-not-ready-v2-runbook",
+          "type": "runbook",
+          "value": "## StatefulSet Replicas Not Ready\n\n### Triage Steps\n1. Identify the affected StatefulSet(s) from the alert results.\n2. Check the Workload Health dashboard for StatefulSet status.\n3. Run `kubectl describe statefulset <name> -n <namespace>` for events.\n4. Check individual pod status: `kubectl get pods -l app=<statefulset> -n <namespace>`.\n5. Verify PVC bindings \u2014 StatefulSet pods require their PVCs to be bound before starting.\n\n### Common Causes\n- PersistentVolumeClaim binding failures (no matching PV available)\n- Pod crash loops in stateful workloads\n- Ordered startup blocked by earlier pod failures (StatefulSets start sequentially)\n- Resource constraints preventing pod scheduling\n\n### Tuning\n- The rule filters out StatefulSets scaled to zero (`desired > 0`).\n- StatefulSets roll out pods sequentially, so transient gaps during updates are normal. The `alertDelay` of 3 runs helps avoid false positives.\n\n### Escalation\nStatefulSet failures often affect databases and message queues. Prioritise investigation to prevent data loss."
+        }
+      ],
+      "query": {
+        "format": "composed",
+        "base": "TS metrics-k8sclusterreceiver.otel-*\n| WHERE k8s.statefulset.desired_pods IS NOT NULL\n    AND k8s.statefulset.ready_pods IS NOT NULL\n| STATS\n    desired = LAST(k8s.statefulset.desired_pods, @timestamp),\n    ready = LAST(k8s.statefulset.ready_pods, @timestamp)\n    BY k8s.statefulset.name, k8s.namespace.name",
+        "breach": {
+          "segment": "WHERE desired > 0\n| WHERE ready < desired\n| EVAL not_ready = desired - ready\n| KEEP k8s.namespace.name, k8s.statefulset.name, desired, ready, not_ready\n| SORT not_ready DESC"
+        }
+      },
+      "grouping": {
+        "fields": [
+          "k8s.statefulset.name",
+          "k8s.namespace.name"
+        ]
+      },
+      "time_field": "@timestamp"
+    }
   }
 }

--- a/packages/kubernetes_otel/manifest.yml
+++ b/packages/kubernetes_otel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: kubernetes_otel
 title: "Kubernetes OpenTelemetry Assets"
-version: 2.4.0
+version: 2.5.0
 description: "Utilise the pre-built dashboard for OTel-native metrics and events collected from a Kubernetes cluster"
 type: content
 categories:
@@ -11,7 +11,7 @@ categories:
   - opentelemetry
 conditions:
   kibana:
-    version: "^9.4.0"
+    version: "^9.6.0"
   elastic:
     subscription: "basic"
 discovery:


### PR DESCRIPTION
## Summary
- This is an example of the schema changes necessary to support v2. 
- Add 18 alerting v2 rule templates for Kubernetes OTel recommended alerts (nodes, pods, containers, workloads, volumes).
- Raise package version to `2.5.0` and require Kibana `^9.6.0` for the v2 alerting template schema.
- Single changelog entry covering the new templates.
- [V1 to V2 reference table](https://gist.github.com/dominiqueclarke/e2352820d9d6b5301d6b36dfd5f73c4e)

## Test plan
- [ ] `elastic-package build` succeeds for `packages/kubernetes_otel`
- [ ] Install package on Kibana >= 9.6 and confirm the 18 v2 templates appear in the rule library
- [ ] Spot-check a composed query template (e.g. Pod CrashLoopBackOff) instantiates and evaluates correctly
- [ ] Confirm v1 templates are unchanged and still available